### PR TITLE
refactor(ui): migrar LandingNavbar a componentes de Nuxt UI

### DIFF
--- a/app/components/landing/LandingNavbar.vue
+++ b/app/components/landing/LandingNavbar.vue
@@ -31,33 +31,44 @@ const goToTop = () => {
   >
     <div class="container mx-auto px-5 sm:px-8 flex items-center justify-between">
       <!-- Logo -->
-      <button type="button" class="group flex items-baseline gap-0 text-3xl font-extrabold tracking-tight" @click="goToTop">
+      <UButton
+        variant="link"
+        color="neutral"
+        class="group flex items-baseline gap-0 p-0 text-3xl font-extrabold tracking-tight hover:bg-transparent"
+        @click="goToTop"
+      >
         <span class="text-white">datea</span>
         <span class="text-secondary">lo</span>
-      </button>
+      </UButton>
 
       <div class="flex items-center gap-2 sm:gap-4">
         <!-- Nav links -->
-        <button
-          class="nav-link hidden sm:inline-flex items-center px-3.5 py-2 text-sm font-semibold text-white/80 hover:text-white rounded-lg hover:bg-white/10 transition-all duration-200"
+        <UButton
+          variant="link"
+          color="neutral"
+          class="nav-link hidden sm:inline-flex items-center px-3.5 py-2 text-sm font-semibold text-white/80 hover:text-white active:text-white rounded-lg hover:bg-white/10 transition-all duration-200"
           @click="scrollToSection('#categorias')"
         >
           Categorías
-        </button>
-        <button
-          class="nav-link hidden sm:inline-flex items-center px-3.5 py-2 text-sm font-semibold text-white/80 hover:text-white rounded-lg hover:bg-white/10 transition-all duration-200"
+        </UButton>
+        <UButton
+          variant="link"
+          color="neutral"
+          class="nav-link hidden sm:inline-flex items-center px-3.5 py-2 text-sm font-semibold text-white/80 hover:text-white active:text-white rounded-lg hover:bg-white/10 transition-all duration-200"
           @click="scrollToSection('#profesionales')"
         >
           Para profesionales
-        </button>
+        </UButton>
 
         <!-- CTA -->
-        <button
-          class="inline-flex items-center h-10 px-5 rounded-xl text-sm font-bold text-primary bg-white shadow-md hover:shadow-lg hover:scale-105 transition-all duration-200 cursor-pointer"
+        <UButton
+          variant="link"
+          color="neutral"
+          class="inline-flex items-center h-10 px-5 rounded-xl text-sm font-bold text-primary hover:text-primary active:text-primary bg-white hover:bg-white shadow-md hover:shadow-lg hover:scale-105 transition-all duration-200 cursor-pointer"
           @click="scrollToSection('#hero-form')"
         >
           Acceso anticipado
-        </button>
+        </UButton>
       </div>
     </div>
   </nav>


### PR DESCRIPTION
## Resumen

- Reemplaza los tres `<button>` nativos de `LandingNavbar.vue` (logo, links "Categorías"/"Para
  profesionales" y CTA "Acceso anticipado") por `<UButton variant="link" color="neutral">` de Nuxt UI.
- Cada `UButton` lleva exactamente las mismas clases Tailwind que tenía el `<button>` original (color,
  padding, radio, hover, tipografía) — `variant="link"` no trae fondo ni padding propios, así que no hay
  clases del tema que pisar; el resultado visual es idéntico.
- El comportamiento (scroll suave a sección, scroll a top, estado `scrolled` de la navbar) no cambió: sigue
  viviendo en el mismo `<script setup>`, sin tocar.

Es S-002 del plan de [la misión 01](https://github.com/PatricioTabilo/datealo/blob/main/docs/missions/01-migracion-nuxt-ui/ingenieria.md),
sobre la base de Nuxt UI que dejó S-001 (#13).

Sustento: A-004 (skill `arquitectura`).

## Test plan

- [x] `npx nuxi typecheck` limpio.
- [x] `npm run build` limpio.
- [x] Navbar revisado en el browser en desktop: logo, links y CTA idénticos, incluyendo estados hover y el
      fondo con blur al hacer scroll.
- [x] Click en "Categorías" dispara el scroll suave a `#categorias` con el mismo offset que antes.
- [x] Sin errores ni warnings nuevos en consola.
- [ ] Verificación visual en 390px pendiente: la herramienta de resize del browser no logró achicar la
      ventana en este entorno (`window.innerWidth` no cambió tras el resize). Las clases responsive
      (`hidden sm:inline-flex`) no se tocaron, así que el comportamiento en mobile no debería cambiar, pero
      vale una revisión manual en un viewport angosto antes de mergear.

Closes #2