### PR TITLE
docs: agregar docs/ al repositorio

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,0 +1,103 @@
+# Mockups de misión
+
+Un flujo escrito se lee bien y aun así no se sostiene en pantalla. El mockup es lo que convierte "cada
+estado tiene contenido concreto" en algo verificable: muestra cuánta información compite por el mismo
+espacio y si la acción principal queda sobre el pliegue.
+
+Cuándo es obligatorio hacer uno, qué debe contener y cómo se itera está en el skill `discovery-ux`. Este
+documento es solo el cómo mecánico.
+
+## Dónde viven
+
+```
+docs/missions/NN-slug/design-mockups/{pantalla}.html
+```
+
+Un archivo por vista. Los modos y estados de esa vista son frames dentro del mismo archivo, en el orden en
+que el usuario los recorre — así el archivo se lee como camino, no como galería. Revisar un diseño no
+debería obligar a abrir cinco pestañas.
+
+## Esqueleto
+
+```html
+<!doctype html>
+<html lang="es-CL" data-theme="datealo">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>V-002 Resultados de búsqueda — misión 01</title>
+
+    <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+    <link href="https://cdn.jsdelivr.net/npm/daisyui@5/daisyui.css" rel="stylesheet" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&family=Plus+Jakarta+Sans:wght@600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../../design/datealo-mockup-kit.css" />
+  </head>
+
+  <body>
+    <div class="frames">
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-002 · modo lista
+          <small>ronda 2 — con el selector de comuna arriba</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <!-- Contenido real de la pantalla, con DaisyUI y utilidades de Tailwind -->
+        </div>
+      </section>
+
+      <section class="frame frame-mobile">
+        <div class="frame-label">V-002 · estado vacío</div>
+        <div class="frame-viewport"><!-- ... --></div>
+      </section>
+    </div>
+  </body>
+</html>
+```
+
+Tres detalles que importan:
+
+- **El `data-theme="datealo"` va en el `<html>`**, igual que en la app real (`nuxt.config.ts`). Sin eso los
+  componentes de DaisyUI salen con el tema por defecto y el mockup miente sobre el color.
+- **El kit se carga después de DaisyUI.** Define los tokens del tema y los marcos; los componentes los pone
+  DaisyUI.
+- **Requiere internet.** Tailwind, DaisyUI y las tipografías vienen por CDN. Si vas a trabajar sin
+  conexión, descarga los dos archivos a `docs/design/vendor/` y apunta los `src`/`href` ahí.
+
+## Cómo verlo
+
+Abrir el `.html` directo en el navegador basta. Para revisarlo en el chat, publicarlo como Artifact — en
+ese caso hay que inlinear el CSS del kit y las fuentes, porque los Artifacts bloquean cualquier petición a
+un host externo.
+
+## Marcos disponibles
+
+| Clase                        | Qué es                                                            |
+| ---------------------------- | ------------------------------------------------------------------ |
+| `frame frame-mobile`         | 390 × 844 px. El caso principal de Datealo: siempre va             |
+| `frame frame-desktop`        | 1280 × 800 px. Solo si la pantalla también vive en desktop         |
+| `frame-viewport is-auto`     | Alto libre, para revisar una pantalla larga completa sin scroll    |
+| `frame-label` + `<small>`    | Rótulo del frame; el `<small>` lleva la ronda y qué cambió         |
+| `status-bar`                 | Barra de estado decorativa, marca dónde empieza el contenido real  |
+| `fold`                       | Línea del pliegue: lo que queda debajo no se ve sin scroll         |
+| `safe-bottom`                | Área segura inferior, donde vive el CTA fijo en móvil              |
+
+## Reglas de contenido
+
+- **Datos reales, nunca placeholders.** "Marcela Fuentes · Peluquería a domicilio · Ñuñoa · 4,8 (23
+  reseñas)" revela los desbordes de texto que "Profesional 1" esconde.
+- **Vocabulario chileno y los términos decididos en `producto.md`.** Un mockup con jerga distinta a la del
+  documento reabre discusiones ya cerradas.
+- **Los tokens los pone el kit.** Un color hexadecimal escrito a mano en el mockup queda desactualizado sin
+  que nadie lo note.
+- **JS puro solo si el flujo se evalúa mejor moviéndolo** — abrir un bottom sheet, cambiar de tab. Un
+  mockup no valida ni persiste nada.
+
+## Sincronizar el kit
+
+`datealo-mockup-kit.css` espeja los tokens de `app/assets/css/main.css`. No hay script: son unas veinte
+líneas y se copian a mano cuando el tema cambia. Si tocas el tema de la app y no el kit, los mockups
+siguientes describirán un producto que ya no existe.

--- a/docs/design/datealo-mockup-kit.css
+++ b/docs/design/datealo-mockup-kit.css
@@ -1,0 +1,159 @@
+/*
+ * Kit de mockups de Datealo
+ * =========================
+ *
+ * Espeja los tokens de `app/assets/css/main.css`. Si ese archivo cambia, este se actualiza a mano
+ * (son ~20 líneas) y se anota en el commit — un mockup con tokens viejos describe un producto
+ * que no existe.
+ *
+ * Los componentes NO viven acá: salen de DaisyUI, cargado por CDN en el esqueleto del mockup.
+ * Este archivo aporta solo dos cosas: los tokens del tema y los marcos de dispositivo.
+ *
+ * Uso: ver docs/design/README.md
+ */
+
+/* ---------------------------------------------------------------- Tokens del tema `datealo` */
+
+[data-theme='datealo'] {
+  --color-base-100: #fafafa;
+  --color-base-200: #f3f4f6;
+  --color-base-300: #e5e7eb;
+  --color-base-content: #1f2937;
+  --color-primary: #423ed0;
+  --color-primary-content: #ffffff;
+  --color-secondary: #3ecbd7;
+  --color-secondary-content: #1f2937;
+  --color-accent: #3ecbd7;
+  --color-accent-content: #1f2937;
+  --color-neutral: #1f2937;
+  --color-neutral-content: #ffffff;
+  --color-success: #10b981;
+  --color-success-content: #ffffff;
+  --color-error: #ef4444;
+  --color-error-content: #ffffff;
+  --radius-btn: 0.75rem;
+  --radius-box: 1rem;
+}
+
+:root {
+  --font-heading: 'Plus Jakarta Sans', system-ui, sans-serif;
+  --font-body: 'DM Sans', system-ui, sans-serif;
+  --mockup-canvas: #e7e8ec;
+  --mockup-label: #6b7280;
+}
+
+body {
+  font-family: var(--font-body);
+  background: var(--mockup-canvas);
+  color: var(--color-base-content);
+  margin: 0;
+  padding: 2.5rem 1.5rem;
+  -webkit-font-smoothing: antialiased;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: var(--font-heading);
+  letter-spacing: -0.02em;
+}
+
+/* ---------------------------------------------------------------- Marcos de dispositivo */
+
+.frames {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2.5rem;
+  align-items: flex-start;
+  justify-content: center;
+}
+
+.frame {
+  display: flex;
+  flex-direction: column;
+  gap: 0.625rem;
+}
+
+.frame-label {
+  font-family: var(--font-heading);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--mockup-label);
+}
+
+.frame-label small {
+  display: block;
+  margin-top: 0.125rem;
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: none;
+  color: #9ca3af;
+}
+
+/* El viewport real del mockup. `overflow: hidden` recorta lo que no cabe:
+   ver qué queda fuera del marco es justamente para lo que sirve. */
+.frame-viewport {
+  background: var(--color-base-100);
+  border-radius: 1.75rem;
+  border: 1px solid #d1d5db;
+  box-shadow: 0 10px 30px -12px rgb(31 41 55 / 0.25);
+  overflow: hidden;
+  position: relative;
+}
+
+.frame-mobile .frame-viewport {
+  width: 390px;
+  height: 844px;
+}
+
+.frame-desktop .frame-viewport {
+  width: 1280px;
+  height: 800px;
+  border-radius: 0.875rem;
+}
+
+/* Alto libre: para pantallas largas que se revisan completas, sin scroll interno. */
+.frame-viewport.is-auto {
+  height: auto;
+  min-height: 0;
+}
+
+/* Barra de estado del celular. Decorativa: da la referencia de dónde empieza el contenido real. */
+.status-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1.5rem 0.25rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--color-base-content);
+}
+
+/* Área segura inferior, donde vive el CTA fijo en móvil. */
+.safe-bottom {
+  padding-bottom: 1.25rem;
+}
+
+/* Marcador de pliegue: lo que queda debajo de esta línea no se ve sin hacer scroll. */
+.fold {
+  position: absolute;
+  left: 0;
+  right: 0;
+  border-top: 1px dashed #ef4444;
+  pointer-events: none;
+}
+
+.fold::after {
+  content: 'pliegue';
+  position: absolute;
+  right: 0.5rem;
+  top: 0.25rem;
+  font-size: 0.625rem;
+  font-weight: 600;
+  color: #ef4444;
+}

--- a/docs/missions/01-migracion-nuxt-ui/README.md
+++ b/docs/missions/01-migracion-nuxt-ui/README.md
@@ -1,0 +1,33 @@
+# Misión 01 — Migración a Nuxt UI
+
+**Tipo:** técnica. **Abierta el** 2026-08-11. **Nace de:** A-004 del skill `arquitectura`.
+
+**Estado de la misión:** lista para construir
+
+**Última actualización:** 2026-08-11
+
+Sin `producto.md` ni `experiencia.md`: no hay cambio de producto observable — quien usa Datealo ve la misma
+landing antes y después. La decisión de fondo (por qué Nuxt UI, qué se descarta, cuándo se reabre) ya está
+tomada y vive en [A-004](../../../.claude/skills/arquitectura/SKILL.md#a-004--nuxt-ui-v4-es-la-base-de-interfaz).
+
+| Documento  | Estado  | Qué falta para su gate  |
+| ---------- | ------- | ------------------------ |
+| Ingeniería | vigente — aprobado por Patricio Tabilo el 2026-08-11 | ninguno — 12 issues abiertos en GitHub (#1 a #12), plan reconciliado |
+
+**Próximo hito:** `S-001` (issue [#1](https://github.com/PatricioTabilo/datealo/issues/1), theming)
+mergeado y verificado en el browser — sin fecha límite todavía, es la primera vez que se ejecuta este tipo
+de misión.
+
+## Resumen ejecutivo
+
+- **Qué cambia:** el motor de componentes de interfaz, de DaisyUI a Nuxt UI v4. Nada del contenido, la
+  copia ni la estructura de la landing.
+- **Por qué:** DaisyUI es solo CSS — la accesibilidad de componentes interactivos (focus trap, teclado,
+  ARIA) se escribiría a mano en cada misión futura. Nuxt UI la trae resuelta. Detalle en A-004.
+- **Alcance de esta entrega:** los 8 componentes de `app/components/landing/`, el theming en
+  `app.config.ts` + `main.css`, retirar DaisyUI del proyecto, y dejar el kit de mockups y el skill
+  `discovery-ux` citando Nuxt UI — para que la primera misión de producto que los use encuentre
+  instrucciones ciertas, no las de un motor que ya no está.
+- **Fuera de alcance:** cualquier cambio visual. Si un slice no se ve idéntico a lo que reemplaza, el
+  slice está mal — no es una oportunidad para mejorar el diseño de paso.
+- **Decisión bloqueante:** ninguna.

--- a/docs/missions/01-migracion-nuxt-ui/ingenieria.md
+++ b/docs/missions/01-migracion-nuxt-ui/ingenieria.md
@@ -1,0 +1,110 @@
+# Misión 01: Migración a Nuxt UI — Ingeniería
+
+**Estado:** activo
+
+**Última actualización:** 2026-08-11
+
+[Índice](./README.md) · [Ingeniería](./ingenieria.md)
+
+## Decisión técnica: reemplazar DaisyUI por Nuxt UI v4 sin cambiar el resultado visual
+
+Sustituir el motor de componentes manteniendo pixel-a-pixel el mismo look: mismo índigo, mismo turquesa,
+misma tipografía, mismos radios. El riesgo no es de arquitectura — es de regresión visual y de bundle,
+porque Nuxt UI trae JS que DaisyUI no tenía.
+
+- **Contratos de producto cubiertos:** A-004 (`arquitectura`).
+- **Riesgo bloqueante:** ninguno.
+
+## Arquitectura: dos capas de theming, cero componentes compartiendo motor a la vez
+
+Nuxt UI separa tokens crudos (Tailwind `@theme`, en `main.css`) de su mapeo semántico (`app.config.ts` bajo
+`ui.colors`). DaisyUI mezcla ambos en `[data-theme="datealo"]`. Los dos motores pueden convivir mientras
+dura la migración: `S-001` instala Nuxt UI y lo tematiza sin tocar ningún componente, así que hasta
+`S-002` la landing sigue siendo 100% DaisyUI y compilando.
+
+El mecanismo exacto (escala de 11 tonos por color, dónde va el mapeo semántico, cómo se overridea el
+radio) está verificado y documentado como receta reutilizable en
+[`arquitectura/references/recetas.md`](../../../.claude/skills/arquitectura/references/recetas.md#colores-de-marca-y-radio-en-nuxt-ui) —
+no se repite acá.
+
+| Componente         | Responsabilidad                              | No debe decidir          | Contratos |
+| ------------------- | --------------------------------------------- | ------------------------ | --------- |
+| `main.css`          | Tokens crudos (`@theme`): color, radio, fuente | Mapeo semántico           | A-004     |
+| `app.config.ts`     | Mapeo semántico (`ui.colors`, `ui.<componente>`) | Valores de color crudos | A-004     |
+| `landing/*.vue`      | Markup y contenido, con componentes de Nuxt UI | Su propio color o radio  | A-004     |
+
+## Contratos
+
+No aplica — esta misión no agrega ni cambia ningún endpoint ni contrato entre capas de datos.
+
+## Modelo de datos
+
+No aplica — no toca `server/`, no hay tabla nueva ni cambiada.
+
+### Impacto en RLS
+
+No aplica — no se crea ni modifica ninguna tabla ni policy.
+
+## Riesgos y experimentos de factibilidad
+
+| ID     | Riesgo o pregunta                                                | Qué invalida            | Experimento o mitigación                                                          | Criterio de salida                                       | Estado  |
+| ------ | ------------------------------------------------------------------ | ------------------------ | ------------------------------------------------------------------------------------ | ------------------------------------------------------------ | ------- |
+| TR-001 | Nuxt UI agrega JS que puede pesar en 3G/4G, el contexto real del buscador | El presupuesto de carga en móvil | Medir el tamaño del bundle de la landing antes de `S-001` y después de `S-010`, con `npx nuxi analyze` | La diferencia queda documentada; si crece más del 30%, se revisa contra A-004 | medido — crece 70% gzip, revisado y aceptado por Patricio Tabilo el 2026-08-12 |
+| TR-002 | Un componente migrado se ve distinto al original y nadie lo nota  | La promesa de "cero cambio visual" | Cada slice de componente compara contra un screenshot del componente actual antes de mergear | Revisión visual en 390px y desktop, lado a lado, antes de cada merge | parcial — S-002 a S-009 verificados en desktop antes de cada merge; 390px quedó pendiente en todos (la herramienta de resize del browser no funcionó en este entorno, ver PRs #14 a #21) |
+
+**TR-001, detalle de la medición** (JS+CSS del cliente, build de producción, tres puntos de comparación):
+
+| | Antes (DaisyUI puro) | S-001 (Nuxt UI instalado, 0 componentes usados) | S-010 (8 componentes migrados, DaisyUI afuera) |
+| - | - | - | - |
+| JS | 214 KB | 264 KB | 352 KB |
+| CSS | 53 KB | 297 KB | 226 KB |
+| Total gzip | 91 KB | 144 KB | 155 KB |
+
+Cruza el 30% (+70% gzip total), pero la causa está identificada y no es preocupante hacia adelante: más de la mitad del salto en JS (+50 KB de los +138 KB) ocurre en `S-001`, antes de usar un solo componente — es el costo fijo de registrar el módulo (plugins de color mode, app-config, íconos). El resto (+88 KB) es `reka-ui` + `tailwind-merge` + el runtime de íconos que traen `UButton`/`UInput`, compartido entre todos los componentes que los usan — no crece linealmente por cada componente nuevo. El CSS no tiene relación con JS: es la escala completa de 11 tonos por color de marca que `S-001` fuerza con `@theme static` (ver `recetas.md`), fija sin importar cuántos componentes la referencien; bajó de `S-001` a `S-010` al retirar el CSS de DaisyUI que convivía en paralelo.
+
+## Estrategia de pruebas
+
+| Contrato o riesgo | Nivel                     | Caso principal                                    | Límite o falla                              |
+| ------------------ | -------------------------- | --------------------------------------------------- | ---------------------------------------------- |
+| Cada slice S-002..S-009 | visual + build         | El componente migrado, en 390px, calza con el original | `npx nuxi typecheck` y `npm run build` limpios |
+| TR-001              | medición                  | Tamaño de bundle antes/después                       | —                                                |
+
+## Plan de construcción
+
+Corte vertical por componente: cada `landing/*.vue` es su propia costura, se puede migrar y verificar sola
+sin tocar las demás. `S-001` es la fundación (nada funciona sin el theming). `S-010` es el borrado de
+DaisyUI — obligatorio desde el principio, no un follow-up que alguien se acuerde de abrir después.
+
+| ID     | Slice (una frase, sin "y")                          | Sustento | Criterio de aceptación principal                                                                 | Depende de | Issue |
+| ------ | ------------------------------------------------------ | -------- | ------------------------------------------------------------------------------------------------- | ---------- | ----- |
+| S-001  | Instalar y tematizar Nuxt UI sin usarlo en ningún componente | A-004    | `npm i @nuxt/ui` + `app.config.ts` con `ui.colors.primary` en el índigo datealo; un `<UButton>` de prueba en una página aislada sale con el color y radio correctos; ningún componente de la landing cambia | —          | [#1](https://github.com/PatricioTabilo/datealo/issues/1) |
+| S-002  | Migrar LandingNavbar a componentes de Nuxt UI           | A-004    | Visualmente idéntico en 390px y desktop; `npx nuxi typecheck` limpio                              | S-001      | [#2](https://github.com/PatricioTabilo/datealo/issues/2) |
+| S-003  | Migrar LandingHero a componentes de Nuxt UI             | A-004    | Idéntico en 390px y desktop, botón e ícono incluidos                                              | S-001      | [#3](https://github.com/PatricioTabilo/datealo/issues/3) |
+| S-004  | Migrar LandingProblem a componentes de Nuxt UI          | A-004    | Idéntico en 390px y desktop                                                                       | S-001      | [#4](https://github.com/PatricioTabilo/datealo/issues/4) |
+| S-005  | Migrar LandingSolution a componentes de Nuxt UI         | A-004    | Idéntico en 390px y desktop                                                                       | S-001      | [#5](https://github.com/PatricioTabilo/datealo/issues/5) |
+| S-006  | Migrar LandingCategories a componentes de Nuxt UI       | A-004    | Idéntico en 390px y desktop, grilla de categorías incluida                                        | S-001      | [#6](https://github.com/PatricioTabilo/datealo/issues/6) |
+| S-007  | Migrar LandingForProfessionals a componentes de Nuxt UI | A-004    | Idéntico en 390px y desktop                                                                       | S-001      | [#7](https://github.com/PatricioTabilo/datealo/issues/7) |
+| S-008  | Migrar LandingFinalCta a componentes de Nuxt UI         | A-004    | Idéntico en 390px y desktop, botón de waitlist incluido                                           | S-001      | [#8](https://github.com/PatricioTabilo/datealo/issues/8) |
+| S-009  | Migrar LandingFooter a componentes de Nuxt UI           | A-004    | Idéntico en 390px y desktop                                                                       | S-001      | [#9](https://github.com/PatricioTabilo/datealo/issues/9) |
+| S-010  | Retirar DaisyUI del proyecto                            | A-004    | `daisyui` fuera de `package.json`; `@plugin "daisyui"` y `[data-theme="datealo"]` fuera de `main.css`; cero referencias a clases DaisyUI en `app/`; `npm run build` limpio | S-002..S-009 | [#10](https://github.com/PatricioTabilo/datealo/issues/10) |
+| S-011  | Actualizar el kit de mockups a Nuxt UI                  | A-004    | `docs/design/datealo-mockup-kit.css` define las mismas variables `--ui-*` (`--ui-primary`, `--ui-bg`, `--ui-text`, `--ui-radius`, etc.) que Nuxt UI genera en runtime desde `app.config.ts`, con los mismos valores; `docs/design/README.md` ya no cita DaisyUI; un mockup de prueba con clases reales de Nuxt UI (`bg-primary`, `text-primary`) reproduce el look real de la app sin correr Vue | S-010      | [#11](https://github.com/PatricioTabilo/datealo/issues/11) |
+| S-012  | Actualizar el skill `discovery-ux` a Nuxt UI             | A-004    | La sección de DaisyUI como base de todo elemento interactivo pasa a citar Nuxt UI y Reka UI; el ejemplo de "algo que DaisyUI no tiene" se revisa porque deja de aplicar igual | S-010      | [#12](https://github.com/PatricioTabilo/datealo/issues/12) |
+
+S-002 a S-009 no dependen entre sí — se pueden mergear en cualquier orden o en paralelo. El orden de la
+tabla sigue el orden en que aparecen en la página, solo para que revisarlos en secuencia sea más fácil de
+seguir.
+
+**Por qué S-011 y S-012 dependen de S-010, no de S-001:** mientras DaisyUI siga en el proyecto, el kit de
+mockups y el skill `discovery-ux` siguen describiendo lo que hay — cambiarlos antes deja al kit
+documentando un motor que la app todavía no usa. El mecanismo de S-011 ya está verificado: Nuxt UI expone
+su mapeo semántico como variables CSS en runtime (`--ui-primary`, `--ui-bg`, `--ui-text`, `--ui-radius`...)
+derivadas de `app.config.ts`. El kit las espeja igual que hoy espeja los tokens de `main.css` — mismo
+patrón, una capa más arriba, sin copiar clases compuestas por componente.
+
+Sin S-011 y S-012, la primera misión de producto que necesite un mockup o abra `discovery-ux` se encuentra
+con instrucciones que ya no son ciertas — por eso quedan en el plan de esta misión y no como una nota
+suelta que alguien tiene que acordarse de retomar.
+
+## Preguntas
+
+Ninguna abierta que bloquee construcción.

--- a/docs/missions/README.md
+++ b/docs/missions/README.md
@@ -1,0 +1,62 @@
+# Misiones
+
+Una misión es el discovery de una feature: investigación, producto, experiencia e ingeniería, en cuatro
+documentos con fuentes de verdad separadas. Cómo se escribe una está en
+[`template/`](./template/README.md). Este archivo responde lo otro: qué misiones existen, en qué orden se
+abrieron y de dónde salió cada una.
+
+## Registro
+
+| #   | Misión | Tipo | Abierta | Estado | En foco | Nace de |
+| --- | ------ | ---- | ------- | ------ | ------- | ------- |
+| 01  | [migración a Nuxt UI](./01-migracion-nuxt-ui/) | técnica | 2026-08-11 | lista para construir | Ingeniería | A-004 |
+
+Estados: `exploración`, `definición`, `lista para construir`, `en construcción`, `en validación`,
+`cerrada`, `pausada`. Al cerrar, el estado lleva su fecha (`cerrada 2026-09-30`). **En foco** es el único
+documento que se está trabajando; el detalle de por qué vive en el README de la misión, no acá.
+
+## Candidatas
+
+Una misión no existe hasta que tiene carpeta y número. Lo anterior a eso vive como issue, para que el
+registro no se llene de intenciones:
+
+| Candidata | Sale de | Issue |
+| --------- | ------- | ----- |
+| —         |         |       |
+
+## Tipos de misión
+
+- **Producto** — el flujo completo: `investigacion.md → producto.md → experiencia.md → ingenieria.md`. Es
+  el caso normal: hay un problema de usuario que investigar y una decisión de alcance que tomar.
+- **Técnica** — solo `ingenieria.md`, sin los otros tres documentos. Aplica cuando no hay cambio de
+  producto observable — el resultado para quien usa Datealo es el mismo antes y después — y la decisión que
+  la sustenta ya está tomada afuera, como un `A-xxx` del skill `arquitectura`. La carpeta no lleva
+  `investigacion.md`, `producto.md` ni `experiencia.md`; el README recorta su tabla de estado a la sola
+  fila de Ingeniería, y `ingenieria.md` cita el `A-xxx` donde el template pide un `F-xxx`.
+
+  Forzar una migración o un cambio de infraestructura al formato de producto (JTBD, señal de éxito, lado
+  del marketplace) produce una funcionalidad hueca solo para llenar el molde — es el antipatrón que
+  `discovery-product` ya nombra como "apuesta sin validar". Si en algún punto una misión técnica descubre
+  que sí cambia algo visible para el usuario, deja de ser técnica: se completa con `producto.md` y
+  `experiencia.md` desde ese punto.
+
+## Convención
+
+- Carpeta `NN-slug/`. `NN` es el orden en que se abrió la misión: nunca se reusa, nunca se reordena, y una
+  misión descartada se queda con su número. Es una bitácora, no un ranking — el número no dice prioridad
+  ni dependencia.
+- La sucesión se ve en el nombre de la carpeta; las fechas y el linaje se leen acá. Por eso el nombre no
+  lleva fecha: una misión dura semanas y su carpeta no debería mentir sobre cuándo terminó.
+- Al abrir una misión: copiar `template/`, tomar el número siguiente y agregar la fila en el registro. Al
+  cerrarla: cambiar el estado acá y en su README.
+- Si una misión nace de una decisión de otra, el "nace de" apunta a esa `D-xxx`. Las misiones se
+  ramifican; sin ese campo, en tres meses nadie reconstruye por qué existe la número 04.
+
+## Cómo se conecta con la ejecución
+
+El discovery termina en el "Plan de construcción" de `ingenieria.md`: una lista ordenada de slices donde
+cada slice es un Issue y un PR. Los issues llevan la etiqueta de la decisión que los sustenta (`D-xxx`,
+`TC-xxx`), para que cuando una decisión cambie se pueda encontrar exactamente qué tareas reescribir.
+
+El método de corte está en el skill `discovery-engineering`
+([`references/slicing.md`](../../.claude/skills/discovery-engineering/references/slicing.md)).

--- a/docs/missions/template/README.md
+++ b/docs/missions/template/README.md
@@ -1,0 +1,109 @@
+# Plantilla de misión
+
+Una misión documenta el discovery de una feature en cuatro documentos con fuentes de verdad separadas.
+La investigación se acumula; el resultado se reescribe. Cada documento debe permitir que otra persona
+entienda, cuestione y ejecute sin reconstruir conversaciones.
+
+La escritura sigue la [narrativa del proyecto](../../project-narrative.md). Las instrucciones en
+comentarios HTML se eliminan al completar cada sección. Las secciones que no aportan una decisión, riesgo
+o contrato verificable también se eliminan.
+
+## Los cuatro documentos
+
+| Documento                                | Naturaleza                  | Fuente de verdad para                            |
+| ---------------------------------------- | --------------------------- | ------------------------------------------------ |
+| [`investigacion.md`](./investigacion.md) | Se acumula, no se reescribe | Evidencia, benchmarks, conclusiones y el ideal   |
+| [`producto.md`](./producto.md)           | Viva, siempre vigente       | Qué construimos: funcionalidades, reglas, señales |
+| [`experiencia.md`](./experiencia.md)     | Viva, siempre vigente       | Flujos, estados, contenido y validación          |
+| [`ingenieria.md`](./ingenieria.md)       | Viva, siempre vigente       | Contratos, datos, factibilidad y pruebas         |
+
+El flujo es `investigacion → producto → experiencia → ingenieria`, con loops de vuelta: si experiencia o
+ingeniería invalidan una decisión, el cambio se registra primero en `producto.md` y desde ahí se propaga.
+Los documentos pueden avanzar en paralelo, pero nada se declara listo fuera de ese orden.
+
+## Trazabilidad
+
+`E-001 evidencia → C-001 conclusión → D-001 decisión → F-001 funcionalidad → M-001 señal de éxito`
+
+Evidencia y conclusiones viven en `investigacion.md`. Decisiones, funcionalidades y señales viven en
+`producto.md` y enlazan hacia la investigación. Experiencia (`UX`) e ingeniería (`T`) enlazan a `F` o `D`.
+Una funcionalidad sin conclusión que la sostenga es una apuesta sin validar y se presenta como tal.
+
+Datealo está pre-lanzamiento: la mayoría de la evidencia disponible es benchmark, entrevista o
+comportamiento observado fuera del producto, no datos de uso propios. Eso no baja el estándar — sube la
+importancia de la columna "límite de la evidencia".
+
+## Cómo iniciar una misión
+
+1. Copiar esta carpeta a `docs/missions/NN-<slug>/`, con el número siguiente del
+   [registro de misiones](../README.md), y agregar ahí su fila.
+2. Empezar por el problema y la evidencia en `investigacion.md`.
+3. Abrir `producto.md` cuando la investigación sostenga al menos una conclusión.
+4. Abrir `experiencia.md` e `ingenieria.md` cuando producto cumpla su gate de salida.
+5. Mantener este README como mapa de estado y decisiones bloqueantes.
+
+## Estado y ciclo de aprobación
+
+**Misión NN** — abierta el AAAA-MM-DD. Nace de: `<D-xxx de la misión NN>` o "ninguna". Ver el
+[registro de misiones](../README.md).
+
+**Estado de la misión:** exploración · definición · lista para construir · en construcción ·
+en validación · cerrada · pausada
+
+**Última actualización:** AAAA-MM-DD
+
+| Documento     | Estado    | Qué falta para su gate              |
+| ------------- | --------- | ----------------------------------- |
+| Investigación | activo    | <conclusión o evidencia faltante>   |
+| Producto      | pendiente | <funcionalidad o decisión faltante> |
+| Experiencia   | pendiente | <flujo o estado faltante>           |
+| Ingeniería    | pendiente | <contrato o riesgo faltante>        |
+
+Estados por documento: `pendiente`, `activo`, `en revisión`, `vigente`.
+
+- Claude puede proponer contenido y marcar `en revisión`. Nunca marca `vigente`.
+- `vigente` lo otorga solo el dueño de producto, y queda registrado: "aprobado por <nombre> el AAAA-MM-DD".
+- Los gates de cada documento están definidos en su propio archivo. Un documento no pasa a `en revisión`
+  sin cumplirlos.
+
+**Próximo hito:** <resultado verificable> — fecha límite AAAA-MM-DD.
+
+Si la fecha del hito pasó, la misión está estancada y este README debe decirlo explícitamente, con la
+causa y la decisión que la destranca.
+
+## Decisiones cruzadas
+
+<!-- Solo decisiones que cambian más de un documento. El detalle vive en su fuente de verdad. -->
+
+| ID    | Decisión en una frase | Fuente de verdad | Impacta | Estado    | Fecha límite |
+| ----- | --------------------- | ---------------- | ------- | --------- | ------------ |
+| D-001 | <decisión>            | `producto.md`    | UX, T   | propuesta | AAAA-MM-DD   |
+
+Toda decisión `propuesta` lleva fecha límite y qué la desbloquea. Una decisión sin deadline es un pocket
+veto: nadie la rechaza, nadie la aprueba y se construye igual. Estados: propuesta, aceptada, reemplazada,
+descartada. Una decisión reemplazada enlaza la nueva.
+
+## Resumen ejecutivo
+
+<!-- Lectura de dos minutos. Resultados y decisiones, no cronología. Se actualiza durante toda la misión. -->
+
+- **Problema confirmado:** <situación observable y consecuencia>.
+- **Dirección elegida:** <cómo cambia el producto>.
+- **Alcance actual:** <resultado que entregará esta etapa>.
+- **Fuera de alcance:** <límite principal>.
+- **Decisión bloqueante:** <pregunta pendiente o "ninguna">.
+
+## Por qué esta estructura
+
+Combina prácticas públicas adaptadas a una misión viva en un repositorio:
+
+- [Working Backwards de Amazon][aws]: el resultado del usuario se escribe antes que el feature, y la
+  investigación es insumo, no parte del comunicado.
+- [Shape Up de Basecamp][basecamp-pitch]: problema concreto, solución al nivel justo de abstracción,
+  límites explícitos.
+- [Procesos RFC][rfc]: la estructura pesada va en la gestión del documento (estados, deadlines, decisor
+  nombrado), no en su contenido.
+
+[aws]: https://docs.aws.amazon.com/prescriptive-guidance/latest/strategy-product-development/start-with-why.html
+[basecamp-pitch]: https://basecamp.com/shapeup/1.5-chapter-06
+[rfc]: https://blog.pragmaticengineer.com/rfcs-and-design-docs/

--- a/docs/missions/template/experiencia.md
+++ b/docs/missions/template/experiencia.md
@@ -1,0 +1,183 @@
+# Misión: <nombre> — Experiencia
+
+**Estado:** borrador
+
+**Última actualización:** AAAA-MM-DD
+
+[Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
+[Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
+
+<!--
+Fuente de verdad para flujos, estados, contenido e interacción. No redefine reglas de producto: si el
+diseño descubre una regla nueva o invalida una, abre o actualiza una decisión en producto.md.
+
+Núcleo obligatorio: vistas, mapa de estados, flujos críticos y estados por superficie. Las secciones bajo
+demanda (modelo mental, jerarquía de información, validación) se agregan solo cuando una decisión las
+necesita.
+
+Gate de salida — experiencia.md está lista para ingenieria.md cuando:
+- cada flujo crítico tiene secuencia, variantes, recuperación y criterio de término
+- cada estado tiene contenido concreto (texto real, información visible, acción disponible)
+- cada vista lista sus modos, y el mapa de estados cubre todas las transiciones entre ellos
+- cada modo tiene su indicador permanente de estado, y cada flujo tiene todas sus salidas documentadas
+- los casos límite de producto.md tienen flujo o estado mapeado
+- cada flujo crítico está mockeado en móvil (390px), y en desktop si también vive ahí
+- ninguna pantalla queda descrita como "similar a X" sin especificar qué cambia
+-->
+
+## Decisión de experiencia: <qué cambia para quien usa el producto>
+
+<Modelo de interacción elegido, flujo más importante y la incertidumbre que sigue abierta.>
+
+- **Funcionalidades cubiertas:** F-001, <otras>.
+- **Pendiente bloqueante:** <pregunta o "ninguna">.
+
+## Vistas
+
+<!--
+El listado de pantallas que define la experiencia — el mapa que se entrega antes de los flujos. Una línea
+por vista, sin tabla, con sus modos anidados debajo. Una vista es un destino: se llega a ella. Un modo es
+un estado de esa vista que cambia qué se puede hacer y qué se ve — se anida, nunca se lista como vista
+hermana.
+
+El porqué de cada vista, su trade-off o su justificación no van aquí: viven en su flujo (UXF) o en una
+decisión (UX-xxx). Regla de formato para todo el documento: las tablas se reservan para índices de celdas
+cortas; lo que lleva justificación extensa va en secciones con header + bullets, nunca en una celda.
+-->
+
+- **V-001 — <vista>** · móvil / desktop · resuelve F-001 · flujos UXF-001 · pendiente
+  - modo **<nombre>** — <qué lo distingue y qué se puede hacer en él>
+  - modo **<nombre>** — <ídem>
+
+## Mapa de estados
+
+<!--
+Vistas y flujos son listas, y una lista no muestra un camino. Esta tabla conecta los modos: qué acción
+lleva de uno a otro y qué pasa con el trabajo del usuario en cada salto. Cada fila que falte es una
+pregunta que ingeniería resuelve inventando.
+-->
+
+| Desde  | Acción             | Queda en | Qué pasa con el trabajo              |
+| ------ | ------------------ | -------- | ------------------------------------ |
+| <modo> | <acción concreta>  | <modo>   | <qué se aplicó, qué quedó pendiente> |
+| <modo> | <salir sin cerrar> | <modo>   | <qué se pierde o se conserva>        |
+
+## UXF-001 — <flujo principal en verbo>
+
+<!--
+Duplica por flujo crítico. Cada paso describe acción → respuesta al nivel de "el usuario toca X → Datealo
+muestra Y". Un mockup no reemplaza la secuencia porque no explica estados ni recuperación.
+-->
+
+**Objetivo:** <qué se completa o comprende>. **Contrato:** [F-001](./producto.md#f-001).
+
+**Punto de entrada:** <estado y superficie inicial, y qué acción trae al usuario hasta acá>.
+
+**Criterio de término:** <estado observable que confirma que el flujo terminó bien>.
+
+**Cómo sabe el usuario dónde está:** <el elemento concreto y permanente en pantalla que se lo dice, por
+cada modo que toca este flujo>.
+
+### Salidas
+
+<!--
+Todas las formas de irse, no solo terminar bien. El criterio de término cubre la salida buena; las otras
+son las que el usuario encuentra primero. Un modo del que no se sabe salir es un modo donde el usuario se
+pierde.
+-->
+
+| Salida                | Cómo se ejecuta       | Qué queda del trabajo           |
+| --------------------- | --------------------- | ------------------------------- |
+| <termina bien>        | <acción>              | <qué se aplicó y dónde>         |
+| <descarta>            | <acción, Esc, cerrar> | <nada, ni a medias>             |
+| <abandona sin cerrar> | <navega a otra parte> | <se conserva, se pierde, avisa> |
+
+### Secuencia principal
+
+| Paso | Acción            | Respuesta del sistema         | Información visible |
+| ---- | ----------------- | ----------------------------- | ------------------- |
+| 1    | <acción concreta> | <feedback o cambio de estado> | <dato y jerarquía>  |
+
+### Variantes y recuperación
+
+| Condición          | Qué cambia              | Cómo se entiende    | Cómo se recupera             |
+| ------------------ | ----------------------- | ------------------- | ---------------------------- |
+| <sin resultados>   | <estado>                | <mensaje concreto>  | <acción disponible>          |
+| <sin permiso de ubicación> | <comportamiento> | <indicador visible> | <alternativa manual>         |
+| <conexión lenta>   | <skeleton, no spinner>  | <qué se ve mientras>| <qué pasa si falla>          |
+
+### Decisiones que no deben quedar implícitas
+
+- <qué ocurre al cancelar, volver atrás, reintentar o confirmar>.
+- <qué cambio se guarda inmediato y cuál necesita confirmación>.
+
+## Estados por superficie
+
+<!--
+El contenido es concreto: texto real, no "mensaje apropiado". El estado vacío de un marketplace
+pre-lanzamiento no es un detalle: para muchas búsquedas será el estado principal durante meses.
+-->
+
+| Estado  | Qué se muestra (texto e información real) | Acción disponible                   |
+| ------- | ----------------------------------------- | ----------------------------------- |
+| inicial | <contenido>                               | <acción>                            |
+| vacío   | <por qué está vacío, con texto concreto>  | <cómo avanzar, o ninguna y por qué> |
+| carga   | <skeleton de qué forma>                   | <ninguna>                           |
+| error   | <causa útil y alcance>                    | <recuperación>                      |
+
+## Mockups
+
+<!--
+Los mockups viven en design-mockups/ como HTML (ver el skill discovery-ux y docs/design/README.md).
+Exploran o materializan una decisión; no son fuente de verdad de reglas de producto.
+-->
+
+| Mockup   | Cubre   | Estado                 | Ruta                              |
+| -------- | ------- | ---------------------- | --------------------------------- |
+| <nombre> | UXF-001 | exploración o validado | `./design-mockups/<archivo>.html` |
+
+## Cobertura
+
+<!-- Detecta huecos antes de construir. Una funcionalidad sin pantalla nueva igual tiene estados. -->
+
+| Funcionalidad | Flujo   | Estados cubiertos       | Estado    |
+| ------------- | ------- | ----------------------- | --------- |
+| F-001         | UXF-001 | principal, vacío, error | pendiente |
+
+## Secciones bajo demanda
+
+<!--
+Agregar solo cuando una decisión las necesite, con estos títulos:
+
+- "Modelo mental y lenguaje": cuando un concepto de producto pueda confundirse en la interfaz.
+- "Jerarquía de información": cuando una superficie densa exija decidir qué se ve primero (una card de
+  resultado con foto, rating, distancia, precio y disponibilidad es exactamente ese caso).
+- "Validación (UXV-xxx)": cuando una incertidumbre de diseño necesite prueba con usuarios.
+- "Accesibilidad y adaptación": cuando el contexto de uso cambie el flujo o la representación.
+-->
+
+## Decisiones de experiencia
+
+<a id="ux-001"></a>
+
+### UX-001 — <decisión en una frase>
+
+- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
+- **Sustento:** F-001 o <hallazgo>.
+- **Alternativas descartadas:** <opciones relevantes y trade-off, con el porqué del rechazo>.
+- **Decisión y consecuencia:** <qué flujo o superficie cambia>.
+- **Impacto en producto:** <ninguno o enlace a D-xxx/F-xxx actualizado>.
+
+## Preguntas
+
+<!--
+Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
+Estado: abierta | resuelta AAAA-MM-DD | disuelta AAAA-MM-DD. Solo las abiertas llevan bloque de detalle.
+-->
+
+<Una frase que responde "¿qué falta?": la pregunta que bloquea construcción y qué bloquea.>
+
+| ID      | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
+| ------- | ---------------------- | ------------------- | --------------------------------------------------------------- |
+| UXQ-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
+| UXQ-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |

--- a/docs/missions/template/ingenieria.md
+++ b/docs/missions/template/ingenieria.md
@@ -1,0 +1,162 @@
+# Misión: <nombre> — Ingeniería
+
+**Estado:** borrador
+
+**Última actualización:** AAAA-MM-DD
+
+[Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
+[Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
+
+<!--
+Fuente de verdad para arquitectura, datos, contratos, factibilidad y pruebas. Consume el comportamiento
+definido en producto. Una limitación técnica cambia el alcance solo mediante una decisión explícita en
+producto.md.
+
+Núcleo obligatorio: contratos, modelo de datos, RLS y riesgos de factibilidad. Las secciones bajo demanda
+(migración, rendimiento, entrega por etapas) se agregan solo cuando el riesgo lo justifica.
+
+Gate de salida — ingenieria.md está lista para construir cuando:
+- los contratos definen qué entra, qué sale y qué invariantes se mantienen, sin ambigüedad
+- el modelo de datos soporta los casos límite de producto.md sin workarounds
+- el impacto en RLS está resuelto: qué policy se crea o cambia, o por qué ninguna
+- la migración de datos existentes tiene estrategia o está explícitamente fuera del alcance
+- los escenarios verificables de producto están mapeados a pruebas
+- el plan de construcción corta el diseño en slices atómicos ordenados (un slice = un Issue = un PR)
+-->
+
+## Decisión técnica: <arquitectura y riesgo principal>
+
+<Dirección técnica, trade-off principal y el riesgo que todavía podría invalidarla.>
+
+- **Contratos de producto cubiertos:** F-001, <otros>.
+- **Riesgo bloqueante:** <incertidumbre o "ninguna">.
+
+## Arquitectura: <cómo se divide la responsabilidad>
+
+<!--
+La lógica de negocio se separa de la infraestructura: funciones puras en utils/ y server/utils/,
+reactividad en composables, acceso a datos en server/api/ con Drizzle. Incluye diagrama solo cuando tres o
+más partes interactúan.
+-->
+
+<Descripción del enfoque y por qué satisface los contratos con menor riesgo.>
+
+| Componente | Responsabilidad       | No debe decidir | Contratos |
+| ---------- | --------------------- | --------------- | --------- |
+| <nombre>   | <una responsabilidad> | <frontera>      | F-001     |
+
+## Contratos
+
+<!--
+Cada contrato especifica entrada, salida e invariantes al nivel en que se puede implementar sin reuniones
+de aclaración. Incluye los errores observables y el código HTTP cuando es un endpoint.
+-->
+
+### TC-001 — <contrato en una frase>
+
+- **Entrada:** <datos y precondiciones, con tipos y forma concreta>.
+- **Salida:** <resultado y su forma concreta>.
+- **Invariantes:** <qué se cumple siempre: atomicidad, consistencia, idempotencia>.
+- **Errores:** <condición → código HTTP y cuerpo `{ error, code? }`, y qué puede hacer el llamador>.
+- **Contrato de producto:** [F-001](./producto.md#f-001).
+
+## Modelo de datos
+
+<!-- Entidades con significado, escritura y ciclo de vida. El schema completo vive en server/db/. -->
+
+| Entidad o campo | Significado             | Escritura          | Retención o historial |
+| --------------- | ----------------------- | ------------------ | --------------------- |
+| <dato>          | <semántica de producto> | <endpoint o acción>| <política>            |
+
+### Invariantes de datos
+
+- <unicidad, pertenencia, orden o consistencia temporal>.
+- <qué operación es atómica o qué dato tiene una única fuente de verdad>.
+
+### Impacto en RLS
+
+<!--
+Obligatorio. Fuente de verdad: server/db/sql/rls.sql. Si el cambio no toca ownership ni relaciones usadas
+en policies, decirlo explícitamente con esa razón — no dejar la sección vacía.
+-->
+
+| Tabla    | Cambio                 | Policy afectada | Acción                    |
+| -------- | ---------------------- | --------------- | ------------------------- |
+| <tabla>  | <nueva, ownership, FK> | <nombre>        | <crear, actualizar, nada> |
+
+## Riesgos y experimentos de factibilidad
+
+<!--
+Un riesgo que podría cambiar el producto se enlaza como pregunta o decisión en producto.md. Un experimento
+tiene pregunta, límite de tiempo y resultado capaz de cerrar la incertidumbre.
+-->
+
+| ID     | Riesgo o pregunta | Qué invalida        | Experimento o mitigación  | Criterio de salida      | Estado  |
+| ------ | ----------------- | ------------------- | ------------------------- | ----------------------- | ------- |
+| TR-001 | <incertidumbre>   | <alcance en riesgo> | <spike, prueba o recorte> | <resultado concluyente> | abierto |
+
+## Estrategia de pruebas
+
+<!-- Mapea los ejemplos verificables de producto.md a niveles de prueba. Qué demuestra cada una. -->
+
+| Contrato o riesgo | Nivel                          | Caso principal | Límite o falla |
+| ----------------- | ------------------------------ | -------------- | -------------- |
+| F-001, CL-001     | <unidad, contrato, integración>| <caso>         | <caso>         |
+
+### Propiedades que deben probarse
+
+- <invariante bajo reintentos, concurrencia o distintas entradas>.
+- <ausencia de efectos parciales en falla>.
+
+## Plan de construcción
+
+<!--
+Se completa al final, cuando el gate de salida se cumple y ninguna pregunta bloqueante sigue abierta —
+cortar sobre decisiones abiertas produce issues que mueren. Cada slice es un cambio funcional atómico: un
+Issue, un PR, ejecutable sin haber leído la misión (el issue lleva su contrato inline) y con criterios
+pass/fail enumerables como tests. Guía completa en el skill discovery-engineering.
+-->
+
+| ID    | Slice (una frase, sin "y") | Sustento      | Criterio de aceptación principal          | Depende de |
+| ----- | -------------------------- | ------------- | ----------------------------------------- | ---------- |
+| S-001 | <cambio atómico>           | TC-001, D-001 | <entrada concreta → resultado observable> | —          |
+
+## Secciones bajo demanda
+
+<!--
+Agregar solo cuando el riesgo lo justifique, con estos títulos:
+
+- "Migración y compatibilidad": cuando existan datos o consumidores que deben llegar al nuevo contrato.
+  Incluye rollback lógico si la migración física no puede revertirse.
+- "Rendimiento y observabilidad": cuando haya presupuesto de latencia o volumen que defender (búsqueda
+  geográfica y listados paginados son los candidatos naturales).
+- "SEO e indexación": cuando la superficie deba ser indexable (páginas por categoría + comuna, datos
+  estructurados).
+- "Entrega por etapas": cuando el cambio necesite despliegue incremental o feature flags.
+-->
+
+## Decisiones técnicas
+
+<a id="t-001"></a>
+
+### T-001 — <decisión en una frase>
+
+- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
+- **Contratos:** F-001 y <regla relevante>.
+- **Alternativas descartadas:** <opciones y trade-offs, con el porqué del rechazo>.
+- **Decisión y consecuencias:** <enfoque elegido, beneficio, costo y trabajo futuro aceptado>.
+- **Reapertura:** <medición o cambio que justificaría revisar>.
+
+## Preguntas
+
+<!--
+Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
+Estado: abierta | resuelta AAAA-MM-DD | disuelta AAAA-MM-DD. Solo las abiertas llevan bloque de detalle.
+-->
+
+<Una frase que responde "¿qué falta?": la pregunta que bloquea construcción y qué bloquea.>
+
+| ID     | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
+| ------ | ---------------------- | ------------------- | --------------------------------------------------------------- |
+| TQ-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
+| TQ-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |

--- a/docs/missions/template/investigacion.md
+++ b/docs/missions/template/investigacion.md
@@ -1,0 +1,118 @@
+# Misión: <nombre> — Investigación
+
+**Estado:** activo
+
+**Última actualización:** AAAA-MM-DD
+
+[Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
+[Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
+
+<!--
+Este documento se acumula: la evidencia y las conclusiones no se borran cuando el alcance cambia, porque
+explican por qué el producto es como es. Lo que sí se actualiza es el ideal, que resume la dirección que
+la investigación sostiene hoy.
+
+Gate de salida — la investigación sostiene un producto.md cuando:
+- el problema tiene situación y consecuencia concretas, no una categoría abstracta
+- al menos una conclusión con confianza alta o media respalda la dirección
+- el ideal describe capacidades observables, no intenciones
+-->
+
+## El problema aparece cuando <historia concreta>
+
+<!--
+Una situación real o reconstruida con precisión. No abras con una categoría como "falta de confianza" —
+abre con quién estaba haciendo qué y qué salió mal. Nombra a la persona y el servicio concreto.
+-->
+
+**Situación:** <qué está ocurriendo antes del problema>.
+
+**Acción o necesidad:** <qué se intenta resolver o decidir>.
+
+**Respuesta actual:** <qué hace hoy la persona: grupo de WhatsApp, Google, recomendación de un vecino,
+Datealo si ya existe la superficie>.
+
+**Consecuencia:** <error, demora, riesgo o decisión que no puede tomarse>.
+
+## Preguntas que la investigación debe resolver
+
+<!--
+Solo preguntas capaces de cambiar el ideal o una decisión. Al resolver una, moverla a evidencia o
+conclusión. No es un backlog.
+-->
+
+- ¿<pregunta y decisión que depende de ella>?
+
+## Evidencia
+
+<!--
+Un hecho verificable con fuente y límite. Prioriza observación directa, entrevistas y comportamiento
+comprobado. Los benchmarks de otros productos también son evidencia: qué hacen, qué trade-off eligieron y
+qué no aplica a Datealo.
+
+Datealo no tiene datos de uso propios todavía. Cuando la única evidencia disponible sea un benchmark o
+una entrevista, la columna "límite" es lo que impide que se lea como dato duro.
+-->
+
+| ID    | Tipo                                              | Fuente                | Hecho verificable | Límite de la evidencia |
+| ----- | ------------------------------------------------- | --------------------- | ----------------- | ---------------------- |
+| E-001 | <entrevista, benchmark, uso, código, observación> | <enlace o referencia> | <hecho>           | <qué no demuestra>     |
+
+<a id="e-001"></a>
+
+### E-001 — <fuente o hecho en una frase>
+
+<!--
+Desarrollar solo cuando la tabla no alcanza para evaluar la calidad de la evidencia. Cierra con la
+consecuencia para la investigación.
+-->
+
+<Observación precisa y contexto necesario.>
+
+Esto permite afirmar <alcance>, pero no demuestra <límite>.
+
+## Conclusiones
+
+<!--
+Una conclusión interpreta evidencia; no es una preferencia ni una funcionalidad. El título expresa el
+hallazgo, no el tema.
+-->
+
+<a id="c-001"></a>
+
+### C-001 — <conclusión en una frase>
+
+- **Sustento:** [E-001](#e-001).
+- **Razonamiento:** <por qué la evidencia conduce a esta lectura y no a otra>.
+- **Implicación:** <qué deberá ser cierto en el producto o qué alternativa queda debilitada>.
+- **Confianza:** <alta, media o baja> porque <razón o validación pendiente>.
+
+## El ideal: <resultado completo, sin recortar>
+
+<!--
+El ideal es el producto de la investigación: la dirección que la evidencia sostiene, sin restricciones de
+implementación. El recorte a la primera entrega no vive aquí — vive en producto.md como decisión de
+alcance. Esta sección sí se reescribe cuando nueva evidencia cambia la dirección.
+-->
+
+### El resultado ideal se ve así
+
+<Narra de principio a fin una situación futura con datos concretos: nombres, comunas, oficios, horarios.
+Qué acción ocurre, qué responde Datealo, qué decisión puede tomar la persona. Evita "una experiencia
+simple" sin comportamiento observable.>
+
+### Capacidades del ideal
+
+| Capacidad | Acción habilitada    | Respuesta esperada              | Conclusión que la justifica |
+| --------- | -------------------- | ------------------------------- | --------------------------- |
+| <nombre>  | <qué se puede hacer> | <qué produce o explica Datealo> | [C-001](#c-001)             |
+
+### El ideal no significa <confusión probable>
+
+- <límite conceptual que evita una interpretación incorrecta>.
+
+## Referencias
+
+<!-- Fuentes primarias citadas por las evidencias. El enlace no sustituye el hecho y el límite en E-xxx. -->
+
+- [<título descriptivo>](URL): usado en E-001 para <afirmación concreta>.

--- a/docs/missions/template/producto.md
+++ b/docs/missions/template/producto.md
@@ -1,0 +1,149 @@
+# Misión: <nombre> — Producto
+
+**Estado:** borrador
+
+**Última actualización:** AAAA-MM-DD
+
+[Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
+[Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
+
+<!--
+Este documento es la spec viva del resultado: qué construimos ahora y bajo qué reglas. El porqué vive en
+investigacion.md — aquí solo se enlaza. Se reescribe cuando el alcance cambia; no acumula historia.
+
+Gate de salida — producto.md está listo para experiencia.md cuando:
+- cada funcionalidad tiene formato JTBD, reglas y al menos un caso límite con comportamiento definido
+- cada funcionalidad enlaza una conclusión de investigacion.md y una señal de éxito
+- cada funcionalidad declara a qué lado del marketplace sirve, y qué necesita del otro lado para funcionar
+- no hay decisiones de producto delegadas a diseño o ingeniería
+- las decisiones propuestas tienen fecha límite en el README
+-->
+
+## Qué construimos: <resultado en una frase>
+
+<!--
+El recorte vigente del ideal y por qué sigue entregando el resultado central. Máximo cuatro párrafos
+cortos. El ideal completo vive en investigacion.md.
+-->
+
+**Resultado:** <qué podrá lograr una persona al finalizar esta entrega>.
+
+**Recorte respecto del ideal:** <qué dimensión se reduce y por qué sigue siendo suficiente>
+(ver [el ideal](./investigacion.md)).
+
+**Restricciones aceptadas:** <plataforma, cobertura geográfica, categorías, volumen inicial de
+profesionales>.
+
+## Funcionalidades
+
+| ID    | Funcionalidad                  | Lado         | Sustento     | Éxito |
+| ----- | ------------------------------ | ------------ | ------------ | ----- |
+| F-001 | <verbo + resultado observable> | buscador     | C-001, D-001 | M-001 |
+
+<a id="f-001"></a>
+
+### F-001 — <verbo + resultado observable>
+
+<!--
+Duplica este bloque por funcionalidad. Se escribe desde el resultado del usuario (working backwards):
+primero el JTBD, después las reglas. Si la respuesta de Datealo no se puede describir sin hablar de tablas
+o componentes, falta cerrar la decisión de producto.
+-->
+
+Cuando <usuario en contexto concreto>,
+quiero <acción>,
+para <resultado observable>.
+
+**Lado del marketplace:** buscador, profesional o ambos. **Qué necesita del otro lado:** <volumen mínimo
+de perfiles, reseñas o cobertura sin el cual esta funcionalidad no entrega su resultado>.
+
+**Sustento:** [C-001](./investigacion.md#c-001) y [D-001](#d-001). **Éxito:** [M-001](#m-001).
+
+**Reglas:**
+
+- Si <condición>, Datealo <comportamiento esperado>.
+- Si <caso límite>, Datealo <comportamiento seguro y qué información muestra>.
+- Datealo nunca <comportamiento que rompería el significado o la confianza>.
+
+**Ejemplo verificable:** dado <estado con datos concretos>, cuando <acción>, entonces <resultado
+observable>.
+
+**No incluye:** <variante del ideal excluida de esta funcionalidad>.
+
+**Experiencia:** <enlace a UXF-xxx cuando exista>. **Ingeniería:** <enlace a T-xxx cuando exista>.
+
+## Casos límite que cruzan funcionalidades
+
+<!--
+Solo condiciones que afectan varias funcionalidades. Las propias de una viven en su bloque. Un caso
+retirado no se borra ni se reutiliza: conserva su fila, o se nombra con su motivo en una línea debajo.
+
+Los casos límite propios de un marketplace pre-lanzamiento aparecen acá: cero resultados en una comuna,
+un profesional sin reseñas, una categoría con un solo perfil, un perfil sin verificar.
+-->
+
+| ID     | Condición concreta     | Comportamiento esperado | Funcionalidades |
+| ------ | ---------------------- | ----------------------- | --------------- |
+| CL-001 | <estado o combinación> | <qué hace Datealo>      | F-001           |
+
+## Fuera de alcance
+
+<!-- Distingue postergado de descartado y qué condición justificaría reabrirlo. -->
+
+| Capacidad o caso      | Estado                  | Razón del recorte | Condición para reconsiderar |
+| --------------------- | ----------------------- | ----------------- | --------------------------- |
+| <capacidad del ideal> | postergada o descartada | <trade-off>       | <evidencia o hito>          |
+
+## Señales de éxito
+
+<a id="m-001"></a>
+
+### M-001 — <señal que demuestra el resultado>
+
+- **Pregunta:** ¿<qué queremos comprobar>?
+- **Señal:** <comportamiento o resultado observable>.
+- **Método y umbral:** <instrumentación o revisión, qué resultado, en qué población y ventana>.
+- **Guardrail:** <daño que no debe aumentar para conseguir la señal>.
+
+## Decisiones de producto
+
+<!--
+Solo decisiones con alternativas reales. No borres decisiones reemplazadas: explican por qué el producto
+es como es. Toda decisión propuesta se refleja en el README con fecha límite.
+-->
+
+<a id="d-001"></a>
+
+### D-001 — <decisión en una frase que se entiende sola>
+
+- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
+- **Sustento:** [C-001](./investigacion.md#c-001).
+- **Tensión:** <criterios que no podían maximizarse al mismo tiempo>.
+- **Alternativas descartadas:** <opciones y razón concreta del rechazo, en la misma línea>.
+- **Decisión y consecuencia:** <qué se hará y qué habilita, limita o exige revisar en UX e ingeniería>.
+- **Reapertura:** <evidencia o cambio que justificaría revisarla>.
+
+## Preguntas
+
+<!--
+Solo preguntas que pueden cambiar una decisión o funcionalidad. Lo demás va a un issue.
+Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
+Estado: abierta | resuelta AAAA-MM-DD (alguien la respondió) | disuelta AAAA-MM-DD (el producto cambió y la
+pregunta dejó de tener sentido). Solo las abiertas llevan bloque de detalle debajo de la tabla.
+-->
+
+<Una frase que responde "¿qué falta?": la pregunta que bloquea y qué bloquea.>
+
+| ID    | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
+| ----- | ---------------------- | ------------------- | --------------------------------------------------------------- |
+| Q-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
+| Q-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |
+
+<a id="q-001"></a>
+
+### Q-001 — <la pregunta en una frase que se entiende sola>
+
+- **La duda, con un ejemplo:** <el caso concreto que muestra por qué hay dos respuestas posibles>.
+- **Afecta a:** D-001 o F-001.
+- **Cómo se resolverá:** <quién y con qué método>.
+- **¿Bloquea algo?:** <qué bloquea y su fecha límite, o no>.

--- a/docs/project-narrative.md
+++ b/docs/project-narrative.md
@@ -1,0 +1,156 @@
+# Narración para documentación de proyecto
+
+Esta convención rige la prosa de la documentación de Datealo:
+
+- Documentos de misión (`docs/missions/`) y planes de implementación.
+- La descripción de un PR y el cuerpo de un issue.
+- Los mensajes de commit.
+- La documentación `.md` de un módulo, READMEs incluidos.
+
+Es documentación para alinear, decidir, ejecutar y volver a consultar después. Por eso debe optimizarse
+para tres modos de lectura:
+
+- **Lectura rápida:** entender en pocos minutos qué pasa, qué se decidió y qué falta.
+- **Lectura profunda:** entender contexto, trade-offs, riesgos y criterios detrás de la propuesta.
+- **Consulta futura:** volver semanas o meses después y recordar por qué se tomó una decisión.
+
+En los documentos de misión el documento además es vivo: muestra las decisiones tomadas, las que faltan
+por tomar, en qué se está trabajando y el estado actual.
+
+El anti-patrón típico de un agente es escribir como si todo tuviera la misma importancia: una muralla de
+contexto, detalles técnicos, alternativas, riesgos y pendientes sin jerarquía. La solución no es "hacerlo
+más bonito", sino imponer una arquitectura narrativa.
+
+La estructura ya viene dada por el artefacto: las secciones del template de misión, el cuerpo del commit
+o las secciones del README. El trabajo tiene dos partes: ubicar cada pieza de información en el lugar que
+le corresponde y presentarla de forma clara y jerárquica.
+
+No toda la información vive en el mismo lugar. Una misma decisión puede enunciarse en la descripción del
+PR y detallarse en el documento de la misión. Cada aparición se presenta según lo que ese lugar necesita.
+
+Si el artefacto tiene convenciones propias (por ejemplo, la convención de commits de `CLAUDE.md`), esas
+mandan en lo que choquen con esta.
+
+## Reglas
+
+1. **Jerarquiza: primero la idea principal, después el detalle**
+
+   Orden recomendado: qué es lo más importante que el lector debe entender, por qué importa, qué detalles
+   lo sostienen, qué consecuencia o pregunta queda abierta. Si hay que leer cinco párrafos antes de llegar
+   al punto, está mal ordenado.
+
+2. **Usa encabezados informativos, no genéricos**
+
+   Que el subtítulo lleve el mensaje, no solo el tema. "El problema aparece cuando el cliente no sabe si
+   el profesional va a llegar" comunica más que "Contexto". "Riesgos: duplicar la lógica de distancia y
+   acoplar la búsqueda a Santiago" comunica más que "Riesgos".
+
+3. **Separa hechos, decisiones, hipótesis y pendientes**
+
+   No mezcles información confirmada con supuestos en el mismo párrafo, ni escondas preguntas abiertas
+   dentro de prosa larga. En un producto pre-lanzamiento esto importa el doble: casi todo lo que sabemos
+   del usuario es hipótesis, y el documento tiene que decir cuál es cuál.
+
+4. **Escribe con trazabilidad**
+
+   Al presentar una decisión, deja clara la cadena: contexto, criterio usado, alternativas o tensiones,
+   decisión, consecuencia práctica. Evita "se recomienda hacer X" sin el criterio detrás: la documentación
+   debe sobrevivir al contexto oral.
+
+5. **No documentes todo lo investigado**
+
+   Incluye información solo si ayuda a entender el problema, tomar una decisión, ejecutar, identificar
+   riesgos o consultar el contexto después. Lo correcto pero inútil para esos fines se resume, se mueve a
+   un anexo o se elimina.
+
+6. **Ajusta la profundidad a la importancia del punto**
+
+   Un punto simple se explica en 1 o 2 frases. Uno con impacto relevante, en un párrafo breve. Una
+   decisión, trade-off, riesgo o cambio de comportamiento se desarrolla. No sobreexpliques lo obvio para
+   que el documento parezca completo.
+
+7. **Párrafos para causalidad, bullets para escanear**
+
+   Párrafos para explicar por qué algo importa, cómo una causa genera un problema, qué trade-off se acepta
+   o por qué se descarta una alternativa. Bullets para información comparable: criterios, riesgos, casos,
+   dependencias, restricciones, pendientes. Un bullet de muchas líneas probablemente es un párrafo.
+
+8. **Cierra cada bloque importante con una consecuencia**
+
+   "Esto implica que…", "Por eso la primera entrega debe limitarse a…", "La decisión pendiente es…". No
+   cierres un bloque con datos sueltos que no dicen qué entender o hacer.
+
+9. **Evita la ambigüedad operativa**
+
+   En vez de "se debería revisar" o "hay que considerar algunos casos", especifica qué hay que revisar,
+   quién debería resolverlo, qué impacto tiene, qué decisión depende de eso y qué pasa si no se resuelve.
+
+10. **Mantén una voz profesional, directa y humana**
+
+    Escribe como una persona senior explicando el proyecto a otro equipo. Evita el tono burocrático ("El
+    presente documento tiene por objetivo…", "Cabe destacar que…"). Prefiere lo directo ("El problema
+    aparece cuando…", "La recomendación es…", "Para avanzar, falta resolver…").
+
+## Formato y presentación
+
+El criterio de fondo es cómo se visualiza la información, no una checklist mecánica. Las listas y los
+títulos son anclas para texto corto; el detalle largo va en prosa. Un contenido correcto pero mal
+maquetado se lee igual de mal que uno desordenado.
+
+1. **Las listas y los títulos son para texto corto**
+
+   Un ítem de lista, un sub-bullet o un título debe caber en 2 líneas; un párrafo, en 4 líneas. Si el
+   contenido no cabe, no lo aprietes: pásalo al formato que sí lo sostiene.
+
+   - Si el título y su detalle son cortos, pueden ir en la misma línea separados por ":".
+   - Si el detalle es largo, el título queda solo en su línea y el detalle baja como párrafo, o como
+     sub-bullets si son varios ítems cortos.
+
+2. **Párrafos de máximo 4 líneas**
+
+   Más que eso se lee como un saco de palabras. Si tienes más, parte en dos párrafos separados por una
+   línea en blanco, cada uno con una idea.
+
+3. **Líneas de máximo 120 caracteres, espacios incluidos**
+
+4. **Una idea por frase; no encadenes con punto y coma**
+
+   El ";" que empalma varias ideas no facilita la lectura, solo esconde que son ideas distintas.
+
+   - Mal: "...renombra el composable y reordena las secciones; el resto no cambia."
+   - Bien: "...renombra el composable y reordena las secciones. El resto no cambia."
+
+5. **Niveles legibles, anidación máxima de 3**
+
+   Que se distinga a simple vista en qué nivel está cada ítem. No mezcles lista numerada y lista con
+   bullets en el mismo nivel.
+
+6. **Si no puedes agregar algo sin quebrar una regla, sube el scope de la revisión**
+
+   El problema casi nunca es de formato. Antes de forzar un cuarto nivel o un párrafo de seis líneas:
+   ¿estás agregando demasiado detalle?, ¿ese detalle va en otra sección?, ¿hay un nivel intermedio que
+   aporta poco y cuyo contenido se puede repartir u omitir?
+
+## Antes de entregar
+
+Revisa cada sección como lo haría un lector que no estuvo en la conversación:
+
+- ¿La primera frase orienta al lector?
+- ¿Se distingue lo confirmado de lo pendiente, y lo observado de lo supuesto?
+- ¿Hay demasiado detalle antes de la idea principal?
+- ¿La sección cierra con una consecuencia clara?
+- ¿Alguien podría entenderla sin haber estado en la conversación, y volver en un mes a entender por qué
+  quedó escrita así?
+- ¿Algún ítem de lista o título arrastra un detalle largo que debería ser párrafo?
+- ¿Hay párrafos de más de 4 líneas, o frases encadenadas con ";"?
+- ¿Alguna línea pasa de 120 caracteres?
+
+Si una sección solo acumula información correcta pero no ayuda a entender, decidir o ejecutar, reescríbela.
+
+## Regla de oro
+
+La documentación de proyecto no cuenta todo lo que se investigó. Explica lo suficiente para que otra
+persona entienda el problema, confíe en la dirección tomada y pueda ejecutar o revisar la decisión después.
+
+Cuando exista más detalle (en otra sección, un anexo o un documento enlazado), la narración guía hacia él
+en lugar de exponerlo todo de entrada.


### PR DESCRIPTION
## Resumen

`docs/` nunca se había commiteado — no está en `.gitignore`, fue un olvido de cuando se armó. Esto incluye:

- `docs/missions/` — el registro de misiones y la misión 01 completa (discovery e ingeniería de la
  migración a Nuxt UI), citada por su URL de GitHub en las descripciones de las PRs #13 a #22. Hasta este
  commit, todos esos links apuntaban a un archivo que no existía en `main`.
- `docs/design/` — el kit de mockups, que S-011 (issue #11) va a actualizar a continuación.
- `docs/project-narrative.md` — la guía de prosa para misiones, PRs y commits que `CLAUDE.md` cita.

No toca `.github/`, `.claude/` ni `CLAUDE.md` — quedan fuera de este PR, sin relación con lo que faltaba acá.

## Test plan

- No aplica cambio de código — es documentación existente que faltaba subir, sin modificaciones de
  contenido.