### PR TITLE
refactor(ui): migrar LandingFooter a componentes de Nuxt UI

### DIFF
--- a/app/components/landing/LandingFooter.vue
+++ b/app/components/landing/LandingFooter.vue
@@ -1,25 +1,25 @@
 <template>
-  <footer class="bg-base-content py-10 sm:py-14">
+  <footer class="bg-datealo-text py-10 sm:py-14">
     <div class="container mx-auto px-5 sm:px-8">
       <div class="flex flex-col sm:flex-row items-center justify-between gap-6">
         <!-- Brand -->
         <div class="text-center sm:text-left">
           <p class="text-2xl font-extrabold font-heading mb-1">
-            <span class="text-base-100">datea</span><span class="text-secondary">lo</span>
+            <span class="text-datealo-bg">datea</span><span class="text-secondary">lo</span>
           </p>
-          <p class="text-sm text-base-100/40">
+          <p class="text-sm text-datealo-bg/40">
             Encuentra al profesional que necesitas, cerca de ti.
           </p>
         </div>
 
         <!-- Contact -->
-        <div class="text-center sm:text-right text-sm text-base-100/40">
+        <div class="text-center sm:text-right text-sm text-datealo-bg/40">
           <p>hola@datealo.cl</p>
           <p>Santiago, Chile</p>
         </div>
       </div>
 
-      <div class="border-t border-base-100/10 mt-8 pt-6 text-center text-xs text-base-100/30">
+      <div class="border-t border-datealo-bg/10 mt-8 pt-6 text-center text-xs text-datealo-bg/30">
         &copy; {{ new Date().getFullYear() }} datealo. Todos los derechos reservados.
       </div>
     </div>

--- a/app/components/landing/LandingHero.vue
+++ b/app/components/landing/LandingHero.vue
@@ -93,7 +93,7 @@ const { email, loading, submitted, error, submit } = useWaitlist('buscador')
               <Star class="w-6 h-6 fill-current" />
             </div>
             <div>
-              <p class="text-sm font-extrabold text-base-content leading-tight">Profesionales<br>verificados</p>
+              <p class="text-sm font-extrabold text-datealo-text leading-tight">Profesionales<br>verificados</p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Resumen

`LandingFooter.vue` no tiene ningún elemento interactivo, mismo caso que LandingProblem/LandingSolution
(#16/#17). Reemplaza los tokens de DaisyUI por los tokens crudos de datealo:

| DaisyUI | Reemplazo | Hex |
| --- | --- | --- |
| `base-content` | `datealo-text` | `#1F2937` |
| `base-100` | `datealo-bg` | `#FAFAFA` |

Con este slice, **S-002 a S-009 quedan completos**: audité toda la carpeta `landing/` buscando tokens de
DaisyUI (`base-100/200/300/content`, clases `btn`, `data-theme`) y encontré uno que se me había pasado en
#15 (S-003) — `text-base-content` en la insignia "Profesionales verificados" de `LandingHero.vue`. Lo
corregí en un segundo commit de este mismo PR en vez de abrir uno aparte, porque es exactamente lo que este
slice ya está verificando.

Queda pendiente **S-010** (retirar DaisyUI del proyecto), que además de sacar el paquete y el plugin de
`main.css` va a necesitar tocar `app/layouts/default.vue` (`bg-base-100`) — es el único archivo fuera de
`landing/` que todavía referencia un token de DaisyUI, lo dejo anotado para no repetir la búsqueda.

Es S-009 del plan de [la misión 01](https://github.com/PatricioTabilo/datealo/blob/main/docs/missions/01-migracion-nuxt-ui/ingenieria.md).

Sustento: A-004 (skill `arquitectura`).

## Test plan

- [x] `npx nuxi typecheck` limpio.
- [x] `npm run build` limpio.
- [x] Footer revisado en el browser: idéntico. Insignia "Profesionales verificados" del hero también
      revisada tras el fix. Sin errores en consola.
- [x] `grep` de tokens DaisyUI (`base-100/200/300/content`, `btn`, `data-theme`) sobre `app/components/landing/*.vue` — limpio.
- [ ] Verificación visual en 390px pendiente (mismo bloqueo de tooling que en las PRs anteriores).

Closes #9