### PR TITLE
chore(ui): retirar DaisyUI del proyecto

### DIFF
--- a/app/app.config.ts
+++ b/app/app.config.ts
@@ -4,6 +4,10 @@ export default defineAppConfig({
       primary: 'indigo-datealo',
       secondary: 'turquesa-datealo',
       neutral: 'gray',
+      // DaisyUI usaba #10B981 para success. El "emerald" nativo de Tailwind v4 se ve parecido pero
+      // no es el mismo hex (OKLCH corrió el tono a #00BC7D) — datealo-success es la escala propia
+      // que reproduce el original exacto (main.css).
+      success: 'datealo-success',
     },
   },
 })

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -1,8 +1,5 @@
 @import "tailwindcss";
 @import "@nuxt/ui";
-@plugin "daisyui" {
-  themes: datealo --default;
-}
 
 @theme {
   --font-heading: "Plus Jakarta Sans", sans-serif;
@@ -42,35 +39,27 @@
   --color-turquesa-datealo-800: #1B7C84;
   --color-turquesa-datealo-900: #1A6168;
   --color-turquesa-datealo-950: #12464B;
+
+  /* El "emerald" nativo de Tailwind v4 no sirve acá: sus colores por defecto se redefinieron en
+     OKLCH y el 500 ya no es el hex clásico #10B981 (queda en #00BC7D). DaisyUI usaba el hex exacto,
+     así que esta escala existe solo para reproducirlo, igual que índigo/turquesa arriba. */
+  --color-datealo-success-50: #F1FEFA;
+  --color-datealo-success-100: #BBF9E4;
+  --color-datealo-success-200: #85F4CF;
+  --color-datealo-success-300: #4FF0BA;
+  --color-datealo-success-400: #19EBA5;
+  --color-datealo-success-500: #10B981;
+  --color-datealo-success-600: #0EA170;
+  --color-datealo-success-700: #0C8960;
+  --color-datealo-success-800: #0A714F;
+  --color-datealo-success-900: #085A3E;
+  --color-datealo-success-950: #06422E;
 }
 
 /* Radio base de Nuxt UI (A-004): DaisyUI usaba --radius-btn: 0.75rem / --radius-box: 1rem.
    --ui-radius es un multiplicador, no un valor 1:1 — 0.5rem reproduce el mismo look "generoso". */
 :root {
   --ui-radius: 0.5rem;
-}
-
-/* DaisyUI custom theme */
-[data-theme="datealo"] {
-  --color-base-100: #FAFAFA;
-  --color-base-200: #F3F4F6;
-  --color-base-300: #E5E7EB;
-  --color-base-content: #1F2937;
-  --base-200-rgb: 243 244 246;
-  --color-primary: #423ED0;
-  --color-primary-content: #FFFFFF;
-  --color-secondary: #3ECBD7;
-  --color-secondary-content: #1F2937;
-  --color-accent: #3ECBD7;
-  --color-accent-content: #1F2937;
-  --color-neutral: #1F2937;
-  --color-neutral-content: #FFFFFF;
-  --color-success: #10B981;
-  --color-success-content: #FFFFFF;
-  --color-error: #EF4444;
-  --color-error-content: #FFFFFF;
-  --radius-btn: 0.75rem;
-  --radius-box: 1rem;
 }
 
 @layer base {

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -2,7 +2,7 @@
 </script>
 
 <template>
-  <div class="min-h-screen bg-base-100">
+  <div class="min-h-screen bg-datealo-bg">
     <slot />
   </div>
 </template>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -10,7 +10,7 @@ export default defineNuxtConfig({
 
   app: {
     head: {
-      htmlAttrs: { lang: 'es-CL', 'data-theme': 'datealo' },
+      htmlAttrs: { lang: 'es-CL' },
       link: [
         { rel: 'preconnect', href: 'https://fonts.googleapis.com' },
         { rel: 'preconnect', href: 'https://fonts.gstatic.com', crossorigin: '' },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "hasInstallScript": true,
       "dependencies": {
         "@nuxt/ui": "^4.10.0",
-        "daisyui": "^5.5.19",
         "lucide-vue-next": "^0.575.0",
         "nuxt": "^4.3.1",
         "vue": "^3.5.28",
@@ -6434,15 +6433,6 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
-    },
-    "node_modules/daisyui": {
-      "version": "5.5.19",
-      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-5.5.19.tgz",
-      "integrity": "sha512-pbFAkl1VCEh/MPCeclKL61I/MqRIFFhNU7yiXoDDRapXN4/qNCoMxeCCswyxEEhqL5eiTTfwHvucFtOE71C9sA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/saadeghi/daisyui?sponsor=1"
-      }
     },
     "node_modules/db0": {
       "version": "0.3.4",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   },
   "dependencies": {
     "@nuxt/ui": "^4.10.0",
-    "daisyui": "^5.5.19",
     "lucide-vue-next": "^0.575.0",
     "nuxt": "^4.3.1",
     "vue": "^3.5.28",


### PR DESCRIPTION
## Resumen

Último slice de la migración (S-010): DaisyUI queda completamente afuera.

- `daisyui` fuera de `package.json`/`package-lock.json` (`npm uninstall daisyui`).
- `@plugin "daisyui" { themes: datealo --default; }` y el bloque `[data-theme="datealo"]` fuera de
  `main.css`.
- `data-theme: 'datealo'` fuera de `nuxt.config.ts` — quedaba muerto sin el selector CSS que lo usaba.
- `app/layouts/default.vue`: `bg-base-100` → `bg-datealo-bg` (el único token de DaisyUI fuera de
  `landing/` que quedaba, encontrado en la auditoría de #21).

## El detalle que no era trivial: `success`

DaisyUI usaba `#10B981` para success. Antes de borrar el bloque `[data-theme="datealo"]` verifiqué qué
color iba a quedar renderizando `text-success`/`bg-success` sin él, porque Nuxt UI también define ese
slot semántico por defecto (mapeado a `"green"`, no a emerald). Configurar `success: 'emerald'` parecía la
solución obvia — pero Tailwind v4 redefinió su paleta por defecto en OKLCH, y el `emerald-500` actual **no
es** el hex clásico `#10B981`: pintando el pixel real (canvas, no solo mirando el valor CSS) da `#00BC7D`.
Cercano, pero no el mismo, justo el tipo de diferencia que TR-002 de esta misión existe para atrapar.

`app/app.config.ts` define `success: 'datealo-success'`, una escala propia de 11 tonos en `main.css` con
el mismo método que `indigo-datealo`/`turquesa-datealo` (S-001) — el 500 reproduce `#10B981` exacto.
Verificado en el browser pintando el estado "enviado" de ambos forms de waitlist y leyendo el color real
del ícono: `rgb(16, 185, 129)` = `#10B981`, byte a byte igual al original.

## TR-001 (riesgo de bundle) — cerrado

Medí el bundle de producción en tres puntos (antes de Nuxt UI, después de S-001 con cero componentes
usados, y ahora): crece **+70% gzip** contra el 30% que fijaba el criterio de salida. El detalle completo
—incluyendo por qué la mayor parte del salto es costo fijo de instalar el módulo, no algo que vaya a
seguir creciendo por cada componente nuevo— queda documentado en
[`ingenieria.md`](https://github.com/PatricioTabilo/datealo/blob/main/docs/missions/01-migracion-nuxt-ui/ingenieria.md).
Revisado y aceptado por Patricio Tabilo.

## Test plan

- [x] `npx nuxi typecheck` limpio.
- [x] `npm run build` limpio (desde caché completamente limpia).
- [x] `grep` de tokens DaisyUI (`base-100/200/300/content`, `btn`, `data-theme`) sobre todo `app/` — limpio.
- [x] Landing revisada en el browser: idéntica.
- [x] Estado "enviado" de ambos forms de waitlist (Hero y ForProfessionals) disparado y verificado — el
      color del ícono/fondo `success` es `#10B981` exacto, no el `emerald` nativo de Tailwind v4.
- [ ] Verificación visual en 390px pendiente (mismo bloqueo de tooling que en las PRs anteriores).

Closes #10