### PR TITLE
refactor(ui): migrar LandingProblem a componentes de Nuxt UI

### DIFF
--- a/app/components/landing/LandingProblem.vue
+++ b/app/components/landing/LandingProblem.vue
@@ -8,18 +8,18 @@ const colorClasses: Record<string, string> = {
   red: 'bg-error/10 text-error border-error/20',
   amber: 'bg-amber-100 text-amber-600 border-amber-200',
   orange: 'bg-orange-100 text-orange-600 border-orange-200',
-  slate: 'bg-base-200 text-base-content/60 border-base-300',
+  slate: 'bg-datealo-surface text-datealo-text/60 border-gray-200',
 }
 </script>
 
 <template>
-  <section class="py-24 sm:py-32 bg-base-100">
+  <section class="py-24 sm:py-32 bg-datealo-bg">
     <div class="container mx-auto px-5 sm:px-8">
       <div class="max-w-2xl mx-auto text-center mb-16 sm:mb-20">
-        <h2 class="text-4xl sm:text-5xl font-extrabold text-base-content mb-6 tracking-tight leading-tight">
+        <h2 class="text-4xl sm:text-5xl font-extrabold text-datealo-text mb-6 tracking-tight leading-tight">
           {{ LANDING_PROBLEM.title }}
         </h2>
-        <p class="text-lg sm:text-xl text-base-content/60 leading-relaxed">
+        <p class="text-lg sm:text-xl text-datealo-text/60 leading-relaxed">
           {{ LANDING_PROBLEM.subtitle }}
         </p>
       </div>
@@ -28,7 +28,7 @@ const colorClasses: Record<string, string> = {
         <div
           v-for="item in LANDING_PROBLEM.items"
           :key="item.title"
-          class="flex flex-col sm:flex-row gap-5 sm:gap-6 rounded-[2rem] bg-white border border-base-200 p-6 sm:p-8 shadow-lg shadow-base-content/[0.02] hover:shadow-xl hover:shadow-base-content/[0.04] transition-shadow duration-300"
+          class="flex flex-col sm:flex-row gap-5 sm:gap-6 rounded-[2rem] bg-white border border-datealo-surface p-6 sm:p-8 shadow-lg shadow-datealo-text/[0.02] hover:shadow-xl hover:shadow-datealo-text/[0.04] transition-shadow duration-300"
         >
           <div
             class="h-14 w-14 sm:h-16 sm:w-16 rounded-2xl flex items-center justify-center shrink-0 border"
@@ -37,10 +37,10 @@ const colorClasses: Record<string, string> = {
             <component :is="iconMap[item.icon]" class="h-6 w-6 sm:h-7 sm:w-7" />
           </div>
           <div>
-            <h3 class="text-xl font-bold text-base-content mb-2">
+            <h3 class="text-xl font-bold text-datealo-text mb-2">
               {{ item.title }}
             </h3>
-            <p class="text-base text-base-content/60 leading-relaxed">
+            <p class="text-base text-datealo-text/60 leading-relaxed">
               {{ item.description }}
             </p>
           </div>


### PR DESCRIPTION
## Resumen

`LandingProblem.vue` es puramente presentacional — cuatro tarjetas con ícono, título y descripción, sin
ningún `<button>` ni `<input>`. No hay nada que envolver en un componente interactivo de Nuxt UI (no gana
foco, teclado ni ARIA porque no tiene estados que gestionar). Evalué usar `UPageCard`/`UPageGrid` (Nuxt UI
trae componentes justo para este patrón), pero:

- La orientación responsive real (`flex-col sm:flex-row`, apilado en mobile) no es un prop de primera clase
  de `PageCard` — tocaría overridear casi toda su estructura interna igual que si se hiciera a mano.
- Los íconos hoy son componentes de `lucide-vue-next` importados directo (`iconMap`), no nombres de string
  para `UIcon`/Nuxt Icon — cambiar de estrategia de íconos es una decisión más grande que este slice, y
  otros componentes de la landing usan el mismo patrón (consistencia).
- Nada de esto está pedido por A-004 ni resuelve un problema real — hubiera sido abstracción sin necesidad
  (YAGNI).

Lo que sí bloquea a S-010 (retirar DaisyUI) es que este archivo usaba los tokens de tema de DaisyUI
(`bg-base-100`, `text-base-content`, `border-base-200`, `border-base-300`, `bg-base-200`). Los reemplacé
por los tokens crudos de datealo que ya existen en `main.css` — mismo valor exacto, mismo patrón que #15:

| DaisyUI | Reemplazo | Hex |
| --- | --- | --- |
| `base-100` | `datealo-bg` | `#FAFAFA` |
| `base-content` | `datealo-text` | `#1F2937` |
| `base-200` | `datealo-surface` | `#F3F4F6` |
| `base-300` | `gray-200` (Tailwind nativo) | `#E5E7EB` — coincidía 1:1 |

Es S-004 del plan de [la misión 01](https://github.com/PatricioTabilo/datealo/blob/main/docs/missions/01-migracion-nuxt-ui/ingenieria.md).

Sustento: A-004 (skill `arquitectura`).

## Test plan

- [x] `npx nuxi typecheck` limpio.
- [x] `npm run build` limpio.
- [x] Revisado en el browser: las cuatro tarjetas (rojo, ámbar, naranjo, gris) idénticas — mismo color,
      borde y sombra. Sin errores en consola.
- [ ] Verificación visual en 390px pendiente (mismo bloqueo de tooling que en #14/#15).

Closes #4