### PR TITLE
docs: actualizar el kit de mockups a Nuxt UI

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -21,19 +21,26 @@ debería obligar a abrir cinco pestañas.
 
 ```html
 <!doctype html>
-<html lang="es-CL" data-theme="datealo">
+<html lang="es-CL">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>V-002 Resultados de búsqueda — misión 01</title>
 
     <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
-    <link href="https://cdn.jsdelivr.net/npm/daisyui@5/daisyui.css" rel="stylesheet" />
     <link
       href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&family=Plus+Jakarta+Sans:wght@600;700;800&display=swap"
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../../design/datealo-mockup-kit.css" />
+    <style type="text/tailwindcss">
+      @theme {
+        --color-primary: var(--ui-primary);
+        --color-secondary: var(--ui-secondary);
+        --color-success: var(--ui-success);
+        --color-error: var(--ui-error);
+      }
+    </style>
   </head>
 
   <body>
@@ -45,7 +52,8 @@ debería obligar a abrir cinco pestañas.
         </div>
         <div class="frame-viewport">
           <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
-          <!-- Contenido real de la pantalla, con DaisyUI y utilidades de Tailwind -->
+          <!-- Contenido real de la pantalla, con utilidades de Tailwind: bg-primary, text-primary,
+               rounded-xl, etc. reproducen el look real porque apuntan a las variables --ui-* del kit -->
         </div>
       </section>
 
@@ -60,12 +68,16 @@ debería obligar a abrir cinco pestañas.
 
 Tres detalles que importan:
 
-- **El `data-theme="datealo"` va en el `<html>`**, igual que en la app real (`nuxt.config.ts`). Sin eso los
-  componentes de DaisyUI salen con el tema por defecto y el mockup miente sobre el color.
-- **El kit se carga después de DaisyUI.** Define los tokens del tema y los marcos; los componentes los pone
-  DaisyUI.
-- **Requiere internet.** Tailwind, DaisyUI y las tipografías vienen por CDN. Si vas a trabajar sin
-  conexión, descarga los dos archivos a `docs/design/vendor/` y apunta los `src`/`href` ahí.
+- **El `@theme` va inline, no en el kit.** El Play CDN de Tailwind solo lee `@theme` de un
+  `<style type="text/tailwindcss">` en el propio HTML — nunca de un archivo enlazado con `<link>`, así que
+  no hay forma de meterlo en `datealo-mockup-kit.css`. Por eso el esqueleto lo trae listo: se copia tal
+  cual, no hay que tocarlo salvo que se agregue un color nuevo.
+- **Sin componentes de librería.** Desde que la app usa Nuxt UI (A-004) no hay una versión "para mockups"
+  de sus componentes — son solo utilidades de Tailwind con overrides completos, igual que en el código real
+  (`<UButton variant="link">` con todas sus clases pisadas). Un botón en el mockup es
+  `<button class="rounded-xl bg-primary px-6 py-3 font-bold text-white">`, no un componente.
+- **Requiere internet.** Tailwind y las tipografías vienen por CDN. Si vas a trabajar sin conexión,
+  descarga el script a `docs/design/vendor/` y apuntá el `src` ahí.
 
 ## Cómo verlo
 
@@ -98,6 +110,14 @@ un host externo.
 
 ## Sincronizar el kit
 
-`datealo-mockup-kit.css` espeja los tokens de `app/assets/css/main.css`. No hay script: son unas veinte
-líneas y se copian a mano cuando el tema cambia. Si tocas el tema de la app y no el kit, los mockups
-siguientes describirán un producto que ya no existe.
+`datealo-mockup-kit.css` espeja las dos capas de theming de la app (A-004): los tokens crudos de
+`app/assets/css/main.css` y los tokens semánticos que Nuxt UI genera en runtime desde
+`app/app.config.ts`. Estos últimos no se calculan a mano — se leen de la app real corriendo
+(`getComputedStyle(document.documentElement)` sobre cada `--ui-*`) y se copian tal cual, oklch()
+incluido, porque es un color CSS válido y convertirlo a hex solo agrega una oportunidad de
+equivocarse.
+
+No hay script: son unas treinta líneas y se copian a mano cuando el tema cambia. Si se agrega un color
+nuevo (por ejemplo `warning`), toca actualizar tres lugares juntos: `app.config.ts`, el kit, y el bloque
+`@theme` inline del esqueleto de arriba (agregar `--color-warning: var(--ui-warning);`). Si tocás el tema
+de la app y no el kit, los mockups siguientes describirán un producto que ya no existe.

--- a/docs/design/datealo-mockup-kit.css
+++ b/docs/design/datealo-mockup-kit.css
@@ -2,50 +2,73 @@
  * Kit de mockups de Datealo
  * =========================
  *
- * Espeja los tokens de `app/assets/css/main.css`. Si ese archivo cambia, este se actualiza a mano
- * (son ~20 líneas) y se anota en el commit — un mockup con tokens viejos describe un producto
- * que no existe.
+ * Espeja los tokens de `app/assets/css/main.css` + `app/app.config.ts` en sus dos capas (A-004):
+ * los tokens crudos que define la app, y los tokens semánticos que Nuxt UI genera en runtime a partir
+ * de ellos. Si esas capas cambian, este archivo se actualiza a mano (son ~30 líneas) y se anota en el
+ * commit — un mockup con tokens viejos describe un producto que no existe.
  *
- * Los componentes NO viven acá: salen de DaisyUI, cargado por CDN en el esqueleto del mockup.
- * Este archivo aporta solo dos cosas: los tokens del tema y los marcos de dispositivo.
+ * Los componentes NO viven acá: en un mockup estático no hay Vue corriendo, así que no hay Nuxt UI de
+ * verdad — se construyen con utilidades de Tailwind puras, coloreadas con las variables `--ui-*` de
+ * este archivo. Es el mismo resultado visual que un `<UButton variant="link">` totalmente sobrescrito,
+ * que es como está armada la app real desde la migración a Nuxt UI (misión 01).
  *
- * Uso: ver docs/design/README.md
+ * Uso: ver docs/design/README.md — el `@theme` de Tailwind que activa clases como `bg-primary` va
+ * inline en cada mockup, no acá (el Play CDN de Tailwind solo lee `@theme` de un
+ * `<style type="text/tailwindcss">`, nunca de un `<link>` externo).
  */
 
-/* ---------------------------------------------------------------- Tokens del tema `datealo` */
-
-[data-theme='datealo'] {
-  --color-base-100: #fafafa;
-  --color-base-200: #f3f4f6;
-  --color-base-300: #e5e7eb;
-  --color-base-content: #1f2937;
-  --color-primary: #423ed0;
-  --color-primary-content: #ffffff;
-  --color-secondary: #3ecbd7;
-  --color-secondary-content: #1f2937;
-  --color-accent: #3ecbd7;
-  --color-accent-content: #1f2937;
-  --color-neutral: #1f2937;
-  --color-neutral-content: #ffffff;
-  --color-success: #10b981;
-  --color-success-content: #ffffff;
-  --color-error: #ef4444;
-  --color-error-content: #ffffff;
-  --radius-btn: 0.75rem;
-  --radius-box: 1rem;
-}
+/* ---------------------------------------------------------------- Tokens crudos (main.css @theme) */
 
 :root {
+  --color-datealo-primary: #423ed0;
+  --color-datealo-accent: #3ecbd7;
+  --color-datealo-bg: #fafafa;
+  --color-datealo-surface: #f3f4f6;
+  --color-datealo-text: #1f2937;
+  --color-datealo-muted: #6b7280;
+
   --font-heading: 'Plus Jakarta Sans', system-ui, sans-serif;
   --font-body: 'DM Sans', system-ui, sans-serif;
   --mockup-canvas: #e7e8ec;
   --mockup-label: #6b7280;
 }
 
+/* ---------------------------------------------------- Tokens semánticos (Nuxt UI, vía app.config.ts) */
+
+/* Valores leídos de la app real corriendo (getComputedStyle sobre <html>) — no son estimados. Los que
+   usan oklch() son el resultado real de la escala "gray" de Tailwind que mapea `neutral` en
+   app.config.ts; se copian tal cual porque oklch() es un color CSS válido, no hace falta convertirlo. */
+:root {
+  --ui-primary: #423ed0;
+  --ui-secondary: #3ecbd7;
+  --ui-success: #10b981;
+  --ui-error: #ef4444;
+
+  --ui-bg: #fff;
+  --ui-bg-muted: oklch(98.5% 0.002 247.839);
+  --ui-bg-elevated: oklch(96.7% 0.003 264.542);
+  --ui-bg-accented: oklch(92.8% 0.006 264.531);
+  --ui-bg-inverted: oklch(21% 0.034 264.665);
+
+  --ui-text: oklch(37.3% 0.034 259.733);
+  --ui-text-dimmed: oklch(70.7% 0.022 261.325);
+  --ui-text-muted: oklch(55.1% 0.027 264.364);
+  --ui-text-toned: oklch(44.6% 0.03 256.802);
+  --ui-text-highlighted: oklch(21% 0.034 264.665);
+  --ui-text-inverted: #fff;
+
+  --ui-border: oklch(92.8% 0.006 264.531);
+  --ui-border-muted: oklch(92.8% 0.006 264.531);
+  --ui-border-accented: oklch(87.2% 0.01 258.338);
+  --ui-border-inverted: oklch(21% 0.034 264.665);
+
+  --ui-radius: 0.5rem;
+}
+
 body {
   font-family: var(--font-body);
   background: var(--mockup-canvas);
-  color: var(--color-base-content);
+  color: var(--color-datealo-text);
   margin: 0;
   padding: 2.5rem 1.5rem;
   -webkit-font-smoothing: antialiased;
@@ -96,9 +119,10 @@ h6 {
 }
 
 /* El viewport real del mockup. `overflow: hidden` recorta lo que no cabe:
-   ver qué queda fuera del marco es justamente para lo que sirve. */
+   ver qué queda fuera del marco es justamente para lo que sirve. Fondo en el token crudo de página
+   (datealo-bg), no en --ui-bg: ese es el blanco de superficie de Nuxt UI, no el fondo de la app. */
 .frame-viewport {
-  background: var(--color-base-100);
+  background: var(--color-datealo-bg);
   border-radius: 1.75rem;
   border: 1px solid #d1d5db;
   box-shadow: 0 10px 30px -12px rgb(31 41 55 / 0.25);
@@ -131,7 +155,7 @@ h6 {
   padding: 0.75rem 1.5rem 0.25rem;
   font-size: 0.8125rem;
   font-weight: 600;
-  color: var(--color-base-content);
+  color: var(--color-datealo-text);
 }
 
 /* Área segura inferior, donde vive el CTA fijo en móvil. */
@@ -139,7 +163,8 @@ h6 {
   padding-bottom: 1.25rem;
 }
 
-/* Marcador de pliegue: lo que queda debajo de esta línea no se ve sin hacer scroll. */
+/* Marcador de pliegue: lo que queda debajo de esta línea no se ve sin hacer scroll. Rojo fijo a
+   propósito — es una anotación de la herramienta, no un color de marca. */
 .fold {
   position: absolute;
   left: 0;


### PR DESCRIPTION
## Resumen

`datealo-mockup-kit.css` espeja ahora las dos capas de theming de la app (A-004):

- **Tokens crudos** (`main.css` `@theme`): sin cambios de valor, solo reorganizados bajo un solo `:root`.
- **Tokens semánticos `--ui-*`** (Nuxt UI, generados en runtime desde `app.config.ts`): nuevos. Los valores
  no se estimaron — se leyeron con `getComputedStyle(document.documentElement)` sobre la app real
  corriendo, `oklch()` incluido donde así lo devuelve el browser (es un color CSS válido; convertirlo a hex
  a mano es una oportunidad más de introducir un error, como pasó con `error` en #24).

`README.md` saca todo rastro de DaisyUI del esqueleto. El cambio que más vale explicar: el `@theme` de
Tailwind que activa clases reales como `bg-primary`/`text-primary` **tiene que ir inline en cada mockup**,
no puede vivir en el kit — verifiqué contra la doc oficial de Tailwind que el Play CDN solo lee `@theme` de
un `<style type="text/tailwindcss">`, nunca de una hoja de estilos enlazada con `<link>`. El esqueleto ya
lo trae listo, apuntando a `var(--ui-primary)` etc. del kit — un solo lugar con el valor real.

Sin componentes de librería: un botón en un mockup es utilidades de Tailwind con overrides completos
(`<button class="rounded-xl bg-primary px-6 py-3 font-bold text-white">`), el mismo patrón que quedó en el
código real de la landing tras la migración (`<UButton variant="link">` totalmente sobrescrito).

Es S-011 del plan de [la misión 01](https://github.com/PatricioTabilo/datealo/blob/main/docs/missions/01-migracion-nuxt-ui/ingenieria.md).

Sustento: A-004 (skill `arquitectura`).

## Test plan

- [x] Mockup de prueba armado fuera del repo (servido por HTTP local, con el kit real enlazado): probé
      `bg-primary`, `text-primary`, `text-secondary`, `bg-success/text-success` y `text-error` — los cinco
      reproducen el hex exacto de la app real (verificado pintando el pixel en un canvas, no solo leyendo
      el valor CSS declarado). En el camino encontré y arreglé el bug de `error` (#24).
- No aplica `npx nuxi typecheck`/`npm run build` como cambio funcional — son limpios de todas formas
  porque este PR no toca `app/`.

Closes #11