### PR TITLE
refactor(ui): migrar LandingSolution a componentes de Nuxt UI

### DIFF
--- a/app/components/landing/LandingSolution.vue
+++ b/app/components/landing/LandingSolution.vue
@@ -6,16 +6,16 @@ const iconMap = { ShieldCheck, Star, MapPin, MessageCircle } as const
 </script>
 
 <template>
-  <section class="py-24 sm:py-32 bg-base-200 relative overflow-hidden">
+  <section class="py-24 sm:py-32 bg-datealo-surface relative overflow-hidden">
     <!-- Decorative background -->
     <div class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[800px] h-[800px] bg-primary/5 rounded-full blur-[120px] pointer-events-none" />
 
     <div class="container mx-auto px-5 sm:px-8 relative z-10">
       <div class="max-w-2xl mx-auto text-center mb-16 sm:mb-20">
-        <h2 class="text-4xl sm:text-5xl font-extrabold text-base-content mb-6 tracking-tight leading-tight">
+        <h2 class="text-4xl sm:text-5xl font-extrabold text-datealo-text mb-6 tracking-tight leading-tight">
           {{ LANDING_SOLUTION.title }}
         </h2>
-        <p class="text-lg sm:text-xl text-base-content/60 leading-relaxed">
+        <p class="text-lg sm:text-xl text-datealo-text/60 leading-relaxed">
           {{ LANDING_SOLUTION.subtitle }}
         </p>
       </div>
@@ -24,7 +24,7 @@ const iconMap = { ShieldCheck, Star, MapPin, MessageCircle } as const
         <div
           v-for="feature in LANDING_SOLUTION.features"
           :key="feature.title"
-          class="group bg-white rounded-[2rem] p-8 text-center border border-base-200 shadow-lg shadow-base-content/[0.02] hover:shadow-xl hover:shadow-primary/10 transition-shadow duration-300 relative overflow-hidden"
+          class="group bg-white rounded-[2rem] p-8 text-center border border-datealo-surface shadow-lg shadow-datealo-text/[0.02] hover:shadow-xl hover:shadow-primary/10 transition-shadow duration-300 relative overflow-hidden"
         >
           <div class="relative mx-auto mb-6">
             <div class="h-20 w-20 rounded-[1.5rem] bg-primary/10 flex items-center justify-center mx-auto group-hover:bg-primary transition-colors duration-300">
@@ -32,10 +32,10 @@ const iconMap = { ShieldCheck, Star, MapPin, MessageCircle } as const
             </div>
           </div>
 
-          <h3 class="text-xl font-bold text-base-content mb-3 relative">
+          <h3 class="text-xl font-bold text-datealo-text mb-3 relative">
             {{ feature.title }}
           </h3>
-          <p class="text-base text-base-content/60 leading-relaxed relative">
+          <p class="text-base text-datealo-text/60 leading-relaxed relative">
             {{ feature.description }}
           </p>
         </div>


### PR DESCRIPTION
## Resumen

Mismo caso que LandingProblem (#16): `LandingSolution.vue` es puramente presentacional — cuatro tarjetas
de feature con ícono, título y descripción, sin `<button>` ni `<input>`. No hay ganancia de accesibilidad
envolviéndolas en un componente interactivo de Nuxt UI.

Lo que sí bloqueaba a S-010 eran los tokens de DaisyUI: `bg-base-200` (fondo de sección), `text-base-content`
y `border-base-200`. Reemplazados por los tokens crudos de datealo, mismo valor exacto:

| DaisyUI | Reemplazo | Hex |
| --- | --- | --- |
| `base-200` | `datealo-surface` | `#F3F4F6` |
| `base-content` | `datealo-text` | `#1F2937` |

Es S-005 del plan de [la misión 01](https://github.com/PatricioTabilo/datealo/blob/main/docs/missions/01-migracion-nuxt-ui/ingenieria.md).

Sustento: A-004 (skill `arquitectura`).

## Test plan

- [x] `npx nuxi typecheck` limpio.
- [x] `npm run build` limpio.
- [x] Revisado en el browser: las 4 tarjetas idénticas, incluyendo el hover del ícono
      (`group-hover:bg-primary`, fondo índigo sólido + ícono blanco). Sin errores en consola.
- [ ] Verificación visual en 390px pendiente (mismo bloqueo de tooling que en #14/#15/#16).

Closes #5