### PR TITLE
refactor(ui): migrar LandingHero a componentes de Nuxt UI

### DIFF
--- a/app/components/landing/LandingHero.vue
+++ b/app/components/landing/LandingHero.vue
@@ -42,25 +42,29 @@ const { email, loading, submitted, error, submit } = useWaitlist('buscador')
               <form class="flex flex-col sm:flex-row gap-2" @submit.prevent="submit">
                 <div class="flex-1 relative">
                   <label for="hero-email" class="sr-only">Email</label>
-                  <input
+                  <UInput
                     id="hero-email"
                     v-model="email"
                     type="email"
                     autocomplete="email"
                     :placeholder="LANDING_HERO.emailPlaceholder"
-                    class="w-full h-14 rounded-xl bg-base-200/50 border-0 px-4 text-base text-base-content placeholder:text-base-content/40 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:bg-base-200 transition-all"
                     :disabled="loading"
+                    variant="none"
+                    class="w-full"
+                    :ui="{ base: 'h-14 rounded-xl bg-datealo-surface/50 px-4 text-base text-datealo-text placeholder:text-datealo-text/40 focus:ring-2 focus:ring-primary/20 focus:bg-datealo-surface transition-all' }"
                   />
                   <p v-if="error" class="absolute -bottom-6 left-2 text-xs text-white bg-error/90 px-2 py-1 rounded">{{ error }}</p>
                 </div>
-                <button
+                <UButton
                   type="submit"
-                  class="btn h-14 rounded-xl px-7 text-sm font-bold bg-secondary text-white border-0 hover:bg-secondary/90 hover:scale-[1.02] shadow-lg shadow-secondary/20 transition-all"
+                  variant="link"
+                  color="neutral"
+                  class="h-14 rounded-xl px-7 text-sm font-bold bg-secondary text-white hover:bg-secondary/90 hover:text-white active:text-white hover:scale-[1.02] shadow-lg shadow-secondary/20 transition-all"
                   :disabled="loading"
                 >
                   <Loader2 v-if="loading" class="h-5 w-5 animate-spin" />
                   <template v-else>{{ LANDING_HERO.cta }}</template>
-                </button>
+                </UButton>
               </form>
             </div>
           </Transition>


### PR DESCRIPTION
## Resumen

- Reemplaza el `<input type="email">` del form de waitlist por `<UInput variant="none">`. El estilo real
  del campo (alto, radio, fondo, foco) va en el prop `ui.base` — el `class` de nivel superior de `UInput`
  apunta al wrapper (`root`), no al `<input>` en sí, así que estilarlo desde ahí no habría funcionado.
- Reemplaza el `<button type="submit">` por `<UButton type="submit" variant="link">`, con las mismas
  clases que ya tenía (bg turquesa, hover, shadow, scale) — mismo patrón que S-002 (#14).
- De paso, cambia `bg-base-200`/`text-base-content` (tokens de DaisyUI) por `bg-datealo-surface`/
  `text-datealo-text` (tokens crudos ya definidos en `main.css`, mismo valor exacto: `#F3F4F6` /
  `#1F2937`). No era estrictamente necesario para este slice, pero ya que había que reescribir el
  `class` del input de todas formas, dejarlo sin depender de DaisyUI evita que S-010 tenga que volver a
  tocar este archivo.
- `v-model`, `:disabled="loading"`, el ícono `Loader2` en loading y el mensaje de error no cambiaron de
  comportamiento — siguen viviendo en `useWaitlist`.

Es S-003 del plan de [la misión 01](https://github.com/PatricioTabilo/datealo/blob/main/docs/missions/01-migracion-nuxt-ui/ingenieria.md).

Sustento: A-004 (skill `arquitectura`).

## Test plan

- [x] `npx nuxi typecheck` limpio.
- [x] `npm run build` limpio.
- [x] Revisado en el browser: input y botón idénticos en reposo, foco (ring), hover (scale) y con texto
      escrito — sin errores en consola.
- [ ] Verificación visual en 390px pendiente (mismo bloqueo de tooling que en #14 — el resize del browser
      no cambia `window.innerWidth` en este entorno). El layout mobile de este form usa `flex-col
      sm:flex-row`, sin tocar, pero vale confirmarlo a ojo antes de mergear.

Closes #3