### PR TITLE
refactor(ui): migrar LandingCategories a componentes de Nuxt UI

### DIFF
--- a/app/components/landing/LandingCategories.vue
+++ b/app/components/landing/LandingCategories.vue
@@ -35,36 +35,40 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <section id="categorias" class="py-24 sm:py-32 bg-base-100">
+  <section id="categorias" class="py-24 sm:py-32 bg-datealo-bg">
     <div class="container mx-auto px-5 sm:px-8">
       <!-- Header with nav arrows -->
       <div class="flex items-end justify-between mb-12 sm:mb-16">
         <div class="max-w-xl">
-          <h2 class="text-4xl sm:text-5xl font-extrabold text-base-content tracking-tight leading-tight">
+          <h2 class="text-4xl sm:text-5xl font-extrabold text-datealo-text tracking-tight leading-tight">
             {{ LANDING_CATEGORIES.title }}
           </h2>
         </div>
 
         <!-- Navigation arrows (desktop only) -->
         <div class="hidden sm:flex items-center gap-3">
-          <button
-            class="h-12 w-12 rounded-full border-2 border-base-300 flex items-center justify-center transition-all duration-200 cursor-pointer"
-            :class="canScrollLeft ? 'hover:border-primary hover:bg-primary hover:text-white text-base-content' : 'opacity-30 cursor-not-allowed text-base-content/40'"
+          <UButton
+            variant="link"
+            color="neutral"
+            class="h-12 w-12 rounded-full border-2 border-gray-200 flex items-center justify-center transition-all duration-200 cursor-pointer"
+            :class="canScrollLeft ? 'hover:border-primary hover:bg-primary hover:text-white active:text-white text-datealo-text' : 'disabled:opacity-30 disabled:cursor-not-allowed disabled:text-datealo-text/40'"
             :disabled="!canScrollLeft"
             aria-label="Anterior"
             @click="scroll('left')"
           >
             <ChevronLeft class="w-5 h-5" />
-          </button>
-          <button
-            class="h-12 w-12 rounded-full border-2 border-base-300 flex items-center justify-center transition-all duration-200 cursor-pointer"
-            :class="canScrollRight ? 'hover:border-primary hover:bg-primary hover:text-white text-base-content' : 'opacity-30 cursor-not-allowed text-base-content/40'"
+          </UButton>
+          <UButton
+            variant="link"
+            color="neutral"
+            class="h-12 w-12 rounded-full border-2 border-gray-200 flex items-center justify-center transition-all duration-200 cursor-pointer"
+            :class="canScrollRight ? 'hover:border-primary hover:bg-primary hover:text-white active:text-white text-datealo-text' : 'disabled:opacity-30 disabled:cursor-not-allowed disabled:text-datealo-text/40'"
             :disabled="!canScrollRight"
             aria-label="Siguiente"
             @click="scroll('right')"
           >
             <ChevronRight class="w-5 h-5" />
-          </button>
+          </UButton>
         </div>
       </div>
     </div>
@@ -79,7 +83,7 @@ onUnmounted(() => {
           v-for="cat in LANDING_CATEGORIES.items"
           :key="cat.name"
           href="#hero-form"
-          class="carousel-card group relative shrink-0 w-[300px] sm:w-[410px] rounded-[2.2rem] overflow-hidden aspect-[3/4] snap-start shadow-sm shadow-base-content/[0.08] text-left"
+          class="carousel-card group relative shrink-0 w-[300px] sm:w-[410px] rounded-[2.2rem] overflow-hidden aspect-[3/4] snap-start shadow-sm shadow-datealo-text/[0.08] text-left"
           :aria-label="cat.query"
         >
           <img
@@ -99,7 +103,7 @@ onUnmounted(() => {
     </div>
 
     <div class="container mx-auto px-5 sm:px-8">
-      <p class="text-base-content/50 text-sm mt-10 font-medium">
+      <p class="text-datealo-text/50 text-sm mt-10 font-medium">
         {{ LANDING_CATEGORIES.subtitle }}
       </p>
     </div>


### PR DESCRIPTION
## Resumen

- Reemplaza los dos `<button>` de navegación del carrusel (flecha anterior/siguiente) por
  `<UButton variant="link" color="neutral">`, con las mismas clases exactas que ya tenían.
- El estado deshabilitado (cuando no hay más scroll en esa dirección) necesitaba cuidado extra: el tema
  de Nuxt UI para botones ya trae `disabled:opacity-75` incluido en su base. Si mis clases de "deshabilitado"
  iban sin el prefijo `disabled:` (ej. `opacity-30` a secas), la regla del tema podía ganar el empate de
  especificidad CSS y el botón terminaba con 75% de opacidad en vez del 30% que pide el diseño. Prefijar
  mis propias clases (`disabled:opacity-30 disabled:cursor-not-allowed disabled:text-datealo-text/40`)
  hace que `twMerge` las reconozca como el mismo grupo de variante+propiedad que las del tema y las pise
  correctamente.
- Las tarjetas del carrusel (`<a href="#hero-form">`) se quedan como anchors nativos — son enlaces de
  ancla simples, sin ruteo ni estado que `ULink` resuelva mejor que un `<a>` nativo (mismo criterio que
  #16/#17 para no forzar un componente sin necesidad real).
- De paso, saca los tokens de DaisyUI restantes (`bg-base-100`, `text-base-content`, `border-base-300`,
  `shadow-base-content`) por los tokens crudos de datealo — mismo patrón que las PRs anteriores.

Es S-006 del plan de [la misión 01](https://github.com/PatricioTabilo/datealo/blob/main/docs/missions/01-migracion-nuxt-ui/ingenieria.md).

Sustento: A-004 (skill `arquitectura`).

## Test plan

- [x] `npx nuxi typecheck` limpio.
- [x] `npm run build` limpio.
- [x] Revisado en el browser: estado inicial (flecha izquierda deshabilitada y tenue, derecha habilitada),
      click en "siguiente" mueve el carrusel correctamente, hover muestra el círculo relleno en índigo con
      ícono blanco. Sin errores en consola.
- [ ] Verificación visual en 390px pendiente (mismo bloqueo de tooling que en las PRs anteriores).

Closes #6