### PR TITLE
docs: abrir las 6 misiones del roadmap al MVP

### DIFF
--- a/docs/missions/02-base-de-datos-y-auth/README.md
+++ b/docs/missions/02-base-de-datos-y-auth/README.md
@@ -7,8 +7,12 @@
 **Última actualización:** 2026-08-13
 
 Primera de seis misiones hacia el MVP (registrarse, mostrarse, buscar, reseñar). Sin `producto.md`,
-`experiencia.md` ni `investigacion.md`: es pura infraestructura, sin cambio de producto observable, y las
-decisiones que la sustentan ya están tomadas en `arquitectura`.
+`experiencia.md` ni `investigacion.md`: es pura infraestructura, sin cambio de producto observable.
+
+**Ojo con esto al tomar la misión:** `A-001`, `A-002` y `A-003` en `arquitectura` están marcadas
+**"propuesta"**, no "aceptada" — no son un hecho consumado que esta misión solo ejecuta. Ratificarlas (o
+ajustarlas) contra una decisión real, con código de por medio, es parte del trabajo de esta misión, no algo
+que ya viene resuelto de afuera.
 
 | Documento  | Estado    | Qué falta para su gate  |
 | ---------- | --------- | ------------------------ |
@@ -18,9 +22,15 @@ decisiones que la sustentan ya están tomadas en `arquitectura`.
 
 ## Brief
 
-Instalar y configurar lo que hoy no existe en el proyecto: Supabase, Drizzle, y el mecanismo de
-autenticación (Supabase Auth) que van a compartir profesionales y buscadores, cada uno con su propio flujo
-de acceso — no lo mismo, pero la misma base.
+Instalar y configurar lo que hoy no existe en el proyecto: la base de datos (Supabase + Drizzle) y el
+mecanismo de autenticación que van a compartir profesionales y buscadores, cada uno con su propio flujo de
+acceso — no lo mismo, pero la misma base.
+
+**Decisión pendiente de confirmar, no de dar por hecha:** en la conversación de roadmap del 2026-08-13 la
+recomendación fue usar Supabase Auth (no construir autenticación in-house, no sumar un tercer proveedor),
+porque ya es la base de datos elegida y trae nativo lo que necesitan los dos flujos — pero es una
+recomendación, no una decisión ratificada. Evaluar build-vs-buy en serio, con la alternativa descartada y
+el porqué documentados, es parte del `ingenieria.md` de esta misión.
 
 Es solo plomería: cero tablas de negocio, cero pantallas, cero flujo de usuario. Cada misión siguiente
 (03 a 07) modela y construye su propia parte del dato y su propia parte del login cuando le toca — acá

--- a/docs/missions/02-base-de-datos-y-auth/README.md
+++ b/docs/missions/02-base-de-datos-y-auth/README.md
@@ -1,4 +1,4 @@
-# Misión 02 — Base de datos y Auth (config)
+# Misión 02 — Base de datos, Auth y correo (config)
 
 **Tipo:** técnica. **Abierta el** 2026-08-13. **Nace de:** A-001, A-002 y A-003 del skill `arquitectura`.
 
@@ -22,19 +22,29 @@ que ya viene resuelto de afuera.
 
 ## Brief
 
-Instalar y configurar lo que hoy no existe en el proyecto: la base de datos (Supabase + Drizzle) y el
-mecanismo de autenticación que van a compartir profesionales y buscadores, cada uno con su propio flujo de
-acceso — no lo mismo, pero la misma base.
+Instalar y configurar lo que hoy no existe en el proyecto: la base de datos (Supabase + Drizzle), el
+mecanismo de autenticación que van a compartir profesionales y buscadores (cada uno con su propio flujo de
+acceso, no lo mismo, pero la misma base), y el envío de correo transaccional.
 
-**Decisión pendiente de confirmar, no de dar por hecha:** en la conversación de roadmap del 2026-08-13 la
-recomendación fue usar Supabase Auth (no construir autenticación in-house, no sumar un tercer proveedor),
-porque ya es la base de datos elegida y trae nativo lo que necesitan los dos flujos — pero es una
-recomendación, no una decisión ratificada. Evaluar build-vs-buy en serio, con la alternativa descartada y
-el porqué documentados, es parte del `ingenieria.md` de esta misión.
+El correo se agregó tarde a este roadmap: hace falta desde el primer flujo real (cuando un profesional se
+registra, algo le tiene que confirmar "recibimos tu solicitud, la vamos a validar pronto" — sin eso el
+registro se siente un hueco negro). No hay nada instalado todavía.
 
-Es solo plomería: cero tablas de negocio, cero pantallas, cero flujo de usuario. Cada misión siguiente
-(03 a 07) modela y construye su propia parte del dato y su propia parte del login cuando le toca — acá
-sale a andar `useDb()`, el helper `requireUser()`, y el mecanismo de RLS (A-002: la policy es respaldo, la
-autorización real vive en el código del endpoint).
+**Decisiones pendientes de confirmar, no de dar por hechas** (ambas salieron de la conversación de roadmap
+del 2026-08-13, ninguna es decisión ratificada — evaluar build-vs-buy en serio, con alternativa descartada
+y porqué documentados, es parte del `ingenieria.md` de esta misión):
+
+- **Auth:** la recomendación fue Supabase Auth (no in-house, no un tercer proveedor), porque ya es la base
+  de datos elegida y trae nativo lo que necesitan los dos flujos.
+- **Correo:** la recomendación fue un proveedor transaccional tipo Resend (no SMTP propio, no otro
+  proveedor sin evaluar) — mismo criterio: bajo costo de integración, no construir algo que ya está
+  resuelto.
+
+Es solo plomería: cero tablas de negocio, cero pantallas, cero flujo de usuario, cero copy de correo. Cada
+misión siguiente (03 a 07) modela y construye su propia parte del dato, su propia parte del login, y
+dispara sus propios correos con su propio contenido cuando le toca — acá sale a andar `useDb()`, el helper
+`requireUser()`, el mecanismo de RLS (A-002: la policy es respaldo, la autorización real vive en el código
+del endpoint), y un `sendEmail()` genérico en `server/utils/` para que nadie reinvente la integración con
+el proveedor cada vez.
 
 Ninguna otra misión de este roadmap puede empezar a construir sin que esta termine primero.

--- a/docs/missions/02-base-de-datos-y-auth/README.md
+++ b/docs/missions/02-base-de-datos-y-auth/README.md
@@ -1,0 +1,30 @@
+# Misión 02 — Base de datos y Auth (config)
+
+**Tipo:** técnica. **Abierta el** 2026-08-13. **Nace de:** A-001, A-002 y A-003 del skill `arquitectura`.
+
+**Estado de la misión:** exploración
+
+**Última actualización:** 2026-08-13
+
+Primera de seis misiones hacia el MVP (registrarse, mostrarse, buscar, reseñar). Sin `producto.md`,
+`experiencia.md` ni `investigacion.md`: es pura infraestructura, sin cambio de producto observable, y las
+decisiones que la sustentan ya están tomadas en `arquitectura`.
+
+| Documento  | Estado    | Qué falta para su gate  |
+| ---------- | --------- | ------------------------ |
+| Ingeniería | pendiente | discovery completo — hoy solo existe la carpeta |
+
+**Próximo hito:** ninguno todavía — esta misión no se ha empezado a trabajar.
+
+## Brief
+
+Instalar y configurar lo que hoy no existe en el proyecto: Supabase, Drizzle, y el mecanismo de
+autenticación (Supabase Auth) que van a compartir profesionales y buscadores, cada uno con su propio flujo
+de acceso — no lo mismo, pero la misma base.
+
+Es solo plomería: cero tablas de negocio, cero pantallas, cero flujo de usuario. Cada misión siguiente
+(03 a 07) modela y construye su propia parte del dato y su propia parte del login cuando le toca — acá
+sale a andar `useDb()`, el helper `requireUser()`, y el mecanismo de RLS (A-002: la policy es respaldo, la
+autorización real vive en el código del endpoint).
+
+Ninguna otra misión de este roadmap puede empezar a construir sin que esta termine primero.

--- a/docs/missions/02-base-de-datos-y-auth/ingenieria.md
+++ b/docs/missions/02-base-de-datos-y-auth/ingenieria.md
@@ -1,0 +1,162 @@
+# Misión: <nombre> — Ingeniería
+
+**Estado:** borrador
+
+**Última actualización:** AAAA-MM-DD
+
+[Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
+[Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
+
+<!--
+Fuente de verdad para arquitectura, datos, contratos, factibilidad y pruebas. Consume el comportamiento
+definido en producto. Una limitación técnica cambia el alcance solo mediante una decisión explícita en
+producto.md.
+
+Núcleo obligatorio: contratos, modelo de datos, RLS y riesgos de factibilidad. Las secciones bajo demanda
+(migración, rendimiento, entrega por etapas) se agregan solo cuando el riesgo lo justifica.
+
+Gate de salida — ingenieria.md está lista para construir cuando:
+- los contratos definen qué entra, qué sale y qué invariantes se mantienen, sin ambigüedad
+- el modelo de datos soporta los casos límite de producto.md sin workarounds
+- el impacto en RLS está resuelto: qué policy se crea o cambia, o por qué ninguna
+- la migración de datos existentes tiene estrategia o está explícitamente fuera del alcance
+- los escenarios verificables de producto están mapeados a pruebas
+- el plan de construcción corta el diseño en slices atómicos ordenados (un slice = un Issue = un PR)
+-->
+
+## Decisión técnica: <arquitectura y riesgo principal>
+
+<Dirección técnica, trade-off principal y el riesgo que todavía podría invalidarla.>
+
+- **Contratos de producto cubiertos:** F-001, <otros>.
+- **Riesgo bloqueante:** <incertidumbre o "ninguna">.
+
+## Arquitectura: <cómo se divide la responsabilidad>
+
+<!--
+La lógica de negocio se separa de la infraestructura: funciones puras en utils/ y server/utils/,
+reactividad en composables, acceso a datos en server/api/ con Drizzle. Incluye diagrama solo cuando tres o
+más partes interactúan.
+-->
+
+<Descripción del enfoque y por qué satisface los contratos con menor riesgo.>
+
+| Componente | Responsabilidad       | No debe decidir | Contratos |
+| ---------- | --------------------- | --------------- | --------- |
+| <nombre>   | <una responsabilidad> | <frontera>      | F-001     |
+
+## Contratos
+
+<!--
+Cada contrato especifica entrada, salida e invariantes al nivel en que se puede implementar sin reuniones
+de aclaración. Incluye los errores observables y el código HTTP cuando es un endpoint.
+-->
+
+### TC-001 — <contrato en una frase>
+
+- **Entrada:** <datos y precondiciones, con tipos y forma concreta>.
+- **Salida:** <resultado y su forma concreta>.
+- **Invariantes:** <qué se cumple siempre: atomicidad, consistencia, idempotencia>.
+- **Errores:** <condición → código HTTP y cuerpo `{ error, code? }`, y qué puede hacer el llamador>.
+- **Contrato de producto:** [F-001](./producto.md#f-001).
+
+## Modelo de datos
+
+<!-- Entidades con significado, escritura y ciclo de vida. El schema completo vive en server/db/. -->
+
+| Entidad o campo | Significado             | Escritura          | Retención o historial |
+| --------------- | ----------------------- | ------------------ | --------------------- |
+| <dato>          | <semántica de producto> | <endpoint o acción>| <política>            |
+
+### Invariantes de datos
+
+- <unicidad, pertenencia, orden o consistencia temporal>.
+- <qué operación es atómica o qué dato tiene una única fuente de verdad>.
+
+### Impacto en RLS
+
+<!--
+Obligatorio. Fuente de verdad: server/db/sql/rls.sql. Si el cambio no toca ownership ni relaciones usadas
+en policies, decirlo explícitamente con esa razón — no dejar la sección vacía.
+-->
+
+| Tabla    | Cambio                 | Policy afectada | Acción                    |
+| -------- | ---------------------- | --------------- | ------------------------- |
+| <tabla>  | <nueva, ownership, FK> | <nombre>        | <crear, actualizar, nada> |
+
+## Riesgos y experimentos de factibilidad
+
+<!--
+Un riesgo que podría cambiar el producto se enlaza como pregunta o decisión en producto.md. Un experimento
+tiene pregunta, límite de tiempo y resultado capaz de cerrar la incertidumbre.
+-->
+
+| ID     | Riesgo o pregunta | Qué invalida        | Experimento o mitigación  | Criterio de salida      | Estado  |
+| ------ | ----------------- | ------------------- | ------------------------- | ----------------------- | ------- |
+| TR-001 | <incertidumbre>   | <alcance en riesgo> | <spike, prueba o recorte> | <resultado concluyente> | abierto |
+
+## Estrategia de pruebas
+
+<!-- Mapea los ejemplos verificables de producto.md a niveles de prueba. Qué demuestra cada una. -->
+
+| Contrato o riesgo | Nivel                          | Caso principal | Límite o falla |
+| ----------------- | ------------------------------ | -------------- | -------------- |
+| F-001, CL-001     | <unidad, contrato, integración>| <caso>         | <caso>         |
+
+### Propiedades que deben probarse
+
+- <invariante bajo reintentos, concurrencia o distintas entradas>.
+- <ausencia de efectos parciales en falla>.
+
+## Plan de construcción
+
+<!--
+Se completa al final, cuando el gate de salida se cumple y ninguna pregunta bloqueante sigue abierta —
+cortar sobre decisiones abiertas produce issues que mueren. Cada slice es un cambio funcional atómico: un
+Issue, un PR, ejecutable sin haber leído la misión (el issue lleva su contrato inline) y con criterios
+pass/fail enumerables como tests. Guía completa en el skill discovery-engineering.
+-->
+
+| ID    | Slice (una frase, sin "y") | Sustento      | Criterio de aceptación principal          | Depende de |
+| ----- | -------------------------- | ------------- | ----------------------------------------- | ---------- |
+| S-001 | <cambio atómico>           | TC-001, D-001 | <entrada concreta → resultado observable> | —          |
+
+## Secciones bajo demanda
+
+<!--
+Agregar solo cuando el riesgo lo justifique, con estos títulos:
+
+- "Migración y compatibilidad": cuando existan datos o consumidores que deben llegar al nuevo contrato.
+  Incluye rollback lógico si la migración física no puede revertirse.
+- "Rendimiento y observabilidad": cuando haya presupuesto de latencia o volumen que defender (búsqueda
+  geográfica y listados paginados son los candidatos naturales).
+- "SEO e indexación": cuando la superficie deba ser indexable (páginas por categoría + comuna, datos
+  estructurados).
+- "Entrega por etapas": cuando el cambio necesite despliegue incremental o feature flags.
+-->
+
+## Decisiones técnicas
+
+<a id="t-001"></a>
+
+### T-001 — <decisión en una frase>
+
+- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
+- **Contratos:** F-001 y <regla relevante>.
+- **Alternativas descartadas:** <opciones y trade-offs, con el porqué del rechazo>.
+- **Decisión y consecuencias:** <enfoque elegido, beneficio, costo y trabajo futuro aceptado>.
+- **Reapertura:** <medición o cambio que justificaría revisar>.
+
+## Preguntas
+
+<!--
+Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
+Estado: abierta | resuelta AAAA-MM-DD | disuelta AAAA-MM-DD. Solo las abiertas llevan bloque de detalle.
+-->
+
+<Una frase que responde "¿qué falta?": la pregunta que bloquea construcción y qué bloquea.>
+
+| ID     | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
+| ------ | ---------------------- | ------------------- | --------------------------------------------------------------- |
+| TQ-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
+| TQ-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |

--- a/docs/missions/03-taxonomia-categorias-y-comunas/README.md
+++ b/docs/missions/03-taxonomia-categorias-y-comunas/README.md
@@ -1,0 +1,29 @@
+# Misión 03 — Taxonomía: categorías y comunas
+
+**Tipo:** producto. **Abierta el** 2026-08-13. **Nace de:** ninguna.
+
+**Estado de la misión:** exploración
+
+**Última actualización:** 2026-08-13
+
+Segunda de seis misiones hacia el MVP (registrarse, mostrarse, buscar, reseñar). Depende de que
+[misión 02](../02-base-de-datos-y-auth/) exista antes de poder guardar algo.
+
+| Documento     | Estado    | Qué falta para su gate              |
+| ------------- | --------- | ------------------------------------ |
+| Investigación | pendiente | discovery completo — hoy solo existe la carpeta |
+| Producto      | pendiente | —                                     |
+| Experiencia   | pendiente | —                                     |
+| Ingeniería    | pendiente | —                                     |
+
+**Próximo hito:** ninguno todavía — esta misión no se ha empezado a trabajar.
+
+## Brief
+
+Definir qué categorías de oficio (gasfitería, electricidad, peluquería, limpieza...) y qué comunas cubre
+datealo en su lanzamiento — probablemente Santiago más otra región para empezar, no todo Chile de una vez.
+
+Es la lista maestra de la que dependen registro (04) y búsqueda (06): sin ella, cada misión inventa su
+propia versión de "qué categorías existen" o "qué comunas están disponibles", y quedan inconsistentes entre
+sí. La decisión de qué entra y qué queda afuera en el lanzamiento es de producto, no algo que se resuelve
+solo en el modelo de datos.

--- a/docs/missions/03-taxonomia-categorias-y-comunas/experiencia.md
+++ b/docs/missions/03-taxonomia-categorias-y-comunas/experiencia.md
@@ -1,0 +1,183 @@
+# Misión: <nombre> — Experiencia
+
+**Estado:** borrador
+
+**Última actualización:** AAAA-MM-DD
+
+[Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
+[Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
+
+<!--
+Fuente de verdad para flujos, estados, contenido e interacción. No redefine reglas de producto: si el
+diseño descubre una regla nueva o invalida una, abre o actualiza una decisión en producto.md.
+
+Núcleo obligatorio: vistas, mapa de estados, flujos críticos y estados por superficie. Las secciones bajo
+demanda (modelo mental, jerarquía de información, validación) se agregan solo cuando una decisión las
+necesita.
+
+Gate de salida — experiencia.md está lista para ingenieria.md cuando:
+- cada flujo crítico tiene secuencia, variantes, recuperación y criterio de término
+- cada estado tiene contenido concreto (texto real, información visible, acción disponible)
+- cada vista lista sus modos, y el mapa de estados cubre todas las transiciones entre ellos
+- cada modo tiene su indicador permanente de estado, y cada flujo tiene todas sus salidas documentadas
+- los casos límite de producto.md tienen flujo o estado mapeado
+- cada flujo crítico está mockeado en móvil (390px), y en desktop si también vive ahí
+- ninguna pantalla queda descrita como "similar a X" sin especificar qué cambia
+-->
+
+## Decisión de experiencia: <qué cambia para quien usa el producto>
+
+<Modelo de interacción elegido, flujo más importante y la incertidumbre que sigue abierta.>
+
+- **Funcionalidades cubiertas:** F-001, <otras>.
+- **Pendiente bloqueante:** <pregunta o "ninguna">.
+
+## Vistas
+
+<!--
+El listado de pantallas que define la experiencia — el mapa que se entrega antes de los flujos. Una línea
+por vista, sin tabla, con sus modos anidados debajo. Una vista es un destino: se llega a ella. Un modo es
+un estado de esa vista que cambia qué se puede hacer y qué se ve — se anida, nunca se lista como vista
+hermana.
+
+El porqué de cada vista, su trade-off o su justificación no van aquí: viven en su flujo (UXF) o en una
+decisión (UX-xxx). Regla de formato para todo el documento: las tablas se reservan para índices de celdas
+cortas; lo que lleva justificación extensa va en secciones con header + bullets, nunca en una celda.
+-->
+
+- **V-001 — <vista>** · móvil / desktop · resuelve F-001 · flujos UXF-001 · pendiente
+  - modo **<nombre>** — <qué lo distingue y qué se puede hacer en él>
+  - modo **<nombre>** — <ídem>
+
+## Mapa de estados
+
+<!--
+Vistas y flujos son listas, y una lista no muestra un camino. Esta tabla conecta los modos: qué acción
+lleva de uno a otro y qué pasa con el trabajo del usuario en cada salto. Cada fila que falte es una
+pregunta que ingeniería resuelve inventando.
+-->
+
+| Desde  | Acción             | Queda en | Qué pasa con el trabajo              |
+| ------ | ------------------ | -------- | ------------------------------------ |
+| <modo> | <acción concreta>  | <modo>   | <qué se aplicó, qué quedó pendiente> |
+| <modo> | <salir sin cerrar> | <modo>   | <qué se pierde o se conserva>        |
+
+## UXF-001 — <flujo principal en verbo>
+
+<!--
+Duplica por flujo crítico. Cada paso describe acción → respuesta al nivel de "el usuario toca X → Datealo
+muestra Y". Un mockup no reemplaza la secuencia porque no explica estados ni recuperación.
+-->
+
+**Objetivo:** <qué se completa o comprende>. **Contrato:** [F-001](./producto.md#f-001).
+
+**Punto de entrada:** <estado y superficie inicial, y qué acción trae al usuario hasta acá>.
+
+**Criterio de término:** <estado observable que confirma que el flujo terminó bien>.
+
+**Cómo sabe el usuario dónde está:** <el elemento concreto y permanente en pantalla que se lo dice, por
+cada modo que toca este flujo>.
+
+### Salidas
+
+<!--
+Todas las formas de irse, no solo terminar bien. El criterio de término cubre la salida buena; las otras
+son las que el usuario encuentra primero. Un modo del que no se sabe salir es un modo donde el usuario se
+pierde.
+-->
+
+| Salida                | Cómo se ejecuta       | Qué queda del trabajo           |
+| --------------------- | --------------------- | ------------------------------- |
+| <termina bien>        | <acción>              | <qué se aplicó y dónde>         |
+| <descarta>            | <acción, Esc, cerrar> | <nada, ni a medias>             |
+| <abandona sin cerrar> | <navega a otra parte> | <se conserva, se pierde, avisa> |
+
+### Secuencia principal
+
+| Paso | Acción            | Respuesta del sistema         | Información visible |
+| ---- | ----------------- | ----------------------------- | ------------------- |
+| 1    | <acción concreta> | <feedback o cambio de estado> | <dato y jerarquía>  |
+
+### Variantes y recuperación
+
+| Condición          | Qué cambia              | Cómo se entiende    | Cómo se recupera             |
+| ------------------ | ----------------------- | ------------------- | ---------------------------- |
+| <sin resultados>   | <estado>                | <mensaje concreto>  | <acción disponible>          |
+| <sin permiso de ubicación> | <comportamiento> | <indicador visible> | <alternativa manual>         |
+| <conexión lenta>   | <skeleton, no spinner>  | <qué se ve mientras>| <qué pasa si falla>          |
+
+### Decisiones que no deben quedar implícitas
+
+- <qué ocurre al cancelar, volver atrás, reintentar o confirmar>.
+- <qué cambio se guarda inmediato y cuál necesita confirmación>.
+
+## Estados por superficie
+
+<!--
+El contenido es concreto: texto real, no "mensaje apropiado". El estado vacío de un marketplace
+pre-lanzamiento no es un detalle: para muchas búsquedas será el estado principal durante meses.
+-->
+
+| Estado  | Qué se muestra (texto e información real) | Acción disponible                   |
+| ------- | ----------------------------------------- | ----------------------------------- |
+| inicial | <contenido>                               | <acción>                            |
+| vacío   | <por qué está vacío, con texto concreto>  | <cómo avanzar, o ninguna y por qué> |
+| carga   | <skeleton de qué forma>                   | <ninguna>                           |
+| error   | <causa útil y alcance>                    | <recuperación>                      |
+
+## Mockups
+
+<!--
+Los mockups viven en design-mockups/ como HTML (ver el skill discovery-ux y docs/design/README.md).
+Exploran o materializan una decisión; no son fuente de verdad de reglas de producto.
+-->
+
+| Mockup   | Cubre   | Estado                 | Ruta                              |
+| -------- | ------- | ---------------------- | --------------------------------- |
+| <nombre> | UXF-001 | exploración o validado | `./design-mockups/<archivo>.html` |
+
+## Cobertura
+
+<!-- Detecta huecos antes de construir. Una funcionalidad sin pantalla nueva igual tiene estados. -->
+
+| Funcionalidad | Flujo   | Estados cubiertos       | Estado    |
+| ------------- | ------- | ----------------------- | --------- |
+| F-001         | UXF-001 | principal, vacío, error | pendiente |
+
+## Secciones bajo demanda
+
+<!--
+Agregar solo cuando una decisión las necesite, con estos títulos:
+
+- "Modelo mental y lenguaje": cuando un concepto de producto pueda confundirse en la interfaz.
+- "Jerarquía de información": cuando una superficie densa exija decidir qué se ve primero (una card de
+  resultado con foto, rating, distancia, precio y disponibilidad es exactamente ese caso).
+- "Validación (UXV-xxx)": cuando una incertidumbre de diseño necesite prueba con usuarios.
+- "Accesibilidad y adaptación": cuando el contexto de uso cambie el flujo o la representación.
+-->
+
+## Decisiones de experiencia
+
+<a id="ux-001"></a>
+
+### UX-001 — <decisión en una frase>
+
+- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
+- **Sustento:** F-001 o <hallazgo>.
+- **Alternativas descartadas:** <opciones relevantes y trade-off, con el porqué del rechazo>.
+- **Decisión y consecuencia:** <qué flujo o superficie cambia>.
+- **Impacto en producto:** <ninguno o enlace a D-xxx/F-xxx actualizado>.
+
+## Preguntas
+
+<!--
+Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
+Estado: abierta | resuelta AAAA-MM-DD | disuelta AAAA-MM-DD. Solo las abiertas llevan bloque de detalle.
+-->
+
+<Una frase que responde "¿qué falta?": la pregunta que bloquea construcción y qué bloquea.>
+
+| ID      | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
+| ------- | ---------------------- | ------------------- | --------------------------------------------------------------- |
+| UXQ-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
+| UXQ-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |

--- a/docs/missions/03-taxonomia-categorias-y-comunas/ingenieria.md
+++ b/docs/missions/03-taxonomia-categorias-y-comunas/ingenieria.md
@@ -1,0 +1,162 @@
+# Misión: <nombre> — Ingeniería
+
+**Estado:** borrador
+
+**Última actualización:** AAAA-MM-DD
+
+[Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
+[Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
+
+<!--
+Fuente de verdad para arquitectura, datos, contratos, factibilidad y pruebas. Consume el comportamiento
+definido en producto. Una limitación técnica cambia el alcance solo mediante una decisión explícita en
+producto.md.
+
+Núcleo obligatorio: contratos, modelo de datos, RLS y riesgos de factibilidad. Las secciones bajo demanda
+(migración, rendimiento, entrega por etapas) se agregan solo cuando el riesgo lo justifica.
+
+Gate de salida — ingenieria.md está lista para construir cuando:
+- los contratos definen qué entra, qué sale y qué invariantes se mantienen, sin ambigüedad
+- el modelo de datos soporta los casos límite de producto.md sin workarounds
+- el impacto en RLS está resuelto: qué policy se crea o cambia, o por qué ninguna
+- la migración de datos existentes tiene estrategia o está explícitamente fuera del alcance
+- los escenarios verificables de producto están mapeados a pruebas
+- el plan de construcción corta el diseño en slices atómicos ordenados (un slice = un Issue = un PR)
+-->
+
+## Decisión técnica: <arquitectura y riesgo principal>
+
+<Dirección técnica, trade-off principal y el riesgo que todavía podría invalidarla.>
+
+- **Contratos de producto cubiertos:** F-001, <otros>.
+- **Riesgo bloqueante:** <incertidumbre o "ninguna">.
+
+## Arquitectura: <cómo se divide la responsabilidad>
+
+<!--
+La lógica de negocio se separa de la infraestructura: funciones puras en utils/ y server/utils/,
+reactividad en composables, acceso a datos en server/api/ con Drizzle. Incluye diagrama solo cuando tres o
+más partes interactúan.
+-->
+
+<Descripción del enfoque y por qué satisface los contratos con menor riesgo.>
+
+| Componente | Responsabilidad       | No debe decidir | Contratos |
+| ---------- | --------------------- | --------------- | --------- |
+| <nombre>   | <una responsabilidad> | <frontera>      | F-001     |
+
+## Contratos
+
+<!--
+Cada contrato especifica entrada, salida e invariantes al nivel en que se puede implementar sin reuniones
+de aclaración. Incluye los errores observables y el código HTTP cuando es un endpoint.
+-->
+
+### TC-001 — <contrato en una frase>
+
+- **Entrada:** <datos y precondiciones, con tipos y forma concreta>.
+- **Salida:** <resultado y su forma concreta>.
+- **Invariantes:** <qué se cumple siempre: atomicidad, consistencia, idempotencia>.
+- **Errores:** <condición → código HTTP y cuerpo `{ error, code? }`, y qué puede hacer el llamador>.
+- **Contrato de producto:** [F-001](./producto.md#f-001).
+
+## Modelo de datos
+
+<!-- Entidades con significado, escritura y ciclo de vida. El schema completo vive en server/db/. -->
+
+| Entidad o campo | Significado             | Escritura          | Retención o historial |
+| --------------- | ----------------------- | ------------------ | --------------------- |
+| <dato>          | <semántica de producto> | <endpoint o acción>| <política>            |
+
+### Invariantes de datos
+
+- <unicidad, pertenencia, orden o consistencia temporal>.
+- <qué operación es atómica o qué dato tiene una única fuente de verdad>.
+
+### Impacto en RLS
+
+<!--
+Obligatorio. Fuente de verdad: server/db/sql/rls.sql. Si el cambio no toca ownership ni relaciones usadas
+en policies, decirlo explícitamente con esa razón — no dejar la sección vacía.
+-->
+
+| Tabla    | Cambio                 | Policy afectada | Acción                    |
+| -------- | ---------------------- | --------------- | ------------------------- |
+| <tabla>  | <nueva, ownership, FK> | <nombre>        | <crear, actualizar, nada> |
+
+## Riesgos y experimentos de factibilidad
+
+<!--
+Un riesgo que podría cambiar el producto se enlaza como pregunta o decisión en producto.md. Un experimento
+tiene pregunta, límite de tiempo y resultado capaz de cerrar la incertidumbre.
+-->
+
+| ID     | Riesgo o pregunta | Qué invalida        | Experimento o mitigación  | Criterio de salida      | Estado  |
+| ------ | ----------------- | ------------------- | ------------------------- | ----------------------- | ------- |
+| TR-001 | <incertidumbre>   | <alcance en riesgo> | <spike, prueba o recorte> | <resultado concluyente> | abierto |
+
+## Estrategia de pruebas
+
+<!-- Mapea los ejemplos verificables de producto.md a niveles de prueba. Qué demuestra cada una. -->
+
+| Contrato o riesgo | Nivel                          | Caso principal | Límite o falla |
+| ----------------- | ------------------------------ | -------------- | -------------- |
+| F-001, CL-001     | <unidad, contrato, integración>| <caso>         | <caso>         |
+
+### Propiedades que deben probarse
+
+- <invariante bajo reintentos, concurrencia o distintas entradas>.
+- <ausencia de efectos parciales en falla>.
+
+## Plan de construcción
+
+<!--
+Se completa al final, cuando el gate de salida se cumple y ninguna pregunta bloqueante sigue abierta —
+cortar sobre decisiones abiertas produce issues que mueren. Cada slice es un cambio funcional atómico: un
+Issue, un PR, ejecutable sin haber leído la misión (el issue lleva su contrato inline) y con criterios
+pass/fail enumerables como tests. Guía completa en el skill discovery-engineering.
+-->
+
+| ID    | Slice (una frase, sin "y") | Sustento      | Criterio de aceptación principal          | Depende de |
+| ----- | -------------------------- | ------------- | ----------------------------------------- | ---------- |
+| S-001 | <cambio atómico>           | TC-001, D-001 | <entrada concreta → resultado observable> | —          |
+
+## Secciones bajo demanda
+
+<!--
+Agregar solo cuando el riesgo lo justifique, con estos títulos:
+
+- "Migración y compatibilidad": cuando existan datos o consumidores que deben llegar al nuevo contrato.
+  Incluye rollback lógico si la migración física no puede revertirse.
+- "Rendimiento y observabilidad": cuando haya presupuesto de latencia o volumen que defender (búsqueda
+  geográfica y listados paginados son los candidatos naturales).
+- "SEO e indexación": cuando la superficie deba ser indexable (páginas por categoría + comuna, datos
+  estructurados).
+- "Entrega por etapas": cuando el cambio necesite despliegue incremental o feature flags.
+-->
+
+## Decisiones técnicas
+
+<a id="t-001"></a>
+
+### T-001 — <decisión en una frase>
+
+- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
+- **Contratos:** F-001 y <regla relevante>.
+- **Alternativas descartadas:** <opciones y trade-offs, con el porqué del rechazo>.
+- **Decisión y consecuencias:** <enfoque elegido, beneficio, costo y trabajo futuro aceptado>.
+- **Reapertura:** <medición o cambio que justificaría revisar>.
+
+## Preguntas
+
+<!--
+Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
+Estado: abierta | resuelta AAAA-MM-DD | disuelta AAAA-MM-DD. Solo las abiertas llevan bloque de detalle.
+-->
+
+<Una frase que responde "¿qué falta?": la pregunta que bloquea construcción y qué bloquea.>
+
+| ID     | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
+| ------ | ---------------------- | ------------------- | --------------------------------------------------------------- |
+| TQ-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
+| TQ-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |

--- a/docs/missions/03-taxonomia-categorias-y-comunas/investigacion.md
+++ b/docs/missions/03-taxonomia-categorias-y-comunas/investigacion.md
@@ -1,0 +1,118 @@
+# Misión: <nombre> — Investigación
+
+**Estado:** activo
+
+**Última actualización:** AAAA-MM-DD
+
+[Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
+[Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
+
+<!--
+Este documento se acumula: la evidencia y las conclusiones no se borran cuando el alcance cambia, porque
+explican por qué el producto es como es. Lo que sí se actualiza es el ideal, que resume la dirección que
+la investigación sostiene hoy.
+
+Gate de salida — la investigación sostiene un producto.md cuando:
+- el problema tiene situación y consecuencia concretas, no una categoría abstracta
+- al menos una conclusión con confianza alta o media respalda la dirección
+- el ideal describe capacidades observables, no intenciones
+-->
+
+## El problema aparece cuando <historia concreta>
+
+<!--
+Una situación real o reconstruida con precisión. No abras con una categoría como "falta de confianza" —
+abre con quién estaba haciendo qué y qué salió mal. Nombra a la persona y el servicio concreto.
+-->
+
+**Situación:** <qué está ocurriendo antes del problema>.
+
+**Acción o necesidad:** <qué se intenta resolver o decidir>.
+
+**Respuesta actual:** <qué hace hoy la persona: grupo de WhatsApp, Google, recomendación de un vecino,
+Datealo si ya existe la superficie>.
+
+**Consecuencia:** <error, demora, riesgo o decisión que no puede tomarse>.
+
+## Preguntas que la investigación debe resolver
+
+<!--
+Solo preguntas capaces de cambiar el ideal o una decisión. Al resolver una, moverla a evidencia o
+conclusión. No es un backlog.
+-->
+
+- ¿<pregunta y decisión que depende de ella>?
+
+## Evidencia
+
+<!--
+Un hecho verificable con fuente y límite. Prioriza observación directa, entrevistas y comportamiento
+comprobado. Los benchmarks de otros productos también son evidencia: qué hacen, qué trade-off eligieron y
+qué no aplica a Datealo.
+
+Datealo no tiene datos de uso propios todavía. Cuando la única evidencia disponible sea un benchmark o
+una entrevista, la columna "límite" es lo que impide que se lea como dato duro.
+-->
+
+| ID    | Tipo                                              | Fuente                | Hecho verificable | Límite de la evidencia |
+| ----- | ------------------------------------------------- | --------------------- | ----------------- | ---------------------- |
+| E-001 | <entrevista, benchmark, uso, código, observación> | <enlace o referencia> | <hecho>           | <qué no demuestra>     |
+
+<a id="e-001"></a>
+
+### E-001 — <fuente o hecho en una frase>
+
+<!--
+Desarrollar solo cuando la tabla no alcanza para evaluar la calidad de la evidencia. Cierra con la
+consecuencia para la investigación.
+-->
+
+<Observación precisa y contexto necesario.>
+
+Esto permite afirmar <alcance>, pero no demuestra <límite>.
+
+## Conclusiones
+
+<!--
+Una conclusión interpreta evidencia; no es una preferencia ni una funcionalidad. El título expresa el
+hallazgo, no el tema.
+-->
+
+<a id="c-001"></a>
+
+### C-001 — <conclusión en una frase>
+
+- **Sustento:** [E-001](#e-001).
+- **Razonamiento:** <por qué la evidencia conduce a esta lectura y no a otra>.
+- **Implicación:** <qué deberá ser cierto en el producto o qué alternativa queda debilitada>.
+- **Confianza:** <alta, media o baja> porque <razón o validación pendiente>.
+
+## El ideal: <resultado completo, sin recortar>
+
+<!--
+El ideal es el producto de la investigación: la dirección que la evidencia sostiene, sin restricciones de
+implementación. El recorte a la primera entrega no vive aquí — vive en producto.md como decisión de
+alcance. Esta sección sí se reescribe cuando nueva evidencia cambia la dirección.
+-->
+
+### El resultado ideal se ve así
+
+<Narra de principio a fin una situación futura con datos concretos: nombres, comunas, oficios, horarios.
+Qué acción ocurre, qué responde Datealo, qué decisión puede tomar la persona. Evita "una experiencia
+simple" sin comportamiento observable.>
+
+### Capacidades del ideal
+
+| Capacidad | Acción habilitada    | Respuesta esperada              | Conclusión que la justifica |
+| --------- | -------------------- | ------------------------------- | --------------------------- |
+| <nombre>  | <qué se puede hacer> | <qué produce o explica Datealo> | [C-001](#c-001)             |
+
+### El ideal no significa <confusión probable>
+
+- <límite conceptual que evita una interpretación incorrecta>.
+
+## Referencias
+
+<!-- Fuentes primarias citadas por las evidencias. El enlace no sustituye el hecho y el límite en E-xxx. -->
+
+- [<título descriptivo>](URL): usado en E-001 para <afirmación concreta>.

--- a/docs/missions/03-taxonomia-categorias-y-comunas/producto.md
+++ b/docs/missions/03-taxonomia-categorias-y-comunas/producto.md
@@ -1,0 +1,149 @@
+# Misión: <nombre> — Producto
+
+**Estado:** borrador
+
+**Última actualización:** AAAA-MM-DD
+
+[Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
+[Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
+
+<!--
+Este documento es la spec viva del resultado: qué construimos ahora y bajo qué reglas. El porqué vive en
+investigacion.md — aquí solo se enlaza. Se reescribe cuando el alcance cambia; no acumula historia.
+
+Gate de salida — producto.md está listo para experiencia.md cuando:
+- cada funcionalidad tiene formato JTBD, reglas y al menos un caso límite con comportamiento definido
+- cada funcionalidad enlaza una conclusión de investigacion.md y una señal de éxito
+- cada funcionalidad declara a qué lado del marketplace sirve, y qué necesita del otro lado para funcionar
+- no hay decisiones de producto delegadas a diseño o ingeniería
+- las decisiones propuestas tienen fecha límite en el README
+-->
+
+## Qué construimos: <resultado en una frase>
+
+<!--
+El recorte vigente del ideal y por qué sigue entregando el resultado central. Máximo cuatro párrafos
+cortos. El ideal completo vive en investigacion.md.
+-->
+
+**Resultado:** <qué podrá lograr una persona al finalizar esta entrega>.
+
+**Recorte respecto del ideal:** <qué dimensión se reduce y por qué sigue siendo suficiente>
+(ver [el ideal](./investigacion.md)).
+
+**Restricciones aceptadas:** <plataforma, cobertura geográfica, categorías, volumen inicial de
+profesionales>.
+
+## Funcionalidades
+
+| ID    | Funcionalidad                  | Lado         | Sustento     | Éxito |
+| ----- | ------------------------------ | ------------ | ------------ | ----- |
+| F-001 | <verbo + resultado observable> | buscador     | C-001, D-001 | M-001 |
+
+<a id="f-001"></a>
+
+### F-001 — <verbo + resultado observable>
+
+<!--
+Duplica este bloque por funcionalidad. Se escribe desde el resultado del usuario (working backwards):
+primero el JTBD, después las reglas. Si la respuesta de Datealo no se puede describir sin hablar de tablas
+o componentes, falta cerrar la decisión de producto.
+-->
+
+Cuando <usuario en contexto concreto>,
+quiero <acción>,
+para <resultado observable>.
+
+**Lado del marketplace:** buscador, profesional o ambos. **Qué necesita del otro lado:** <volumen mínimo
+de perfiles, reseñas o cobertura sin el cual esta funcionalidad no entrega su resultado>.
+
+**Sustento:** [C-001](./investigacion.md#c-001) y [D-001](#d-001). **Éxito:** [M-001](#m-001).
+
+**Reglas:**
+
+- Si <condición>, Datealo <comportamiento esperado>.
+- Si <caso límite>, Datealo <comportamiento seguro y qué información muestra>.
+- Datealo nunca <comportamiento que rompería el significado o la confianza>.
+
+**Ejemplo verificable:** dado <estado con datos concretos>, cuando <acción>, entonces <resultado
+observable>.
+
+**No incluye:** <variante del ideal excluida de esta funcionalidad>.
+
+**Experiencia:** <enlace a UXF-xxx cuando exista>. **Ingeniería:** <enlace a T-xxx cuando exista>.
+
+## Casos límite que cruzan funcionalidades
+
+<!--
+Solo condiciones que afectan varias funcionalidades. Las propias de una viven en su bloque. Un caso
+retirado no se borra ni se reutiliza: conserva su fila, o se nombra con su motivo en una línea debajo.
+
+Los casos límite propios de un marketplace pre-lanzamiento aparecen acá: cero resultados en una comuna,
+un profesional sin reseñas, una categoría con un solo perfil, un perfil sin verificar.
+-->
+
+| ID     | Condición concreta     | Comportamiento esperado | Funcionalidades |
+| ------ | ---------------------- | ----------------------- | --------------- |
+| CL-001 | <estado o combinación> | <qué hace Datealo>      | F-001           |
+
+## Fuera de alcance
+
+<!-- Distingue postergado de descartado y qué condición justificaría reabrirlo. -->
+
+| Capacidad o caso      | Estado                  | Razón del recorte | Condición para reconsiderar |
+| --------------------- | ----------------------- | ----------------- | --------------------------- |
+| <capacidad del ideal> | postergada o descartada | <trade-off>       | <evidencia o hito>          |
+
+## Señales de éxito
+
+<a id="m-001"></a>
+
+### M-001 — <señal que demuestra el resultado>
+
+- **Pregunta:** ¿<qué queremos comprobar>?
+- **Señal:** <comportamiento o resultado observable>.
+- **Método y umbral:** <instrumentación o revisión, qué resultado, en qué población y ventana>.
+- **Guardrail:** <daño que no debe aumentar para conseguir la señal>.
+
+## Decisiones de producto
+
+<!--
+Solo decisiones con alternativas reales. No borres decisiones reemplazadas: explican por qué el producto
+es como es. Toda decisión propuesta se refleja en el README con fecha límite.
+-->
+
+<a id="d-001"></a>
+
+### D-001 — <decisión en una frase que se entiende sola>
+
+- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
+- **Sustento:** [C-001](./investigacion.md#c-001).
+- **Tensión:** <criterios que no podían maximizarse al mismo tiempo>.
+- **Alternativas descartadas:** <opciones y razón concreta del rechazo, en la misma línea>.
+- **Decisión y consecuencia:** <qué se hará y qué habilita, limita o exige revisar en UX e ingeniería>.
+- **Reapertura:** <evidencia o cambio que justificaría revisarla>.
+
+## Preguntas
+
+<!--
+Solo preguntas que pueden cambiar una decisión o funcionalidad. Lo demás va a un issue.
+Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
+Estado: abierta | resuelta AAAA-MM-DD (alguien la respondió) | disuelta AAAA-MM-DD (el producto cambió y la
+pregunta dejó de tener sentido). Solo las abiertas llevan bloque de detalle debajo de la tabla.
+-->
+
+<Una frase que responde "¿qué falta?": la pregunta que bloquea y qué bloquea.>
+
+| ID    | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
+| ----- | ---------------------- | ------------------- | --------------------------------------------------------------- |
+| Q-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
+| Q-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |
+
+<a id="q-001"></a>
+
+### Q-001 — <la pregunta en una frase que se entiende sola>
+
+- **La duda, con un ejemplo:** <el caso concreto que muestra por qué hay dos respuestas posibles>.
+- **Afecta a:** D-001 o F-001.
+- **Cómo se resolverá:** <quién y con qué método>.
+- **¿Bloquea algo?:** <qué bloquea y su fecha límite, o no>.

--- a/docs/missions/04-registro-perfil-profesional/README.md
+++ b/docs/missions/04-registro-perfil-profesional/README.md
@@ -1,0 +1,30 @@
+# Misión 04 — Registro y perfil de profesional
+
+**Tipo:** producto. **Abierta el** 2026-08-13. **Nace de:** ninguna.
+
+**Estado de la misión:** exploración
+
+**Última actualización:** 2026-08-13
+
+Tercera de seis misiones hacia el MVP (registrarse, mostrarse, buscar, reseñar). Depende de
+[misión 02](../02-base-de-datos-y-auth/) (login del profesional) y de
+[misión 03](../03-taxonomia-categorias-y-comunas/) (contra qué categorías y comunas se registra).
+
+| Documento     | Estado    | Qué falta para su gate              |
+| ------------- | --------- | ------------------------------------ |
+| Investigación | pendiente | discovery completo — hoy solo existe la carpeta |
+| Producto      | pendiente | —                                     |
+| Experiencia   | pendiente | —                                     |
+| Ingeniería    | pendiente | —                                     |
+
+**Próximo hito:** ninguno todavía — esta misión no se ha empezado a trabajar.
+
+## Brief
+
+El profesional crea su cuenta y completa su perfil público: qué servicios ofrece, en qué comuna trabaja,
+fotos de trabajos anteriores, precios orientativos. Es el "registrarse" del MVP, y el lado "mostrarse"
+desde quien ofrece el servicio — acá vive el login del profesional (email/password o magic link, sobre
+Supabase Auth de la misión 02).
+
+Verificación de profesional queda fuera de esta misión: para el MVP es manual, un admin marca el flag
+directamente en la base — no hay flujo que construir todavía.

--- a/docs/missions/04-registro-perfil-profesional/README.md
+++ b/docs/missions/04-registro-perfil-profesional/README.md
@@ -23,8 +23,8 @@ Tercera de seis misiones hacia el MVP (registrarse, mostrarse, buscar, reseñar)
 
 El profesional crea su cuenta y completa su perfil público: qué servicios ofrece, en qué comuna trabaja,
 fotos de trabajos anteriores, precios orientativos. Es el "registrarse" del MVP, y el lado "mostrarse"
-desde quien ofrece el servicio — acá vive el login del profesional (email/password o magic link, sobre
-Supabase Auth de la misión 02).
+desde quien ofrece el servicio — acá vive el login del profesional, sobre lo que la misión 02 termine
+ratificando (no necesariamente email/password o magic link — eso también queda por confirmar).
 
 Verificación de profesional queda fuera de esta misión: para el MVP es manual, un admin marca el flag
 directamente en la base — no hay flujo que construir todavía.

--- a/docs/missions/04-registro-perfil-profesional/README.md
+++ b/docs/missions/04-registro-perfil-profesional/README.md
@@ -7,8 +7,9 @@
 **Última actualización:** 2026-08-13
 
 Tercera de seis misiones hacia el MVP (registrarse, mostrarse, buscar, reseñar). Depende de
-[misión 02](../02-base-de-datos-y-auth/) (login del profesional) y de
-[misión 03](../03-taxonomia-categorias-y-comunas/) (contra qué categorías y comunas se registra).
+[misión 02](../02-base-de-datos-y-auth/) (login del profesional, y el `sendEmail()` que esta misión usa
+para el primer correo real del producto) y de [misión 03](../03-taxonomia-categorias-y-comunas/) (contra
+qué categorías y comunas se registra).
 
 | Documento     | Estado    | Qué falta para su gate              |
 | ------------- | --------- | ------------------------------------ |
@@ -25,6 +26,10 @@ El profesional crea su cuenta y completa su perfil público: qué servicios ofre
 fotos de trabajos anteriores, precios orientativos. Es el "registrarse" del MVP, y el lado "mostrarse"
 desde quien ofrece el servicio — acá vive el login del profesional, sobre lo que la misión 02 termine
 ratificando (no necesariamente email/password o magic link — eso también queda por confirmar).
+
+Al completar el registro, algo le tiene que confirmar al profesional que su solicitud llegó y que se va a
+validar pronto — un correo, no dejarlo mirando una pantalla sin saber si funcionó. El contenido y el
+trigger exacto son de esta misión; el mecanismo de envío lo deja listo la 02.
 
 Verificación de profesional queda fuera de esta misión: para el MVP es manual, un admin marca el flag
 directamente en la base — no hay flujo que construir todavía.

--- a/docs/missions/04-registro-perfil-profesional/experiencia.md
+++ b/docs/missions/04-registro-perfil-profesional/experiencia.md
@@ -1,0 +1,183 @@
+# Misión: <nombre> — Experiencia
+
+**Estado:** borrador
+
+**Última actualización:** AAAA-MM-DD
+
+[Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
+[Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
+
+<!--
+Fuente de verdad para flujos, estados, contenido e interacción. No redefine reglas de producto: si el
+diseño descubre una regla nueva o invalida una, abre o actualiza una decisión en producto.md.
+
+Núcleo obligatorio: vistas, mapa de estados, flujos críticos y estados por superficie. Las secciones bajo
+demanda (modelo mental, jerarquía de información, validación) se agregan solo cuando una decisión las
+necesita.
+
+Gate de salida — experiencia.md está lista para ingenieria.md cuando:
+- cada flujo crítico tiene secuencia, variantes, recuperación y criterio de término
+- cada estado tiene contenido concreto (texto real, información visible, acción disponible)
+- cada vista lista sus modos, y el mapa de estados cubre todas las transiciones entre ellos
+- cada modo tiene su indicador permanente de estado, y cada flujo tiene todas sus salidas documentadas
+- los casos límite de producto.md tienen flujo o estado mapeado
+- cada flujo crítico está mockeado en móvil (390px), y en desktop si también vive ahí
+- ninguna pantalla queda descrita como "similar a X" sin especificar qué cambia
+-->
+
+## Decisión de experiencia: <qué cambia para quien usa el producto>
+
+<Modelo de interacción elegido, flujo más importante y la incertidumbre que sigue abierta.>
+
+- **Funcionalidades cubiertas:** F-001, <otras>.
+- **Pendiente bloqueante:** <pregunta o "ninguna">.
+
+## Vistas
+
+<!--
+El listado de pantallas que define la experiencia — el mapa que se entrega antes de los flujos. Una línea
+por vista, sin tabla, con sus modos anidados debajo. Una vista es un destino: se llega a ella. Un modo es
+un estado de esa vista que cambia qué se puede hacer y qué se ve — se anida, nunca se lista como vista
+hermana.
+
+El porqué de cada vista, su trade-off o su justificación no van aquí: viven en su flujo (UXF) o en una
+decisión (UX-xxx). Regla de formato para todo el documento: las tablas se reservan para índices de celdas
+cortas; lo que lleva justificación extensa va en secciones con header + bullets, nunca en una celda.
+-->
+
+- **V-001 — <vista>** · móvil / desktop · resuelve F-001 · flujos UXF-001 · pendiente
+  - modo **<nombre>** — <qué lo distingue y qué se puede hacer en él>
+  - modo **<nombre>** — <ídem>
+
+## Mapa de estados
+
+<!--
+Vistas y flujos son listas, y una lista no muestra un camino. Esta tabla conecta los modos: qué acción
+lleva de uno a otro y qué pasa con el trabajo del usuario en cada salto. Cada fila que falte es una
+pregunta que ingeniería resuelve inventando.
+-->
+
+| Desde  | Acción             | Queda en | Qué pasa con el trabajo              |
+| ------ | ------------------ | -------- | ------------------------------------ |
+| <modo> | <acción concreta>  | <modo>   | <qué se aplicó, qué quedó pendiente> |
+| <modo> | <salir sin cerrar> | <modo>   | <qué se pierde o se conserva>        |
+
+## UXF-001 — <flujo principal en verbo>
+
+<!--
+Duplica por flujo crítico. Cada paso describe acción → respuesta al nivel de "el usuario toca X → Datealo
+muestra Y". Un mockup no reemplaza la secuencia porque no explica estados ni recuperación.
+-->
+
+**Objetivo:** <qué se completa o comprende>. **Contrato:** [F-001](./producto.md#f-001).
+
+**Punto de entrada:** <estado y superficie inicial, y qué acción trae al usuario hasta acá>.
+
+**Criterio de término:** <estado observable que confirma que el flujo terminó bien>.
+
+**Cómo sabe el usuario dónde está:** <el elemento concreto y permanente en pantalla que se lo dice, por
+cada modo que toca este flujo>.
+
+### Salidas
+
+<!--
+Todas las formas de irse, no solo terminar bien. El criterio de término cubre la salida buena; las otras
+son las que el usuario encuentra primero. Un modo del que no se sabe salir es un modo donde el usuario se
+pierde.
+-->
+
+| Salida                | Cómo se ejecuta       | Qué queda del trabajo           |
+| --------------------- | --------------------- | ------------------------------- |
+| <termina bien>        | <acción>              | <qué se aplicó y dónde>         |
+| <descarta>            | <acción, Esc, cerrar> | <nada, ni a medias>             |
+| <abandona sin cerrar> | <navega a otra parte> | <se conserva, se pierde, avisa> |
+
+### Secuencia principal
+
+| Paso | Acción            | Respuesta del sistema         | Información visible |
+| ---- | ----------------- | ----------------------------- | ------------------- |
+| 1    | <acción concreta> | <feedback o cambio de estado> | <dato y jerarquía>  |
+
+### Variantes y recuperación
+
+| Condición          | Qué cambia              | Cómo se entiende    | Cómo se recupera             |
+| ------------------ | ----------------------- | ------------------- | ---------------------------- |
+| <sin resultados>   | <estado>                | <mensaje concreto>  | <acción disponible>          |
+| <sin permiso de ubicación> | <comportamiento> | <indicador visible> | <alternativa manual>         |
+| <conexión lenta>   | <skeleton, no spinner>  | <qué se ve mientras>| <qué pasa si falla>          |
+
+### Decisiones que no deben quedar implícitas
+
+- <qué ocurre al cancelar, volver atrás, reintentar o confirmar>.
+- <qué cambio se guarda inmediato y cuál necesita confirmación>.
+
+## Estados por superficie
+
+<!--
+El contenido es concreto: texto real, no "mensaje apropiado". El estado vacío de un marketplace
+pre-lanzamiento no es un detalle: para muchas búsquedas será el estado principal durante meses.
+-->
+
+| Estado  | Qué se muestra (texto e información real) | Acción disponible                   |
+| ------- | ----------------------------------------- | ----------------------------------- |
+| inicial | <contenido>                               | <acción>                            |
+| vacío   | <por qué está vacío, con texto concreto>  | <cómo avanzar, o ninguna y por qué> |
+| carga   | <skeleton de qué forma>                   | <ninguna>                           |
+| error   | <causa útil y alcance>                    | <recuperación>                      |
+
+## Mockups
+
+<!--
+Los mockups viven en design-mockups/ como HTML (ver el skill discovery-ux y docs/design/README.md).
+Exploran o materializan una decisión; no son fuente de verdad de reglas de producto.
+-->
+
+| Mockup   | Cubre   | Estado                 | Ruta                              |
+| -------- | ------- | ---------------------- | --------------------------------- |
+| <nombre> | UXF-001 | exploración o validado | `./design-mockups/<archivo>.html` |
+
+## Cobertura
+
+<!-- Detecta huecos antes de construir. Una funcionalidad sin pantalla nueva igual tiene estados. -->
+
+| Funcionalidad | Flujo   | Estados cubiertos       | Estado    |
+| ------------- | ------- | ----------------------- | --------- |
+| F-001         | UXF-001 | principal, vacío, error | pendiente |
+
+## Secciones bajo demanda
+
+<!--
+Agregar solo cuando una decisión las necesite, con estos títulos:
+
+- "Modelo mental y lenguaje": cuando un concepto de producto pueda confundirse en la interfaz.
+- "Jerarquía de información": cuando una superficie densa exija decidir qué se ve primero (una card de
+  resultado con foto, rating, distancia, precio y disponibilidad es exactamente ese caso).
+- "Validación (UXV-xxx)": cuando una incertidumbre de diseño necesite prueba con usuarios.
+- "Accesibilidad y adaptación": cuando el contexto de uso cambie el flujo o la representación.
+-->
+
+## Decisiones de experiencia
+
+<a id="ux-001"></a>
+
+### UX-001 — <decisión en una frase>
+
+- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
+- **Sustento:** F-001 o <hallazgo>.
+- **Alternativas descartadas:** <opciones relevantes y trade-off, con el porqué del rechazo>.
+- **Decisión y consecuencia:** <qué flujo o superficie cambia>.
+- **Impacto en producto:** <ninguno o enlace a D-xxx/F-xxx actualizado>.
+
+## Preguntas
+
+<!--
+Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
+Estado: abierta | resuelta AAAA-MM-DD | disuelta AAAA-MM-DD. Solo las abiertas llevan bloque de detalle.
+-->
+
+<Una frase que responde "¿qué falta?": la pregunta que bloquea construcción y qué bloquea.>
+
+| ID      | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
+| ------- | ---------------------- | ------------------- | --------------------------------------------------------------- |
+| UXQ-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
+| UXQ-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |

--- a/docs/missions/04-registro-perfil-profesional/ingenieria.md
+++ b/docs/missions/04-registro-perfil-profesional/ingenieria.md
@@ -1,0 +1,162 @@
+# Misión: <nombre> — Ingeniería
+
+**Estado:** borrador
+
+**Última actualización:** AAAA-MM-DD
+
+[Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
+[Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
+
+<!--
+Fuente de verdad para arquitectura, datos, contratos, factibilidad y pruebas. Consume el comportamiento
+definido en producto. Una limitación técnica cambia el alcance solo mediante una decisión explícita en
+producto.md.
+
+Núcleo obligatorio: contratos, modelo de datos, RLS y riesgos de factibilidad. Las secciones bajo demanda
+(migración, rendimiento, entrega por etapas) se agregan solo cuando el riesgo lo justifica.
+
+Gate de salida — ingenieria.md está lista para construir cuando:
+- los contratos definen qué entra, qué sale y qué invariantes se mantienen, sin ambigüedad
+- el modelo de datos soporta los casos límite de producto.md sin workarounds
+- el impacto en RLS está resuelto: qué policy se crea o cambia, o por qué ninguna
+- la migración de datos existentes tiene estrategia o está explícitamente fuera del alcance
+- los escenarios verificables de producto están mapeados a pruebas
+- el plan de construcción corta el diseño en slices atómicos ordenados (un slice = un Issue = un PR)
+-->
+
+## Decisión técnica: <arquitectura y riesgo principal>
+
+<Dirección técnica, trade-off principal y el riesgo que todavía podría invalidarla.>
+
+- **Contratos de producto cubiertos:** F-001, <otros>.
+- **Riesgo bloqueante:** <incertidumbre o "ninguna">.
+
+## Arquitectura: <cómo se divide la responsabilidad>
+
+<!--
+La lógica de negocio se separa de la infraestructura: funciones puras en utils/ y server/utils/,
+reactividad en composables, acceso a datos en server/api/ con Drizzle. Incluye diagrama solo cuando tres o
+más partes interactúan.
+-->
+
+<Descripción del enfoque y por qué satisface los contratos con menor riesgo.>
+
+| Componente | Responsabilidad       | No debe decidir | Contratos |
+| ---------- | --------------------- | --------------- | --------- |
+| <nombre>   | <una responsabilidad> | <frontera>      | F-001     |
+
+## Contratos
+
+<!--
+Cada contrato especifica entrada, salida e invariantes al nivel en que se puede implementar sin reuniones
+de aclaración. Incluye los errores observables y el código HTTP cuando es un endpoint.
+-->
+
+### TC-001 — <contrato en una frase>
+
+- **Entrada:** <datos y precondiciones, con tipos y forma concreta>.
+- **Salida:** <resultado y su forma concreta>.
+- **Invariantes:** <qué se cumple siempre: atomicidad, consistencia, idempotencia>.
+- **Errores:** <condición → código HTTP y cuerpo `{ error, code? }`, y qué puede hacer el llamador>.
+- **Contrato de producto:** [F-001](./producto.md#f-001).
+
+## Modelo de datos
+
+<!-- Entidades con significado, escritura y ciclo de vida. El schema completo vive en server/db/. -->
+
+| Entidad o campo | Significado             | Escritura          | Retención o historial |
+| --------------- | ----------------------- | ------------------ | --------------------- |
+| <dato>          | <semántica de producto> | <endpoint o acción>| <política>            |
+
+### Invariantes de datos
+
+- <unicidad, pertenencia, orden o consistencia temporal>.
+- <qué operación es atómica o qué dato tiene una única fuente de verdad>.
+
+### Impacto en RLS
+
+<!--
+Obligatorio. Fuente de verdad: server/db/sql/rls.sql. Si el cambio no toca ownership ni relaciones usadas
+en policies, decirlo explícitamente con esa razón — no dejar la sección vacía.
+-->
+
+| Tabla    | Cambio                 | Policy afectada | Acción                    |
+| -------- | ---------------------- | --------------- | ------------------------- |
+| <tabla>  | <nueva, ownership, FK> | <nombre>        | <crear, actualizar, nada> |
+
+## Riesgos y experimentos de factibilidad
+
+<!--
+Un riesgo que podría cambiar el producto se enlaza como pregunta o decisión en producto.md. Un experimento
+tiene pregunta, límite de tiempo y resultado capaz de cerrar la incertidumbre.
+-->
+
+| ID     | Riesgo o pregunta | Qué invalida        | Experimento o mitigación  | Criterio de salida      | Estado  |
+| ------ | ----------------- | ------------------- | ------------------------- | ----------------------- | ------- |
+| TR-001 | <incertidumbre>   | <alcance en riesgo> | <spike, prueba o recorte> | <resultado concluyente> | abierto |
+
+## Estrategia de pruebas
+
+<!-- Mapea los ejemplos verificables de producto.md a niveles de prueba. Qué demuestra cada una. -->
+
+| Contrato o riesgo | Nivel                          | Caso principal | Límite o falla |
+| ----------------- | ------------------------------ | -------------- | -------------- |
+| F-001, CL-001     | <unidad, contrato, integración>| <caso>         | <caso>         |
+
+### Propiedades que deben probarse
+
+- <invariante bajo reintentos, concurrencia o distintas entradas>.
+- <ausencia de efectos parciales en falla>.
+
+## Plan de construcción
+
+<!--
+Se completa al final, cuando el gate de salida se cumple y ninguna pregunta bloqueante sigue abierta —
+cortar sobre decisiones abiertas produce issues que mueren. Cada slice es un cambio funcional atómico: un
+Issue, un PR, ejecutable sin haber leído la misión (el issue lleva su contrato inline) y con criterios
+pass/fail enumerables como tests. Guía completa en el skill discovery-engineering.
+-->
+
+| ID    | Slice (una frase, sin "y") | Sustento      | Criterio de aceptación principal          | Depende de |
+| ----- | -------------------------- | ------------- | ----------------------------------------- | ---------- |
+| S-001 | <cambio atómico>           | TC-001, D-001 | <entrada concreta → resultado observable> | —          |
+
+## Secciones bajo demanda
+
+<!--
+Agregar solo cuando el riesgo lo justifique, con estos títulos:
+
+- "Migración y compatibilidad": cuando existan datos o consumidores que deben llegar al nuevo contrato.
+  Incluye rollback lógico si la migración física no puede revertirse.
+- "Rendimiento y observabilidad": cuando haya presupuesto de latencia o volumen que defender (búsqueda
+  geográfica y listados paginados son los candidatos naturales).
+- "SEO e indexación": cuando la superficie deba ser indexable (páginas por categoría + comuna, datos
+  estructurados).
+- "Entrega por etapas": cuando el cambio necesite despliegue incremental o feature flags.
+-->
+
+## Decisiones técnicas
+
+<a id="t-001"></a>
+
+### T-001 — <decisión en una frase>
+
+- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
+- **Contratos:** F-001 y <regla relevante>.
+- **Alternativas descartadas:** <opciones y trade-offs, con el porqué del rechazo>.
+- **Decisión y consecuencias:** <enfoque elegido, beneficio, costo y trabajo futuro aceptado>.
+- **Reapertura:** <medición o cambio que justificaría revisar>.
+
+## Preguntas
+
+<!--
+Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
+Estado: abierta | resuelta AAAA-MM-DD | disuelta AAAA-MM-DD. Solo las abiertas llevan bloque de detalle.
+-->
+
+<Una frase que responde "¿qué falta?": la pregunta que bloquea construcción y qué bloquea.>
+
+| ID     | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
+| ------ | ---------------------- | ------------------- | --------------------------------------------------------------- |
+| TQ-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
+| TQ-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |

--- a/docs/missions/04-registro-perfil-profesional/investigacion.md
+++ b/docs/missions/04-registro-perfil-profesional/investigacion.md
@@ -1,0 +1,118 @@
+# Misión: <nombre> — Investigación
+
+**Estado:** activo
+
+**Última actualización:** AAAA-MM-DD
+
+[Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
+[Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
+
+<!--
+Este documento se acumula: la evidencia y las conclusiones no se borran cuando el alcance cambia, porque
+explican por qué el producto es como es. Lo que sí se actualiza es el ideal, que resume la dirección que
+la investigación sostiene hoy.
+
+Gate de salida — la investigación sostiene un producto.md cuando:
+- el problema tiene situación y consecuencia concretas, no una categoría abstracta
+- al menos una conclusión con confianza alta o media respalda la dirección
+- el ideal describe capacidades observables, no intenciones
+-->
+
+## El problema aparece cuando <historia concreta>
+
+<!--
+Una situación real o reconstruida con precisión. No abras con una categoría como "falta de confianza" —
+abre con quién estaba haciendo qué y qué salió mal. Nombra a la persona y el servicio concreto.
+-->
+
+**Situación:** <qué está ocurriendo antes del problema>.
+
+**Acción o necesidad:** <qué se intenta resolver o decidir>.
+
+**Respuesta actual:** <qué hace hoy la persona: grupo de WhatsApp, Google, recomendación de un vecino,
+Datealo si ya existe la superficie>.
+
+**Consecuencia:** <error, demora, riesgo o decisión que no puede tomarse>.
+
+## Preguntas que la investigación debe resolver
+
+<!--
+Solo preguntas capaces de cambiar el ideal o una decisión. Al resolver una, moverla a evidencia o
+conclusión. No es un backlog.
+-->
+
+- ¿<pregunta y decisión que depende de ella>?
+
+## Evidencia
+
+<!--
+Un hecho verificable con fuente y límite. Prioriza observación directa, entrevistas y comportamiento
+comprobado. Los benchmarks de otros productos también son evidencia: qué hacen, qué trade-off eligieron y
+qué no aplica a Datealo.
+
+Datealo no tiene datos de uso propios todavía. Cuando la única evidencia disponible sea un benchmark o
+una entrevista, la columna "límite" es lo que impide que se lea como dato duro.
+-->
+
+| ID    | Tipo                                              | Fuente                | Hecho verificable | Límite de la evidencia |
+| ----- | ------------------------------------------------- | --------------------- | ----------------- | ---------------------- |
+| E-001 | <entrevista, benchmark, uso, código, observación> | <enlace o referencia> | <hecho>           | <qué no demuestra>     |
+
+<a id="e-001"></a>
+
+### E-001 — <fuente o hecho en una frase>
+
+<!--
+Desarrollar solo cuando la tabla no alcanza para evaluar la calidad de la evidencia. Cierra con la
+consecuencia para la investigación.
+-->
+
+<Observación precisa y contexto necesario.>
+
+Esto permite afirmar <alcance>, pero no demuestra <límite>.
+
+## Conclusiones
+
+<!--
+Una conclusión interpreta evidencia; no es una preferencia ni una funcionalidad. El título expresa el
+hallazgo, no el tema.
+-->
+
+<a id="c-001"></a>
+
+### C-001 — <conclusión en una frase>
+
+- **Sustento:** [E-001](#e-001).
+- **Razonamiento:** <por qué la evidencia conduce a esta lectura y no a otra>.
+- **Implicación:** <qué deberá ser cierto en el producto o qué alternativa queda debilitada>.
+- **Confianza:** <alta, media o baja> porque <razón o validación pendiente>.
+
+## El ideal: <resultado completo, sin recortar>
+
+<!--
+El ideal es el producto de la investigación: la dirección que la evidencia sostiene, sin restricciones de
+implementación. El recorte a la primera entrega no vive aquí — vive en producto.md como decisión de
+alcance. Esta sección sí se reescribe cuando nueva evidencia cambia la dirección.
+-->
+
+### El resultado ideal se ve así
+
+<Narra de principio a fin una situación futura con datos concretos: nombres, comunas, oficios, horarios.
+Qué acción ocurre, qué responde Datealo, qué decisión puede tomar la persona. Evita "una experiencia
+simple" sin comportamiento observable.>
+
+### Capacidades del ideal
+
+| Capacidad | Acción habilitada    | Respuesta esperada              | Conclusión que la justifica |
+| --------- | -------------------- | ------------------------------- | --------------------------- |
+| <nombre>  | <qué se puede hacer> | <qué produce o explica Datealo> | [C-001](#c-001)             |
+
+### El ideal no significa <confusión probable>
+
+- <límite conceptual que evita una interpretación incorrecta>.
+
+## Referencias
+
+<!-- Fuentes primarias citadas por las evidencias. El enlace no sustituye el hecho y el límite en E-xxx. -->
+
+- [<título descriptivo>](URL): usado en E-001 para <afirmación concreta>.

--- a/docs/missions/04-registro-perfil-profesional/producto.md
+++ b/docs/missions/04-registro-perfil-profesional/producto.md
@@ -1,0 +1,149 @@
+# Misión: <nombre> — Producto
+
+**Estado:** borrador
+
+**Última actualización:** AAAA-MM-DD
+
+[Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
+[Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
+
+<!--
+Este documento es la spec viva del resultado: qué construimos ahora y bajo qué reglas. El porqué vive en
+investigacion.md — aquí solo se enlaza. Se reescribe cuando el alcance cambia; no acumula historia.
+
+Gate de salida — producto.md está listo para experiencia.md cuando:
+- cada funcionalidad tiene formato JTBD, reglas y al menos un caso límite con comportamiento definido
+- cada funcionalidad enlaza una conclusión de investigacion.md y una señal de éxito
+- cada funcionalidad declara a qué lado del marketplace sirve, y qué necesita del otro lado para funcionar
+- no hay decisiones de producto delegadas a diseño o ingeniería
+- las decisiones propuestas tienen fecha límite en el README
+-->
+
+## Qué construimos: <resultado en una frase>
+
+<!--
+El recorte vigente del ideal y por qué sigue entregando el resultado central. Máximo cuatro párrafos
+cortos. El ideal completo vive en investigacion.md.
+-->
+
+**Resultado:** <qué podrá lograr una persona al finalizar esta entrega>.
+
+**Recorte respecto del ideal:** <qué dimensión se reduce y por qué sigue siendo suficiente>
+(ver [el ideal](./investigacion.md)).
+
+**Restricciones aceptadas:** <plataforma, cobertura geográfica, categorías, volumen inicial de
+profesionales>.
+
+## Funcionalidades
+
+| ID    | Funcionalidad                  | Lado         | Sustento     | Éxito |
+| ----- | ------------------------------ | ------------ | ------------ | ----- |
+| F-001 | <verbo + resultado observable> | buscador     | C-001, D-001 | M-001 |
+
+<a id="f-001"></a>
+
+### F-001 — <verbo + resultado observable>
+
+<!--
+Duplica este bloque por funcionalidad. Se escribe desde el resultado del usuario (working backwards):
+primero el JTBD, después las reglas. Si la respuesta de Datealo no se puede describir sin hablar de tablas
+o componentes, falta cerrar la decisión de producto.
+-->
+
+Cuando <usuario en contexto concreto>,
+quiero <acción>,
+para <resultado observable>.
+
+**Lado del marketplace:** buscador, profesional o ambos. **Qué necesita del otro lado:** <volumen mínimo
+de perfiles, reseñas o cobertura sin el cual esta funcionalidad no entrega su resultado>.
+
+**Sustento:** [C-001](./investigacion.md#c-001) y [D-001](#d-001). **Éxito:** [M-001](#m-001).
+
+**Reglas:**
+
+- Si <condición>, Datealo <comportamiento esperado>.
+- Si <caso límite>, Datealo <comportamiento seguro y qué información muestra>.
+- Datealo nunca <comportamiento que rompería el significado o la confianza>.
+
+**Ejemplo verificable:** dado <estado con datos concretos>, cuando <acción>, entonces <resultado
+observable>.
+
+**No incluye:** <variante del ideal excluida de esta funcionalidad>.
+
+**Experiencia:** <enlace a UXF-xxx cuando exista>. **Ingeniería:** <enlace a T-xxx cuando exista>.
+
+## Casos límite que cruzan funcionalidades
+
+<!--
+Solo condiciones que afectan varias funcionalidades. Las propias de una viven en su bloque. Un caso
+retirado no se borra ni se reutiliza: conserva su fila, o se nombra con su motivo en una línea debajo.
+
+Los casos límite propios de un marketplace pre-lanzamiento aparecen acá: cero resultados en una comuna,
+un profesional sin reseñas, una categoría con un solo perfil, un perfil sin verificar.
+-->
+
+| ID     | Condición concreta     | Comportamiento esperado | Funcionalidades |
+| ------ | ---------------------- | ----------------------- | --------------- |
+| CL-001 | <estado o combinación> | <qué hace Datealo>      | F-001           |
+
+## Fuera de alcance
+
+<!-- Distingue postergado de descartado y qué condición justificaría reabrirlo. -->
+
+| Capacidad o caso      | Estado                  | Razón del recorte | Condición para reconsiderar |
+| --------------------- | ----------------------- | ----------------- | --------------------------- |
+| <capacidad del ideal> | postergada o descartada | <trade-off>       | <evidencia o hito>          |
+
+## Señales de éxito
+
+<a id="m-001"></a>
+
+### M-001 — <señal que demuestra el resultado>
+
+- **Pregunta:** ¿<qué queremos comprobar>?
+- **Señal:** <comportamiento o resultado observable>.
+- **Método y umbral:** <instrumentación o revisión, qué resultado, en qué población y ventana>.
+- **Guardrail:** <daño que no debe aumentar para conseguir la señal>.
+
+## Decisiones de producto
+
+<!--
+Solo decisiones con alternativas reales. No borres decisiones reemplazadas: explican por qué el producto
+es como es. Toda decisión propuesta se refleja en el README con fecha límite.
+-->
+
+<a id="d-001"></a>
+
+### D-001 — <decisión en una frase que se entiende sola>
+
+- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
+- **Sustento:** [C-001](./investigacion.md#c-001).
+- **Tensión:** <criterios que no podían maximizarse al mismo tiempo>.
+- **Alternativas descartadas:** <opciones y razón concreta del rechazo, en la misma línea>.
+- **Decisión y consecuencia:** <qué se hará y qué habilita, limita o exige revisar en UX e ingeniería>.
+- **Reapertura:** <evidencia o cambio que justificaría revisarla>.
+
+## Preguntas
+
+<!--
+Solo preguntas que pueden cambiar una decisión o funcionalidad. Lo demás va a un issue.
+Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
+Estado: abierta | resuelta AAAA-MM-DD (alguien la respondió) | disuelta AAAA-MM-DD (el producto cambió y la
+pregunta dejó de tener sentido). Solo las abiertas llevan bloque de detalle debajo de la tabla.
+-->
+
+<Una frase que responde "¿qué falta?": la pregunta que bloquea y qué bloquea.>
+
+| ID    | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
+| ----- | ---------------------- | ------------------- | --------------------------------------------------------------- |
+| Q-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
+| Q-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |
+
+<a id="q-001"></a>
+
+### Q-001 — <la pregunta en una frase que se entiende sola>
+
+- **La duda, con un ejemplo:** <el caso concreto que muestra por qué hay dos respuestas posibles>.
+- **Afecta a:** D-001 o F-001.
+- **Cómo se resolverá:** <quién y con qué método>.
+- **¿Bloquea algo?:** <qué bloquea y su fecha límite, o no>.

--- a/docs/missions/05-perfil-publico-profesional/README.md
+++ b/docs/missions/05-perfil-publico-profesional/README.md
@@ -1,0 +1,29 @@
+# Misión 05 — Perfil público de profesional
+
+**Tipo:** producto. **Abierta el** 2026-08-13. **Nace de:** ninguna.
+
+**Estado de la misión:** exploración
+
+**Última actualización:** 2026-08-13
+
+Cuarta de seis misiones hacia el MVP (registrarse, mostrarse, buscar, reseñar). Depende de
+[misión 04](../04-registro-perfil-profesional/): sin perfiles de profesional reales, no hay qué mostrar.
+
+| Documento     | Estado    | Qué falta para su gate              |
+| ------------- | --------- | ------------------------------------ |
+| Investigación | pendiente | discovery completo — hoy solo existe la carpeta |
+| Producto      | pendiente | —                                     |
+| Experiencia   | pendiente | —                                     |
+| Ingeniería    | pendiente | —                                     |
+
+**Próximo hito:** ninguno todavía — esta misión no se ha empezado a trabajar.
+
+## Brief
+
+Lo que ve el buscador al entrar al perfil de un profesional: fotos, precios orientativos, reseñas, badge de
+verificado, y el botón de contacto directo (WhatsApp o teléfono, sin intermediarios — la landing ya lo
+prometió). Es el lado "mostrarse" desde quien busca.
+
+Acá vive el evento de contacto: cuando el buscador aprieta el botón, eso queda registrado — es lo que
+después habilita dejar una reseña en la [misión 07](../07-resenas-verificadas-por-contacto/), sin esta
+misión esa no tiene de qué agarrarse.

--- a/docs/missions/05-perfil-publico-profesional/experiencia.md
+++ b/docs/missions/05-perfil-publico-profesional/experiencia.md
@@ -1,0 +1,183 @@
+# Misión: <nombre> — Experiencia
+
+**Estado:** borrador
+
+**Última actualización:** AAAA-MM-DD
+
+[Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
+[Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
+
+<!--
+Fuente de verdad para flujos, estados, contenido e interacción. No redefine reglas de producto: si el
+diseño descubre una regla nueva o invalida una, abre o actualiza una decisión en producto.md.
+
+Núcleo obligatorio: vistas, mapa de estados, flujos críticos y estados por superficie. Las secciones bajo
+demanda (modelo mental, jerarquía de información, validación) se agregan solo cuando una decisión las
+necesita.
+
+Gate de salida — experiencia.md está lista para ingenieria.md cuando:
+- cada flujo crítico tiene secuencia, variantes, recuperación y criterio de término
+- cada estado tiene contenido concreto (texto real, información visible, acción disponible)
+- cada vista lista sus modos, y el mapa de estados cubre todas las transiciones entre ellos
+- cada modo tiene su indicador permanente de estado, y cada flujo tiene todas sus salidas documentadas
+- los casos límite de producto.md tienen flujo o estado mapeado
+- cada flujo crítico está mockeado en móvil (390px), y en desktop si también vive ahí
+- ninguna pantalla queda descrita como "similar a X" sin especificar qué cambia
+-->
+
+## Decisión de experiencia: <qué cambia para quien usa el producto>
+
+<Modelo de interacción elegido, flujo más importante y la incertidumbre que sigue abierta.>
+
+- **Funcionalidades cubiertas:** F-001, <otras>.
+- **Pendiente bloqueante:** <pregunta o "ninguna">.
+
+## Vistas
+
+<!--
+El listado de pantallas que define la experiencia — el mapa que se entrega antes de los flujos. Una línea
+por vista, sin tabla, con sus modos anidados debajo. Una vista es un destino: se llega a ella. Un modo es
+un estado de esa vista que cambia qué se puede hacer y qué se ve — se anida, nunca se lista como vista
+hermana.
+
+El porqué de cada vista, su trade-off o su justificación no van aquí: viven en su flujo (UXF) o en una
+decisión (UX-xxx). Regla de formato para todo el documento: las tablas se reservan para índices de celdas
+cortas; lo que lleva justificación extensa va en secciones con header + bullets, nunca en una celda.
+-->
+
+- **V-001 — <vista>** · móvil / desktop · resuelve F-001 · flujos UXF-001 · pendiente
+  - modo **<nombre>** — <qué lo distingue y qué se puede hacer en él>
+  - modo **<nombre>** — <ídem>
+
+## Mapa de estados
+
+<!--
+Vistas y flujos son listas, y una lista no muestra un camino. Esta tabla conecta los modos: qué acción
+lleva de uno a otro y qué pasa con el trabajo del usuario en cada salto. Cada fila que falte es una
+pregunta que ingeniería resuelve inventando.
+-->
+
+| Desde  | Acción             | Queda en | Qué pasa con el trabajo              |
+| ------ | ------------------ | -------- | ------------------------------------ |
+| <modo> | <acción concreta>  | <modo>   | <qué se aplicó, qué quedó pendiente> |
+| <modo> | <salir sin cerrar> | <modo>   | <qué se pierde o se conserva>        |
+
+## UXF-001 — <flujo principal en verbo>
+
+<!--
+Duplica por flujo crítico. Cada paso describe acción → respuesta al nivel de "el usuario toca X → Datealo
+muestra Y". Un mockup no reemplaza la secuencia porque no explica estados ni recuperación.
+-->
+
+**Objetivo:** <qué se completa o comprende>. **Contrato:** [F-001](./producto.md#f-001).
+
+**Punto de entrada:** <estado y superficie inicial, y qué acción trae al usuario hasta acá>.
+
+**Criterio de término:** <estado observable que confirma que el flujo terminó bien>.
+
+**Cómo sabe el usuario dónde está:** <el elemento concreto y permanente en pantalla que se lo dice, por
+cada modo que toca este flujo>.
+
+### Salidas
+
+<!--
+Todas las formas de irse, no solo terminar bien. El criterio de término cubre la salida buena; las otras
+son las que el usuario encuentra primero. Un modo del que no se sabe salir es un modo donde el usuario se
+pierde.
+-->
+
+| Salida                | Cómo se ejecuta       | Qué queda del trabajo           |
+| --------------------- | --------------------- | ------------------------------- |
+| <termina bien>        | <acción>              | <qué se aplicó y dónde>         |
+| <descarta>            | <acción, Esc, cerrar> | <nada, ni a medias>             |
+| <abandona sin cerrar> | <navega a otra parte> | <se conserva, se pierde, avisa> |
+
+### Secuencia principal
+
+| Paso | Acción            | Respuesta del sistema         | Información visible |
+| ---- | ----------------- | ----------------------------- | ------------------- |
+| 1    | <acción concreta> | <feedback o cambio de estado> | <dato y jerarquía>  |
+
+### Variantes y recuperación
+
+| Condición          | Qué cambia              | Cómo se entiende    | Cómo se recupera             |
+| ------------------ | ----------------------- | ------------------- | ---------------------------- |
+| <sin resultados>   | <estado>                | <mensaje concreto>  | <acción disponible>          |
+| <sin permiso de ubicación> | <comportamiento> | <indicador visible> | <alternativa manual>         |
+| <conexión lenta>   | <skeleton, no spinner>  | <qué se ve mientras>| <qué pasa si falla>          |
+
+### Decisiones que no deben quedar implícitas
+
+- <qué ocurre al cancelar, volver atrás, reintentar o confirmar>.
+- <qué cambio se guarda inmediato y cuál necesita confirmación>.
+
+## Estados por superficie
+
+<!--
+El contenido es concreto: texto real, no "mensaje apropiado". El estado vacío de un marketplace
+pre-lanzamiento no es un detalle: para muchas búsquedas será el estado principal durante meses.
+-->
+
+| Estado  | Qué se muestra (texto e información real) | Acción disponible                   |
+| ------- | ----------------------------------------- | ----------------------------------- |
+| inicial | <contenido>                               | <acción>                            |
+| vacío   | <por qué está vacío, con texto concreto>  | <cómo avanzar, o ninguna y por qué> |
+| carga   | <skeleton de qué forma>                   | <ninguna>                           |
+| error   | <causa útil y alcance>                    | <recuperación>                      |
+
+## Mockups
+
+<!--
+Los mockups viven en design-mockups/ como HTML (ver el skill discovery-ux y docs/design/README.md).
+Exploran o materializan una decisión; no son fuente de verdad de reglas de producto.
+-->
+
+| Mockup   | Cubre   | Estado                 | Ruta                              |
+| -------- | ------- | ---------------------- | --------------------------------- |
+| <nombre> | UXF-001 | exploración o validado | `./design-mockups/<archivo>.html` |
+
+## Cobertura
+
+<!-- Detecta huecos antes de construir. Una funcionalidad sin pantalla nueva igual tiene estados. -->
+
+| Funcionalidad | Flujo   | Estados cubiertos       | Estado    |
+| ------------- | ------- | ----------------------- | --------- |
+| F-001         | UXF-001 | principal, vacío, error | pendiente |
+
+## Secciones bajo demanda
+
+<!--
+Agregar solo cuando una decisión las necesite, con estos títulos:
+
+- "Modelo mental y lenguaje": cuando un concepto de producto pueda confundirse en la interfaz.
+- "Jerarquía de información": cuando una superficie densa exija decidir qué se ve primero (una card de
+  resultado con foto, rating, distancia, precio y disponibilidad es exactamente ese caso).
+- "Validación (UXV-xxx)": cuando una incertidumbre de diseño necesite prueba con usuarios.
+- "Accesibilidad y adaptación": cuando el contexto de uso cambie el flujo o la representación.
+-->
+
+## Decisiones de experiencia
+
+<a id="ux-001"></a>
+
+### UX-001 — <decisión en una frase>
+
+- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
+- **Sustento:** F-001 o <hallazgo>.
+- **Alternativas descartadas:** <opciones relevantes y trade-off, con el porqué del rechazo>.
+- **Decisión y consecuencia:** <qué flujo o superficie cambia>.
+- **Impacto en producto:** <ninguno o enlace a D-xxx/F-xxx actualizado>.
+
+## Preguntas
+
+<!--
+Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
+Estado: abierta | resuelta AAAA-MM-DD | disuelta AAAA-MM-DD. Solo las abiertas llevan bloque de detalle.
+-->
+
+<Una frase que responde "¿qué falta?": la pregunta que bloquea construcción y qué bloquea.>
+
+| ID      | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
+| ------- | ---------------------- | ------------------- | --------------------------------------------------------------- |
+| UXQ-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
+| UXQ-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |

--- a/docs/missions/05-perfil-publico-profesional/ingenieria.md
+++ b/docs/missions/05-perfil-publico-profesional/ingenieria.md
@@ -1,0 +1,162 @@
+# Misión: <nombre> — Ingeniería
+
+**Estado:** borrador
+
+**Última actualización:** AAAA-MM-DD
+
+[Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
+[Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
+
+<!--
+Fuente de verdad para arquitectura, datos, contratos, factibilidad y pruebas. Consume el comportamiento
+definido en producto. Una limitación técnica cambia el alcance solo mediante una decisión explícita en
+producto.md.
+
+Núcleo obligatorio: contratos, modelo de datos, RLS y riesgos de factibilidad. Las secciones bajo demanda
+(migración, rendimiento, entrega por etapas) se agregan solo cuando el riesgo lo justifica.
+
+Gate de salida — ingenieria.md está lista para construir cuando:
+- los contratos definen qué entra, qué sale y qué invariantes se mantienen, sin ambigüedad
+- el modelo de datos soporta los casos límite de producto.md sin workarounds
+- el impacto en RLS está resuelto: qué policy se crea o cambia, o por qué ninguna
+- la migración de datos existentes tiene estrategia o está explícitamente fuera del alcance
+- los escenarios verificables de producto están mapeados a pruebas
+- el plan de construcción corta el diseño en slices atómicos ordenados (un slice = un Issue = un PR)
+-->
+
+## Decisión técnica: <arquitectura y riesgo principal>
+
+<Dirección técnica, trade-off principal y el riesgo que todavía podría invalidarla.>
+
+- **Contratos de producto cubiertos:** F-001, <otros>.
+- **Riesgo bloqueante:** <incertidumbre o "ninguna">.
+
+## Arquitectura: <cómo se divide la responsabilidad>
+
+<!--
+La lógica de negocio se separa de la infraestructura: funciones puras en utils/ y server/utils/,
+reactividad en composables, acceso a datos en server/api/ con Drizzle. Incluye diagrama solo cuando tres o
+más partes interactúan.
+-->
+
+<Descripción del enfoque y por qué satisface los contratos con menor riesgo.>
+
+| Componente | Responsabilidad       | No debe decidir | Contratos |
+| ---------- | --------------------- | --------------- | --------- |
+| <nombre>   | <una responsabilidad> | <frontera>      | F-001     |
+
+## Contratos
+
+<!--
+Cada contrato especifica entrada, salida e invariantes al nivel en que se puede implementar sin reuniones
+de aclaración. Incluye los errores observables y el código HTTP cuando es un endpoint.
+-->
+
+### TC-001 — <contrato en una frase>
+
+- **Entrada:** <datos y precondiciones, con tipos y forma concreta>.
+- **Salida:** <resultado y su forma concreta>.
+- **Invariantes:** <qué se cumple siempre: atomicidad, consistencia, idempotencia>.
+- **Errores:** <condición → código HTTP y cuerpo `{ error, code? }`, y qué puede hacer el llamador>.
+- **Contrato de producto:** [F-001](./producto.md#f-001).
+
+## Modelo de datos
+
+<!-- Entidades con significado, escritura y ciclo de vida. El schema completo vive en server/db/. -->
+
+| Entidad o campo | Significado             | Escritura          | Retención o historial |
+| --------------- | ----------------------- | ------------------ | --------------------- |
+| <dato>          | <semántica de producto> | <endpoint o acción>| <política>            |
+
+### Invariantes de datos
+
+- <unicidad, pertenencia, orden o consistencia temporal>.
+- <qué operación es atómica o qué dato tiene una única fuente de verdad>.
+
+### Impacto en RLS
+
+<!--
+Obligatorio. Fuente de verdad: server/db/sql/rls.sql. Si el cambio no toca ownership ni relaciones usadas
+en policies, decirlo explícitamente con esa razón — no dejar la sección vacía.
+-->
+
+| Tabla    | Cambio                 | Policy afectada | Acción                    |
+| -------- | ---------------------- | --------------- | ------------------------- |
+| <tabla>  | <nueva, ownership, FK> | <nombre>        | <crear, actualizar, nada> |
+
+## Riesgos y experimentos de factibilidad
+
+<!--
+Un riesgo que podría cambiar el producto se enlaza como pregunta o decisión en producto.md. Un experimento
+tiene pregunta, límite de tiempo y resultado capaz de cerrar la incertidumbre.
+-->
+
+| ID     | Riesgo o pregunta | Qué invalida        | Experimento o mitigación  | Criterio de salida      | Estado  |
+| ------ | ----------------- | ------------------- | ------------------------- | ----------------------- | ------- |
+| TR-001 | <incertidumbre>   | <alcance en riesgo> | <spike, prueba o recorte> | <resultado concluyente> | abierto |
+
+## Estrategia de pruebas
+
+<!-- Mapea los ejemplos verificables de producto.md a niveles de prueba. Qué demuestra cada una. -->
+
+| Contrato o riesgo | Nivel                          | Caso principal | Límite o falla |
+| ----------------- | ------------------------------ | -------------- | -------------- |
+| F-001, CL-001     | <unidad, contrato, integración>| <caso>         | <caso>         |
+
+### Propiedades que deben probarse
+
+- <invariante bajo reintentos, concurrencia o distintas entradas>.
+- <ausencia de efectos parciales en falla>.
+
+## Plan de construcción
+
+<!--
+Se completa al final, cuando el gate de salida se cumple y ninguna pregunta bloqueante sigue abierta —
+cortar sobre decisiones abiertas produce issues que mueren. Cada slice es un cambio funcional atómico: un
+Issue, un PR, ejecutable sin haber leído la misión (el issue lleva su contrato inline) y con criterios
+pass/fail enumerables como tests. Guía completa en el skill discovery-engineering.
+-->
+
+| ID    | Slice (una frase, sin "y") | Sustento      | Criterio de aceptación principal          | Depende de |
+| ----- | -------------------------- | ------------- | ----------------------------------------- | ---------- |
+| S-001 | <cambio atómico>           | TC-001, D-001 | <entrada concreta → resultado observable> | —          |
+
+## Secciones bajo demanda
+
+<!--
+Agregar solo cuando el riesgo lo justifique, con estos títulos:
+
+- "Migración y compatibilidad": cuando existan datos o consumidores que deben llegar al nuevo contrato.
+  Incluye rollback lógico si la migración física no puede revertirse.
+- "Rendimiento y observabilidad": cuando haya presupuesto de latencia o volumen que defender (búsqueda
+  geográfica y listados paginados son los candidatos naturales).
+- "SEO e indexación": cuando la superficie deba ser indexable (páginas por categoría + comuna, datos
+  estructurados).
+- "Entrega por etapas": cuando el cambio necesite despliegue incremental o feature flags.
+-->
+
+## Decisiones técnicas
+
+<a id="t-001"></a>
+
+### T-001 — <decisión en una frase>
+
+- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
+- **Contratos:** F-001 y <regla relevante>.
+- **Alternativas descartadas:** <opciones y trade-offs, con el porqué del rechazo>.
+- **Decisión y consecuencias:** <enfoque elegido, beneficio, costo y trabajo futuro aceptado>.
+- **Reapertura:** <medición o cambio que justificaría revisar>.
+
+## Preguntas
+
+<!--
+Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
+Estado: abierta | resuelta AAAA-MM-DD | disuelta AAAA-MM-DD. Solo las abiertas llevan bloque de detalle.
+-->
+
+<Una frase que responde "¿qué falta?": la pregunta que bloquea construcción y qué bloquea.>
+
+| ID     | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
+| ------ | ---------------------- | ------------------- | --------------------------------------------------------------- |
+| TQ-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
+| TQ-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |

--- a/docs/missions/05-perfil-publico-profesional/investigacion.md
+++ b/docs/missions/05-perfil-publico-profesional/investigacion.md
@@ -1,0 +1,118 @@
+# Misión: <nombre> — Investigación
+
+**Estado:** activo
+
+**Última actualización:** AAAA-MM-DD
+
+[Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
+[Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
+
+<!--
+Este documento se acumula: la evidencia y las conclusiones no se borran cuando el alcance cambia, porque
+explican por qué el producto es como es. Lo que sí se actualiza es el ideal, que resume la dirección que
+la investigación sostiene hoy.
+
+Gate de salida — la investigación sostiene un producto.md cuando:
+- el problema tiene situación y consecuencia concretas, no una categoría abstracta
+- al menos una conclusión con confianza alta o media respalda la dirección
+- el ideal describe capacidades observables, no intenciones
+-->
+
+## El problema aparece cuando <historia concreta>
+
+<!--
+Una situación real o reconstruida con precisión. No abras con una categoría como "falta de confianza" —
+abre con quién estaba haciendo qué y qué salió mal. Nombra a la persona y el servicio concreto.
+-->
+
+**Situación:** <qué está ocurriendo antes del problema>.
+
+**Acción o necesidad:** <qué se intenta resolver o decidir>.
+
+**Respuesta actual:** <qué hace hoy la persona: grupo de WhatsApp, Google, recomendación de un vecino,
+Datealo si ya existe la superficie>.
+
+**Consecuencia:** <error, demora, riesgo o decisión que no puede tomarse>.
+
+## Preguntas que la investigación debe resolver
+
+<!--
+Solo preguntas capaces de cambiar el ideal o una decisión. Al resolver una, moverla a evidencia o
+conclusión. No es un backlog.
+-->
+
+- ¿<pregunta y decisión que depende de ella>?
+
+## Evidencia
+
+<!--
+Un hecho verificable con fuente y límite. Prioriza observación directa, entrevistas y comportamiento
+comprobado. Los benchmarks de otros productos también son evidencia: qué hacen, qué trade-off eligieron y
+qué no aplica a Datealo.
+
+Datealo no tiene datos de uso propios todavía. Cuando la única evidencia disponible sea un benchmark o
+una entrevista, la columna "límite" es lo que impide que se lea como dato duro.
+-->
+
+| ID    | Tipo                                              | Fuente                | Hecho verificable | Límite de la evidencia |
+| ----- | ------------------------------------------------- | --------------------- | ----------------- | ---------------------- |
+| E-001 | <entrevista, benchmark, uso, código, observación> | <enlace o referencia> | <hecho>           | <qué no demuestra>     |
+
+<a id="e-001"></a>
+
+### E-001 — <fuente o hecho en una frase>
+
+<!--
+Desarrollar solo cuando la tabla no alcanza para evaluar la calidad de la evidencia. Cierra con la
+consecuencia para la investigación.
+-->
+
+<Observación precisa y contexto necesario.>
+
+Esto permite afirmar <alcance>, pero no demuestra <límite>.
+
+## Conclusiones
+
+<!--
+Una conclusión interpreta evidencia; no es una preferencia ni una funcionalidad. El título expresa el
+hallazgo, no el tema.
+-->
+
+<a id="c-001"></a>
+
+### C-001 — <conclusión en una frase>
+
+- **Sustento:** [E-001](#e-001).
+- **Razonamiento:** <por qué la evidencia conduce a esta lectura y no a otra>.
+- **Implicación:** <qué deberá ser cierto en el producto o qué alternativa queda debilitada>.
+- **Confianza:** <alta, media o baja> porque <razón o validación pendiente>.
+
+## El ideal: <resultado completo, sin recortar>
+
+<!--
+El ideal es el producto de la investigación: la dirección que la evidencia sostiene, sin restricciones de
+implementación. El recorte a la primera entrega no vive aquí — vive en producto.md como decisión de
+alcance. Esta sección sí se reescribe cuando nueva evidencia cambia la dirección.
+-->
+
+### El resultado ideal se ve así
+
+<Narra de principio a fin una situación futura con datos concretos: nombres, comunas, oficios, horarios.
+Qué acción ocurre, qué responde Datealo, qué decisión puede tomar la persona. Evita "una experiencia
+simple" sin comportamiento observable.>
+
+### Capacidades del ideal
+
+| Capacidad | Acción habilitada    | Respuesta esperada              | Conclusión que la justifica |
+| --------- | -------------------- | ------------------------------- | --------------------------- |
+| <nombre>  | <qué se puede hacer> | <qué produce o explica Datealo> | [C-001](#c-001)             |
+
+### El ideal no significa <confusión probable>
+
+- <límite conceptual que evita una interpretación incorrecta>.
+
+## Referencias
+
+<!-- Fuentes primarias citadas por las evidencias. El enlace no sustituye el hecho y el límite en E-xxx. -->
+
+- [<título descriptivo>](URL): usado en E-001 para <afirmación concreta>.

--- a/docs/missions/05-perfil-publico-profesional/producto.md
+++ b/docs/missions/05-perfil-publico-profesional/producto.md
@@ -1,0 +1,149 @@
+# Misión: <nombre> — Producto
+
+**Estado:** borrador
+
+**Última actualización:** AAAA-MM-DD
+
+[Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
+[Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
+
+<!--
+Este documento es la spec viva del resultado: qué construimos ahora y bajo qué reglas. El porqué vive en
+investigacion.md — aquí solo se enlaza. Se reescribe cuando el alcance cambia; no acumula historia.
+
+Gate de salida — producto.md está listo para experiencia.md cuando:
+- cada funcionalidad tiene formato JTBD, reglas y al menos un caso límite con comportamiento definido
+- cada funcionalidad enlaza una conclusión de investigacion.md y una señal de éxito
+- cada funcionalidad declara a qué lado del marketplace sirve, y qué necesita del otro lado para funcionar
+- no hay decisiones de producto delegadas a diseño o ingeniería
+- las decisiones propuestas tienen fecha límite en el README
+-->
+
+## Qué construimos: <resultado en una frase>
+
+<!--
+El recorte vigente del ideal y por qué sigue entregando el resultado central. Máximo cuatro párrafos
+cortos. El ideal completo vive en investigacion.md.
+-->
+
+**Resultado:** <qué podrá lograr una persona al finalizar esta entrega>.
+
+**Recorte respecto del ideal:** <qué dimensión se reduce y por qué sigue siendo suficiente>
+(ver [el ideal](./investigacion.md)).
+
+**Restricciones aceptadas:** <plataforma, cobertura geográfica, categorías, volumen inicial de
+profesionales>.
+
+## Funcionalidades
+
+| ID    | Funcionalidad                  | Lado         | Sustento     | Éxito |
+| ----- | ------------------------------ | ------------ | ------------ | ----- |
+| F-001 | <verbo + resultado observable> | buscador     | C-001, D-001 | M-001 |
+
+<a id="f-001"></a>
+
+### F-001 — <verbo + resultado observable>
+
+<!--
+Duplica este bloque por funcionalidad. Se escribe desde el resultado del usuario (working backwards):
+primero el JTBD, después las reglas. Si la respuesta de Datealo no se puede describir sin hablar de tablas
+o componentes, falta cerrar la decisión de producto.
+-->
+
+Cuando <usuario en contexto concreto>,
+quiero <acción>,
+para <resultado observable>.
+
+**Lado del marketplace:** buscador, profesional o ambos. **Qué necesita del otro lado:** <volumen mínimo
+de perfiles, reseñas o cobertura sin el cual esta funcionalidad no entrega su resultado>.
+
+**Sustento:** [C-001](./investigacion.md#c-001) y [D-001](#d-001). **Éxito:** [M-001](#m-001).
+
+**Reglas:**
+
+- Si <condición>, Datealo <comportamiento esperado>.
+- Si <caso límite>, Datealo <comportamiento seguro y qué información muestra>.
+- Datealo nunca <comportamiento que rompería el significado o la confianza>.
+
+**Ejemplo verificable:** dado <estado con datos concretos>, cuando <acción>, entonces <resultado
+observable>.
+
+**No incluye:** <variante del ideal excluida de esta funcionalidad>.
+
+**Experiencia:** <enlace a UXF-xxx cuando exista>. **Ingeniería:** <enlace a T-xxx cuando exista>.
+
+## Casos límite que cruzan funcionalidades
+
+<!--
+Solo condiciones que afectan varias funcionalidades. Las propias de una viven en su bloque. Un caso
+retirado no se borra ni se reutiliza: conserva su fila, o se nombra con su motivo en una línea debajo.
+
+Los casos límite propios de un marketplace pre-lanzamiento aparecen acá: cero resultados en una comuna,
+un profesional sin reseñas, una categoría con un solo perfil, un perfil sin verificar.
+-->
+
+| ID     | Condición concreta     | Comportamiento esperado | Funcionalidades |
+| ------ | ---------------------- | ----------------------- | --------------- |
+| CL-001 | <estado o combinación> | <qué hace Datealo>      | F-001           |
+
+## Fuera de alcance
+
+<!-- Distingue postergado de descartado y qué condición justificaría reabrirlo. -->
+
+| Capacidad o caso      | Estado                  | Razón del recorte | Condición para reconsiderar |
+| --------------------- | ----------------------- | ----------------- | --------------------------- |
+| <capacidad del ideal> | postergada o descartada | <trade-off>       | <evidencia o hito>          |
+
+## Señales de éxito
+
+<a id="m-001"></a>
+
+### M-001 — <señal que demuestra el resultado>
+
+- **Pregunta:** ¿<qué queremos comprobar>?
+- **Señal:** <comportamiento o resultado observable>.
+- **Método y umbral:** <instrumentación o revisión, qué resultado, en qué población y ventana>.
+- **Guardrail:** <daño que no debe aumentar para conseguir la señal>.
+
+## Decisiones de producto
+
+<!--
+Solo decisiones con alternativas reales. No borres decisiones reemplazadas: explican por qué el producto
+es como es. Toda decisión propuesta se refleja en el README con fecha límite.
+-->
+
+<a id="d-001"></a>
+
+### D-001 — <decisión en una frase que se entiende sola>
+
+- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
+- **Sustento:** [C-001](./investigacion.md#c-001).
+- **Tensión:** <criterios que no podían maximizarse al mismo tiempo>.
+- **Alternativas descartadas:** <opciones y razón concreta del rechazo, en la misma línea>.
+- **Decisión y consecuencia:** <qué se hará y qué habilita, limita o exige revisar en UX e ingeniería>.
+- **Reapertura:** <evidencia o cambio que justificaría revisarla>.
+
+## Preguntas
+
+<!--
+Solo preguntas que pueden cambiar una decisión o funcionalidad. Lo demás va a un issue.
+Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
+Estado: abierta | resuelta AAAA-MM-DD (alguien la respondió) | disuelta AAAA-MM-DD (el producto cambió y la
+pregunta dejó de tener sentido). Solo las abiertas llevan bloque de detalle debajo de la tabla.
+-->
+
+<Una frase que responde "¿qué falta?": la pregunta que bloquea y qué bloquea.>
+
+| ID    | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
+| ----- | ---------------------- | ------------------- | --------------------------------------------------------------- |
+| Q-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
+| Q-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |
+
+<a id="q-001"></a>
+
+### Q-001 — <la pregunta en una frase que se entiende sola>
+
+- **La duda, con un ejemplo:** <el caso concreto que muestra por qué hay dos respuestas posibles>.
+- **Afecta a:** D-001 o F-001.
+- **Cómo se resolverá:** <quién y con qué método>.
+- **¿Bloquea algo?:** <qué bloquea y su fecha límite, o no>.

--- a/docs/missions/06-busqueda-resultados/README.md
+++ b/docs/missions/06-busqueda-resultados/README.md
@@ -22,9 +22,10 @@ perfiles reales que buscar — sin datos, no hay resultados que mostrar ni relev
 
 ## Brief
 
-El buscador filtra por categoría y comuna y ve una lista de profesionales — el "buscar" del MVP. Ordenado
-por relevancia y cercanía por comuna (como un portal inmobiliario, no geolocalización de precisión — esa
-decisión ya está tomada, ver conversación de arquitectura del roadmap, 2026-08-13).
+El buscador filtra por categoría y comuna y ve una lista de profesionales — el "buscar" del MVP. La
+dirección que salió de la conversación de roadmap (2026-08-13) es ordenar por relevancia y cercanía por
+comuna, como un portal inmobiliario, sin geolocalización de precisión — pero es una recomendación a
+confirmar en `producto.md`, no una decisión ratificada.
 
 Sin resultados mientras se escribe (debounce 300ms) y empty states que inviten a probar otra categoría o
 comuna cercana son estándar del producto, no algo que se re-discuta acá (`CLAUDE.md`).

--- a/docs/missions/06-busqueda-resultados/README.md
+++ b/docs/missions/06-busqueda-resultados/README.md
@@ -1,0 +1,30 @@
+# Misión 06 — Búsqueda y resultados
+
+**Tipo:** producto. **Abierta el** 2026-08-13. **Nace de:** ninguna.
+
+**Estado de la misión:** exploración
+
+**Última actualización:** 2026-08-13
+
+Quinta de seis misiones hacia el MVP (registrarse, mostrarse, buscar, reseñar). Depende de
+[misión 03](../03-taxonomia-categorias-y-comunas/) (contra qué categorías/comunas se filtra) y de
+[misión 04](../04-registro-perfil-profesional/)/[05](../05-perfil-publico-profesional/) (que existan
+perfiles reales que buscar — sin datos, no hay resultados que mostrar ni relevancia que ordenar).
+
+| Documento     | Estado    | Qué falta para su gate              |
+| ------------- | --------- | ------------------------------------ |
+| Investigación | pendiente | discovery completo — hoy solo existe la carpeta |
+| Producto      | pendiente | —                                     |
+| Experiencia   | pendiente | —                                     |
+| Ingeniería    | pendiente | —                                     |
+
+**Próximo hito:** ninguno todavía — esta misión no se ha empezado a trabajar.
+
+## Brief
+
+El buscador filtra por categoría y comuna y ve una lista de profesionales — el "buscar" del MVP. Ordenado
+por relevancia y cercanía por comuna (como un portal inmobiliario, no geolocalización de precisión — esa
+decisión ya está tomada, ver conversación de arquitectura del roadmap, 2026-08-13).
+
+Sin resultados mientras se escribe (debounce 300ms) y empty states que inviten a probar otra categoría o
+comuna cercana son estándar del producto, no algo que se re-discuta acá (`CLAUDE.md`).

--- a/docs/missions/06-busqueda-resultados/experiencia.md
+++ b/docs/missions/06-busqueda-resultados/experiencia.md
@@ -1,0 +1,183 @@
+# Misión: <nombre> — Experiencia
+
+**Estado:** borrador
+
+**Última actualización:** AAAA-MM-DD
+
+[Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
+[Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
+
+<!--
+Fuente de verdad para flujos, estados, contenido e interacción. No redefine reglas de producto: si el
+diseño descubre una regla nueva o invalida una, abre o actualiza una decisión en producto.md.
+
+Núcleo obligatorio: vistas, mapa de estados, flujos críticos y estados por superficie. Las secciones bajo
+demanda (modelo mental, jerarquía de información, validación) se agregan solo cuando una decisión las
+necesita.
+
+Gate de salida — experiencia.md está lista para ingenieria.md cuando:
+- cada flujo crítico tiene secuencia, variantes, recuperación y criterio de término
+- cada estado tiene contenido concreto (texto real, información visible, acción disponible)
+- cada vista lista sus modos, y el mapa de estados cubre todas las transiciones entre ellos
+- cada modo tiene su indicador permanente de estado, y cada flujo tiene todas sus salidas documentadas
+- los casos límite de producto.md tienen flujo o estado mapeado
+- cada flujo crítico está mockeado en móvil (390px), y en desktop si también vive ahí
+- ninguna pantalla queda descrita como "similar a X" sin especificar qué cambia
+-->
+
+## Decisión de experiencia: <qué cambia para quien usa el producto>
+
+<Modelo de interacción elegido, flujo más importante y la incertidumbre que sigue abierta.>
+
+- **Funcionalidades cubiertas:** F-001, <otras>.
+- **Pendiente bloqueante:** <pregunta o "ninguna">.
+
+## Vistas
+
+<!--
+El listado de pantallas que define la experiencia — el mapa que se entrega antes de los flujos. Una línea
+por vista, sin tabla, con sus modos anidados debajo. Una vista es un destino: se llega a ella. Un modo es
+un estado de esa vista que cambia qué se puede hacer y qué se ve — se anida, nunca se lista como vista
+hermana.
+
+El porqué de cada vista, su trade-off o su justificación no van aquí: viven en su flujo (UXF) o en una
+decisión (UX-xxx). Regla de formato para todo el documento: las tablas se reservan para índices de celdas
+cortas; lo que lleva justificación extensa va en secciones con header + bullets, nunca en una celda.
+-->
+
+- **V-001 — <vista>** · móvil / desktop · resuelve F-001 · flujos UXF-001 · pendiente
+  - modo **<nombre>** — <qué lo distingue y qué se puede hacer en él>
+  - modo **<nombre>** — <ídem>
+
+## Mapa de estados
+
+<!--
+Vistas y flujos son listas, y una lista no muestra un camino. Esta tabla conecta los modos: qué acción
+lleva de uno a otro y qué pasa con el trabajo del usuario en cada salto. Cada fila que falte es una
+pregunta que ingeniería resuelve inventando.
+-->
+
+| Desde  | Acción             | Queda en | Qué pasa con el trabajo              |
+| ------ | ------------------ | -------- | ------------------------------------ |
+| <modo> | <acción concreta>  | <modo>   | <qué se aplicó, qué quedó pendiente> |
+| <modo> | <salir sin cerrar> | <modo>   | <qué se pierde o se conserva>        |
+
+## UXF-001 — <flujo principal en verbo>
+
+<!--
+Duplica por flujo crítico. Cada paso describe acción → respuesta al nivel de "el usuario toca X → Datealo
+muestra Y". Un mockup no reemplaza la secuencia porque no explica estados ni recuperación.
+-->
+
+**Objetivo:** <qué se completa o comprende>. **Contrato:** [F-001](./producto.md#f-001).
+
+**Punto de entrada:** <estado y superficie inicial, y qué acción trae al usuario hasta acá>.
+
+**Criterio de término:** <estado observable que confirma que el flujo terminó bien>.
+
+**Cómo sabe el usuario dónde está:** <el elemento concreto y permanente en pantalla que se lo dice, por
+cada modo que toca este flujo>.
+
+### Salidas
+
+<!--
+Todas las formas de irse, no solo terminar bien. El criterio de término cubre la salida buena; las otras
+son las que el usuario encuentra primero. Un modo del que no se sabe salir es un modo donde el usuario se
+pierde.
+-->
+
+| Salida                | Cómo se ejecuta       | Qué queda del trabajo           |
+| --------------------- | --------------------- | ------------------------------- |
+| <termina bien>        | <acción>              | <qué se aplicó y dónde>         |
+| <descarta>            | <acción, Esc, cerrar> | <nada, ni a medias>             |
+| <abandona sin cerrar> | <navega a otra parte> | <se conserva, se pierde, avisa> |
+
+### Secuencia principal
+
+| Paso | Acción            | Respuesta del sistema         | Información visible |
+| ---- | ----------------- | ----------------------------- | ------------------- |
+| 1    | <acción concreta> | <feedback o cambio de estado> | <dato y jerarquía>  |
+
+### Variantes y recuperación
+
+| Condición          | Qué cambia              | Cómo se entiende    | Cómo se recupera             |
+| ------------------ | ----------------------- | ------------------- | ---------------------------- |
+| <sin resultados>   | <estado>                | <mensaje concreto>  | <acción disponible>          |
+| <sin permiso de ubicación> | <comportamiento> | <indicador visible> | <alternativa manual>         |
+| <conexión lenta>   | <skeleton, no spinner>  | <qué se ve mientras>| <qué pasa si falla>          |
+
+### Decisiones que no deben quedar implícitas
+
+- <qué ocurre al cancelar, volver atrás, reintentar o confirmar>.
+- <qué cambio se guarda inmediato y cuál necesita confirmación>.
+
+## Estados por superficie
+
+<!--
+El contenido es concreto: texto real, no "mensaje apropiado". El estado vacío de un marketplace
+pre-lanzamiento no es un detalle: para muchas búsquedas será el estado principal durante meses.
+-->
+
+| Estado  | Qué se muestra (texto e información real) | Acción disponible                   |
+| ------- | ----------------------------------------- | ----------------------------------- |
+| inicial | <contenido>                               | <acción>                            |
+| vacío   | <por qué está vacío, con texto concreto>  | <cómo avanzar, o ninguna y por qué> |
+| carga   | <skeleton de qué forma>                   | <ninguna>                           |
+| error   | <causa útil y alcance>                    | <recuperación>                      |
+
+## Mockups
+
+<!--
+Los mockups viven en design-mockups/ como HTML (ver el skill discovery-ux y docs/design/README.md).
+Exploran o materializan una decisión; no son fuente de verdad de reglas de producto.
+-->
+
+| Mockup   | Cubre   | Estado                 | Ruta                              |
+| -------- | ------- | ---------------------- | --------------------------------- |
+| <nombre> | UXF-001 | exploración o validado | `./design-mockups/<archivo>.html` |
+
+## Cobertura
+
+<!-- Detecta huecos antes de construir. Una funcionalidad sin pantalla nueva igual tiene estados. -->
+
+| Funcionalidad | Flujo   | Estados cubiertos       | Estado    |
+| ------------- | ------- | ----------------------- | --------- |
+| F-001         | UXF-001 | principal, vacío, error | pendiente |
+
+## Secciones bajo demanda
+
+<!--
+Agregar solo cuando una decisión las necesite, con estos títulos:
+
+- "Modelo mental y lenguaje": cuando un concepto de producto pueda confundirse en la interfaz.
+- "Jerarquía de información": cuando una superficie densa exija decidir qué se ve primero (una card de
+  resultado con foto, rating, distancia, precio y disponibilidad es exactamente ese caso).
+- "Validación (UXV-xxx)": cuando una incertidumbre de diseño necesite prueba con usuarios.
+- "Accesibilidad y adaptación": cuando el contexto de uso cambie el flujo o la representación.
+-->
+
+## Decisiones de experiencia
+
+<a id="ux-001"></a>
+
+### UX-001 — <decisión en una frase>
+
+- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
+- **Sustento:** F-001 o <hallazgo>.
+- **Alternativas descartadas:** <opciones relevantes y trade-off, con el porqué del rechazo>.
+- **Decisión y consecuencia:** <qué flujo o superficie cambia>.
+- **Impacto en producto:** <ninguno o enlace a D-xxx/F-xxx actualizado>.
+
+## Preguntas
+
+<!--
+Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
+Estado: abierta | resuelta AAAA-MM-DD | disuelta AAAA-MM-DD. Solo las abiertas llevan bloque de detalle.
+-->
+
+<Una frase que responde "¿qué falta?": la pregunta que bloquea construcción y qué bloquea.>
+
+| ID      | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
+| ------- | ---------------------- | ------------------- | --------------------------------------------------------------- |
+| UXQ-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
+| UXQ-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |

--- a/docs/missions/06-busqueda-resultados/ingenieria.md
+++ b/docs/missions/06-busqueda-resultados/ingenieria.md
@@ -1,0 +1,162 @@
+# Misión: <nombre> — Ingeniería
+
+**Estado:** borrador
+
+**Última actualización:** AAAA-MM-DD
+
+[Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
+[Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
+
+<!--
+Fuente de verdad para arquitectura, datos, contratos, factibilidad y pruebas. Consume el comportamiento
+definido en producto. Una limitación técnica cambia el alcance solo mediante una decisión explícita en
+producto.md.
+
+Núcleo obligatorio: contratos, modelo de datos, RLS y riesgos de factibilidad. Las secciones bajo demanda
+(migración, rendimiento, entrega por etapas) se agregan solo cuando el riesgo lo justifica.
+
+Gate de salida — ingenieria.md está lista para construir cuando:
+- los contratos definen qué entra, qué sale y qué invariantes se mantienen, sin ambigüedad
+- el modelo de datos soporta los casos límite de producto.md sin workarounds
+- el impacto en RLS está resuelto: qué policy se crea o cambia, o por qué ninguna
+- la migración de datos existentes tiene estrategia o está explícitamente fuera del alcance
+- los escenarios verificables de producto están mapeados a pruebas
+- el plan de construcción corta el diseño en slices atómicos ordenados (un slice = un Issue = un PR)
+-->
+
+## Decisión técnica: <arquitectura y riesgo principal>
+
+<Dirección técnica, trade-off principal y el riesgo que todavía podría invalidarla.>
+
+- **Contratos de producto cubiertos:** F-001, <otros>.
+- **Riesgo bloqueante:** <incertidumbre o "ninguna">.
+
+## Arquitectura: <cómo se divide la responsabilidad>
+
+<!--
+La lógica de negocio se separa de la infraestructura: funciones puras en utils/ y server/utils/,
+reactividad en composables, acceso a datos en server/api/ con Drizzle. Incluye diagrama solo cuando tres o
+más partes interactúan.
+-->
+
+<Descripción del enfoque y por qué satisface los contratos con menor riesgo.>
+
+| Componente | Responsabilidad       | No debe decidir | Contratos |
+| ---------- | --------------------- | --------------- | --------- |
+| <nombre>   | <una responsabilidad> | <frontera>      | F-001     |
+
+## Contratos
+
+<!--
+Cada contrato especifica entrada, salida e invariantes al nivel en que se puede implementar sin reuniones
+de aclaración. Incluye los errores observables y el código HTTP cuando es un endpoint.
+-->
+
+### TC-001 — <contrato en una frase>
+
+- **Entrada:** <datos y precondiciones, con tipos y forma concreta>.
+- **Salida:** <resultado y su forma concreta>.
+- **Invariantes:** <qué se cumple siempre: atomicidad, consistencia, idempotencia>.
+- **Errores:** <condición → código HTTP y cuerpo `{ error, code? }`, y qué puede hacer el llamador>.
+- **Contrato de producto:** [F-001](./producto.md#f-001).
+
+## Modelo de datos
+
+<!-- Entidades con significado, escritura y ciclo de vida. El schema completo vive en server/db/. -->
+
+| Entidad o campo | Significado             | Escritura          | Retención o historial |
+| --------------- | ----------------------- | ------------------ | --------------------- |
+| <dato>          | <semántica de producto> | <endpoint o acción>| <política>            |
+
+### Invariantes de datos
+
+- <unicidad, pertenencia, orden o consistencia temporal>.
+- <qué operación es atómica o qué dato tiene una única fuente de verdad>.
+
+### Impacto en RLS
+
+<!--
+Obligatorio. Fuente de verdad: server/db/sql/rls.sql. Si el cambio no toca ownership ni relaciones usadas
+en policies, decirlo explícitamente con esa razón — no dejar la sección vacía.
+-->
+
+| Tabla    | Cambio                 | Policy afectada | Acción                    |
+| -------- | ---------------------- | --------------- | ------------------------- |
+| <tabla>  | <nueva, ownership, FK> | <nombre>        | <crear, actualizar, nada> |
+
+## Riesgos y experimentos de factibilidad
+
+<!--
+Un riesgo que podría cambiar el producto se enlaza como pregunta o decisión en producto.md. Un experimento
+tiene pregunta, límite de tiempo y resultado capaz de cerrar la incertidumbre.
+-->
+
+| ID     | Riesgo o pregunta | Qué invalida        | Experimento o mitigación  | Criterio de salida      | Estado  |
+| ------ | ----------------- | ------------------- | ------------------------- | ----------------------- | ------- |
+| TR-001 | <incertidumbre>   | <alcance en riesgo> | <spike, prueba o recorte> | <resultado concluyente> | abierto |
+
+## Estrategia de pruebas
+
+<!-- Mapea los ejemplos verificables de producto.md a niveles de prueba. Qué demuestra cada una. -->
+
+| Contrato o riesgo | Nivel                          | Caso principal | Límite o falla |
+| ----------------- | ------------------------------ | -------------- | -------------- |
+| F-001, CL-001     | <unidad, contrato, integración>| <caso>         | <caso>         |
+
+### Propiedades que deben probarse
+
+- <invariante bajo reintentos, concurrencia o distintas entradas>.
+- <ausencia de efectos parciales en falla>.
+
+## Plan de construcción
+
+<!--
+Se completa al final, cuando el gate de salida se cumple y ninguna pregunta bloqueante sigue abierta —
+cortar sobre decisiones abiertas produce issues que mueren. Cada slice es un cambio funcional atómico: un
+Issue, un PR, ejecutable sin haber leído la misión (el issue lleva su contrato inline) y con criterios
+pass/fail enumerables como tests. Guía completa en el skill discovery-engineering.
+-->
+
+| ID    | Slice (una frase, sin "y") | Sustento      | Criterio de aceptación principal          | Depende de |
+| ----- | -------------------------- | ------------- | ----------------------------------------- | ---------- |
+| S-001 | <cambio atómico>           | TC-001, D-001 | <entrada concreta → resultado observable> | —          |
+
+## Secciones bajo demanda
+
+<!--
+Agregar solo cuando el riesgo lo justifique, con estos títulos:
+
+- "Migración y compatibilidad": cuando existan datos o consumidores que deben llegar al nuevo contrato.
+  Incluye rollback lógico si la migración física no puede revertirse.
+- "Rendimiento y observabilidad": cuando haya presupuesto de latencia o volumen que defender (búsqueda
+  geográfica y listados paginados son los candidatos naturales).
+- "SEO e indexación": cuando la superficie deba ser indexable (páginas por categoría + comuna, datos
+  estructurados).
+- "Entrega por etapas": cuando el cambio necesite despliegue incremental o feature flags.
+-->
+
+## Decisiones técnicas
+
+<a id="t-001"></a>
+
+### T-001 — <decisión en una frase>
+
+- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
+- **Contratos:** F-001 y <regla relevante>.
+- **Alternativas descartadas:** <opciones y trade-offs, con el porqué del rechazo>.
+- **Decisión y consecuencias:** <enfoque elegido, beneficio, costo y trabajo futuro aceptado>.
+- **Reapertura:** <medición o cambio que justificaría revisar>.
+
+## Preguntas
+
+<!--
+Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
+Estado: abierta | resuelta AAAA-MM-DD | disuelta AAAA-MM-DD. Solo las abiertas llevan bloque de detalle.
+-->
+
+<Una frase que responde "¿qué falta?": la pregunta que bloquea construcción y qué bloquea.>
+
+| ID     | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
+| ------ | ---------------------- | ------------------- | --------------------------------------------------------------- |
+| TQ-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
+| TQ-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |

--- a/docs/missions/06-busqueda-resultados/investigacion.md
+++ b/docs/missions/06-busqueda-resultados/investigacion.md
@@ -1,0 +1,118 @@
+# Misión: <nombre> — Investigación
+
+**Estado:** activo
+
+**Última actualización:** AAAA-MM-DD
+
+[Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
+[Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
+
+<!--
+Este documento se acumula: la evidencia y las conclusiones no se borran cuando el alcance cambia, porque
+explican por qué el producto es como es. Lo que sí se actualiza es el ideal, que resume la dirección que
+la investigación sostiene hoy.
+
+Gate de salida — la investigación sostiene un producto.md cuando:
+- el problema tiene situación y consecuencia concretas, no una categoría abstracta
+- al menos una conclusión con confianza alta o media respalda la dirección
+- el ideal describe capacidades observables, no intenciones
+-->
+
+## El problema aparece cuando <historia concreta>
+
+<!--
+Una situación real o reconstruida con precisión. No abras con una categoría como "falta de confianza" —
+abre con quién estaba haciendo qué y qué salió mal. Nombra a la persona y el servicio concreto.
+-->
+
+**Situación:** <qué está ocurriendo antes del problema>.
+
+**Acción o necesidad:** <qué se intenta resolver o decidir>.
+
+**Respuesta actual:** <qué hace hoy la persona: grupo de WhatsApp, Google, recomendación de un vecino,
+Datealo si ya existe la superficie>.
+
+**Consecuencia:** <error, demora, riesgo o decisión que no puede tomarse>.
+
+## Preguntas que la investigación debe resolver
+
+<!--
+Solo preguntas capaces de cambiar el ideal o una decisión. Al resolver una, moverla a evidencia o
+conclusión. No es un backlog.
+-->
+
+- ¿<pregunta y decisión que depende de ella>?
+
+## Evidencia
+
+<!--
+Un hecho verificable con fuente y límite. Prioriza observación directa, entrevistas y comportamiento
+comprobado. Los benchmarks de otros productos también son evidencia: qué hacen, qué trade-off eligieron y
+qué no aplica a Datealo.
+
+Datealo no tiene datos de uso propios todavía. Cuando la única evidencia disponible sea un benchmark o
+una entrevista, la columna "límite" es lo que impide que se lea como dato duro.
+-->
+
+| ID    | Tipo                                              | Fuente                | Hecho verificable | Límite de la evidencia |
+| ----- | ------------------------------------------------- | --------------------- | ----------------- | ---------------------- |
+| E-001 | <entrevista, benchmark, uso, código, observación> | <enlace o referencia> | <hecho>           | <qué no demuestra>     |
+
+<a id="e-001"></a>
+
+### E-001 — <fuente o hecho en una frase>
+
+<!--
+Desarrollar solo cuando la tabla no alcanza para evaluar la calidad de la evidencia. Cierra con la
+consecuencia para la investigación.
+-->
+
+<Observación precisa y contexto necesario.>
+
+Esto permite afirmar <alcance>, pero no demuestra <límite>.
+
+## Conclusiones
+
+<!--
+Una conclusión interpreta evidencia; no es una preferencia ni una funcionalidad. El título expresa el
+hallazgo, no el tema.
+-->
+
+<a id="c-001"></a>
+
+### C-001 — <conclusión en una frase>
+
+- **Sustento:** [E-001](#e-001).
+- **Razonamiento:** <por qué la evidencia conduce a esta lectura y no a otra>.
+- **Implicación:** <qué deberá ser cierto en el producto o qué alternativa queda debilitada>.
+- **Confianza:** <alta, media o baja> porque <razón o validación pendiente>.
+
+## El ideal: <resultado completo, sin recortar>
+
+<!--
+El ideal es el producto de la investigación: la dirección que la evidencia sostiene, sin restricciones de
+implementación. El recorte a la primera entrega no vive aquí — vive en producto.md como decisión de
+alcance. Esta sección sí se reescribe cuando nueva evidencia cambia la dirección.
+-->
+
+### El resultado ideal se ve así
+
+<Narra de principio a fin una situación futura con datos concretos: nombres, comunas, oficios, horarios.
+Qué acción ocurre, qué responde Datealo, qué decisión puede tomar la persona. Evita "una experiencia
+simple" sin comportamiento observable.>
+
+### Capacidades del ideal
+
+| Capacidad | Acción habilitada    | Respuesta esperada              | Conclusión que la justifica |
+| --------- | -------------------- | ------------------------------- | --------------------------- |
+| <nombre>  | <qué se puede hacer> | <qué produce o explica Datealo> | [C-001](#c-001)             |
+
+### El ideal no significa <confusión probable>
+
+- <límite conceptual que evita una interpretación incorrecta>.
+
+## Referencias
+
+<!-- Fuentes primarias citadas por las evidencias. El enlace no sustituye el hecho y el límite en E-xxx. -->
+
+- [<título descriptivo>](URL): usado en E-001 para <afirmación concreta>.

--- a/docs/missions/06-busqueda-resultados/producto.md
+++ b/docs/missions/06-busqueda-resultados/producto.md
@@ -1,0 +1,149 @@
+# Misión: <nombre> — Producto
+
+**Estado:** borrador
+
+**Última actualización:** AAAA-MM-DD
+
+[Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
+[Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
+
+<!--
+Este documento es la spec viva del resultado: qué construimos ahora y bajo qué reglas. El porqué vive en
+investigacion.md — aquí solo se enlaza. Se reescribe cuando el alcance cambia; no acumula historia.
+
+Gate de salida — producto.md está listo para experiencia.md cuando:
+- cada funcionalidad tiene formato JTBD, reglas y al menos un caso límite con comportamiento definido
+- cada funcionalidad enlaza una conclusión de investigacion.md y una señal de éxito
+- cada funcionalidad declara a qué lado del marketplace sirve, y qué necesita del otro lado para funcionar
+- no hay decisiones de producto delegadas a diseño o ingeniería
+- las decisiones propuestas tienen fecha límite en el README
+-->
+
+## Qué construimos: <resultado en una frase>
+
+<!--
+El recorte vigente del ideal y por qué sigue entregando el resultado central. Máximo cuatro párrafos
+cortos. El ideal completo vive en investigacion.md.
+-->
+
+**Resultado:** <qué podrá lograr una persona al finalizar esta entrega>.
+
+**Recorte respecto del ideal:** <qué dimensión se reduce y por qué sigue siendo suficiente>
+(ver [el ideal](./investigacion.md)).
+
+**Restricciones aceptadas:** <plataforma, cobertura geográfica, categorías, volumen inicial de
+profesionales>.
+
+## Funcionalidades
+
+| ID    | Funcionalidad                  | Lado         | Sustento     | Éxito |
+| ----- | ------------------------------ | ------------ | ------------ | ----- |
+| F-001 | <verbo + resultado observable> | buscador     | C-001, D-001 | M-001 |
+
+<a id="f-001"></a>
+
+### F-001 — <verbo + resultado observable>
+
+<!--
+Duplica este bloque por funcionalidad. Se escribe desde el resultado del usuario (working backwards):
+primero el JTBD, después las reglas. Si la respuesta de Datealo no se puede describir sin hablar de tablas
+o componentes, falta cerrar la decisión de producto.
+-->
+
+Cuando <usuario en contexto concreto>,
+quiero <acción>,
+para <resultado observable>.
+
+**Lado del marketplace:** buscador, profesional o ambos. **Qué necesita del otro lado:** <volumen mínimo
+de perfiles, reseñas o cobertura sin el cual esta funcionalidad no entrega su resultado>.
+
+**Sustento:** [C-001](./investigacion.md#c-001) y [D-001](#d-001). **Éxito:** [M-001](#m-001).
+
+**Reglas:**
+
+- Si <condición>, Datealo <comportamiento esperado>.
+- Si <caso límite>, Datealo <comportamiento seguro y qué información muestra>.
+- Datealo nunca <comportamiento que rompería el significado o la confianza>.
+
+**Ejemplo verificable:** dado <estado con datos concretos>, cuando <acción>, entonces <resultado
+observable>.
+
+**No incluye:** <variante del ideal excluida de esta funcionalidad>.
+
+**Experiencia:** <enlace a UXF-xxx cuando exista>. **Ingeniería:** <enlace a T-xxx cuando exista>.
+
+## Casos límite que cruzan funcionalidades
+
+<!--
+Solo condiciones que afectan varias funcionalidades. Las propias de una viven en su bloque. Un caso
+retirado no se borra ni se reutiliza: conserva su fila, o se nombra con su motivo en una línea debajo.
+
+Los casos límite propios de un marketplace pre-lanzamiento aparecen acá: cero resultados en una comuna,
+un profesional sin reseñas, una categoría con un solo perfil, un perfil sin verificar.
+-->
+
+| ID     | Condición concreta     | Comportamiento esperado | Funcionalidades |
+| ------ | ---------------------- | ----------------------- | --------------- |
+| CL-001 | <estado o combinación> | <qué hace Datealo>      | F-001           |
+
+## Fuera de alcance
+
+<!-- Distingue postergado de descartado y qué condición justificaría reabrirlo. -->
+
+| Capacidad o caso      | Estado                  | Razón del recorte | Condición para reconsiderar |
+| --------------------- | ----------------------- | ----------------- | --------------------------- |
+| <capacidad del ideal> | postergada o descartada | <trade-off>       | <evidencia o hito>          |
+
+## Señales de éxito
+
+<a id="m-001"></a>
+
+### M-001 — <señal que demuestra el resultado>
+
+- **Pregunta:** ¿<qué queremos comprobar>?
+- **Señal:** <comportamiento o resultado observable>.
+- **Método y umbral:** <instrumentación o revisión, qué resultado, en qué población y ventana>.
+- **Guardrail:** <daño que no debe aumentar para conseguir la señal>.
+
+## Decisiones de producto
+
+<!--
+Solo decisiones con alternativas reales. No borres decisiones reemplazadas: explican por qué el producto
+es como es. Toda decisión propuesta se refleja en el README con fecha límite.
+-->
+
+<a id="d-001"></a>
+
+### D-001 — <decisión en una frase que se entiende sola>
+
+- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
+- **Sustento:** [C-001](./investigacion.md#c-001).
+- **Tensión:** <criterios que no podían maximizarse al mismo tiempo>.
+- **Alternativas descartadas:** <opciones y razón concreta del rechazo, en la misma línea>.
+- **Decisión y consecuencia:** <qué se hará y qué habilita, limita o exige revisar en UX e ingeniería>.
+- **Reapertura:** <evidencia o cambio que justificaría revisarla>.
+
+## Preguntas
+
+<!--
+Solo preguntas que pueden cambiar una decisión o funcionalidad. Lo demás va a un issue.
+Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
+Estado: abierta | resuelta AAAA-MM-DD (alguien la respondió) | disuelta AAAA-MM-DD (el producto cambió y la
+pregunta dejó de tener sentido). Solo las abiertas llevan bloque de detalle debajo de la tabla.
+-->
+
+<Una frase que responde "¿qué falta?": la pregunta que bloquea y qué bloquea.>
+
+| ID    | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
+| ----- | ---------------------- | ------------------- | --------------------------------------------------------------- |
+| Q-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
+| Q-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |
+
+<a id="q-001"></a>
+
+### Q-001 — <la pregunta en una frase que se entiende sola>
+
+- **La duda, con un ejemplo:** <el caso concreto que muestra por qué hay dos respuestas posibles>.
+- **Afecta a:** D-001 o F-001.
+- **Cómo se resolverá:** <quién y con qué método>.
+- **¿Bloquea algo?:** <qué bloquea y su fecha límite, o no>.

--- a/docs/missions/07-resenas-verificadas-por-contacto/README.md
+++ b/docs/missions/07-resenas-verificadas-por-contacto/README.md
@@ -7,8 +7,9 @@
 **Última actualización:** 2026-08-13
 
 Sexta y última misión hacia el MVP (registrarse, mostrarse, buscar, reseñar). Depende de
-[misión 02](../02-base-de-datos-y-auth/) (verificación de teléfono del buscador, sobre Supabase Auth) y de
-[misión 05](../05-perfil-publico-profesional/) (el evento de contacto al que se ata cada reseña).
+[misión 02](../02-base-de-datos-y-auth/) (la identidad ligera del buscador, cualquiera sea el mecanismo que
+esa misión ratifique) y de [misión 05](../05-perfil-publico-profesional/) (el evento de contacto al que se
+ata cada reseña).
 
 | Documento     | Estado    | Qué falta para su gate              |
 | ------------- | --------- | ------------------------------------ |
@@ -21,12 +22,13 @@ Sexta y última misión hacia el MVP (registrarse, mostrarse, buscar, reseñar).
 
 ## Brief
 
-Después de contactar a un profesional, el buscador puede dejar una reseña — verificada por teléfono (no
-cuenta completa, solo un OTP puntual), atada al hecho de que el contacto realmente ocurrió. No es un
-formulario abierto que cualquiera llena: es la pieza que sostiene la promesa de "reseñas reales, sin
-inventadas" que la landing ya le mostró a gente real.
+Después de contactar a un profesional, el buscador puede dejar una reseña — atada al hecho de que el
+contacto realmente ocurrió, no un formulario abierto que cualquiera llena. Es la pieza que sostiene la
+promesa de "reseñas reales, sin inventadas" que la landing ya le mostró a gente real.
 
-El buscador no necesita cuenta persistente para buscar ni para contactar — solo para esto. Ver la
-conversación de arquitectura del roadmap (2026-08-13) para el porqué: research sobre verificación de
-reviews sin transacción dentro de la plataforma, y por qué "cuenta completa" sería fricción sin beneficio
-para el resto del flujo.
+**Dirección a confirmar, no decisión cerrada:** la conversación de roadmap (2026-08-13) exploró verificar
+por teléfono (OTP puntual, no cuenta completa) en vez de pedirle cuenta persistente al buscador — el
+buscador no la necesita para buscar ni para contactar, por el principio de "sin fricción" de `CLAUDE.md`.
+Hay research general sobre verificación de reviews sin transacción dentro de la plataforma que la respalda,
+pero el mecanismo exacto (qué se verifica, cuándo, con qué fricción real) se define en el `producto.md` y
+`experiencia.md` de esta misión, no acá.

--- a/docs/missions/07-resenas-verificadas-por-contacto/README.md
+++ b/docs/missions/07-resenas-verificadas-por-contacto/README.md
@@ -8,8 +8,8 @@
 
 Sexta y última misión hacia el MVP (registrarse, mostrarse, buscar, reseñar). Depende de
 [misión 02](../02-base-de-datos-y-auth/) (la identidad ligera del buscador, cualquiera sea el mecanismo que
-esa misión ratifique) y de [misión 05](../05-perfil-publico-profesional/) (el evento de contacto al que se
-ata cada reseña).
+esa misión ratifique, y el `sendEmail()` para notificar al profesional) y de
+[misión 05](../05-perfil-publico-profesional/) (el evento de contacto al que se ata cada reseña).
 
 | Documento     | Estado    | Qué falta para su gate              |
 | ------------- | --------- | ------------------------------------ |
@@ -32,3 +32,9 @@ buscador no la necesita para buscar ni para contactar, por el principio de "sin 
 Hay research general sobre verificación de reviews sin transacción dentro de la plataforma que la respalda,
 pero el mecanismo exacto (qué se verifica, cuándo, con qué fricción real) se define en el `producto.md` y
 `experiencia.md` de esta misión, no acá.
+
+**También entra en el alcance:** cuando llega una reseña nueva, el profesional recibe un correo —
+individual por reseña, no un digest agrupado (no hay volumen todavía que lo justifique), y siempre, buena o
+mala, porque afecta su reputación igual. Lo mantiene volviendo a la plataforma y es el gancho natural si
+más adelante se agrega poder responder una reseña. El contenido y el trigger son de esta misión; el envío
+lo deja listo la 02.

--- a/docs/missions/07-resenas-verificadas-por-contacto/README.md
+++ b/docs/missions/07-resenas-verificadas-por-contacto/README.md
@@ -1,0 +1,32 @@
+# Misión 07 — Reseñas verificadas por contacto
+
+**Tipo:** producto. **Abierta el** 2026-08-13. **Nace de:** ninguna.
+
+**Estado de la misión:** exploración
+
+**Última actualización:** 2026-08-13
+
+Sexta y última misión hacia el MVP (registrarse, mostrarse, buscar, reseñar). Depende de
+[misión 02](../02-base-de-datos-y-auth/) (verificación de teléfono del buscador, sobre Supabase Auth) y de
+[misión 05](../05-perfil-publico-profesional/) (el evento de contacto al que se ata cada reseña).
+
+| Documento     | Estado    | Qué falta para su gate              |
+| ------------- | --------- | ------------------------------------ |
+| Investigación | pendiente | discovery completo — hoy solo existe la carpeta |
+| Producto      | pendiente | —                                     |
+| Experiencia   | pendiente | —                                     |
+| Ingeniería    | pendiente | —                                     |
+
+**Próximo hito:** ninguno todavía — esta misión no se ha empezado a trabajar.
+
+## Brief
+
+Después de contactar a un profesional, el buscador puede dejar una reseña — verificada por teléfono (no
+cuenta completa, solo un OTP puntual), atada al hecho de que el contacto realmente ocurrió. No es un
+formulario abierto que cualquiera llena: es la pieza que sostiene la promesa de "reseñas reales, sin
+inventadas" que la landing ya le mostró a gente real.
+
+El buscador no necesita cuenta persistente para buscar ni para contactar — solo para esto. Ver la
+conversación de arquitectura del roadmap (2026-08-13) para el porqué: research sobre verificación de
+reviews sin transacción dentro de la plataforma, y por qué "cuenta completa" sería fricción sin beneficio
+para el resto del flujo.

--- a/docs/missions/07-resenas-verificadas-por-contacto/experiencia.md
+++ b/docs/missions/07-resenas-verificadas-por-contacto/experiencia.md
@@ -1,0 +1,183 @@
+# Misión: <nombre> — Experiencia
+
+**Estado:** borrador
+
+**Última actualización:** AAAA-MM-DD
+
+[Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
+[Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
+
+<!--
+Fuente de verdad para flujos, estados, contenido e interacción. No redefine reglas de producto: si el
+diseño descubre una regla nueva o invalida una, abre o actualiza una decisión en producto.md.
+
+Núcleo obligatorio: vistas, mapa de estados, flujos críticos y estados por superficie. Las secciones bajo
+demanda (modelo mental, jerarquía de información, validación) se agregan solo cuando una decisión las
+necesita.
+
+Gate de salida — experiencia.md está lista para ingenieria.md cuando:
+- cada flujo crítico tiene secuencia, variantes, recuperación y criterio de término
+- cada estado tiene contenido concreto (texto real, información visible, acción disponible)
+- cada vista lista sus modos, y el mapa de estados cubre todas las transiciones entre ellos
+- cada modo tiene su indicador permanente de estado, y cada flujo tiene todas sus salidas documentadas
+- los casos límite de producto.md tienen flujo o estado mapeado
+- cada flujo crítico está mockeado en móvil (390px), y en desktop si también vive ahí
+- ninguna pantalla queda descrita como "similar a X" sin especificar qué cambia
+-->
+
+## Decisión de experiencia: <qué cambia para quien usa el producto>
+
+<Modelo de interacción elegido, flujo más importante y la incertidumbre que sigue abierta.>
+
+- **Funcionalidades cubiertas:** F-001, <otras>.
+- **Pendiente bloqueante:** <pregunta o "ninguna">.
+
+## Vistas
+
+<!--
+El listado de pantallas que define la experiencia — el mapa que se entrega antes de los flujos. Una línea
+por vista, sin tabla, con sus modos anidados debajo. Una vista es un destino: se llega a ella. Un modo es
+un estado de esa vista que cambia qué se puede hacer y qué se ve — se anida, nunca se lista como vista
+hermana.
+
+El porqué de cada vista, su trade-off o su justificación no van aquí: viven en su flujo (UXF) o en una
+decisión (UX-xxx). Regla de formato para todo el documento: las tablas se reservan para índices de celdas
+cortas; lo que lleva justificación extensa va en secciones con header + bullets, nunca en una celda.
+-->
+
+- **V-001 — <vista>** · móvil / desktop · resuelve F-001 · flujos UXF-001 · pendiente
+  - modo **<nombre>** — <qué lo distingue y qué se puede hacer en él>
+  - modo **<nombre>** — <ídem>
+
+## Mapa de estados
+
+<!--
+Vistas y flujos son listas, y una lista no muestra un camino. Esta tabla conecta los modos: qué acción
+lleva de uno a otro y qué pasa con el trabajo del usuario en cada salto. Cada fila que falte es una
+pregunta que ingeniería resuelve inventando.
+-->
+
+| Desde  | Acción             | Queda en | Qué pasa con el trabajo              |
+| ------ | ------------------ | -------- | ------------------------------------ |
+| <modo> | <acción concreta>  | <modo>   | <qué se aplicó, qué quedó pendiente> |
+| <modo> | <salir sin cerrar> | <modo>   | <qué se pierde o se conserva>        |
+
+## UXF-001 — <flujo principal en verbo>
+
+<!--
+Duplica por flujo crítico. Cada paso describe acción → respuesta al nivel de "el usuario toca X → Datealo
+muestra Y". Un mockup no reemplaza la secuencia porque no explica estados ni recuperación.
+-->
+
+**Objetivo:** <qué se completa o comprende>. **Contrato:** [F-001](./producto.md#f-001).
+
+**Punto de entrada:** <estado y superficie inicial, y qué acción trae al usuario hasta acá>.
+
+**Criterio de término:** <estado observable que confirma que el flujo terminó bien>.
+
+**Cómo sabe el usuario dónde está:** <el elemento concreto y permanente en pantalla que se lo dice, por
+cada modo que toca este flujo>.
+
+### Salidas
+
+<!--
+Todas las formas de irse, no solo terminar bien. El criterio de término cubre la salida buena; las otras
+son las que el usuario encuentra primero. Un modo del que no se sabe salir es un modo donde el usuario se
+pierde.
+-->
+
+| Salida                | Cómo se ejecuta       | Qué queda del trabajo           |
+| --------------------- | --------------------- | ------------------------------- |
+| <termina bien>        | <acción>              | <qué se aplicó y dónde>         |
+| <descarta>            | <acción, Esc, cerrar> | <nada, ni a medias>             |
+| <abandona sin cerrar> | <navega a otra parte> | <se conserva, se pierde, avisa> |
+
+### Secuencia principal
+
+| Paso | Acción            | Respuesta del sistema         | Información visible |
+| ---- | ----------------- | ----------------------------- | ------------------- |
+| 1    | <acción concreta> | <feedback o cambio de estado> | <dato y jerarquía>  |
+
+### Variantes y recuperación
+
+| Condición          | Qué cambia              | Cómo se entiende    | Cómo se recupera             |
+| ------------------ | ----------------------- | ------------------- | ---------------------------- |
+| <sin resultados>   | <estado>                | <mensaje concreto>  | <acción disponible>          |
+| <sin permiso de ubicación> | <comportamiento> | <indicador visible> | <alternativa manual>         |
+| <conexión lenta>   | <skeleton, no spinner>  | <qué se ve mientras>| <qué pasa si falla>          |
+
+### Decisiones que no deben quedar implícitas
+
+- <qué ocurre al cancelar, volver atrás, reintentar o confirmar>.
+- <qué cambio se guarda inmediato y cuál necesita confirmación>.
+
+## Estados por superficie
+
+<!--
+El contenido es concreto: texto real, no "mensaje apropiado". El estado vacío de un marketplace
+pre-lanzamiento no es un detalle: para muchas búsquedas será el estado principal durante meses.
+-->
+
+| Estado  | Qué se muestra (texto e información real) | Acción disponible                   |
+| ------- | ----------------------------------------- | ----------------------------------- |
+| inicial | <contenido>                               | <acción>                            |
+| vacío   | <por qué está vacío, con texto concreto>  | <cómo avanzar, o ninguna y por qué> |
+| carga   | <skeleton de qué forma>                   | <ninguna>                           |
+| error   | <causa útil y alcance>                    | <recuperación>                      |
+
+## Mockups
+
+<!--
+Los mockups viven en design-mockups/ como HTML (ver el skill discovery-ux y docs/design/README.md).
+Exploran o materializan una decisión; no son fuente de verdad de reglas de producto.
+-->
+
+| Mockup   | Cubre   | Estado                 | Ruta                              |
+| -------- | ------- | ---------------------- | --------------------------------- |
+| <nombre> | UXF-001 | exploración o validado | `./design-mockups/<archivo>.html` |
+
+## Cobertura
+
+<!-- Detecta huecos antes de construir. Una funcionalidad sin pantalla nueva igual tiene estados. -->
+
+| Funcionalidad | Flujo   | Estados cubiertos       | Estado    |
+| ------------- | ------- | ----------------------- | --------- |
+| F-001         | UXF-001 | principal, vacío, error | pendiente |
+
+## Secciones bajo demanda
+
+<!--
+Agregar solo cuando una decisión las necesite, con estos títulos:
+
+- "Modelo mental y lenguaje": cuando un concepto de producto pueda confundirse en la interfaz.
+- "Jerarquía de información": cuando una superficie densa exija decidir qué se ve primero (una card de
+  resultado con foto, rating, distancia, precio y disponibilidad es exactamente ese caso).
+- "Validación (UXV-xxx)": cuando una incertidumbre de diseño necesite prueba con usuarios.
+- "Accesibilidad y adaptación": cuando el contexto de uso cambie el flujo o la representación.
+-->
+
+## Decisiones de experiencia
+
+<a id="ux-001"></a>
+
+### UX-001 — <decisión en una frase>
+
+- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
+- **Sustento:** F-001 o <hallazgo>.
+- **Alternativas descartadas:** <opciones relevantes y trade-off, con el porqué del rechazo>.
+- **Decisión y consecuencia:** <qué flujo o superficie cambia>.
+- **Impacto en producto:** <ninguno o enlace a D-xxx/F-xxx actualizado>.
+
+## Preguntas
+
+<!--
+Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
+Estado: abierta | resuelta AAAA-MM-DD | disuelta AAAA-MM-DD. Solo las abiertas llevan bloque de detalle.
+-->
+
+<Una frase que responde "¿qué falta?": la pregunta que bloquea construcción y qué bloquea.>
+
+| ID      | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
+| ------- | ---------------------- | ------------------- | --------------------------------------------------------------- |
+| UXQ-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
+| UXQ-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |

--- a/docs/missions/07-resenas-verificadas-por-contacto/ingenieria.md
+++ b/docs/missions/07-resenas-verificadas-por-contacto/ingenieria.md
@@ -1,0 +1,162 @@
+# Misión: <nombre> — Ingeniería
+
+**Estado:** borrador
+
+**Última actualización:** AAAA-MM-DD
+
+[Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
+[Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
+
+<!--
+Fuente de verdad para arquitectura, datos, contratos, factibilidad y pruebas. Consume el comportamiento
+definido en producto. Una limitación técnica cambia el alcance solo mediante una decisión explícita en
+producto.md.
+
+Núcleo obligatorio: contratos, modelo de datos, RLS y riesgos de factibilidad. Las secciones bajo demanda
+(migración, rendimiento, entrega por etapas) se agregan solo cuando el riesgo lo justifica.
+
+Gate de salida — ingenieria.md está lista para construir cuando:
+- los contratos definen qué entra, qué sale y qué invariantes se mantienen, sin ambigüedad
+- el modelo de datos soporta los casos límite de producto.md sin workarounds
+- el impacto en RLS está resuelto: qué policy se crea o cambia, o por qué ninguna
+- la migración de datos existentes tiene estrategia o está explícitamente fuera del alcance
+- los escenarios verificables de producto están mapeados a pruebas
+- el plan de construcción corta el diseño en slices atómicos ordenados (un slice = un Issue = un PR)
+-->
+
+## Decisión técnica: <arquitectura y riesgo principal>
+
+<Dirección técnica, trade-off principal y el riesgo que todavía podría invalidarla.>
+
+- **Contratos de producto cubiertos:** F-001, <otros>.
+- **Riesgo bloqueante:** <incertidumbre o "ninguna">.
+
+## Arquitectura: <cómo se divide la responsabilidad>
+
+<!--
+La lógica de negocio se separa de la infraestructura: funciones puras en utils/ y server/utils/,
+reactividad en composables, acceso a datos en server/api/ con Drizzle. Incluye diagrama solo cuando tres o
+más partes interactúan.
+-->
+
+<Descripción del enfoque y por qué satisface los contratos con menor riesgo.>
+
+| Componente | Responsabilidad       | No debe decidir | Contratos |
+| ---------- | --------------------- | --------------- | --------- |
+| <nombre>   | <una responsabilidad> | <frontera>      | F-001     |
+
+## Contratos
+
+<!--
+Cada contrato especifica entrada, salida e invariantes al nivel en que se puede implementar sin reuniones
+de aclaración. Incluye los errores observables y el código HTTP cuando es un endpoint.
+-->
+
+### TC-001 — <contrato en una frase>
+
+- **Entrada:** <datos y precondiciones, con tipos y forma concreta>.
+- **Salida:** <resultado y su forma concreta>.
+- **Invariantes:** <qué se cumple siempre: atomicidad, consistencia, idempotencia>.
+- **Errores:** <condición → código HTTP y cuerpo `{ error, code? }`, y qué puede hacer el llamador>.
+- **Contrato de producto:** [F-001](./producto.md#f-001).
+
+## Modelo de datos
+
+<!-- Entidades con significado, escritura y ciclo de vida. El schema completo vive en server/db/. -->
+
+| Entidad o campo | Significado             | Escritura          | Retención o historial |
+| --------------- | ----------------------- | ------------------ | --------------------- |
+| <dato>          | <semántica de producto> | <endpoint o acción>| <política>            |
+
+### Invariantes de datos
+
+- <unicidad, pertenencia, orden o consistencia temporal>.
+- <qué operación es atómica o qué dato tiene una única fuente de verdad>.
+
+### Impacto en RLS
+
+<!--
+Obligatorio. Fuente de verdad: server/db/sql/rls.sql. Si el cambio no toca ownership ni relaciones usadas
+en policies, decirlo explícitamente con esa razón — no dejar la sección vacía.
+-->
+
+| Tabla    | Cambio                 | Policy afectada | Acción                    |
+| -------- | ---------------------- | --------------- | ------------------------- |
+| <tabla>  | <nueva, ownership, FK> | <nombre>        | <crear, actualizar, nada> |
+
+## Riesgos y experimentos de factibilidad
+
+<!--
+Un riesgo que podría cambiar el producto se enlaza como pregunta o decisión en producto.md. Un experimento
+tiene pregunta, límite de tiempo y resultado capaz de cerrar la incertidumbre.
+-->
+
+| ID     | Riesgo o pregunta | Qué invalida        | Experimento o mitigación  | Criterio de salida      | Estado  |
+| ------ | ----------------- | ------------------- | ------------------------- | ----------------------- | ------- |
+| TR-001 | <incertidumbre>   | <alcance en riesgo> | <spike, prueba o recorte> | <resultado concluyente> | abierto |
+
+## Estrategia de pruebas
+
+<!-- Mapea los ejemplos verificables de producto.md a niveles de prueba. Qué demuestra cada una. -->
+
+| Contrato o riesgo | Nivel                          | Caso principal | Límite o falla |
+| ----------------- | ------------------------------ | -------------- | -------------- |
+| F-001, CL-001     | <unidad, contrato, integración>| <caso>         | <caso>         |
+
+### Propiedades que deben probarse
+
+- <invariante bajo reintentos, concurrencia o distintas entradas>.
+- <ausencia de efectos parciales en falla>.
+
+## Plan de construcción
+
+<!--
+Se completa al final, cuando el gate de salida se cumple y ninguna pregunta bloqueante sigue abierta —
+cortar sobre decisiones abiertas produce issues que mueren. Cada slice es un cambio funcional atómico: un
+Issue, un PR, ejecutable sin haber leído la misión (el issue lleva su contrato inline) y con criterios
+pass/fail enumerables como tests. Guía completa en el skill discovery-engineering.
+-->
+
+| ID    | Slice (una frase, sin "y") | Sustento      | Criterio de aceptación principal          | Depende de |
+| ----- | -------------------------- | ------------- | ----------------------------------------- | ---------- |
+| S-001 | <cambio atómico>           | TC-001, D-001 | <entrada concreta → resultado observable> | —          |
+
+## Secciones bajo demanda
+
+<!--
+Agregar solo cuando el riesgo lo justifique, con estos títulos:
+
+- "Migración y compatibilidad": cuando existan datos o consumidores que deben llegar al nuevo contrato.
+  Incluye rollback lógico si la migración física no puede revertirse.
+- "Rendimiento y observabilidad": cuando haya presupuesto de latencia o volumen que defender (búsqueda
+  geográfica y listados paginados son los candidatos naturales).
+- "SEO e indexación": cuando la superficie deba ser indexable (páginas por categoría + comuna, datos
+  estructurados).
+- "Entrega por etapas": cuando el cambio necesite despliegue incremental o feature flags.
+-->
+
+## Decisiones técnicas
+
+<a id="t-001"></a>
+
+### T-001 — <decisión en una frase>
+
+- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
+- **Contratos:** F-001 y <regla relevante>.
+- **Alternativas descartadas:** <opciones y trade-offs, con el porqué del rechazo>.
+- **Decisión y consecuencias:** <enfoque elegido, beneficio, costo y trabajo futuro aceptado>.
+- **Reapertura:** <medición o cambio que justificaría revisar>.
+
+## Preguntas
+
+<!--
+Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
+Estado: abierta | resuelta AAAA-MM-DD | disuelta AAAA-MM-DD. Solo las abiertas llevan bloque de detalle.
+-->
+
+<Una frase que responde "¿qué falta?": la pregunta que bloquea construcción y qué bloquea.>
+
+| ID     | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
+| ------ | ---------------------- | ------------------- | --------------------------------------------------------------- |
+| TQ-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
+| TQ-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |

--- a/docs/missions/07-resenas-verificadas-por-contacto/investigacion.md
+++ b/docs/missions/07-resenas-verificadas-por-contacto/investigacion.md
@@ -1,0 +1,118 @@
+# Misión: <nombre> — Investigación
+
+**Estado:** activo
+
+**Última actualización:** AAAA-MM-DD
+
+[Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
+[Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
+
+<!--
+Este documento se acumula: la evidencia y las conclusiones no se borran cuando el alcance cambia, porque
+explican por qué el producto es como es. Lo que sí se actualiza es el ideal, que resume la dirección que
+la investigación sostiene hoy.
+
+Gate de salida — la investigación sostiene un producto.md cuando:
+- el problema tiene situación y consecuencia concretas, no una categoría abstracta
+- al menos una conclusión con confianza alta o media respalda la dirección
+- el ideal describe capacidades observables, no intenciones
+-->
+
+## El problema aparece cuando <historia concreta>
+
+<!--
+Una situación real o reconstruida con precisión. No abras con una categoría como "falta de confianza" —
+abre con quién estaba haciendo qué y qué salió mal. Nombra a la persona y el servicio concreto.
+-->
+
+**Situación:** <qué está ocurriendo antes del problema>.
+
+**Acción o necesidad:** <qué se intenta resolver o decidir>.
+
+**Respuesta actual:** <qué hace hoy la persona: grupo de WhatsApp, Google, recomendación de un vecino,
+Datealo si ya existe la superficie>.
+
+**Consecuencia:** <error, demora, riesgo o decisión que no puede tomarse>.
+
+## Preguntas que la investigación debe resolver
+
+<!--
+Solo preguntas capaces de cambiar el ideal o una decisión. Al resolver una, moverla a evidencia o
+conclusión. No es un backlog.
+-->
+
+- ¿<pregunta y decisión que depende de ella>?
+
+## Evidencia
+
+<!--
+Un hecho verificable con fuente y límite. Prioriza observación directa, entrevistas y comportamiento
+comprobado. Los benchmarks de otros productos también son evidencia: qué hacen, qué trade-off eligieron y
+qué no aplica a Datealo.
+
+Datealo no tiene datos de uso propios todavía. Cuando la única evidencia disponible sea un benchmark o
+una entrevista, la columna "límite" es lo que impide que se lea como dato duro.
+-->
+
+| ID    | Tipo                                              | Fuente                | Hecho verificable | Límite de la evidencia |
+| ----- | ------------------------------------------------- | --------------------- | ----------------- | ---------------------- |
+| E-001 | <entrevista, benchmark, uso, código, observación> | <enlace o referencia> | <hecho>           | <qué no demuestra>     |
+
+<a id="e-001"></a>
+
+### E-001 — <fuente o hecho en una frase>
+
+<!--
+Desarrollar solo cuando la tabla no alcanza para evaluar la calidad de la evidencia. Cierra con la
+consecuencia para la investigación.
+-->
+
+<Observación precisa y contexto necesario.>
+
+Esto permite afirmar <alcance>, pero no demuestra <límite>.
+
+## Conclusiones
+
+<!--
+Una conclusión interpreta evidencia; no es una preferencia ni una funcionalidad. El título expresa el
+hallazgo, no el tema.
+-->
+
+<a id="c-001"></a>
+
+### C-001 — <conclusión en una frase>
+
+- **Sustento:** [E-001](#e-001).
+- **Razonamiento:** <por qué la evidencia conduce a esta lectura y no a otra>.
+- **Implicación:** <qué deberá ser cierto en el producto o qué alternativa queda debilitada>.
+- **Confianza:** <alta, media o baja> porque <razón o validación pendiente>.
+
+## El ideal: <resultado completo, sin recortar>
+
+<!--
+El ideal es el producto de la investigación: la dirección que la evidencia sostiene, sin restricciones de
+implementación. El recorte a la primera entrega no vive aquí — vive en producto.md como decisión de
+alcance. Esta sección sí se reescribe cuando nueva evidencia cambia la dirección.
+-->
+
+### El resultado ideal se ve así
+
+<Narra de principio a fin una situación futura con datos concretos: nombres, comunas, oficios, horarios.
+Qué acción ocurre, qué responde Datealo, qué decisión puede tomar la persona. Evita "una experiencia
+simple" sin comportamiento observable.>
+
+### Capacidades del ideal
+
+| Capacidad | Acción habilitada    | Respuesta esperada              | Conclusión que la justifica |
+| --------- | -------------------- | ------------------------------- | --------------------------- |
+| <nombre>  | <qué se puede hacer> | <qué produce o explica Datealo> | [C-001](#c-001)             |
+
+### El ideal no significa <confusión probable>
+
+- <límite conceptual que evita una interpretación incorrecta>.
+
+## Referencias
+
+<!-- Fuentes primarias citadas por las evidencias. El enlace no sustituye el hecho y el límite en E-xxx. -->
+
+- [<título descriptivo>](URL): usado en E-001 para <afirmación concreta>.

--- a/docs/missions/07-resenas-verificadas-por-contacto/producto.md
+++ b/docs/missions/07-resenas-verificadas-por-contacto/producto.md
@@ -1,0 +1,149 @@
+# Misión: <nombre> — Producto
+
+**Estado:** borrador
+
+**Última actualización:** AAAA-MM-DD
+
+[Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
+[Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
+
+<!--
+Este documento es la spec viva del resultado: qué construimos ahora y bajo qué reglas. El porqué vive en
+investigacion.md — aquí solo se enlaza. Se reescribe cuando el alcance cambia; no acumula historia.
+
+Gate de salida — producto.md está listo para experiencia.md cuando:
+- cada funcionalidad tiene formato JTBD, reglas y al menos un caso límite con comportamiento definido
+- cada funcionalidad enlaza una conclusión de investigacion.md y una señal de éxito
+- cada funcionalidad declara a qué lado del marketplace sirve, y qué necesita del otro lado para funcionar
+- no hay decisiones de producto delegadas a diseño o ingeniería
+- las decisiones propuestas tienen fecha límite en el README
+-->
+
+## Qué construimos: <resultado en una frase>
+
+<!--
+El recorte vigente del ideal y por qué sigue entregando el resultado central. Máximo cuatro párrafos
+cortos. El ideal completo vive en investigacion.md.
+-->
+
+**Resultado:** <qué podrá lograr una persona al finalizar esta entrega>.
+
+**Recorte respecto del ideal:** <qué dimensión se reduce y por qué sigue siendo suficiente>
+(ver [el ideal](./investigacion.md)).
+
+**Restricciones aceptadas:** <plataforma, cobertura geográfica, categorías, volumen inicial de
+profesionales>.
+
+## Funcionalidades
+
+| ID    | Funcionalidad                  | Lado         | Sustento     | Éxito |
+| ----- | ------------------------------ | ------------ | ------------ | ----- |
+| F-001 | <verbo + resultado observable> | buscador     | C-001, D-001 | M-001 |
+
+<a id="f-001"></a>
+
+### F-001 — <verbo + resultado observable>
+
+<!--
+Duplica este bloque por funcionalidad. Se escribe desde el resultado del usuario (working backwards):
+primero el JTBD, después las reglas. Si la respuesta de Datealo no se puede describir sin hablar de tablas
+o componentes, falta cerrar la decisión de producto.
+-->
+
+Cuando <usuario en contexto concreto>,
+quiero <acción>,
+para <resultado observable>.
+
+**Lado del marketplace:** buscador, profesional o ambos. **Qué necesita del otro lado:** <volumen mínimo
+de perfiles, reseñas o cobertura sin el cual esta funcionalidad no entrega su resultado>.
+
+**Sustento:** [C-001](./investigacion.md#c-001) y [D-001](#d-001). **Éxito:** [M-001](#m-001).
+
+**Reglas:**
+
+- Si <condición>, Datealo <comportamiento esperado>.
+- Si <caso límite>, Datealo <comportamiento seguro y qué información muestra>.
+- Datealo nunca <comportamiento que rompería el significado o la confianza>.
+
+**Ejemplo verificable:** dado <estado con datos concretos>, cuando <acción>, entonces <resultado
+observable>.
+
+**No incluye:** <variante del ideal excluida de esta funcionalidad>.
+
+**Experiencia:** <enlace a UXF-xxx cuando exista>. **Ingeniería:** <enlace a T-xxx cuando exista>.
+
+## Casos límite que cruzan funcionalidades
+
+<!--
+Solo condiciones que afectan varias funcionalidades. Las propias de una viven en su bloque. Un caso
+retirado no se borra ni se reutiliza: conserva su fila, o se nombra con su motivo en una línea debajo.
+
+Los casos límite propios de un marketplace pre-lanzamiento aparecen acá: cero resultados en una comuna,
+un profesional sin reseñas, una categoría con un solo perfil, un perfil sin verificar.
+-->
+
+| ID     | Condición concreta     | Comportamiento esperado | Funcionalidades |
+| ------ | ---------------------- | ----------------------- | --------------- |
+| CL-001 | <estado o combinación> | <qué hace Datealo>      | F-001           |
+
+## Fuera de alcance
+
+<!-- Distingue postergado de descartado y qué condición justificaría reabrirlo. -->
+
+| Capacidad o caso      | Estado                  | Razón del recorte | Condición para reconsiderar |
+| --------------------- | ----------------------- | ----------------- | --------------------------- |
+| <capacidad del ideal> | postergada o descartada | <trade-off>       | <evidencia o hito>          |
+
+## Señales de éxito
+
+<a id="m-001"></a>
+
+### M-001 — <señal que demuestra el resultado>
+
+- **Pregunta:** ¿<qué queremos comprobar>?
+- **Señal:** <comportamiento o resultado observable>.
+- **Método y umbral:** <instrumentación o revisión, qué resultado, en qué población y ventana>.
+- **Guardrail:** <daño que no debe aumentar para conseguir la señal>.
+
+## Decisiones de producto
+
+<!--
+Solo decisiones con alternativas reales. No borres decisiones reemplazadas: explican por qué el producto
+es como es. Toda decisión propuesta se refleja en el README con fecha límite.
+-->
+
+<a id="d-001"></a>
+
+### D-001 — <decisión en una frase que se entiende sola>
+
+- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
+- **Sustento:** [C-001](./investigacion.md#c-001).
+- **Tensión:** <criterios que no podían maximizarse al mismo tiempo>.
+- **Alternativas descartadas:** <opciones y razón concreta del rechazo, en la misma línea>.
+- **Decisión y consecuencia:** <qué se hará y qué habilita, limita o exige revisar en UX e ingeniería>.
+- **Reapertura:** <evidencia o cambio que justificaría revisarla>.
+
+## Preguntas
+
+<!--
+Solo preguntas que pueden cambiar una decisión o funcionalidad. Lo demás va a un issue.
+Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
+Estado: abierta | resuelta AAAA-MM-DD (alguien la respondió) | disuelta AAAA-MM-DD (el producto cambió y la
+pregunta dejó de tener sentido). Solo las abiertas llevan bloque de detalle debajo de la tabla.
+-->
+
+<Una frase que responde "¿qué falta?": la pregunta que bloquea y qué bloquea.>
+
+| ID    | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
+| ----- | ---------------------- | ------------------- | --------------------------------------------------------------- |
+| Q-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
+| Q-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |
+
+<a id="q-001"></a>
+
+### Q-001 — <la pregunta en una frase que se entiende sola>
+
+- **La duda, con un ejemplo:** <el caso concreto que muestra por qué hay dos respuestas posibles>.
+- **Afecta a:** D-001 o F-001.
+- **Cómo se resolverá:** <quién y con qué método>.
+- **¿Bloquea algo?:** <qué bloquea y su fecha límite, o no>.

--- a/docs/missions/README.md
+++ b/docs/missions/README.md
@@ -10,6 +10,17 @@ abrieron y de dónde salió cada una.
 | #   | Misión | Tipo | Abierta | Estado | En foco | Nace de |
 | --- | ------ | ---- | ------- | ------ | ------- | ------- |
 | 01  | [migración a Nuxt UI](./01-migracion-nuxt-ui/) | técnica | 2026-08-11 | cerrada 2026-08-13 | — | A-004 |
+| 02  | [base de datos y Auth (config)](./02-base-de-datos-y-auth/) | técnica | 2026-08-13 | exploración | — | A-001, A-002, A-003 |
+| 03  | [taxonomía: categorías y comunas](./03-taxonomia-categorias-y-comunas/) | producto | 2026-08-13 | exploración | — | — |
+| 04  | [registro y perfil de profesional](./04-registro-perfil-profesional/) | producto | 2026-08-13 | exploración | — | — |
+| 05  | [perfil público de profesional](./05-perfil-publico-profesional/) | producto | 2026-08-13 | exploración | — | — |
+| 06  | [búsqueda y resultados](./06-busqueda-resultados/) | producto | 2026-08-13 | exploración | — | — |
+| 07  | [reseñas verificadas por contacto](./07-resenas-verificadas-por-contacto/) | producto | 2026-08-13 | exploración | — | — |
+
+Misiones 02 a 07 son las seis que llevan al MVP (registrarse, mostrarse, buscar, reseñar), en el orden de
+dependencia definido en la conversación de roadmap del 2026-08-13 — el número no es prioridad, pero acá sí
+refleja el orden real en que cada una desbloquea a la siguiente (ver el "Depende de" en el README de cada
+una).
 
 Estados: `exploración`, `definición`, `lista para construir`, `en construcción`, `en validación`,
 `cerrada`, `pausada`. Al cerrar, el estado lleva su fecha (`cerrada 2026-09-30`). **En foco** es el único

--- a/docs/missions/README.md
+++ b/docs/missions/README.md
@@ -10,7 +10,7 @@ abrieron y de dónde salió cada una.
 | #   | Misión | Tipo | Abierta | Estado | En foco | Nace de |
 | --- | ------ | ---- | ------- | ------ | ------- | ------- |
 | 01  | [migración a Nuxt UI](./01-migracion-nuxt-ui/) | técnica | 2026-08-11 | cerrada 2026-08-13 | — | A-004 |
-| 02  | [base de datos y Auth (config)](./02-base-de-datos-y-auth/) | técnica | 2026-08-13 | exploración | — | A-001, A-002, A-003 |
+| 02  | [base de datos, Auth y correo (config)](./02-base-de-datos-y-auth/) | técnica | 2026-08-13 | exploración | — | A-001, A-002, A-003 |
 | 03  | [taxonomía: categorías y comunas](./03-taxonomia-categorias-y-comunas/) | producto | 2026-08-13 | exploración | — | — |
 | 04  | [registro y perfil de profesional](./04-registro-perfil-profesional/) | producto | 2026-08-13 | exploración | — | — |
 | 05  | [perfil público de profesional](./05-perfil-publico-profesional/) | producto | 2026-08-13 | exploración | — | — |


### PR DESCRIPTION
## Resumen

Abre las 6 misiones definidas en la conversación de roadmap del 2026-08-13, hacia el MVP (registrarse,
mostrarse, buscar, reseñar). Cada carpeta trae solo su `README.md` con un brief descriptivo — qué resuelve,
de qué depende, por qué existe — sin discovery técnico todavía. Los cuatro documentos del template
(`investigacion.md`, `producto.md`, `experiencia.md`, `ingenieria.md`) quedan sin tocar, listos para cuando
cada una se tome en serio con los skills `discovery-product`/`discovery-ux`/`discovery-engineering`.

| # | Misión | Tipo |
|---|---|---|
| 02 | Base de datos, Auth y correo (config) | técnica — fundacional, sin tablas de negocio ni pantallas |
| 03 | Taxonomía: categorías y comunas | producto |
| 04 | Registro y perfil de profesional | producto |
| 05 | Perfil público de profesional | producto |
| 06 | Búsqueda y resultados | producto |
| 07 | Reseñas verificadas por contacto | producto |

El orden de los números sigue la dependencia real entre ellas (detalle en el "depende de" de cada README),
no una prioridad de negocio — 03 a 07 se podrían trabajar en paralelo una vez que 02 esté lista, si hace
falta.

**Segundo commit:** el primer draft presentaba recomendaciones de la conversación de roadmap como si fueran
decisiones ya tomadas ("A-001/A-002/A-003 ya están tomadas", "esa decisión ya está tomada"). Corregido en
02, 04, 06 y 07 para presentar la dirección como recomendación a confirmar en el discovery de cada misión,
no como decisión cerrada. 03 y 05 ya estaban bien planteadas.

**Tercer commit:** faltaba correo transaccional en el alcance — el primer flujo real (registro de
profesional) necesita confirmar "recibimos tu solicitud" por correo. Se agrega a la 02 junto con DB y Auth
(mismo criterio: proveedor tipo Resend a evaluar, no construir algo ya resuelto), y la 04 referencia el
primer correo real del producto. La 02 se renombra a "Base de datos, Auth y correo (config)".

Actualiza también el registro en `docs/missions/README.md`.

## Test plan

- No aplica cambio de código — es apertura de misiones (discovery), sin contenido técnico todavía.