### PR TITLE
chore: agregar .claude/ y CLAUDE.md al repositorio

### DIFF
--- a/.claude/skills/arquitectura/SKILL.md
+++ b/.claude/skills/arquitectura/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: arquitectura
+description: Decisiones de arquitectura vigentes de Datealo y dónde va cada cosa al construir. Usar antes de crear un endpoint o una ruta de servidor, tocar la base de datos, agregar o migrar una tabla, escribir o revisar políticas RLS, conectar Supabase o Drizzle, manejar secretos y variables de entorno, desplegar a Vercel, o elegir un componente de interfaz. También al preguntar "¿dónde pongo esto?", "¿cómo creo este endpoint?", "¿esto necesita RLS?", "¿qué librería de UI usamos?" o "¿por qué está armado así?".
+---
+
+# Arquitectura de Datealo
+
+Las decisiones que valen para todo el producto y que ninguna misión decide por su cuenta: quién habla con
+la base de datos, dónde vive la autorización, cómo se conecta a Postgres y con qué se construye la interfaz.
+
+Un `ingenieria.md` las da por supuestas y las cita como sustento. No las re-decide.
+
+Este skill es operativo: dice qué hacer y dónde ponerlo. Cada decisión trae su porqué comprimido para que
+no se re-litigue, y su condición de reapertura para que tampoco quede congelada.
+
+## Estado: casi nada de esto está construido
+
+Datealo es pre-lanzamiento y lo único que existe es la landing. Antes de escribir código contra este
+documento, verificar qué hay:
+
+| Pieza                                    | Estado                                          |
+| ---------------------------------------- | ----------------------------------------------- |
+| `server/` (endpoints, schema, RLS)       | no existe — se crea en la primera misión con datos |
+| Supabase, Drizzle, `postgres.js`         | no instalados                                   |
+| DaisyUI v5                               | instalado y en uso en toda la landing            |
+| Nuxt UI v4                               | no instalado — A-004 es una migración pendiente  |
+
+**Consecuencia inmediata:** hasta que A-004 se ejecute, la interfaz se sigue escribiendo con DaisyUI. No
+escribir componentes `U*` en un repo que no tiene `@nuxt/ui` instalado.
+
+## A-001 — El browser nunca habla con Supabase, habla con Nitro
+
+**Estado:** propuesta. **Fecha:** 2026-08-11.
+
+Supabase se puede usar de dos formas opuestas. Como BaaS, el browser lleva la publishable key y consulta
+PostgREST directo: ese endpoint es público por diseño y toda la seguridad recae en las policies. Como base
+de datos a secas, el browser solo conoce `/api/*` del propio dominio.
+
+Datealo usa la segunda. El cliente pega a rutas de Nitro en el mismo origen, y esas rutas hablan con
+Postgres vía Drizzle. Ninguna credencial de Supabase ni cadena de conexión cruza al bundle del navegador.
+
+**La excepción es Auth.** La sesión de Supabase Auth vive en el browser porque tiene que vivir ahí, y la
+publishable key es pública por diseño. Lo que nunca baja es la secret key ni la cadena de conexión.
+
+**Al construir:**
+
+- Todo acceso a datos pasa por `server/api/`. Un componente que importa un cliente de Supabase y consulta
+  directo viola esta decisión, aunque funcione.
+- Los secretos van en `runtimeConfig` a secas. Lo que se pone en `runtimeConfig.public` queda embebido en
+  el JavaScript del cliente y se lee desde el código fuente de la página.
+- En `runtimeConfig.public` solo van la URL del proyecto y la publishable key.
+
+**Alternativas descartadas:** Supabase como BaaS con RLS como única defensa — expone la superficie completa
+de la base. Un backend separado (Express, Fastify) — agrega un despliegue y un origen más sin resolver nada
+que Nitro no resuelva.
+
+## A-002 — RLS es la red de seguridad, no el mecanismo de autorización
+
+**Estado:** propuesta. **Fecha:** 2026-08-11.
+
+RLS se evalúa contra el rol de Postgres y los claims del JWT, y PostgREST los setea en cada request. **Una
+conexión de Drizzle con la cadena de conexión normal entra como rol dueño y se salta RLS por completo.**
+Escribir las policies y consultar con Drizzle sin más las deja como decoración: no corren nunca.
+
+La autorización de Datealo vive en las rutas de `server/api/`, que ya son la única puerta por A-001. Las
+policies de `server/db/sql/rls.sql` se escriben igual, como respaldo para la superficie de Supabase y para
+el día que algo consulte por fuera del servidor.
+
+**Al construir, esto es lo que más se olvida:**
+
+- Cada endpoint que lee o escribe datos de un usuario verifica pertenencia **en el código**, explícitamente.
+  No alcanza con que exista la policy.
+- Cada tabla con datos de usuario igual nace con su policy en `server/db/sql/rls.sql`.
+- Cada tabla con datos de usuario lleva además una prueba de que un cliente anónimo no lee lo que no debe.
+
+El caso típico de Datealo tiene dos lados asimétricos: el perfil de un profesional es de **lectura pública**
+(es el producto) y de **escritura solo del dueño**. Una reseña la escribe el cliente y la lee todo el mundo.
+Confundir esos dos ejes es cómo se filtra un teléfono que el profesional no quería público.
+
+**Alternativa descartada:** forzar RLS real envolviendo cada query en una transacción con
+`set_config('request.jwt.claims', ...)` y `SET LOCAL ROLE authenticated`. Funciona y hay implementaciones de
+referencia, pero obliga a un wrapper en cada acceso a datos y el contexto no persiste fuera de la
+transacción. El costo no se justifica cuando el servidor ya es la única puerta.
+
+**Reapertura:** si alguna vez algo consulta la base sin pasar por `server/api/` —un job externo, una
+integración, el cliente de Supabase desde el browser—, esta decisión se revisa antes de construirlo.
+
+## A-003 — La conexión va por Supavisor en modo transacción
+
+**Estado:** propuesta. **Fecha:** 2026-08-11.
+
+Vercel corre funciones serverless y cada invocación abre su conexión. Contra Postgres directo se agota el
+límite apenas hay tráfico paralelo.
+
+| Uso                       | Destino                                        |
+| ------------------------- | ---------------------------------------------- |
+| Conexión de la app        | Supavisor transacción, `...pooler.supabase.com:6543` |
+| Migraciones de drizzle-kit| Conexión directa, puerto `5432`                |
+| Driver                    | `postgres.js` — el que documenta Drizzle para Supabase |
+| Preset de Nitro           | `vercel` (no `vercel-edge`: no tiene APIs de Node) |
+
+El modo transacción no soporta prepared statements y Drizzle los usa por defecto, así que la conexión se
+abre con `prepare: false`. Sin ese flag la app compila y falla en runtime contra el pooler — un error que
+no aparece en desarrollo local contra una base directa.
+
+Supavisor es además el único con IPv4 en todos los planes. La conexión directa es IPv6-only sin el add-on
+pagado.
+
+## A-004 — Nuxt UI v4 es la base de interfaz
+
+**Estado:** aceptada. **Fecha:** 2026-08-11.
+
+DaisyUI es un plugin de CSS: entrega clases, no comportamiento. Los bottom sheets, el combobox con búsqueda
+y los modales que pide el flujo core necesitan focus trap, navegación por teclado y roles ARIA, y con
+DaisyUI eso se escribe a mano cada vez. Nuxt UI v4 está construido sobre Reka UI y lo trae resuelto.
+
+Pesa que viene del core team de Nuxt, que en v4 el tier Pro pasó a ser gratuito, y que Datealo es
+mobile-first para usuarios con poca familiaridad con apps — accesibilidad a mano es donde ese perfil se
+pierde.
+
+**La migración todavía no ocurrió.** Mientras `@nuxt/ui` no esté en `package.json`, se escribe DaisyUI.
+Cuando ocurra, toca cuatro cosas y ninguna es solo la app:
+
+- `app/assets/css/main.css` pierde `@plugin "daisyui"` y el tema `[data-theme="datealo"]`. Los tokens
+  crudos quedan en `@theme` y el mapeo semántico pasa a `app.config.ts` bajo `ui.colors`.
+- Los ocho componentes de `app/components/landing/` se reescriben.
+- `docs/design/datealo-mockup-kit.css` deja de espejar DaisyUI, y esa parte de `docs/design/README.md`
+  se reescribe.
+- El skill `discovery-ux` tiene DaisyUI hardcodeado como base de todo elemento interactivo.
+
+**Alternativas descartadas:** quedarse en DaisyUI — cero migración y más liviano, pero traslada el costo de
+accesibilidad a cada misión que necesite un componente interactivo. shadcn-vue — mismo cimiento (Reka UI +
+Tailwind v4), pero cada componente pasa a ser código propio que mantener y auditar.
+
+**Reapertura:** si Nuxt UI resulta demasiado pesado para el presupuesto de carga en móvil con datos
+móviles, se revisa contra una medición concreta, no contra una impresión.
+
+## Dónde va cada cosa
+
+`CLAUDE.md` define la estructura de carpetas y la separación de responsabilidades del lado de la app. Esto
+completa el lado de servidor y datos, que ahí solo está esbozado.
+
+| Qué                                          | Dónde                                  |
+| -------------------------------------------- | -------------------------------------- |
+| Endpoint HTTP                                | `server/api/<recurso>.<método>.ts`     |
+| Regla de negocio o cálculo (función pura)    | `server/utils/<dominio>.ts`            |
+| Cliente de base de datos (singleton)         | `server/utils/db.ts`                   |
+| Schema de Drizzle                            | `server/db/schema/<entidad>.ts`        |
+| Políticas RLS                                | `server/db/sql/rls.sql`                |
+| Esquema de validación de entrada             | junto a su endpoint                    |
+| Secretos y config de runtime                 | `runtimeConfig` en `nuxt.config.ts`    |
+| Estado y acciones del cliente                | `app/composables/`                     |
+
+Dos fronteras que no se cruzan:
+
+- **La regla de negocio no vive en el handler.** Una función pura en `server/utils/` se prueba con una
+  llamada y un `expect`. La misma regla dentro de un `defineEventHandler` solo se prueba levantando Nitro y
+  la base. Esto aplica a ranking, distancia, agregación de rating y reglas de verificación — no a CRUD
+  simple, donde la abstracción cuesta y no rinde.
+- **El endpoint no decide presentación** y el composable no decide autorización.
+
+## Recetas concretas
+
+El código de cada operación —crear un endpoint con validación y verificación de pertenencia, montar el
+cliente de base de datos, agregar una tabla con su policy, tematizar Nuxt UI con un color de marca,
+configurar el despliegue— vive en [`references/recetas.md`](./references/recetas.md). Leerlo antes de
+escribir la primera de cada tipo, no a mitad de una.
+
+## Qué hacer cuando algo choca con esto
+
+Estas decisiones son el terreno, no una sugerencia. Si una misión necesita contradecirlas, el orden es:
+
+1. Nombrar la contradicción en el `ingenieria.md` de la misión, no resolverla en silencio en un PR.
+2. Si además cambia lo que el producto promete, entra primero como decisión en `producto.md`.
+3. Recién entonces se actualiza este skill, con la alternativa descartada anotada.
+
+Una limitación técnica puede influir en el recorte de alcance, pero no se presenta como necesidad de
+producto.

--- a/.claude/skills/arquitectura/references/recetas.md
+++ b/.claude/skills/arquitectura/references/recetas.md
@@ -1,0 +1,285 @@
+# Recetas de construcción
+
+El código concreto de cada operación que toca servidor, datos, interfaz o despliegue. Las decisiones que lo
+sustentan están en el [SKILL.md](../SKILL.md); acá está el cómo.
+
+De servidor y datos (A-001 a A-003), nada existe todavía en el repo: no hay `server/`, ni Supabase, ni
+Drizzle instalados. La primera misión que necesite datos crea la base, y esas recetas son su forma. De
+interfaz (A-004), la migración está en curso — ver la [misión 01](../../../../docs/missions/01-migracion-nuxt-ui/).
+
+## Contenido
+
+- [Instalar la base de datos](#instalar-la-base-de-datos)
+- [El cliente de base de datos](#el-cliente-de-base-de-datos)
+- [Secretos y runtimeConfig](#secretos-y-runtimeconfig)
+- [Un endpoint de lectura](#un-endpoint-de-lectura)
+- [Un endpoint de escritura, con su verificación](#un-endpoint-de-escritura-con-su-verificación)
+- [Agregar una tabla](#agregar-una-tabla)
+- [Desplegar a Vercel](#desplegar-a-vercel)
+- [Antes de dar por terminado un endpoint](#antes-de-dar-por-terminado-un-endpoint)
+- [Colores de marca y radio en Nuxt UI](#colores-de-marca-y-radio-en-nuxt-ui)
+
+## Instalar la base de datos
+
+```bash
+npm i drizzle-orm postgres
+npm i -D drizzle-kit
+npm i zod          # validación de entrada en los endpoints
+```
+
+`postgres.js` es el driver que documenta Drizzle para Supabase. No usar `node-postgres` salvo que aparezca
+una razón concreta, porque la doc oficial y los ejemplos asumen el primero.
+
+## El cliente de base de datos
+
+Un singleton perezoso en `server/utils/db.ts`. Nitro auto-importa lo que está en `server/utils/`, así que
+`useDb()` queda disponible en cualquier handler sin import.
+
+```ts
+// server/utils/db.ts
+import { drizzle } from 'drizzle-orm/postgres-js'
+import postgres from 'postgres'
+import * as schema from '../db/schema'
+
+let db: ReturnType<typeof drizzle<typeof schema>> | undefined
+
+export function useDb() {
+  if (!db) {
+    const { databaseUrl } = useRuntimeConfig()
+    // prepare: false es obligatorio contra Supavisor en modo transacción (A-003).
+    // Sin esto compila y falla en runtime, pero funciona en local contra una base directa.
+    const client = postgres(databaseUrl, { prepare: false })
+    db = drizzle({ client, schema })
+  }
+  return db
+}
+```
+
+El singleton importa: en serverless cada invocación reutiliza el módulo si el contenedor sigue caliente, y
+abrir una conexión por request agota el pooler.
+
+## Secretos y runtimeConfig
+
+```ts
+// nuxt.config.ts
+export default defineNuxtConfig({
+  runtimeConfig: {
+    // Privado: solo servidor. Nunca llega al bundle del cliente.
+    databaseUrl: '',
+    supabaseSecretKey: '',
+
+    public: {
+      // Público por diseño: la publishable key no es un secreto.
+      supabaseUrl: '',
+      supabaseKey: '',
+    },
+  },
+})
+```
+
+Nuxt mapea las variables de entorno con prefijo `NUXT_` a las claves de `runtimeConfig`, y `NUXT_PUBLIC_` a
+las de `public`:
+
+```bash
+# .env — nunca se commitea
+NUXT_DATABASE_URL=postgresql://postgres.<ref>:<pass>@aws-<region>.pooler.supabase.com:6543/postgres
+NUXT_SUPABASE_SECRET_KEY=...
+NUXT_PUBLIC_SUPABASE_URL=https://<ref>.supabase.co
+NUXT_PUBLIC_SUPABASE_KEY=...
+```
+
+**La regla que no se negocia:** todo lo que entra a `public` es legible desde el código fuente de la página.
+Antes de agregar una clave ahí, la pregunta es "¿me da lo mismo publicar esto en el README?".
+
+## Un endpoint de lectura
+
+```ts
+// server/api/professionals/[id].get.ts
+import { z } from 'zod'
+
+const params = z.object({ id: z.string().uuid() })
+
+export default defineEventHandler(async (event) => {
+  const { id } = await getValidatedRouterParams(event, params.parse)
+
+  const profile = await findPublicProfile(id)   // server/utils/professionals.ts
+  if (!profile) {
+    throw createError({ statusCode: 404, statusMessage: 'not_found' })
+  }
+
+  return profile
+})
+```
+
+El handler hace I/O y orquestación. La consulta y cualquier regla viven en `server/utils/`, donde se prueban
+sin levantar Nitro.
+
+## Un endpoint de escritura, con su verificación
+
+Este es el patrón que materializa A-002. La policy RLS existe, pero **no corre en esta conexión** — si la
+verificación de pertenencia no está en el código, no está en ninguna parte.
+
+```ts
+// server/api/professionals/[id].patch.ts
+import { z } from 'zod'
+
+const params = z.object({ id: z.string().uuid() })
+const body = z.object({
+  displayName: z.string().min(2).max(80).optional(),
+  phone: z.string().regex(/^\+56\d{9}$/).optional(),
+})
+
+export default defineEventHandler(async (event) => {
+  const user = await requireUser(event)   // valida la sesión en el servidor, nunca confía en el cliente
+  const { id } = await getValidatedRouterParams(event, params.parse)
+  const patch = await readValidatedBody(event, body.parse)
+
+  const owner = await findProfileOwnerId(id)
+  if (!owner) {
+    throw createError({ statusCode: 404, statusMessage: 'not_found' })
+  }
+
+  // A-002: acá vive la autorización real. La policy es respaldo, no el mecanismo.
+  if (owner !== user.id) {
+    throw createError({ statusCode: 403, statusMessage: 'forbidden' })
+  }
+
+  return updateProfile(id, patch)
+})
+```
+
+Devolver `404` en vez de `403` cuando el recurso no existe evita confirmarle a un tercero que un ID es
+válido. Cuando existe pero no es suyo, `403` es correcto y más útil para depurar.
+
+## Agregar una tabla
+
+Tres archivos cambian juntos, y el tercero es el que se olvida.
+
+**1. El schema** en `server/db/schema/<entidad>.ts`:
+
+```ts
+import { pgTable, uuid, text, timestamp } from 'drizzle-orm/pg-core'
+
+export const professionals = pgTable('professionals', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  userId: uuid('user_id').notNull(),
+  displayName: text('display_name').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+})
+```
+
+**2. La policy** en `server/db/sql/rls.sql`, con los dos ejes separados:
+
+```sql
+alter table professionals enable row level security;
+
+-- El perfil es el producto: lo lee cualquiera.
+create policy professionals_select_public on professionals
+  for select using (true);
+
+-- Lo edita solo su dueño.
+create policy professionals_update_own on professionals
+  for update using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+```
+
+**3. La verificación en el endpoint**, como en la receta anterior. Sin esto, los dos archivos anteriores no
+protegen nada por A-002.
+
+Las migraciones se generan con `drizzle-kit` contra la **conexión directa** (puerto `5432`), no contra el
+pooler. El `drizzle.config.ts` lleva esa URL, distinta de la que usa la app.
+
+## Desplegar a Vercel
+
+```ts
+// nuxt.config.ts
+export default defineNuxtConfig({
+  nitro: { preset: 'vercel' },
+})
+```
+
+`vercel` y no `vercel-edge`: edge corre en V8 sin APIs de Node y el driver de Postgres no funciona ahí.
+
+Las variables de entorno se cargan en Vercel bajo *Settings → Environment Variables*, con los mismos nombres
+`NUXT_*` del `.env` local. Vercel detecta Nuxt solo, así que el preset explícito es defensa contra que
+cambie el default, no un requisito.
+
+## Antes de dar por terminado un endpoint
+
+Además de `npx nuxi typecheck` y `npm run build` que exige `CLAUDE.md`:
+
+- [ ] La entrada está validada — params, query y body, no solo el body.
+- [ ] Si toca datos de un usuario, la pertenencia se verifica en el código (A-002).
+- [ ] La tabla tiene su policy en `rls.sql`, aunque la autorización real esté en el handler.
+- [ ] Hay una prueba de que un cliente anónimo no lee lo que no debe.
+- [ ] Ningún secreto entró a `runtimeConfig.public`.
+- [ ] Los errores devuelven código HTTP y cuerpo legibles, no un 500 genérico.
+- [ ] La regla de negocio quedó en `server/utils/`, no enterrada en el handler.
+
+## Colores de marca y radio en Nuxt UI
+
+Verificado al ejecutar S-001 de la migración — dejarlo acá evita que la próxima vez alguien tenga que
+volver a investigarlo a mitad de un slice.
+
+**Un color custom necesita su escala completa de 11 tonos (`50` a `950`), no un valor plano.** Nuxt UI
+referencia los tonos por número en sus componentes; un solo hex no alcanza. El `500` es el que se ve en el
+estado normal de un botón — ahí va el hex de marca exacto, para que el resultado sea indistinguible del
+que tenías antes.
+
+```css
+/* app/assets/css/main.css */
+@theme static {
+  --color-indigo-datealo-50: #F9F9FD;
+  --color-indigo-datealo-100: #F0EFFA;
+  --color-indigo-datealo-200: #CFCEF3;
+  --color-indigo-datealo-300: #A2A0E8;
+  --color-indigo-datealo-400: #726FDC;
+  --color-indigo-datealo-500: #423ED0;  /* el hex de marca exacto */
+  --color-indigo-datealo-600: #312DB8;
+  --color-indigo-datealo-700: #282598;
+  --color-indigo-datealo-800: #201E7B;
+  --color-indigo-datealo-900: #1D1B5F;
+  --color-indigo-datealo-950: #141343;
+}
+```
+
+`@theme static` y no `@theme`: sin `static`, Tailwind solo genera el CSS de los tonos que detecta usados
+en el código en build-time, y Nuxt UI los referencia dinámicamente por prop — se pierden tonos en
+producción si no se fuerza la generación completa.
+
+Si aparece un color de marca nuevo sin escala ya calculada, generarla en vez de estimarla a ojo: tomar el
+HSL del hex, mantener el mismo hue/saturación y variar la luminosidad según una curva pareja (50 ≈ 97% de
+luminosidad, 500 = la luminosidad real del hex de marca, 950 ≈ 14%), forzando que el escalón `500`
+reproduzca el hex original exacto.
+
+**El mapeo semántico va en `app/app.config.ts`, no en `main.css`.** Los tonos de arriba son crudos; acá se
+dice cuál es "primario":
+
+```ts
+// app/app.config.ts
+export default defineAppConfig({
+  ui: {
+    colors: {
+      primary: 'indigo-datealo',
+      secondary: 'turquesa-datealo',
+      neutral: 'gray',  // el gris de datealo (#1F2937/#6B7280) ya es gray-800/gray-500 de Tailwind
+    },
+  },
+})
+```
+
+Antes de crear una escala custom para un gris o un color de estado (éxito, error), comprobar si ya coincide
+con un color nativo de Tailwind — ahorra los 11 tonos.
+
+**El radio base se overridea como variable CSS, no en `app.config.ts`:**
+
+```css
+/* app/assets/css/main.css */
+:root {
+  --ui-radius: 0.5rem; /* default de Nuxt UI: 0.25rem */
+}
+```
+
+`--ui-radius` es un multiplicador que los componentes calculan internamente (`rounded-md`, `rounded-lg`,
+etc.), no un valor 1:1 con el `border-radius` final — no asumir que "quiero 1rem de radio" es
+`--ui-radius: 1rem` sin verificarlo visualmente primero.

--- a/.claude/skills/discovery-engineering/SKILL.md
+++ b/.claude/skills/discovery-engineering/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: discovery-engineering
+description: Investigación y documentación de ingeniería para features nuevas en Datealo. Usar cuando iteres sobre `ingenieria.md` de una misión, definas la arquitectura de un feature, diseñes contratos entre capas, evalúes factibilidad técnica, audites el código existente contra las decisiones vigentes de producto ("¿lo que ya tenemos sirve?", "audita lo que hay hoy"), planifiques el reemplazo de algo ya construido ("cómo migramos sin romper"), cortes un diseño en tareas atómicas ("slicing", "generar issues desde ingenieria.md", "plan de construcción"), o preguntes "¿cómo estructuramos esto?" o "¿cómo partimos esto en tareas?".
+---
+
+# Discovery de ingeniería en Datealo
+
+Este skill aplica cuando el foco es `ingenieria.md`: arquitectura, datos, contratos, RLS, migración y
+pruebas. Para el problema y el alcance, ver `discovery-product`. Para flujos e interacción, ver
+`discovery-ux`.
+
+**Las decisiones de arquitectura vigentes viven en el skill `arquitectura`** — quién habla con la base de
+datos, dónde vive la autorización, cómo se conecta a Postgres y con qué se construye la interfaz. Un
+`ingenieria.md` las da por supuestas y las cita como sustento; no las re-decide. Leerlo antes de diseñar:
+un diseño que las contradice sin nombrarlo produce slices que no se pueden mergear.
+
+## Vocabulario e invariantes alineados con producto
+
+Los diseños usan los términos decididos en las `D-xxx` de `producto.md` de la misión. El código puede usar
+inglés técnico (`Professional`, `Review`), y en ese caso `ingenieria.md` registra el mapeo término ↔
+entidad — así producto e ingeniería hablan de lo mismo aunque el schema hable en inglés.
+
+```markdown
+| Término de producto | Entidad/campo en código                    |
+| ------------------- | ------------------------------------------ |
+| profesional         | `professionals`                            |
+| zona de atención    | `professionals.service_areas` (por definir)|
+| reseña              | `reviews`                                  |
+| verificado          | `professionals.status = 'active'`          |
+```
+
+Invariante de diseño que viene de los guardrails de `CLAUDE.md`: el contacto sale directo hacia el
+profesional. Un diseño que introduce una bandeja intermedia, una cola de solicitudes o un paso de pago
+contradice una decisión vigente de producto y vuelve primero a `producto.md`.
+
+## Flujo y handoffs
+
+`ingenieria.md` cierra el discovery definiendo cómo se construye lo que producto y experiencia
+especificaron.
+
+```
+investigacion.md → producto.md → experiencia.md → ingenieria.md
+                        ↑                                ↑
+                        └────────────────────────────────┘  loop de vuelta si algo es inviable
+```
+
+**Qué recibe:** los flujos y estados de `experiencia.md` con sus casos límite y condiciones de error
+resueltos. **Excepción — misión técnica:** cuando no hay cambio de producto observable y la decisión ya
+está tomada como `A-xxx` del skill `arquitectura`, `ingenieria.md` se escribe solo, sin los otros tres
+documentos, citando el `A-xxx` donde el template pide un `F-xxx`. Ver
+[tipos de misión](../../../docs/missions/README.md#tipos-de-misión).
+
+**Un documento a la vez:** `ingenieria.md` se trabaja cuando el dueño de producto da el paso explícito — no
+en paralelo a una revisión de producto o experiencia "para mantenerlo alineado". Diseñar sobre definiciones
+en revisión se paga dos veces.
+
+**Gate de salida — `ingenieria.md` está lista para construir cuando:**
+
+- los contratos entre capas están definidos (qué entra, qué sale, qué invariantes se mantienen)
+- el modelo de datos soporta los casos límite de `producto.md` sin workarounds
+- el impacto en RLS está resuelto explícitamente: qué policy se crea o cambia, o por qué ninguna
+- cada dato de usuario nombra **dónde se verifica la pertenencia en el servidor**, no solo su policy
+- el diseño respeta las decisiones del skill `arquitectura`, o nombra cuál contradice y por qué
+- la migración de datos existentes tiene estrategia concreta o está explícitamente fuera del alcance
+- los escenarios críticos tienen criterio de prueba antes de considerar el feature listo
+- el diseño está cortado en slices (ver [Slicing](#slicing-del-diseño-a-tareas-atómicas)) y el plan de
+  construcción vive en la sección homónima de `ingenieria.md`
+
+**Loop de vuelta:** si ingeniería descubre que algo es inviable, el cambio entra primero en `producto.md`
+como recorte de alcance con trade-off explícito, luego se actualiza `experiencia.md`, y por último
+`ingenieria.md`.
+
+**Aprobación:** Claude propone y marca `en revisión`; `vigente` lo otorga solo el dueño de producto.
+
+## Auditoría sin lealtad al código existente
+
+`ingenieria.md` empieza auditando lo que ya existe —schema, endpoints, composables, políticas RLS— porque
+diseñar sin ese mapa produce decisiones que ya estaban resueltas o ya estaban rotas. Pero la auditoría es
+insumo, no ancla: cuánto código ya existe no es un criterio para elegir un diseño. Cada opción —mantener,
+extender o reemplazar— se compara contra las decisiones vigentes de `producto.md` y `experiencia.md` por
+sus méritos, no por el costo de rehacerla.
+
+Si lo existente contradice una decisión vigente, `ingenieria.md` lo nombra como contradicción, no como
+ajuste menor.
+
+```
+❌ Títere de lo existente: "El composable de búsqueda ya filtra por categoría;
+   le agregamos el orden por distancia sin tocar el resto."
+   (sigue trayendo todos los perfiles al cliente para filtrar en memoria — no escala
+   ni sirve para el ranking que pide D-004)
+
+✅ Crítico: "El filtro actual ocurre en el cliente sobre una lista completa. D-004 exige
+   ordenar por distancia contra la ubicación del usuario, que es una consulta geográfica
+   del servidor. Son dos diseños distintos, no un filtro más — el orden se mueve a la
+   query, conservando el composable como consumidor."
+```
+
+Esto corta en ambas direcciones: tan títere es defender el código actual sin cuestionarlo como proponer un
+rediseño completo cuando un ajuste acotado ya cumple el contrato. La pregunta no es "¿cambiamos todo?" sino
+"¿lo existente cumple la decisión vigente, sí o no?".
+
+## Qué se ve concreto en Datealo
+
+`ingenieria.md` debe describir contratos y datos al nivel en que se puede implementar sin reuniones de
+aclaración. Si el diseño no especifica qué entra, qué sale y qué invariantes se mantienen, está incompleto.
+
+```
+❌ Abstracto: "El endpoint de búsqueda devolverá los profesionales relevantes para el usuario"
+
+✅ Concreto: "GET /api/search recibe { category: string, lat?: number, lng?: number,
+   comuna?: string, cursor?: string } y devuelve { results: SearchResult[], nextCursor: string | null }.
+   SearchResult = { id, displayName, category, comuna, distanceKm: number | null,
+   rating: number | null, reviewCount: number, isVerified: boolean, photoUrl: string | null }.
+   Sin lat/lng ni comuna → 400 { error: 'location_required' }. distanceKm es null cuando
+   se buscó por comuna y no por coordenadas — el orden entonces es por rating, no por distancia."
+```
+
+```
+❌ "Se agregará una tabla para guardar las zonas de atención"
+
+✅ "Nueva tabla professional_service_areas: professional_id (FK), comuna_code TEXT,
+   PRIMARY KEY (professional_id, comuna_code). Un profesional sin ninguna fila no aparece
+   en resultados por comuna. RLS: lectura pública, escritura solo del dueño del perfil."
+```
+
+## Principio central: la lógica pura vive fuera de la infraestructura
+
+Para features con reglas o cálculos propios (ranking de resultados, cálculo de distancia, agregación de
+rating, reglas de verificación), la lógica se escribe como **funciones puras** y la infraestructura
+—Drizzle, `event`, Supabase, reactividad de Vue— la envuelve.
+
+El motivo es práctico: la lógica pura se prueba con una llamada y un `expect`, sin base de datos ni
+servidor. La misma regla escrita dentro de un handler de Nitro solo se puede probar levantando todo.
+
+```ts
+// ✅ La regla vive en una función pura, testeable sin infraestructura
+// server/utils/ranking.ts
+export function rankResults(candidates: Candidate[], origin: Coords | null): Candidate[] {
+  /* orden por distancia, con rating como desempate */
+}
+
+// server/api/search.get.ts — solo I/O y orquestación
+export default defineEventHandler(async (event) => {
+  const query = getValidatedQuery(event, searchQuerySchema.parse)
+  const candidates = await findCandidates(query)
+  return rankResults(candidates, query.coords)
+})
+
+// ❌ La regla enterrada en el handler: para probar el orden hay que levantar Nitro y la DB
+export default defineEventHandler(async (event) => {
+  const rows = await db.select()/* ... */
+  return rows.sort((a, b) => /* 30 líneas de reglas de ranking */)
+})
+```
+
+Cuando la lógica además puede **cambiar de forma** (un motor de ranking que se va a reemplazar, un
+proveedor de geocoding que puede cambiar), el contrato se define con una interfaz y la implementación se
+inyecta. Su valor real no es elegancia: es que vuelve cortable la sustitución (ver
+[Cortar un reemplazo de código vivo](./references/slicing.md#cortar-un-reemplazo-de-código-vivo)).
+
+No aplicar a CRUD simple ni a features de presentación — la abstracción tiene costo real y no hay
+beneficio si la lógica no cambia de forma.
+
+## RLS no es un paso posterior, y tampoco es la autorización
+
+Toda tabla con datos de usuario nace con su política. `ingenieria.md` resuelve, para cada cambio de schema:
+qué policy se crea o cambia, o por qué ninguna hace falta. La fuente de verdad es `server/db/sql/rls.sql`.
+
+El caso típico de Datealo tiene dos lados asimétricos y conviene escribirlo explícito: el perfil de un
+profesional es **de lectura pública** (es el producto) y **de escritura solo del dueño**. Una reseña la
+escribe el cliente y la lee todo el mundo. Confundir esos dos ejes es cómo se filtra un teléfono que el
+profesional no quería público.
+
+**La policy sola no protege.** Por A-002 del skill `arquitectura`, la conexión de Drizzle entra como rol
+dueño y se salta RLS: la autorización real vive en el código de `server/api/`. Por eso el diseño no está
+completo cuando nombra la policy — tiene que nombrar además **en qué endpoint se verifica la pertenencia**.
+Un `ingenieria.md` que solo dice "RLS: lectura pública, escritura del dueño" describe una defensa que no
+corre.
+
+## Preguntas para evaluar la factibilidad en discovery
+
+- ¿La lógica de negocio está separada de Drizzle, del handler y de la reactividad?
+- ¿Los contratos de datos entre capas están definidos antes de la implementación?
+- ¿El diseño de datos soporta los casos límite de `producto.md`, empezando por "no hay resultados"?
+- ¿Qué pasa si Supabase responde lento o falla? ¿La pantalla degrada con gracia?
+- ¿Qué policy RLS toca este cambio?
+- ¿La consulta escala más allá de una comuna, o asume que caben todos los perfiles en memoria?
+- ¿Hay decisiones de arquitectura que podrían invalidar el alcance de la entrega?
+- ¿El diseño encaja con las decisiones vigentes de producto y experiencia, o solo se adapta lo mínimo para
+  no rehacerlo?
+
+## Slicing: del diseño a tareas atómicas
+
+El último paso del discovery de ingeniería convierte el diseño en un plan de construcción: una lista
+ordenada de slices donde cada slice es un cambio funcional atómico — un Issue, un PR (el flujo de
+`CLAUDE.md`). El plan vive en la sección "Plan de construcción" de `ingenieria.md`.
+
+Cortar recién cuando el gate de salida se cumple y ninguna pregunta bloqueante sigue abierta: slicing sobre
+decisiones abiertas produce issues que mueren.
+
+**El método completo vive en [`references/slicing.md`](./references/slicing.md)** — cómo encontrar los
+slices desde las costuras del diseño, qué eje de corte usar según dónde está la incertidumbre, cómo cortar
+el reemplazo de código que ya está en producción, qué hace atómico a un slice, y cómo ordenarlos por
+riesgo. Leerlo al armar el plan de construcción o al generar issues desde `ingenieria.md`.
+
+Al crear las tarjetas (issues) desde el plan, la validación de
+[trazabilidad](./references/slicing.md#validar-antes-de-crear-la-tarjeta) corre siempre, sin que se pida
+aparte: cada tarjeta se abre solo si su sustento (`D-xxx`, `TC-xxx`) existe, sigue vigente y queda copiado
+en el cuerpo del issue.
+
+## Relación con `producto.md` y `experiencia.md`
+
+Una limitación técnica puede influir en el recorte, pero no debe presentarse como necesidad de producto. Si
+ingeniería descubre que algo es inviable, el cambio se registra primero en `producto.md` como decisión de
+alcance con su trade-off, y luego se actualiza `ingenieria.md`.
+
+Para patrones de Nuxt y Nitro, ver `.agents/skills/nuxt/`. Para schemas y queries, ver
+`.agents/skills/drizzle-orm/`. Para extraer composables y componentes al implementar, ver el skill
+`vue-composition`.

--- a/.claude/skills/discovery-engineering/references/slicing.md
+++ b/.claude/skills/discovery-engineering/references/slicing.md
@@ -1,0 +1,235 @@
+# Slicing: del diseño a tareas atómicas
+
+Convierte un `ingenieria.md` cerrado en un plan de construcción: una lista ordenada de slices donde cada
+slice es un cambio funcional atómico — un Issue, un PR (el flujo de `CLAUDE.md`). El plan vive en la
+sección "Plan de construcción" de `ingenieria.md`; los issues se crean desde ahí cuando el usuario lo pida.
+
+## Contenido
+
+- [Cuándo cortar](#cuándo-cortar)
+- [Cómo encontrar los slices](#cómo-encontrar-los-slices)
+- [Qué eje de corte usar](#qué-eje-de-corte-usar)
+- [Cortar un reemplazo de código vivo](#cortar-un-reemplazo-de-código-vivo)
+- [Qué hace atómico a un slice](#qué-hace-atómico-a-un-slice)
+- [Lo que la arquitectura obliga a cortar junto](#lo-que-la-arquitectura-obliga-a-cortar-junto)
+- [Trazabilidad para detectar obsolescencia](#trazabilidad-para-detectar-obsolescencia)
+- [Validar antes de crear la tarjeta](#validar-antes-de-crear-la-tarjeta)
+- [Ejemplo](#ejemplo)
+- [Orden y dependencias](#orden-y-dependencias)
+
+## Cuándo cortar
+
+Cortar recién cuando el gate de salida se cumple y las preguntas que bloquean construcción están resueltas.
+Slicing sobre decisiones abiertas produce issues que mueren: un cambio de modelo posterior no invalida un
+issue, invalida la tanda completa, y hay que redactarla dos veces.
+
+## Cómo encontrar los slices
+
+Los slices se derivan de las **costuras del diseño** — los lugares donde el sistema ya está partido y por
+lo tanto se puede construir y verificar una parte sin la otra:
+
+| Costura                                          | Slice candidato                                                 |
+| ------------------------------------------------ | --------------------------------------------------------------- |
+| Cada `TC-xxx` de Contratos                       | Su entrada/salida ya está definida: se implementa y testea sola |
+| Cada tabla nueva                                 | El schema, su policy y la verificación que la hace valer (ver abajo) |
+| Cada capa (función pura → endpoint → composable → componente) | El comportamiento de esa capa con las demás simuladas |
+| Cada paso de un cambio de datos                  | Un paso del expand/contract, nunca la migración completa        |
+
+El procedimiento: enumerar las costuras, y para cada candidato preguntar *"¿esto se puede mergear solo,
+dejando el sistema consistente?"*. Si sí, es un slice. Si no, le falta un predecesor — y ese predecesor es
+otro slice que todavía no estaba en la lista.
+
+La lista de funcionalidades es la fuente equivocada: una `F-xxx` es una unidad de valor para el usuario y
+un slice es una unidad de cambio para el código, y casi nunca coinciden. Un slice por funcionalidad produce
+issues-feature imposibles de revisar.
+
+## Qué eje de corte usar
+
+La pregunta que decide el eje es **dónde está la incertidumbre**, no qué es más ordenado:
+
+- **Riesgo en el algoritmo o las reglas** (ranking, cálculo de distancia, agregación de rating) → cortar
+  **horizontal** sobre la lógica pura: cada slice es una capacidad, verificable sin base de datos ni
+  servidor. Costo aceptado: los primeros slices no entregan nada visible, así que el plan **debe nombrar
+  explícitamente el slice de integración** que los expone.
+- **Riesgo en la integración** (¿el contrato aguanta?, ¿funciona punta a punta?, ¿la query rinde?) → cortar
+  **vertical**: primero un *walking skeleton*, el camino más delgado que atraviesa todas las capas con el
+  caso más trivial, y engrosarlo después.
+
+```markdown
+Walking skeleton de la búsqueda (el riesgo está en la integración, no en el ranking):
+
+S-001 "Listar los profesionales de una categoría en una comuna, sin orden ni filtros"
+      Atraviesa endpoint → composable → lista de cards con el caso más simple.
+      Acepta: una comuna con 3 perfiles activos devuelve 3 cards con nombre y oficio;
+      una comuna sin perfiles muestra el estado vacío de UXF-001.
+
+Los slices siguientes engrosan ese esqueleto —orden por distancia, filtros, mapa— sin
+volver a tocar el contrato entre capas, que quedó probado en el primero.
+```
+
+En Datealo, con producto nuevo y pocas capas construidas, el default es **vertical**: casi todo el riesgo
+está en que el camino completo exista, no en un cálculo. El corte horizontal aparece cuando la misión trae
+un motor propio (ranking geográfico, reglas de verificación).
+
+**Señal de que elegiste mal el eje:** seis slices mergeados y todavía no hay nada que se pueda probar en la
+aplicación.
+
+## Cortar un reemplazo de código vivo
+
+Reemplazar código que ya está desplegado se corta como **convivencia**: el reemplazo nace al lado de lo
+viejo, ambos coexisten, y la sustitución ocurre al final. Un slice "reemplazar X" no deja verde nunca.
+
+```markdown
+Reemplazar el filtrado en cliente por búsqueda en servidor (Branch by Abstraction):
+
+S-001 Introducir la interfaz `SearchProvider` sobre el comportamiento actual, sin cambiarlo.
+      Acepta: mismos resultados que hoy en todos los casos existentes.
+S-002..N Implementar el provider de servidor detrás de la misma interfaz, sin conectarlo.
+      Acepta: el provider nuevo pasa sus propios tests; la app sigue usando el viejo.
+S-N+1 Conmutar el consumidor al provider nuevo.
+      Acepta: el flujo UXF-001 completo funciona contra el provider nuevo.
+S-N+2 Borrar el provider viejo y su código muerto.
+      Acepta: no quedan imports ni utilidades del filtrado en cliente.
+```
+
+Para cambios de datos, la misma lógica en pasos (*expand/contract*): agregar los campos nuevos → escribir
+en ambos → backfill de lo existente → leer del nuevo → borrar el viejo. Cada paso es un slice; "migrar el
+campo" como slice único deja el sistema inconsistente a mitad de camino. En Supabase, cada paso lleva su
+revisión de RLS: una columna nueva que participa de una policy cambia el paso, no solo el schema.
+
+**El slice de borrado es obligatorio y entra al plan desde el principio.** Sin un issue propio no ocurre:
+el código viejo queda vivo y aparece meses después como deuda que nadie recuerda.
+
+## Qué hace atómico a un slice
+
+Un slice está bien cortado cuando un modelo simple puede ejecutarlo sin haber leído la misión:
+
+- **Pass/fail sin juicio:** los criterios de aceptación se pueden enumerar como tests concretos. "El
+  endpoint valida la entrada" es verificable; "el endpoint es robusto" no. Este es el filtro que de verdad
+  descarta un slice mal cortado — si no puedes escribir sus criterios, no está cortado.
+- **Autocontenido:** el issue lleva su contrato inline — entrada, salida, invariantes y ejemplos de
+  aceptación copiados o resumidos, no solo enlazados. El enlace a `F-xxx`/`D-xxx`/`TC-xxx` es para
+  trazabilidad, no para que el ejecutor reconstruya contexto.
+- **Dentro de un límite claro:** un slice vive en una capa y un dominio. Si necesita cruzar —el endpoint
+  necesita una tabla que no existe—, el cruce es su propio slice y va antes.
+- **Sin decisiones pendientes:** si al ejecutarlo habría que decidir algo que no está escrito en la misión,
+  el slice es prematuro o el diseño está incompleto — volver al documento, no decidir en el PR. Esto
+  incluye verificar cómo funciona una librería o API externa que el slice asume: si el criterio de
+  aceptación depende de un mecanismo concreto (¿esta librería necesita una escala de colores completa o un
+  valor plano? ¿el override va en config o en una variable de runtime?), esa verificación se hace al
+  escribir `ingenieria.md` y su resultado queda en una receta del skill `arquitectura` — no se investiga
+  por primera vez a mitad de la ejecución, porque ahí un hallazgo incómodo invalida trabajo ya empezado en
+  vez de solo una fila del documento.
+- **Deja verde:** cada slice mergeado deja `npx nuxi typecheck` y `npm run build` pasando, y el sistema
+  consistente. Un slice que necesita "el que sigue" para no romper es un slice mal cortado.
+- **Respeta los umbrales de salud:** si el slice empuja un componente o composable a zona roja, la
+  extracción es parte del slice, no un issue aparte (ver el skill `vue-composition`).
+- **Una frase sin "y":** señal débil, útil solo como primer descarte. "implementar la búsqueda de
+  profesionales" es una frase sin conjunciones y aun así son semanas — la abstracción esconde el alcance.
+  Si la frase pasa pero los criterios no son enumerables, gana el criterio.
+
+## Lo que la arquitectura obliga a cortar junto
+
+Las decisiones del skill `arquitectura` no solo dicen cómo construir: cambian dónde **no** se puede cortar.
+Un slice que deja el sistema inseguro a mitad de camino está mal cortado aunque compile y aunque su frase
+no lleve "y".
+
+**Una tabla con datos de usuario entra con su verificación, no después.** Por A-002 la policy RLS no corre
+en la conexión de Drizzle, así que el slice tiene que incluir los tres pedazos: schema, policy y la
+verificación de pertenencia en el endpoint que la expone.
+
+```markdown
+❌ S-004 "Crear la tabla professional_service_areas con su policy de escritura del dueño"
+   S-007 "Verificar pertenencia al editar zonas de atención"
+   — entre el merge de S-004 y el de S-007, cualquiera edita las zonas de cualquiera.
+     La policy existe y no corre. El hueco vive en main tres PRs.
+
+✅ S-004 "Permitir que un profesional edite sus zonas de atención, solo las suyas"
+   Acepta: el dueño actualiza y recibe 200; otro usuario autenticado recibe 403;
+   un anónimo recibe 401; la policy existe en rls.sql.
+```
+
+Eso no colapsa toda la tabla en un slice gigante. Si la tabla se lee público antes de poder escribirse, el
+slice de lectura va solo y el de escritura trae su verificación cuando llega.
+
+**Dos cortes más que vienen de la arquitectura:**
+
+- **La primera misión que toque datos necesita un slice de fundación antes que cualquier endpoint**: el
+  cliente de `server/utils/db.ts`, la conexión por el pooler con `prepare: false` y el `runtimeConfig`. Sin
+  eso el segundo slice no puede dejar verde.
+- **Las capas de A-001 son las costuras naturales** — función pura en `server/utils/` → endpoint →
+  composable → componente. Cortar sobre ellas sale gratis porque el diseño ya está partido ahí.
+
+## Trazabilidad para detectar obsolescencia
+
+Cada issue nombra las decisiones (`D-xxx`, `T-xxx`) que lo sustentan. El porqué: cuando una decisión
+cambia, buscar esa etiqueta en los issues abiertos entrega la lista exacta de tareas a reescribir o cerrar
+— sin eso, la auditoría es releer todo el backlog contra toda la misión.
+
+Esa trazabilidad depende por completo de que el texto quede bien escrito en el issue. Nada en GitHub la
+verifica — por eso el paso siguiente es obligatorio, no opcional, cada vez que se crean tarjetas.
+
+## Validar antes de crear la tarjeta
+
+Este chequeo corre solo, como parte de crear los issues desde el "Plan de construcción" — no es una
+auditoría aparte que alguien pide después. Se hace en dos momentos: antes de abrir cada tarjeta, y una vez
+al final del lote.
+
+**Antes de abrir cada tarjeta**, por cada fila `S-xxx` del plan:
+
+- La columna "Sustento" no está vacía y cada ID que lista (`D-xxx`, `TC-xxx`, `F-xxx`) existe de verdad en
+  `producto.md` o `ingenieria.md` — no es un ID inventado ni uno que se retiró sin que el slice se haya
+  actualizado.
+- Ningún ID de sustento apunta a una decisión en estado `reemplazada` o `descartada`. Si eso pasa, el
+  slice quedó desactualizado respecto al documento — se corrige el sustento antes de crear la tarjeta, no
+  después.
+- El cuerpo del issue **copia** la línea de sustento tal cual ("Sustento: TC-002, D-003"), no solo enlaza
+  a la misión. Es lo que hace que buscar "D-003" en GitHub encuentre esta tarjeta más adelante.
+- Los labels `type:*` y `scope:*` que le corresponden ya existen en el repo. Si no existen, se crean antes
+  de asignarlos — no se abre el issue sin label y "se etiqueta después".
+
+**Al terminar el lote**, antes de darlo por cerrado:
+
+- Cada fila del Plan de construcción tiene su número de issue anotado — ningún slice quedó cortado en el
+  documento sin su tarjeta correspondiente.
+- Se repasa la lista de issues recién creados y se confirma que todos llevan su línea de sustento, no solo
+  los primeros.
+
+Si algo de esto falla, se corrige antes de seguir — un lote de tarjetas sin trazabilidad limpia es el
+mismo problema que describe la sección anterior, solo que recién creado.
+
+## Ejemplo
+
+```markdown
+❌ Un issue-feature:
+"feat(app): implementar búsqueda de profesionales con filtros y mapa"
+— 8 bullets de alcance, 6 criterios, 3 dependencias.
+Mezcla schema, endpoint, ranking, lista, mapa y estados vacíos: semanas de trabajo,
+PR imposible de revisar, y cualquier cambio de modelo lo invalida entero.
+
+✅ Slices del mismo trabajo (cada uno un Issue → un PR):
+S-001 "Crear la tabla professional_service_areas con su policy de lectura pública"
+Sustento: TC-002, D-003. Acepta: un profesional con dos comunas devuelve dos filas;
+un usuario anónimo puede leerlas; solo el dueño puede insertarlas.
+S-002 "Devolver los profesionales activos de una categoría y comuna, sin orden"
+Sustento: TC-001. Acepta: categoría con 3 perfiles activos y 1 inactivo devuelve 3;
+comuna sin perfiles devuelve `{ results: [], nextCursor: null }`, no un 404.
+S-003 "Ordenar los resultados por distancia cuando la petición trae coordenadas"
+Sustento: TC-001, D-004. Acepta: con origen en Ñuñoa, el de Ñuñoa va antes que el de
+Maipú; sin coordenadas, `distanceKm` es null y el orden cae a rating.
+```
+
+## Orden y dependencias
+
+Los slices se ordenan para que cada uno construya sobre lo ya mergeado. Las dependencias se declaran en el
+issue ("requiere S-002") solo cuando son reales; una cadena lineal artificial serializa trabajo que podía
+avanzar en paralelo.
+
+**Entre dos slices sin dependencia entre sí, va antes el que puede invalidar el diseño.** Un slice que
+demuestra que el modelo no aguanta cuesta un PR si va primero, y seis PRs botados si va séptimo. El orden
+lo fija el riesgo, no la comodidad de construir lo fácil primero.
+
+Un riesgo `TR-xxx` que no se puede cerrar con un slice entregable se corta como **spike acotado**:
+pregunta, límite de tiempo y resultado capaz de cerrar la incertidumbre. Va en el plan marcado como no
+entregable y su resultado vuelve a la tabla de riesgos de `ingenieria.md` — el código de un spike no se
+mergea.

--- a/.claude/skills/discovery-product/SKILL.md
+++ b/.claude/skills/discovery-product/SKILL.md
@@ -1,0 +1,333 @@
+---
+name: discovery-product
+description: Investigación y documentación de producto para features nuevas en Datealo. Usar cuando iteres sobre `investigacion.md` o `producto.md` de una misión, explores un problema de usuario, investigues cómo lo resuelven otros marketplaces de servicios, o definas funcionalidades y alcance. También cuando alguien pregunte "¿cómo lo resuelven otros productos?", "¿qué evidencia tenemos para esto?" o "¿esto entra en el MVP?".
+---
+
+# Discovery de producto en Datealo
+
+Este skill cubre dos documentos con naturalezas distintas:
+
+- **`investigacion.md`** — se acumula, no se reescribe: evidencia, benchmarks, conclusiones y el ideal.
+- **`producto.md`** — spec viva del resultado: funcionalidades JTBD, reglas, señales y decisiones de alcance.
+
+Para flujos e interacción, ver `discovery-ux`. Para arquitectura y contratos, ver `discovery-engineering`.
+
+El conocimiento del dominio vive en las misiones de `docs/missions/`, en `CLAUDE.md` y en el producto mismo
+— es punto de partida, no restricción. Si la investigación indica que una entidad o un término tiene
+problemas, la evidencia gana sobre el modelo actual.
+
+## Qué es Datealo — el sesgo que filtra toda funcionalidad
+
+Datealo es un buscador de profesionales de servicios: alguien tiene un problema concreto y necesita a la
+persona correcta, cerca, hoy. Toda funcionalidad propuesta pasa por estos filtros antes de entrar a
+`producto.md`:
+
+- **El flujo core es sagrado.** buscar → resultados → perfil → contactar. Una funcionalidad que agrega un
+  paso a ese camino necesita justificar por qué el resultado sin ella es peor, no solo por qué es útil.
+- **La confianza se muestra, no se promete.** Verificación, reseñas de personas reales, fotos de trabajos
+  hechos. Un badge sin respaldo verificable es peor que no tenerlo: transfiere a Datealo la culpa del mal
+  servicio.
+- **El contacto es directo y sin intermediación.** WhatsApp o teléfono, sin formularios de cotización, sin
+  subastas, sin pago para desbloquear. Cualquier concepto que ponga a Datealo entre las dos personas
+  necesita una decisión de producto explícita, no entra por conveniencia técnica.
+- **Chileno y hablado.** El copy de la landing es la referencia de tono: "¿Alguien cacha un gasfiter
+  bueno?" no es un chiste, es el lenguaje del usuario.
+
+### El arranque en frío no es un detalle, es una restricción de diseño
+
+Datealo es un marketplace de dos lados y está pre-lanzamiento: cero profesionales, cero reseñas, cero
+búsquedas. Toda funcionalidad del lado buscador depende de que exista oferta del otro lado.
+
+Por eso cada `F-xxx` declara **a qué lado sirve** y **qué necesita del otro lado para entregar su
+resultado**. Y por eso el estado vacío no es un caso límite decorativo: para muchas búsquedas será el
+estado principal durante meses.
+
+```
+❌ "F-004: filtrar resultados por rating mínimo, disponibilidad y rango de precio"
+   (con 6 profesionales en una comuna, tres filtros combinados devuelven cero siempre)
+
+✅ "F-004: ordenar resultados por cercanía, con el filtro de categoría como único corte.
+   Los filtros por rating y precio entran cuando una categoría-comuna promedie 15+ perfiles
+   (ver Fuera de alcance)."
+```
+
+La pregunta que corre este filtro: **¿esta funcionalidad sigue entregando su resultado con la oferta que
+tenemos hoy?** Si la respuesta es no, la funcionalidad no está mal — está fuera de fase, y su fila va a
+"Fuera de alcance" con la condición que la reabre.
+
+### El test del concepto importado
+
+Yelp, Thumbtack, Angi y Airbnb son marketplaces maduros: millones de perfiles, equipos de moderación,
+años de datos de comportamiento. Sus soluciones asumen esa escala. Antes de aceptar un concepto de una de
+esas fuentes:
+
+1. ¿Funciona con la oferta y el volumen que Datealo tendrá el primer año? (no con el que quisiéramos)
+2. ¿Quién lo opera? Un concepto que exige moderación humana continua no tiene quién lo sostenga hoy.
+3. ¿Se puede explicar usando solo cosas que ya existen en Datealo?
+
+Si explicarlo exige inventar pantallas, rituales o roles hipotéticos, el concepto aún no pertenece al
+producto: registrarlo como hipótesis en "Fuera de alcance" con su condición de reconsideración.
+
+## El vocabulario es una decisión de producto
+
+El idioma canónico es el del usuario chileno, no el de las fuentes ni el del código. Un término nuevo entra
+a los documentos solo definido y aprobado por el dueño de producto, registrado como decisión `D-xxx` en
+`producto.md` — no en un glosario aislado. Producto, experiencia e ingeniería usan el mismo término.
+
+```
+❌ "El prestador de servicios recibe leads calificados en su bandeja"
+   (jerga de marketplace — ninguna de esas tres palabras existe para un gasfiter)
+
+✅ "El profesional recibe el mensaje directo del cliente por WhatsApp"
+```
+
+Términos semilla en uso hoy (landing y código), pendientes de confirmar como `D-xxx` en la primera misión
+que los toque: **profesional** (no "prestador" ni "proveedor"), **buscador** o **cliente** para el otro
+lado, **zona** y **comuna** para geografía, **reseña** (no "review" ni "valoración"), **categoría**,
+**verificado**.
+
+## Flujo y handoffs
+
+```
+investigacion.md → producto.md → experiencia.md → ingenieria.md
+        ↑               ↑                ↑
+        └───────────────┴────────────────┘  (loops de vuelta vía decisiones en producto.md)
+```
+
+**`investigacion.md` no se aprueba.** Es un registro que se acumula: informa al producto pero no lo
+autoriza, y no bloquea nada. Está en buena forma cuando el problema tiene situación y consecuencia
+concretas (no "falta confianza"), alguna conclusión respalda la dirección y el ideal describe capacidades
+observables. El único documento que el dueño de producto aprueba es `producto.md`.
+
+**Gate de `producto.md`** — está listo para `experiencia.md` cuando:
+
+- cada funcionalidad tiene formato JTBD, reglas y al menos un caso límite definido
+- cada funcionalidad enlaza una conclusión de `investigacion.md` y una señal de éxito
+- cada funcionalidad declara su lado del marketplace y qué necesita del otro lado
+- no hay decisiones de producto delegadas a diseño o ingeniería
+- las decisiones propuestas tienen fecha límite en el README de la misión
+
+**Aprobación:** Claude propone y marca `en revisión`; `vigente` lo otorga solo el dueño de producto. Toda
+decisión `propuesta` lleva fecha límite — sin deadline es pocket veto.
+
+**El producto puede decidir en contra de la evidencia, a propósito.** Investigar algo y hacer lo contrario
+es una jugada válida: la evidencia informa, el dueño de producto decide. Cuando pase, la conclusión
+afectada lleva una "Revisión (fecha)" que diga qué se decidió en contra, por qué y qué parte de ella
+sobrevive — nunca se borra ni se reescribe para que calce. Sin esa marca, la próxima lectura la toma como
+vigente y reabre lo ya decidido.
+
+**Loop de vuelta:** si UX o ingeniería invalidan algo, el cambio entra primero como decisión `D-xxx` en
+`producto.md`. Si además cambia la dirección, el ideal se actualiza en `investigacion.md` con la nueva
+evidencia.
+
+**Un documento a la vez:** se trabaja solo el documento en foco de la misión. Mientras `producto.md` está
+en revisión, `experiencia.md` e `ingenieria.md` no se crean ni se actualizan "para mantenerlos alineados"
+— se rehacen cuando el dueño de producto dé el paso explícito. El loop de vuelta sí es válido en cualquier
+momento. Trabajo aguas abajo sobre definiciones en revisión queda obsoleto y se paga dos veces.
+
+## La evidencia de un producto sin usuarios
+
+Datealo no tiene datos de uso propios. La consecuencia práctica: **el benchmark es la evidencia más fácil
+de conseguir y la más fácil de sobrevalorar.** Ver que Thumbtack hace X demuestra que Thumbtack hace X,
+no que sus usuarios lo prefieran ni que a nosotros nos sirva.
+
+Jerarquía de evidencia mientras no haya producto en producción:
+
+| Tipo                                    | Qué demuestra                                   | Límite típico                        |
+| --------------------------------------- | ----------------------------------------------- | ------------------------------------ |
+| Entrevista o conversación con un usuario| Cómo describe su problema y qué hizo la última vez | Lo que dice que haría ≠ lo que hará |
+| Comportamiento observado fuera del producto | Que el problema existe (grupos de WhatsApp, Marketplace) | No dice si nuestra solución sirve |
+| Benchmark de otro producto              | Qué trade-off eligió alguien con otra escala    | No transfiere a nuestro volumen      |
+| Intuición del equipo                     | Nada. Es hipótesis                              | Se declara como tal o no se escribe  |
+
+Toda `C-xxx` sostenida solo por benchmark lleva confianza `media` o `baja`, y su implicación se escribe
+como "esto deberá ser cierto", no como "esto es así".
+
+## Qué se ve concreto en Datealo
+
+El objetivo es que cualquier persona pueda leer `producto.md` y saber exactamente qué construir. Si una
+funcionalidad puede interpretarse de dos formas distintas, no está lista.
+
+```
+❌ Abstracto: "Datealo debe ofrecer resultados de búsqueda relevantes según la ubicación del usuario"
+
+✅ Concreto: "El buscador ve los profesionales de la categoría ordenados por distancia a su ubicación.
+   Si no dio permiso de ubicación, ve los de la comuna que eligió a mano, con el selector de comuna
+   visible arriba de la lista. Si la comuna no tiene ninguno, ve los de las comunas vecinas
+   marcados con su distancia, no un estado vacío."
+```
+
+La regla práctica: si la funcionalidad no describe quién hace qué, qué responde Datealo, y qué pasa en el
+caso edge más probable (que acá casi siempre es "no hay resultados"), está incompleta.
+
+### Prueba de lectura en frío
+
+El documento se escribe en el lenguaje en que se lo explicarías en voz alta al dueño de producto — no en
+registro de spec. Antes de presentar una sección, releerla preguntando: ¿esta frase necesitaría traducción
+oral? Si sí, la traducción oral es la redacción correcta.
+
+- El vocabulario del aparato del template (señal, umbral, guardrail, canónico) lleva su significado en la
+  misma frase o no aparece en el cuerpo.
+- Toda afirmación abstracta lleva su ejemplo con nombres, comunas y oficios reales en el mismo párrafo.
+- Cuando el dueño de producto pregunta "¿qué significa esto?", la respuesta incluye reescribir el texto en
+  el documento — la explicación que funcionó en la conversación es la redacción nueva, no un extra.
+
+```
+❌ "Señal: la tasa de conversión a contacto sobre sesiones con intención de búsqueda
+   supera el umbral definido para la cohorte inicial."
+
+✅ "Señal (qué observaríamos si funciona): de cada 10 personas que buscan una categoría
+   y abren un perfil, al menos 3 tocan el botón de WhatsApp."
+```
+
+### Cómo se redacta una decisión (D-xxx)
+
+- **Título = la decisión en una frase que se entiende sola**, no una etiqueta abstracta.
+  ❌ "Modelo de contacto y trazabilidad de la conversación"
+  ✅ "El contacto sale de Datealo hacia WhatsApp y no vuelve"
+- **"Alternativas descartadas"**, no "Alternativas" — el lector debe saber sin deducir que son opciones
+  rechazadas, no cosas que el producto hace. Cada una con el porqué del rechazo en la misma línea.
+- **La decisión abre con la afirmación directa**, incluidas las negaciones que el lector podría dudar ("no
+  existe un chat interno"), y lleva su ejemplo con nombres reales en el mismo párrafo.
+- **Si una decisión describe algo que el sistema hace solo bajo cierta condición**, nombrar la causa en la
+  primera frase — que nunca se lea como comportamiento automático inexplicado.
+- **Una decisión reemplazada se colapsa**: estado, "Qué decía, en corto" (3-5 líneas: qué decía, por qué
+  murió, qué sobrevive y dónde), y nada más — el detalle vive en el historial de git.
+- **Los cambios posteriores entran como "Revisión (fecha)"** al final, en el mismo lenguaje llano,
+  enlazando la decisión que los produjo.
+
+### Los IDs son permanentes y viven en su lugar
+
+Todo ID de una misión (E, C, D, F, M, CL, Q) es permanente. Cuando algo muere no se borra de su lista ni
+migra a una sección de cerrados al final: se colapsa en su lugar, en orden, con su estado y el porqué. Un
+ID retirado no se reutiliza nunca.
+
+- Si el ítem vive en prosa (una decisión), se colapsa donde está, con su estado en la primera línea.
+- Si vive en una tabla, conserva su fila con el estado. Si son pocos y la tabla no tiene columna de estado,
+  basta una línea bajo la tabla que los nombre con su motivo y su decisión.
+
+Si la lista salta de CL-007 a CL-009, el lector no puede distinguir un caso retirado de un error, y tiene
+que reconstruir el conjunto desde dos lugares.
+
+### Cómo se registran las preguntas (Q-xxx)
+
+La forma literal de la tabla vive en [`docs/missions/template/producto.md`](../../../docs/missions/template/producto.md);
+lo que sigue es el porqué y las trampas. Todas las preguntas viven en **una sola tabla ordenada por ID**,
+abiertas y cerradas juntas, con la respuesta a la vista.
+
+- **El estado distingue tres cosas:** `abierta`, `resuelta AAAA-MM-DD` (alguien la respondió) y
+  `disuelta AAAA-MM-DD` (el producto cambió y la pregunta dejó de tener sentido). Colapsar resuelta y
+  disuelta en un solo "cerrada" borra lo más útil para el lector futuro.
+- **La última columna contiene la respuesta, no un puntero.** Cerrada: qué se respondió y con qué decisión.
+  Abierta: quién la resuelve, con qué método, qué bloquea mientras tanto y su fecha límite.
+- **Solo las abiertas llevan bloque de detalle** debajo de la tabla, con "La duda, con un ejemplo" (el caso
+  concreto que muestra por qué hay dos respuestas posibles), "Afecta a", "Cómo se resolverá" y "¿Bloquea
+  algo?". La fila sola comprime justo el contexto que hace entendible la duda.
+- **Antes de la tabla, una frase responde "¿qué falta?"** nombrando la pregunta que bloquea y qué bloquea.
+
+## Trazabilidad entre los dos documentos
+
+```
+investigacion.md:  E-001 evidencia → C-001 conclusión → ideal
+producto.md:       D-001 decisión → F-001 funcionalidad → M-001 señal de éxito
+                   (D y F enlazan a C-xxx de investigacion.md)
+```
+
+Toda funcionalidad necesita al menos una conclusión y una señal. Sin esa cadena es una apuesta sin validar
+— presentarla como tal.
+
+## Formato JTBD para funcionalidades
+
+Cada funcionalidad se escribe primero desde el resultado del usuario (working backwards), luego las reglas
+y casos límite.
+
+```
+Cuando [usuario en contexto concreto],
+quiero [acción],
+para [resultado observable].
+
+Reglas:
+- Si [condición], Datealo [comportamiento].
+- Si [caso límite], Datealo [comportamiento seguro].
+```
+
+```
+✅ F-001: Cuando se me tapa el desagüe un domingo y no conozco ningún gasfiter,
+          quiero ver quiénes trabajan hoy cerca de mi casa,
+          para llamar a uno sin tener que preguntar en el grupo del edificio.
+          Reglas:
+          - Si el profesional marcó que atiende fines de semana, aparece con la etiqueta "Atiende hoy".
+          - Si ninguno de la comuna atiende hoy, la lista muestra los de comunas vecinas
+            con su distancia, antes que los de la comuna que no atienden.
+          - Datealo nunca muestra un teléfono sin que el profesional lo haya verificado.
+
+❌ F-001: "Búsqueda de profesionales con filtro de disponibilidad"
+          (no describe quién, en qué contexto, ni qué pasa cuando no hay nadie)
+```
+
+## Cómo estructurar la investigación
+
+1. Describir el problema con situación + acción + respuesta actual + consecuencia.
+2. Formular las preguntas que pueden cambiar el ideal o el alcance (solo esas).
+3. Investigar cómo otros productos resuelven el mismo problema, y con qué escala lo asumen.
+4. Registrar cada hallazgo como evidencia con su límite antes de concluir.
+5. Derivar conclusiones y recién entonces escribir el ideal.
+
+Una investigación extensa que no concluye qué cambia en el producto es un antipatrón. La evidencia debe
+llevar a conclusiones, las conclusiones a decisiones, las decisiones a funcionalidades.
+
+## Herramientas de referencia
+
+Antes de proponer una solución, investigar cómo la resuelven productos con usuarios o restricciones
+similares. La referencia es para entender trade-offs, no para copiar — y siempre pasa por el test del
+concepto importado.
+
+**Marketplaces de servicios a domicilio** — el análogo más directo:
+
+| Producto             | Qué observar                                                                    |
+| -------------------- | ------------------------------------------------------------------------------- |
+| **Thumbtack**        | Matching por solicitud, cómo presenta precio estimado y por qué cobra al pro    |
+| **Angi (HomeAdvisor)** | Categorización de oficios, verificación de background, páginas por ciudad     |
+| **TaskRabbit**       | Selección directa del profesional, disponibilidad por franja horaria            |
+| **Yelp**             | Perfil de negocio local, jerarquía de la card de resultado, sistema de reseñas  |
+
+**Descubrimiento local y búsqueda geográfica**:
+
+| Producto             | Qué observar                                                                |
+| -------------------- | --------------------------------------------------------------------------- |
+| **Google Maps**      | Búsqueda + mapa + lista, permiso de ubicación, cómo degrada sin él          |
+| **Airbnb**           | Card con foto + rating + precio, filtros progresivos, estados vacíos        |
+| **Booksy**           | Reserva de servicios personales, perfil de profesional individual           |
+| **Doctoralia**       | Perfil profesional verificado, reseñas moderadas, SEO por especialidad+ciudad |
+
+**Confianza y reputación** — el problema central de Datealo:
+
+| Producto             | Qué observar                                                                |
+| -------------------- | --------------------------------------------------------------------------- |
+| **Airbnb**           | Reseñas de doble lado, qué se publica y cuándo                              |
+| **Yelp**             | Filtro de reseñas no recomendadas, respuesta del negocio                    |
+| **Mercado Libre**    | Reputación acumulada visible, contexto latinoamericano y de confianza baja  |
+
+Para el mercado chileno, el punto de comparación honesto no es Yelp: es el grupo de WhatsApp del edificio,
+Marketplace de Facebook y la recomendación de un vecino. Ese es el sustituto real, y es contra ese
+estándar que una funcionalidad tiene que ganar.
+
+## El ideal vive en investigación; el recorte, en producto
+
+El ideal es el producto de la investigación: la dirección que la evidencia sostiene, sin restricciones de
+implementación. Vive al final de `investigacion.md`. El recorte de alcance es una decisión de producto y
+vive en `producto.md` con su trade-off explícito.
+
+```
+✅ investigacion.md: "cualquier persona encuentra en menos de un minuto un profesional
+   disponible, verificado y cerca, para cualquier oficio" (ideal, sin recortar)
+✅ producto.md: "esta entrega cubre 6 categorías en 4 comunas de Santiago con contacto por
+   WhatsApp; se posterga el sistema de reseñas porque sin volumen de servicios completados
+   una reseña sola distorsiona más de lo que informa"
+
+❌ "El MVP no tiene reseñas porque implementarlas es complejo"
+   (límite técnico disfrazado de decisión de producto)
+```
+
+Una limitación de implementación puede influir en el recorte, pero no debe presentarse como necesidad de
+producto.

--- a/.claude/skills/discovery-ux/SKILL.md
+++ b/.claude/skills/discovery-ux/SKILL.md
@@ -1,0 +1,300 @@
+---
+name: discovery-ux
+description: Diseña la experiencia de features nuevas en Datealo — vistas y sus modos, flujos, estados y mockups. Se usa al iterar `experiencia.md` de una misión, al definir el flujo o los estados de un feature, al mapear cómo se entra y se sale de una pantalla ("no veo el camino completo", "¿cómo llego a esta pantalla?", "¿cómo salgo de esto?"), y al pedir ver una pantalla ("muéstrame cómo se vería", "hazme un mockup", "¿cómo debería verse esto?", "¿cuántos pasos tiene este flujo?").
+---
+
+# Discovery de experiencia en Datealo
+
+Este skill aplica cuando el foco es `experiencia.md`: vistas, flujos, estados, contenido e interacción.
+Para el problema y el alcance, ver `discovery-product`. Para arquitectura y contratos, ver
+`discovery-engineering`.
+
+DaisyUI v5 sobre Tailwind v4 es la base para todo elemento interactivo. La investigación de UX define el
+comportamiento esperado; el componente concreto de DaisyUI se decide en implementación.
+
+Cuando una vista necesita algo que DaisyUI no tiene (un mapa interactivo, un selector de zona, una galería
+de trabajos), experiencia no elige librería ni componente: **especifica la interacción** —qué se hace, cómo
+se manipula, qué responde—, y esa mecánica se funda en research, heurísticas y la `investigacion.md` de la
+misión, no pidiéndole al dueño de producto que adivine la mejor forma. Al dueño se le llevan trade-offs de
+producto; la interacción se investiga. La decisión build-vs-buy es de ingeniería, contra esa especificación
+(ver YAGNI en `CLAUDE.md`).
+
+El design system es el tema `datealo` de DaisyUI: fondo claro `#FAFAFA`, primario índigo `#423ED0`,
+secundario turquesa `#3ECBD7`, texto `#1F2937`, radios generosos (`--radius-box: 1rem`), Plus Jakarta Sans
+para títulos y DM Sans para cuerpo. La fuente de verdad es `app/assets/css/main.css`. Cualquier propuesta
+visual parte de ahí.
+
+## La landing ya hizo promesas públicas
+
+Datealo todavía no tiene producto, pero sí tiene una landing publicada que promete cuatro cosas concretas:
+**profesionales verificados**, **reseñas de vecinos reales**, **los más cerca de ti** y **contacto directo
+sin intermediarios**. Esas promesas están en `app/constants/landing.ts` y ya se le mostraron a gente que
+dejó su correo.
+
+Un flujo que las contradice no es una decisión de diseño, es una promesa rota:
+
+```
+❌ Un formulario "cuéntanos qué necesitas" que envía la solicitud a varios profesionales
+   y espera respuestas. (La landing prometió contacto directo, sin intermediarios,
+   sin formularios.)
+
+✅ El perfil tiene el botón de WhatsApp fijo abajo. Si el flujo necesita capturar qué necesita
+   el cliente, ese texto pre-llena el mensaje de WhatsApp — no crea una bandeja intermedia.
+```
+
+Si una misión concluye que una promesa de la landing está equivocada, eso vuelve a `producto.md` como
+decisión y la landing se corrige. No se resuelve en silencio en un flujo.
+
+## Lo que existe se audita, no se hereda
+
+La experiencia se diseña desde el `producto.md` aprobado —sus `F-xxx` y `D-xxx`—, no desde lo que la app ya
+hace. Hoy lo construido es solo la landing, así que la trampa todavía es chica; crecerá rápido.
+
+Regla: cada pantalla, flujo o componente existente se **audita contra el producto vigente**, no se hereda.
+
+- Si una pieza encarna algo que el producto cortó, se **descarta**: no se rediseña ni "se itera sobre lo
+  actual". Nómbrala y cita la `D-xxx`/`F-xxx` que la deja fuera.
+- Si una pieza sirve a una `F`/`D` vigente, puede **informar** el diseño — pero se justifica por el
+  producto, nunca con "así funciona hoy".
+- Reusar código existente es una decisión de **ingeniería**, no una restricción de experiencia: experiencia
+  diseña lo correcto; ingeniería decide cómo se construye.
+
+## Contexto real de uso
+
+```
+Buscador (cliente)  → celular, de pie en la cocina inundada, apurado, con una mano,
+                      datos móviles, sin ganas de leer. A veces sin permiso de ubicación.
+Profesional         → celular, entre trabajos o de noche, poca familiaridad con apps,
+                      sube fotos desde la galería, escribe poco.
+```
+
+Toda propuesta de flujo se evalúa contra el usuario más limitado que la usará. Dos criterios operativos:
+
+- **Móvil 390px es el caso principal, no una variante.** Un flujo que solo se entiende en desktop está
+  incompleto.
+- **El camino crítico del buscador se completa sin leer instrucciones.** Si llegar del inicio a un teléfono
+  marcable exige más de tres toques o una explicación, el flujo necesita revisión antes de ingeniería.
+
+## Flujo y handoffs
+
+`experiencia.md` traduce las funcionalidades de producto en flujos que ingeniería puede implementar sin
+adivinar.
+
+```
+investigacion.md → producto.md → experiencia.md → ingenieria.md
+                        ↑               ↑
+                        └───────────────┘  loop de vuelta si un flujo invalida una decisión
+```
+
+**Qué recibe:** las funcionalidades `F-xxx` de `producto.md` con su formato JTBD, reglas y casos límite
+aprobados.
+
+**Un documento a la vez:** `experiencia.md` se trabaja cuando el dueño de producto da el paso explícito
+desde producto — no en paralelo a una revisión de `producto.md` "para mantenerlo alineado".
+
+**Gate de salida — `experiencia.md` está lista para `ingenieria.md` cuando:**
+
+- los flujos críticos tienen punto de partida, camino principal, estados intermedios, errores y recuperación
+- cada estado tiene contenido concreto (texto real, acción disponible) — no "mensaje de error apropiado"
+- cada vista lista sus modos, y el mapa de estados cubre todas las transiciones entre ellos
+- cada modo tiene su indicador permanente de estado, y cada flujo tiene todas sus salidas documentadas
+- los casos límite de `producto.md` tienen flujo mapeado, empezando por "no hay resultados"
+- cada flujo crítico está mockeado en móvil, y en desktop si también vive ahí
+- no quedan pantallas descritas como "similar a X" sin especificar qué cambia
+- los flujos críticos pasaron una evaluación heurística y sus hallazgos bloqueantes están resueltos
+
+**Evaluar antes de cerrar:** proponer y juzgar son actos distintos, y hacerlos en la misma pasada produce
+ceguera — el flujo recién escrito parece bueno porque uno acaba de convencerse a sí mismo. Antes de marcar
+`en revisión`, contrastar los flujos críticos contra heurísticas de usabilidad usando los skills instalados
+en `.agents/skills/`: `ui-ux-pro-max` y `web-design-guidelines` para el juicio, `frontend-design` para la
+propuesta visual.
+
+**Loop de vuelta:** si al diseñar un flujo se descubre que una regla de producto no funciona, registrar la
+contradicción en `producto.md` antes de simplificar el flujo aquí.
+
+**Aprobación:** Claude propone y marca `en revisión`; `vigente` lo otorga solo el dueño de producto.
+
+## Qué se ve concreto en Datealo
+
+`experiencia.md` debe describir flujos al nivel de "el usuario toca X → Datealo muestra Y → si Z pasa,
+muestra W". Si la descripción no permite saber qué aparece en pantalla, está incompleta.
+
+```
+❌ Abstracto: "El usuario puede buscar profesionales de forma simple con feedback apropiado"
+
+✅ Concreto: "El buscador escribe 'gasfi' en el campo de búsqueda. A los 300ms aparecen
+   sugerencias de categoría bajo el campo: 'Gasfitería' primero, con el número de
+   profesionales en su comuna al lado. Toca una → navega a resultados. Mientras cargan,
+   ve 4 skeletons con la forma de la card, no un spinner."
+```
+
+```
+❌ "El estado vacío debe orientar al usuario"
+
+✅ "Si no hay ningún gasfiter en Ñuñoa, ve: ícono de mapa, título 'Todavía no hay gasfiters
+   en Ñuñoa', y debajo la lista de los 3 más cercanos de comunas vecinas con su distancia
+   ('Providencia · a 2,4 km'). Botón secundario: 'Avísame cuando haya uno en mi comuna'."
+```
+
+El estado vacío merece esa atención porque, con la oferta actual, va a ser lo primero que vea mucha gente.
+Un empty state que solo dice "sin resultados" convierte el arranque en frío en una salida del producto.
+
+## Preguntas para evaluar un flujo en discovery
+
+- ¿Qué información necesita el usuario para tomar la acción? ¿Está disponible en ese momento y lugar?
+- ¿Cuántos toques tiene el camino crítico? ¿Cuál se puede eliminar?
+- ¿Qué pasa si no hay resultados? ¿Y si hay uno solo?
+- ¿Qué pasa si el usuario niega el permiso de ubicación?
+- ¿El estado resultante es visible sin necesitar texto de confirmación?
+- ¿El flujo es completable sin haber leído nada?
+- ¿Qué hace el usuario si comete un error? ¿Puede deshacerlo?
+
+## Estructura de `experiencia.md`
+
+El esqueleto con todas las secciones y sus comentarios de uso vive en
+[`docs/missions/template/experiencia.md`](../../../docs/missions/template/experiencia.md) — se copia de
+ahí, no se reconstruye de memoria. Lo que sigue es el porqué de las secciones que se documentan mal si solo
+se ve el esqueleto.
+
+Regla de formato: las tablas se reservan para índices de celdas cortas (referencias, IDs, estados de una
+palabra). Todo lo que lleve justificación extensa va en secciones con header + bullets —como las
+`UX-xxx`—, nunca en una celda de tabla, que se desvirtúa en cuanto el texto crece.
+
+### Vistas y modos
+
+Una vista es un destino: se llega a ella. Un modo es un estado de esa vista que cambia qué se puede hacer y
+qué se ve. Los modos se anidan bajo su vista, nunca al mismo nivel:
+
+```
+✅ - V-002 — Resultados de búsqueda · móvil + desktop · resuelve F-001, F-002 · flujos UXF-001
+     - modo lista    — el default; cards ordenadas por distancia
+     - modo mapa     — los mismos resultados como pines; la card del seleccionado abajo
+     - modo sin ubicación — pide comuna a mano antes de poder ordenar por cercanía
+
+❌ - V-005 — Vista de mapa (sobre los resultados de V-002, no una página aparte) · resuelve F-002
+```
+
+Ese paréntesis del ejemplo malo es la estructura peleando con el diseño: corrige el nivel equivocado, y el
+mockup del modo termina huérfano porque nada dice de qué vista es un modo.
+
+### Mapa de estados
+
+Vistas y flujos son listas, y una lista no muestra un camino. La sección **Mapa de estados** conecta los
+modos: qué acción lleva de uno a otro, y qué pasa con el trabajo del usuario en cada salto.
+
+| Desde         | Acción                | Queda en      | Qué pasa con el trabajo              |
+| ------------- | --------------------- | ------------- | ------------------------------------ |
+| lista         | toca "Ver mapa"       | mapa          | los filtros y el orden se conservan  |
+| mapa          | toca un pin           | mapa          | la card del pin sube desde abajo     |
+| mapa          | toca la card          | perfil        | vuelve al mapa en la misma posición  |
+| sin ubicación | elige comuna a mano   | lista         | la comuna queda guardada             |
+
+Sin esta tabla el documento puede tener todas sus secciones completas y el dueño de producto igual decir
+"no veo el camino completo". Cada fila que falte es una pregunta que ingeniería resuelve inventando.
+
+### Qué documenta cada flujo crítico
+
+- **Punto de partida**: datos, estado y contexto necesarios.
+- **Camino principal**: pasos en orden con la acción y la respuesta del sistema.
+- **Estados intermedios**: qué ve el usuario mientras espera. Skeleton con la forma del contenido si pasa
+  de 300ms; nunca un spinner genérico.
+- **Salidas**: todas las formas de irse, no solo terminar bien — volver, cerrar, navegar a otra parte,
+  irse a WhatsApp. Por cada una, qué queda del trabajo. El caso de Datealo que más se olvida: el usuario
+  se va a WhatsApp y vuelve; la pantalla tiene que estar donde la dejó.
+- **Cómo sabe el usuario dónde está**: el elemento concreto y permanente en pantalla que se lo dice, por
+  cada modo. Un modo sin indicador permanente es un modo en el que el usuario se pierde.
+- **Errores y recuperación**: qué pasa cuando algo falla y cómo retoma.
+- **Casos límite**: cero resultados, un solo resultado, perfil sin fotos, profesional sin reseñas.
+
+## Mockups visuales
+
+Un flujo escrito se lee bien y aun así no se sostiene en pantalla: el texto no muestra cuánta información
+compite por el mismo espacio, ni si la acción principal queda por debajo del pliegue. En una card de
+resultado con foto, nombre, oficio, rating, número de reseñas, distancia y disponibilidad, eso es
+exactamente lo que se decide. El mockup convierte "cada estado tiene contenido concreto" de una promesa del
+gate en algo verificable.
+
+### Cuándo se hace un mockup
+
+**Obligatorio** antes de marcar `experiencia.md` como `en revisión`:
+
+- la pantalla principal de cada funcionalidad `F-xxx` con datos reales, no vacía;
+- **un frame por cada modo de la vista** — si V-002 tiene lista, mapa y sin-ubicación, van los tres. Los
+  modos son lo que hace visible el camino;
+- todo estado de datos que el flujo declare y no se deduzca del anterior — vacío, carga, error, y el
+  "solo un resultado" que en un marketplace nuevo es el caso frecuente;
+- cualquier pantalla donde el usuario decide entre opciones con consecuencias.
+
+**No corresponde** para: variantes de un layout ya mockeado, copy que se resuelve en el documento, o
+pantallas que solo cambian de datos.
+
+El mockup no reemplaza al documento. `experiencia.md` sigue siendo la fuente de verdad del flujo; el mockup
+es la evidencia de que ese flujo cabe en una pantalla. Si se contradicen, gana el documento y el mockup se
+corrige.
+
+### Cadencia: el mockup itera, el documento se escribe una vez
+
+Un archivo por vista, iterado en su lugar: modos y estados van como frames dentro del mismo archivo, y el
+número de ronda vive en el rótulo del frame para poder conversarlo. Revisar un diseño no debería obligar a
+abrir cinco pestañas.
+
+El mockup itera libre —cuantas rondas necesite el visual— y en esas rondas `experiencia.md` no se toca.
+Cuando el dueño de producto aprueba el visual, **una sola pasada** baja el estado final al documento, con
+las `UX-xxx` redactadas en presente como si fueran la primera versión.
+
+```
+❌ Una UX-xxx con tres bullets "Refinamiento (fecha)" apilados, donde el cuerpo dice una
+   cosa y el último refinamiento dice la contraria.
+
+✅ Una sola redacción vigente. "Alternativas descartadas" conserva lo que se probó y se dejó
+   —eso es una decisión y evita re-litigar—; el historial cronológico no.
+```
+
+### Cómo se hace
+
+Los mockups van en `docs/missions/NN-slug/design-mockups/{pantalla}.html`. Cómo se escribe uno, el
+esqueleto HTML y los frames están en [`docs/design/README.md`](../../../docs/design/README.md) — leerlo
+antes del primero.
+
+Tres cosas que el kit ya resuelve:
+
+- **Los tokens de color, radio y tipografía salen de `docs/design/datealo-mockup-kit.css`**, que espeja
+  `app/assets/css/main.css`. Un token escrito a mano en el mockup queda desactualizado sin que nadie lo
+  note, y el mockup pasa a describir un producto que no existe.
+- **Los componentes salen de DaisyUI**, cargado por CDN en el mismo esqueleto. Si el mockup necesita algo
+  que DaisyUI no da, se arma con utilidades de Tailwind, no con CSS inventado.
+- **El marco de dispositivo correcto**: `frame-mobile` (390px) siempre; `frame-desktop` además si la
+  pantalla también vive ahí.
+
+### Qué contiene un buen mockup
+
+- **Contenido real del feature**, con vocabulario chileno y los términos decididos en `producto.md`. Nada
+  de lorem ipsum ni "Profesional 1": "Marcela Fuentes · Peluquería a domicilio · Ñuñoa · 4,8 (23 reseñas)"
+  revela los desbordes de texto que "Profesional 1" esconde.
+- **Los modos y estados como frames rotulados** en el orden en que el usuario los recorre — así el archivo
+  se lee como camino, no como galería.
+- **Interacción con JS puro solo si el flujo se evalúa mejor moviéndolo** — abrir un bottom sheet, cambiar
+  de tab. Un mockup no valida ni persiste nada.
+
+## Patrones de interacción que ya están decididos
+
+Estos son estándar del producto y no se re-discuten por flujo. Vienen de `CLAUDE.md` y de las referencias
+del stack:
+
+- **Feedback bajo 100ms.** Si la respuesta pasa de 300ms, skeleton con la forma del contenido, no spinner.
+- **Resultados mientras se escribe**, con debounce de 300ms.
+- **Touch targets de 44×44px mínimo.** Bottom sheets en móvil, dropdowns en desktop.
+- **Transiciones de 200ms o menos.** Las acciones destructivas piden confirmación; nunca `alert()` nativo.
+- **Optimistic UI** donde el resultado es predecible: se actualiza local y se revierte si falla.
+- **Empty states que invitan**, con sugerencias de categorías o comunas cercanas.
+
+## Relación entre `experiencia.md` y `producto.md`
+
+Un hallazgo de experiencia puede cambiar una decisión de producto. Cuando eso ocurre, el cambio se registra
+primero en `producto.md` (fuente de verdad del problema) y luego se actualiza `experiencia.md`. Los
+documentos no deben contradecirse en silencio.
+
+```
+✅ "El flujo de 5 pasos detectado en experiencia cambió la decisión D-002 en producto"
+❌ "Experiencia define un flujo de 3 pasos y producto dice que hay 5" (contradicción silenciosa)
+```

--- a/.claude/skills/vue-composition/SKILL.md
+++ b/.claude/skills/vue-composition/SKILL.md
@@ -1,0 +1,260 @@
+---
+name: vue-composition
+description: Arquitectura de composición de componentes y composables en Datealo — cuándo extraer un sub-componente, un composable o un util, y cómo. Usar antes de agregar código a cualquier `.vue` o composable, cuando un archivo se siente grande, cuando aparecen "god composables" o componentes de 400+ líneas, o al pedir "refactoriza esto", "extrae este componente", "esto está muy grande". Incluye la auditoría de salud de archivos obligatoria antes de editar.
+---
+
+# Arquitectura de composición en Datealo
+
+Los componentes grandes son el code smell más caro del frontend. Un componente de 1000 líneas es difícil de
+leer, navegar, testear y modificar sin romper cosas. Este skill define cuándo extraer, qué extraer y cómo.
+
+**Fuentes**: Vue Composition API FAQ (Evan You muestra que ~400 LOC con múltiples concerns ya es
+problemático), Vue Composables docs ("components that are too large to navigate and reason about"), Google
+Engineering Practices, defaults de SonarQube (complejidad cognitiva ≤ 15 por función).
+
+## Auditoría antes de editar
+
+Antes de tocar un `.vue` o un composable, mide. No es opcional y no es un refactor extra: es parte de
+implementar.
+
+1. `wc -l <archivo>`.
+2. Para componentes y páginas: contar funciones declaradas en `<script setup>`.
+3. Para composables: contar miembros del return y entidades o recursos de API distintos.
+4. Clasificar en verde / amarilla / roja.
+
+| Recurso                       | Verde     | Amarilla | Roja      |
+| ----------------------------- | --------- | -------- | --------- |
+| Componente `.vue`             | ≤ 200 LOC | 200–400  | > 400 LOC |
+| Composable `.ts`              | ≤ 150 LOC | 150–300  | > 300 LOC |
+| Función/método                | ≤ 30 LOC  | 30–60    | > 60 LOC  |
+| Props por componente          | ≤ 5       | 6–8      | > 8       |
+| Funciones en `<script setup>` | ≤ 5       | 6–10     | > 10      |
+| Miembros en el return         | ≤ 15      | —        | > 15      |
+| Variables de estado           | ≤ 7       | —        | > 7       |
+| Entidades por composable      | 1         | —        | > 1       |
+
+**Qué hacer con el resultado:**
+
+- **Zona roja** → extraer **antes** de implementar el feature. La extracción es parte de la tarea.
+- **Zona amarilla que tu cambio empujaría a roja** → extraer lo suficiente para quedar en verde o amarilla
+  después del cambio.
+- **Zona verde, o amarilla sin riesgo** → editar directo.
+
+**La regla que más se rompe:** un archivo de 500 LOC con "solo 5 líneas más" sigue siendo un archivo de
+505 LOC en zona roja. Si saltaste la auditoría, la implementación es inválida.
+
+Al terminar, re-audita: ningún archivo tocado debe haber quedado en zona roja.
+
+## Triggers obligatorios de extracción
+
+Extraer si **cualquiera** es verdadero:
+
+1. **Múltiples concerns lógicos** — el componente maneja 2+ dominios (búsqueda + filtros + mapa).
+2. **3+ secciones UI distintas** — bloques de template con responsabilidades independientes.
+3. **Template repetible** — un bloque de markup se repite o podría reutilizarse (cards, ítems de lista).
+4. **Lógica y presentación mezcladas** — el `<script>` tiene orquestación de estado y lógica de UI.
+5. **Zona roja** en cualquier umbral de la tabla.
+6. **Densidad de funciones alta** — más de 10 funciones declaradas en `<script setup>`.
+
+## Dónde vive cada función
+
+Un componente no solo crece por template grande: también crece cuando su `<script>` acumula funciones
+auxiliares. Cada función en un `<script setup>` debe justificar por qué vive ahí.
+
+| Tipo de función                              | Dónde debe vivir                    | Ejemplo                                     |
+| -------------------------------------------- | ----------------------------------- | ------------------------------------------- |
+| **Stateful** (lee/muta refs, watchers, lifecycle) | Composable (`useFeature()`)     | `search()`, `saveProfile()`, `fetchReviews()`|
+| **Pura** (input → output, sin estado)        | `app/utils/`                        | `formatDistance()`, `slugify()`             |
+| **Handler del template** (1-3 líneas, delega)| Componente, inline o función corta  | `const onSubmit = () => save()`             |
+| **Específica de una sub-sección UI**         | Sub-componente con su propio script | `toggleDropdown()`, `handleDrag()`          |
+
+```ts
+// ❌ MAL: 9 funciones sueltas en SearchResults.vue
+const fetchResults = async () => { ... }
+const applyFilters = () => { ... }
+const updateLocation = () => { ... }
+const toggleMapView = () => { ... }
+const handleCardClick = (id: string) => { ... }
+const loadMore = async () => { ... }
+const sortBy = (criteria: string) => { ... }
+const openFilterSheet = () => { ... }
+const closeFilterSheet = () => { ... }
+
+// ✅ BIEN: concerns extraídos, el componente orquesta
+const { results, fetchResults, loadMore } = useSearch()
+const { filters, applyFilters, toggleFilter } = useSearchFilters()
+const { mapView, toggleMapView, updateLocation } = useSearchMap()
+```
+
+## Estrategias de extracción, en orden de preferencia
+
+1. **Extraer composable** — cuando la lógica (estado + side effects) es lo pesado. `useFeature()` devuelve
+   estado y acciones; el componente consume y renderiza.
+2. **Extraer sub-componente** — cuando hay una sección de template con su propia responsabilidad visual.
+   Props down, events up.
+3. **Extraer util** — cuando hay transformaciones puras inlineadas en el script.
+4. **Combinar** — los componentes grandes normalmente necesitan las tres.
+
+### Naming de componentes hijos acoplados
+
+Convención del Vue Style Guide (Priority B, tightly coupled component names): el hijo lleva el prefijo del
+padre.
+
+```
+components/
+└── search/
+    ├── SearchResults.vue         # Orquestador
+    ├── SearchResultsCard.vue     # Card de profesional
+    ├── SearchResultsFilters.vue  # Panel de filtros
+    └── SearchResultsMap.vue      # Mapa
+```
+
+El padre queda como **orquestador delgado**: importa sub-componentes, pasa props, escucha eventos y delega
+la lógica pesada a composables.
+
+```vue
+<!-- SearchResults.vue — orquestador delgado -->
+<script setup lang="ts">
+import { useSearch } from '~/composables/useSearch'
+import SearchResultsCard from './SearchResultsCard.vue'
+import SearchResultsFilters from './SearchResultsFilters.vue'
+
+const props = defineProps<{ category?: string, comuna?: string }>()
+const { results, loading, fetchResults } = useSearch(props)
+</script>
+
+<template>
+  <div>
+    <SearchResultsFilters @apply="fetchResults" />
+    <SearchResultsCard v-for="pro in results" :key="pro.id" :professional="pro" />
+  </div>
+</template>
+```
+
+## Arquitectura de composables
+
+Los composables son a la lógica lo que los componentes son a la UI. Un composable god es tan costoso como
+un componente god.
+
+**Fuentes**: Vue docs ("compose complex logic using small, isolated units"), Vue Composition API FAQ
+(agrupar por concern y extraer cada uno), Michael Thiessen (thin composables: separar lógica pura de
+reactividad; logic composables: extraer para organización, no solo para reutilizar).
+
+### Principio: un composable, un concern
+
+Un composable maneja **un dominio de datos** y expone **una API cohesiva**. Si necesitas scroll para
+entender qué hace, ya hay más de un concern.
+
+### Triggers de extracción
+
+Splitear si **cualquiera** es verdadero:
+
+1. **Múltiples entidades** — gestiona profesionales Y reseñas Y categorías. Cada entidad, su composable.
+2. **Múltiples recursos de API** — llama a `/api/search`, `/api/professionals/:id`, `/api/reviews`. Cada
+   familia de endpoints, su composable.
+3. **Zona roja** — supera 300 LOC.
+4. **Clusters de estado independientes** — grupos de `useState` que nunca se referencian entre sí.
+5. **Return masivo** — más de 15 miembros indica varias APIs mezcladas.
+6. **Lógica duplicable** — patrones de optimistic update, fetch + rollback o debounced save repetidos entre
+   funciones.
+
+### Patrones de composición
+
+**1. Composables anidados.** Un composable puede llamar a otros. Es el patrón principal para descomponer.
+
+```ts
+// ❌ MAL: un god composable de 470 LOC
+export const useProfessionals = () => {
+  // 13 useState, 6 computed, búsqueda, filtros, reseñas, perfil, geolocalización...
+  return { /* 40+ miembros */ }
+}
+
+// ✅ BIEN: un composable por concern, orquestador delgado
+// composables/useSearch.ts              — resultados + paginación
+// composables/useSearchFilters.ts       — filtros
+// composables/useProfessionalProfile.ts — perfil individual + galería + contacto
+// composables/useReviews.ts             — reseñas + rating promedio
+```
+
+**2. Estado local vs compartido.** Estado dentro de la función → una instancia por llamada, ideal para
+lógica per-component. `useState('key')` de Nuxt → singleton compartido, para estado global. Usar
+`useState` en vez de refs a nivel de módulo: ya gestiona el singleton y es SSR-safe.
+
+```ts
+// Local — cada componente tiene su copia
+export function useFormValidation() {
+  const errors = ref<string[]>([])
+  return { errors, validate }
+}
+
+// Compartido — todos ven los mismos resultados
+export function useSearch() {
+  const results = useState<Professional[]>('search-results', () => [])
+  return { results, search, loadMore }
+}
+```
+
+**3. Composable delgado.** Las reglas de negocio van en funciones puras testeables; el composable las
+envuelve con reactividad.
+
+```ts
+// utils/search-filters.ts — pura, testeable, sin Vue
+export function filterByCategory(items: Professional[], category: string): Professional[] {
+  return items.filter(p => p.categories.includes(category))
+}
+
+// composables/useSearchFilters.ts — envuelve con reactividad
+export function useSearchFilters(items: Ref<Professional[]>) {
+  const category = useState<string | null>('filter-category', () => null)
+  const filtered = computed(() =>
+    category.value ? filterByCategory(items.value, category.value) : items.value,
+  )
+  return { category, filtered }
+}
+```
+
+**4. Pipeline por refs.** Conectar composables pasando refs de uno como input del siguiente.
+
+```ts
+const { results } = useSearch()
+const { filtered } = useSearchFilters(results)
+const { sorted } = useSearchSorting(filtered)
+```
+
+### Anti-patrones
+
+| Anti-patrón                | Problema                                                  | Solución                             |
+| -------------------------- | --------------------------------------------------------- | ------------------------------------ |
+| **God composable**         | Gestiona búsqueda + reseñas + perfil                      | Un composable por entidad            |
+| **Mapper soup**            | `mapProfessional()`, `mapReview()` inline en el composable | Mover a `utils/mappers.ts`          |
+| **Optimistic boilerplate** | Cada acción repite snapshot → update → try/catch → rollback| Extraer un helper reutilizable       |
+| **Flag explosion**         | 13 `useState` para filtros y flags                        | Agrupar en un composable de filtros  |
+| **Return gigante**         | 40 miembros en el return                                  | Cada concern devuelve solo su API    |
+| **Dependencia oculta**     | Comparten estado vía keys de `useState` sin declararlo    | Pasar refs como parámetros           |
+
+### Proceso para partir un composable god
+
+1. **Mapear entidades** que gestiona (profesionales, reseñas, categorías, ubicación).
+2. **Agrupar** estado, acciones y computeds de cada una.
+3. **Identificar puentes**: qué dato necesita un concern del otro.
+4. **Extraer de abajo arriba**: empezar por el concern más independiente.
+5. **Conectar vía parámetros**: el orquestador pasa refs entre los especializados.
+6. **Mover funciones puras** (mappers, sanitizers, formatters) a `utils/`.
+
+## Convenciones
+
+- **Naming**: `use` + dominio — `useSearch`, `useSearchFilters`, `useReviews`.
+- **Archivos**: un composable exportado por archivo, con el mismo nombre que la función.
+- **Parámetros**: aceptar `Ref<T>` o valor raw con `toValue()` cuando el input puede ser reactivo.
+- **Return**: objeto plano con refs, no `reactive` — permite destructuring sin perder reactividad.
+- **Cleanup**: siempre limpiar side effects con `onUnmounted` (intervals, listeners, subscriptions).
+- **Sin imports circulares**: si A necesita B y B necesita A, hay un concern mal separado. Extraer la parte
+  compartida a un tercer composable.
+
+## Regla de oro
+
+> Antes de agregar código a un archivo, revisa su tamaño. Si está en zona amarilla o roja, extrae primero —
+> luego implementa el feature sobre la estructura limpia.
+
+Esto no es refactoring por capricho: es preparación del terreno para que el cambio sea más limpio, más
+pequeño y más fácil de revisar.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,243 @@
+# Datealo — Instrucciones para Claude Code
+
+## Identidad del producto
+
+Datealo es un buscador de profesionales y servicios para el hogar y la vida diaria. Conecta a personas
+que necesitan resolver algo (gasfitería, electricidad, peluquería, mudanzas, limpieza) con profesionales
+verificados de su zona.
+
+**Mensaje core**: encuentra al profesional que necesitas, cerca de ti.
+
+**Flujo core**: buscar → explorar resultados → ver perfil → contactar. Cada feature nueva debe reforzar
+ese flujo, no romperlo.
+
+**Estado actual**: pre-lanzamiento. Solo existe la landing con lista de espera — no hay usuarios reales
+todavía. Esto tiene una consecuencia directa en cómo se decide: no hay datos de uso propios, así que toda
+afirmación sobre "lo que hace el usuario" es hipótesis hasta que se declare como tal.
+
+**Guardrails de producto** — nunca implementar:
+
+- Subastas o bidding entre profesionales por un cliente.
+- Pago obligatorio para contactar (en esta fase).
+- Dashboards complejos antes de tener tracción.
+- Copy agresivo o de urgencia artificial.
+- Features que agreguen pasos al flujo buscar → perfil → contactar.
+
+## Tipos de usuario
+
+**Buscador (cliente)** — busca un servicio por categoría, ubicación o nombre; explora perfiles, lee
+reseñas, ve trabajos anteriores; contacta por WhatsApp o teléfono; deja reseña después del servicio.
+Llega con un problema concreto y a menudo urgente, desde el celular.
+
+**Profesional** — crea y gestiona su perfil público (servicios, zona, fotos, precios orientativos);
+recibe contactos; acumula reseñas y reputación. No es un usuario técnico y gestiona su perfil entre
+trabajos, también desde el celular.
+
+## Principios de experiencia
+
+- Búsqueda directa: el usuario llega, busca y encuentra — sin fricción.
+- Confianza primero: perfiles con reseñas, fotos de trabajos y verificación.
+- Resultados relevantes: proximidad geográfica + calidad del profesional.
+- Mobile-first: la mayoría de las búsquedas ocurren desde el celular.
+- Simplicidad: pocas pantallas, flujo claro, cero confusión.
+- Inclusivo en categorías: oficios del hogar, servicios personales, profesionales especializados — todo
+  cabe si alguien lo busca.
+
+## Stack técnico
+
+- **Frontend**: Nuxt 4, Vue 3, TypeScript strict
+- **Estilos**: Tailwind CSS v4, DaisyUI v5 (tema `datealo`), tipografías Plus Jakarta Sans + DM Sans
+  — la migración a Nuxt UI v4 está decidida y pendiente (A-004 del skill `arquitectura`). Nuxt UI trae
+  `@nuxt/fonts`, que auto-hospeda las tipografías en vez de cargarlas por `<link>` a Google Fonts — ojo con
+  esto al tocar `nuxt.config.ts` o `app.head` una vez que la migración aterrice.
+- **Iconos**: `lucide-vue-next`
+- **Auth/DB**: Supabase (PostgreSQL + Auth + RLS)
+- **ORM**: Drizzle
+- **Estado**: Composition API + composables de Nuxt (`useState`)
+
+## Estructura del proyecto
+
+Estructura oficial de Nuxt 4, sin refactoring prematuro. **YAGNI**: no mover a `src/` ni crear aliases
+custom hasta que haya fricción real.
+
+```
+app/
+├── components/      # Componentes Vue
+├── composables/     # Lógica de negocio (estado + acciones)
+├── constants/       # Valores runtime (PROFESSIONAL_STATUS, CATEGORY_TYPE)
+├── fixtures/        # Mock data (JSON)
+├── layouts/         # Layouts de Nuxt
+├── pages/           # Routing basado en archivos
+├── types/           # Solo tipos TypeScript
+└── utils/           # Funciones puras (formatters, helpers)
+
+server/
+├── api/             # Endpoints del servidor
+├── db/              # Schema Drizzle + migraciones
+│   └── sql/         # SQL crudo (políticas RLS)
+└── utils/           # Utilidades del servidor
+
+docs/missions/       # Discovery de features (ver "Flujo de trabajo")
+docs/design/         # Kit de mockups
+```
+
+### Separación de responsabilidades
+
+| Carpeta       | Contiene                                              | No contiene                          |
+| ------------- | ----------------------------------------------------- | ------------------------------------ |
+| `composables` | Estado, reglas de negocio, mutaciones, side effects   | Formateo, traducciones, lógica de UI |
+| `utils`       | Funciones puras: formatters, labels, cálculos de UI   | Estado reactivo                      |
+| `constants`   | Enums como objetos `as const`, config, valores fijos  | Tipos                                |
+| `types`       | Tipos derivados de constantes, entidades              | Valores runtime                      |
+
+```ts
+// constants/professional.ts — valores runtime
+export const PROFESSIONAL_STATUS = {
+  ACTIVE: 'active',
+  INACTIVE: 'inactive',
+  PENDING_VERIFICATION: 'pending_verification',
+} as const
+
+// types/professional.ts — tipos compile-time
+import type { PROFESSIONAL_STATUS } from '~/constants/professional'
+export type ProfessionalStatus = (typeof PROFESSIONAL_STATUS)[keyof typeof PROFESSIONAL_STATUS]
+```
+
+## Comandos de verificación
+
+Antes de dar por terminado cualquier cambio de código:
+
+```bash
+npx nuxi typecheck      # Cero errores
+npm run build           # Compila
+```
+
+**Verificación visual**: para cambios de UI, levantar `npm run dev` (puerto 3001) y probar en el browser
+antes de dar el cambio por hecho. Móvil primero: 390px de ancho es el caso principal, no una variante.
+
+## Principios de código
+
+**YAGNI**: cada línea de código es deuda técnica. Antes de escribir código custom: (1) buscar si ya existe
+en el proyecto, (2) evaluar si una librería establecida lo resuelve, (3) recién entonces escribir lo mínimo.
+Esto **no aplica a la estructura de lo que sí se va a construir**: aislar un dominio, definir un contrato
+entre capas o separar lógica pura de reactividad no son abstracciones especulativas, son la forma de que lo
+pedido quede bien hecho. La pregunta no es "¿sería más simple sin esto?" sino "¿esto existe por algo que ya
+nos pidieron?".
+
+**TypeScript strict**: `type` sobre `interface` para modelos de dominio. `as const` para enums. Derivar
+tipos de las constantes. Sin `any` — usar `unknown` + narrowing. Sin `@ts-ignore`.
+
+**Composables**: `useState()` en vez de `ref()` para compatibilidad SSR. Un composable, un dominio. Return
+como objeto plano de refs, agrupado (estado, computeds, acciones). Cleanup con `onUnmounted` para
+intervals, listeners y subscriptions.
+
+**Componentes**: siempre `<script setup lang="ts">`. `computed()` sobre métodos para estado derivado.
+Presentacionales — la lógica vive en composables. Ver el skill `vue-composition` para umbrales, triggers
+de extracción y patrones.
+
+**Errores**: ningún `catch` vacío. Fallo de red → feedback visible. Fallo de servidor → mensaje legible.
+Sin `console.log` de debug en el código que se mergea.
+
+**Naming**: archivos en kebab-case, componentes en PascalCase, composables `useAlgo`, constantes en
+SCREAMING_SNAKE_CASE, tipos en PascalCase, funciones en camelCase. Named exports sobre default exports.
+
+**Comentarios**: solo para reglas de negocio no obvias. El naming claro es la documentación por defecto.
+
+## Umbrales de salud de archivos
+
+| Recurso                        | Verde     | Amarilla  | Roja      |
+| ------------------------------ | --------- | --------- | --------- |
+| Componente `.vue`              | ≤ 200 LOC | 200–400   | > 400 LOC |
+| Composable `.ts`               | ≤ 150 LOC | 150–300   | > 300 LOC |
+| Función/método                 | ≤ 30 LOC  | 30–60     | > 60 LOC  |
+| Props por componente           | ≤ 5       | 6–8       | > 8       |
+| Funciones en `<script setup>`  | ≤ 5       | 6–10      | > 10      |
+| Miembros en el return          | ≤ 15      | —         | > 15      |
+| Entidades por composable       | 1         | —         | > 1       |
+
+Verde: editar. Amarilla: evaluar extracción si vas a agregar código. Roja: extraer **antes** de agregar
+código — un archivo de 500 LOC con "solo 5 líneas más" sigue siendo un archivo en zona roja. La extracción
+es parte de implementar, no un refactor extra.
+
+## Seguridad RLS
+
+Toda tabla con datos multi-usuario tiene su policy en `server/db/sql/rls.sql`, que es su fuente de verdad.
+Pero la policy **no es lo que protege**: la conexión de Drizzle se salta RLS, así que la autorización real
+vive en el código de `server/api/`. El detalle está en A-002 del skill `arquitectura`.
+
+Cada cambio de schema debe evaluar si RLS necesita actualización antes de cerrar el issue:
+
+- **Sí actualizar** cuando se crea una tabla con datos de usuario, cambia el ownership (`user_id`) o las
+  relaciones usadas en policies (`EXISTS`/FKs), o se renombran tablas/columnas referenciadas.
+- **No hace falta** cuando solo se agregan campos de negocio (`title`, `color`, `price`) sin tocar
+  ownership ni seguridad.
+
+## Flujo de trabajo: misión → issue atómico → PR
+
+El discovery de una feature vive en `docs/missions/`. El tracking de ejecución vive en **GitHub Issues**.
+
+**Una misión** documenta el discovery de una feature en cuatro documentos con fuentes de verdad separadas
+(`investigacion.md` → `producto.md` → `experiencia.md` → `ingenieria.md`). Cómo se escribe cada uno está en
+los skills `discovery-product`, `discovery-ux` y `discovery-engineering`. El registro de misiones y la
+convención de carpetas están en [`docs/missions/README.md`](docs/missions/README.md).
+
+**Una tarea = un Issue = un PR chico y revisable.** No una feature completa punta a punta — un cambio
+funcional atómico. Los issues salen del "Plan de construcción" de `ingenieria.md`, ya cortado en slices.
+
+- Si se pide algo sin issue asociado, crearlo primero (o preguntar si ya existe) antes de tocar código.
+- Al terminar una tarea, abrir el PR y **detenerse ahí**. El checkpoint de revisión humana es el punto
+  central del flujo, no un paso opcional.
+- Labels en dos dimensiones, alineadas a la convención de commits:
+  - `type: feat|fix|chore|refactor|docs`
+  - `scope: app|server|db|ui|infra|docs`
+
+La prosa de misiones, PRs, commits y READMEs sigue [`docs/project-narrative.md`](docs/project-narrative.md).
+
+## Convención de commits
+
+Conventional Commits en español: `<tipo>(<scope>): <descripción corta en imperativo>`.
+
+Tipos: `feat`, `fix`, `chore`, `refactor`, `docs`, `test`, `ci`, `perf`. Scopes: `app`, `server`, `db`,
+`ui`, `infra`, `docs`.
+
+Descripción en español, imperativo, sin punto final, sin mayúscula inicial. Cuerpo opcional (máx 3 líneas).
+No hacer commits por iniciativa propia — solo cuando el usuario lo pida, y ahí ejecutar directo sin pedir
+confirmación.
+
+Antes de redactar: `git diff --stat HEAD` para revisar todos los archivos. Antes de `git add`: revisar
+`git status` y separar cambios legítimos de basura (archivos no-config en la raíz, `.save`/`.bak`/`.tmp`) —
+si hay basura, mostrar la lista al usuario.
+
+## Skills
+
+Skills propios del repo en `.claude/skills/`:
+
+| Skill                     | Cuándo                                                             |
+| ------------------------- | ------------------------------------------------------------------ |
+| `arquitectura`            | Endpoints, base de datos, RLS, secretos, despliegue, librería de UI |
+| `discovery-product`       | Iterar `investigacion.md` o `producto.md` de una misión            |
+| `discovery-ux`            | Iterar `experiencia.md`: vistas, flujos, estados, mockups          |
+| `discovery-engineering`   | Iterar `ingenieria.md`: contratos, datos, slicing en issues        |
+| `vue-composition`         | Extraer componentes o composables; auditoría de salud de archivos  |
+
+Skills de terceros pre-instalados en `.agents/skills/` (ver `skills-lock.json`): `nuxt`, `vue`,
+`drizzle-orm`, `frontend-design`, `ui-ux-pro-max`, `web-design-guidelines`, `marketing-psychology`,
+`ai-seo`, `content-strategy`, `page-cro`. Están todos localmente — nunca sugerir instalarlos.
+
+## Guardrails de trabajo
+
+Ante duda entre investigar y preguntar, investiga primero (cuesta cero):
+
+| Tipo de duda                                                            | Acción                                |
+| ----------------------------------------------------------------------- | ------------------------------------- |
+| Mejores prácticas, cómo lo resuelven otros productos, patrones técnicos | Investiga online y en el codebase     |
+| Ambigüedad técnica con respuesta verificable (API, sintaxis, patrón)     | Investiga docs, codebase, online      |
+| Decisión de negocio que solo el usuario conoce (prioridad, alcance)      | Pregunta al usuario                   |
+| Bloqueo real (herramienta caída, credencial faltante)                    | Reporta el bloqueo y detente          |
+
+- Al implementar con versiones recientes (Nuxt 4, Tailwind v4, DaisyUI v5, Drizzle), verifica la API
+  contra la documentación oficial en vez de asumir por memoria — las tres cambiaron de forma en su
+  última mayor.
+- Lee un archivo completo antes de editarlo. Un edit sobre contexto parcial pisa código que no viste.
+- Si encuentras algo roto y el fix es claro, arréglalo.
+- No dejes código muerto, imports sin usar ni funciones que nadie llama.


### PR DESCRIPTION
## Resumen

Mismo caso que `docs/` (#23): `.claude/` y `CLAUDE.md` de la raíz nunca se habían commiteado. No están en
`.gitignore`, fue un olvido.

Incluye los cinco skills propios del repo:

- `arquitectura` (con `references/recetas.md`) — las decisiones A-001 a A-004 citadas como sustento en
  cada PR de la migración a Nuxt UI.
- `discovery-product`, `discovery-ux`, `discovery-engineering` (con `references/slicing.md`),
  `vue-composition`.

`CLAUDE.md` los llama explícitamente "skills propios del repo" y describe el flujo de trabajo
misión → issue → PR apoyado en ellos — hasta este commit, ese flujo citaba archivos que no existían en
`main`.

Sin cambios de contenido: es lo que ya estaba en disco, tal cual. No toca `.github/`, que sigue fuera de
este PR sin relación con lo que faltaba acá.

## Test plan

- No aplica cambio de código — es infraestructura de documentación existente que faltaba subir.