### PR TITLE
refactor(ui): migrar LandingFinalCta a componentes de Nuxt UI

### DIFF
--- a/app/components/landing/LandingFinalCta.vue
+++ b/app/components/landing/LandingFinalCta.vue
@@ -10,26 +10,28 @@ const scrollToHero = () => {
 </script>
 
 <template>
-  <section class="py-24 sm:py-32 bg-base-200">
+  <section class="py-24 sm:py-32 bg-datealo-surface">
     <div class="container mx-auto px-5 sm:px-8">
       <div class="max-w-3xl mx-auto text-center">
-        <h2 class="text-4xl sm:text-5xl lg:text-6xl font-extrabold text-base-content mb-6 tracking-tight leading-tight">
+        <h2 class="text-4xl sm:text-5xl lg:text-6xl font-extrabold text-datealo-text mb-6 tracking-tight leading-tight">
           {{ LANDING_FINAL_CTA.headline }}
           <span class="text-primary">{{ LANDING_FINAL_CTA.headlineAccent }}</span>
         </h2>
 
-        <p class="text-lg sm:text-xl text-base-content/60 mb-12 leading-relaxed font-medium max-w-xl mx-auto">
+        <p class="text-lg sm:text-xl text-datealo-text/60 mb-12 leading-relaxed font-medium max-w-xl mx-auto">
           {{ LANDING_FINAL_CTA.subheadline }}
         </p>
 
-        <button
-          class="btn btn-primary h-14 rounded-xl px-10 text-base font-bold shadow-lg shadow-primary/20 hover:shadow-xl hover:shadow-primary/30 transition-all"
+        <UButton
+          variant="solid"
+          color="primary"
+          class="h-14 rounded-xl px-10 text-base font-bold shadow-lg shadow-primary/20 hover:bg-primary active:bg-primary hover:shadow-xl hover:shadow-primary/30 transition-all"
           @click="scrollToHero"
         >
           {{ LANDING_FINAL_CTA.cta }}
-        </button>
+        </UButton>
 
-        <ul class="flex flex-wrap items-center justify-center gap-x-6 gap-y-3 mt-8 text-sm text-base-content/50 font-semibold">
+        <ul class="flex flex-wrap items-center justify-center gap-x-6 gap-y-3 mt-8 text-sm text-datealo-text/50 font-semibold">
           <li v-for="item in LANDING_FINAL_CTA.trust" :key="item" class="flex items-center gap-2">
             <CheckCircle class="w-4 h-4 text-primary" />
             {{ item }}


### PR DESCRIPTION
## Resumen

Reemplaza `<button class="btn btn-primary">` por `<UButton variant="solid" color="primary">` — el único
botón sólido-primario que queda en la landing (los demás CTAs son secundario/turquesa o llevan su propio
override de color, ya migrados en #15/#19).

Antes de tocar el código medí el botón original en el browser (`getComputedStyle` en reposo y en
`:hover` real): el `bg-primary` de DaisyUI **no cambia de color al hover** en este caso — solo agranda la
sombra (`hover:shadow-xl hover:shadow-primary/30`, ya presente en el código). Nuxt UI sí trae un hover por
defecto para `variant="solid"` (`hover:bg-primary/75`, aclara el botón), así que lo cancelo explícitamente
con `hover:bg-primary active:bg-primary` para que el fondo se quede sólido igual que antes y el único
cambio en hover siga siendo la sombra.

De paso, saca los tokens de DaisyUI restantes (`bg-base-200`, `text-base-content`) por los tokens crudos
de datealo — mismo patrón que las PRs anteriores.

Es S-008 del plan de [la misión 01](https://github.com/PatricioTabilo/datealo/blob/main/docs/missions/01-migracion-nuxt-ui/ingenieria.md).

Sustento: A-004 (skill `arquitectura`).

## Test plan

- [x] `npx nuxi typecheck` limpio.
- [x] `npm run build` limpio.
- [x] Comparé `backgroundColor`/`boxShadow` computados antes y después del cambio: `rgb(66, 62, 208)`
      idéntico en reposo, mismo comportamiento de sombra en hover, sin cambio de color de fondo. Sin
      errores en consola.
- [ ] Verificación visual en 390px pendiente (mismo bloqueo de tooling que en las PRs anteriores).

Closes #8