### PR TITLE
fix(ui): reproducir el error rojo exacto de DaisyUI tras retirarlo

### DIFF
--- a/app/app.config.ts
+++ b/app/app.config.ts
@@ -8,6 +8,9 @@ export default defineAppConfig({
       // no es el mismo hex (OKLCH corrió el tono a #00BC7D) — datealo-success es la escala propia
       // que reproduce el original exacto (main.css).
       success: 'datealo-success',
+      // Mismo caso que success: el "red" nativo de Tailwind v4 quedó en #FB2C36, no en el #EF4444
+      // que usaba DaisyUI para error.
+      error: 'datealo-error',
     },
   },
 })

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -54,6 +54,20 @@
   --color-datealo-success-800: #0A714F;
   --color-datealo-success-900: #085A3E;
   --color-datealo-success-950: #06422E;
+
+  /* Mismo problema que success: el "red" nativo de Tailwind v4 (el que usa error por defecto) quedó
+     en #FB2C36 tras la redefinición en OKLCH, no en el #EF4444 que usaba DaisyUI. */
+  --color-datealo-error-50: #FEF1F1;
+  --color-datealo-error-100: #FCD7D7;
+  --color-datealo-error-200: #F9B4B4;
+  --color-datealo-error-300: #F69292;
+  --color-datealo-error-400: #F26A6A;
+  --color-datealo-error-500: #EF4444;
+  --color-datealo-error-600: #EC1F1F;
+  --color-datealo-error-700: #D11212;
+  --color-datealo-error-800: #AD0F0F;
+  --color-datealo-error-900: #880C0C;
+  --color-datealo-error-950: #640909;
 }
 
 /* Radio base de Nuxt UI (A-004): DaisyUI usaba --radius-btn: 0.75rem / --radius-box: 1rem.


### PR DESCRIPTION
## Resumen

Bug de regresión visual en `main`, encontrado armando el mockup de prueba de S-011 (issue #11), no en su
propio slice.

DaisyUI usaba `#EF4444` para `error`. En #22 (S-010) verifiqué rigurosamente `success` (pintando el pixel
real, no confiando en el nombre del color) porque sabía que Tailwind v4 redefinió su paleta en OKLCH — pero
para `error` asumí que "red" nativo coincidía sin hacer la misma verificación, porque en Tailwind v3 sí era
el mismo hex. No lo es en v4: el `red-500` actual pinta `#FB2C36`, no `#EF4444`. Lo until ahora estuvo
mostrando el mensaje de validación de ambos forms de waitlist (Hero, ForProfessionals) en un rojo distinto
al original, sin que nadie lo notara — exactamente el escenario que TR-002 de la misión existe para atrapar.

`datealo-error` es una escala propia de 11 tonos en `main.css`, mismo método que `datealo-success` (y
antes, `indigo-datealo`/`turquesa-datealo` en S-001): el 500 reproduce el hex original exacto, verificado
en runtime.

Sustento: A-004 (skill `arquitectura`).

## Test plan

- [x] `npx nuxi typecheck` limpio.
- [x] `npm run build` limpio.
- [x] Verificado en el browser: `getComputedStyle(document.documentElement).getPropertyValue('--ui-error')`
      da `#EF4444` exacto (antes: `oklch(63.7% 0.237 25.331)` = `#FB2C36`).