### PR TITLE
docs(infra): agregar A-005 y A-006 al skill arquitectura

### DIFF
--- a/.claude/skills/arquitectura/SKILL.md
+++ b/.claude/skills/arquitectura/SKILL.md
@@ -38,6 +38,14 @@ Postgres vía Drizzle. Ninguna credencial de Supabase ni cadena de conexión cru
 **La excepción es Auth.** La sesión de Supabase Auth vive en el browser porque tiene que vivir ahí, y la
 publishable key es pública por diseño. Lo que nunca baja es la secret key ni la cadena de conexión.
 
+**La sesión viaja en cookies, no en `localStorage`.** Datealo es SSR, no SPA (misión 02, TC-002): el
+servidor necesita leer la sesión en cada request para que `requireUser()` funcione. El cliente de Supabase
+del browser se arma con `createBrowserClient()` de `@supabase/ssr`, nunca con el `createClient()` plano de
+`@supabase/supabase-js` — ese guarda la sesión en `localStorage`, invisible para el servidor, y el síntoma
+es silencioso: el login "funciona" del lado del browser y cualquier endpoint protegido devuelve `401`
+siempre, porque `requireUser()` nunca ve la cookie que nunca se escribió. Receta concreta en
+[`recetas.md`](./references/recetas.md#requireuser-con-supabasessr).
+
 **Al construir:**
 
 - Todo acceso a datos pasa por `server/api/`. Un componente que importa un cliente de Supabase y consulta

--- a/.claude/skills/arquitectura/SKILL.md
+++ b/.claude/skills/arquitectura/SKILL.md
@@ -132,29 +132,112 @@ bundle de la landing creció 70% gzip con la migración completa, revisado y ace
 en `ingenieria.md` de la misión 01, TR-001) — la próxima medición se compara contra esa, no contra el
 DaisyUI original.
 
+## A-005 — Un endpoint nunca devuelve una fila cruda de Drizzle
+
+**Estado:** propuesta. **Fecha:** 2026-08-13.
+
+`select().from(professionals)` devuelve todas las columnas que la tabla tenga, incluida cualquiera que se
+agregue después sin pensar en quién la lee. Nada en TypeScript distingue "columna que el schema tiene" de
+"columna que el cliente debería ver" — compila igual, pasa review igual, y el filtrado solo se nota cuando
+ya salió por la red. `professionals` va a tener campos que no son parte del contrato público desde el día
+uno de la misión 04: notas de moderación, el estado interno de una verificación en curso, quizás un score
+de ranking — ninguno de esos es lo que un buscador debería poder leer en el JSON de un perfil.
+
+**Al construir:**
+
+- Todo endpoint que devuelve una entidad define su forma pública como un `select` explícito de columnas
+  (`select({ id: professionals.id, displayName: professionals.displayName, ... })`) o un mapeo posterior a
+  un tipo propio — nunca el resultado de Drizzle pasado directo al `return` del handler.
+- Una columna nueva en una tabla es privada por default. Se agrega a la forma pública como un cambio
+  explícito, no como un efecto colateral de tocar el schema.
+- Esto es una regla de forma de respuesta, distinta de A-002 (qué filas) y A-001 (qué credenciales) — las
+  tres cierran huecos distintos y ninguna reemplaza a las otras dos.
+
+**Alternativa descartada:** confiar en que RLS filtra columnas — RLS decide qué filas son visibles, nunca
+qué columnas de una fila, y de todos modos no corre en esta conexión (A-002). Confiar en la disciplina de
+"no selecciono esas columnas a mano" sin un tipo que lo fuerce — funciona hasta el primer `select(*)`
+copiado bajo presión de tiempo.
+
+## A-006 — `server/` se organiza por dominio, no solo por tipo de archivo
+
+**Estado:** propuesta. **Fecha:** 2026-08-13.
+
+`CLAUDE.md` ya fija la carpeta por tipo (`api/`, `utils/`, `db/schema/`) para el lado de la app, con la
+YAGNI explícita de no mover nada a `src/` ni inventar estructura antes de que haya fricción real. Eso sigue
+vigente para `app/`. Del lado de `server/`, la fricción ya es previsible: misiones 03 a 07 van a agregar
+`professionals`, `reviews`, `search` como dominios reales, y sin un segundo eje `server/utils/` termina
+mezclando singletons de infraestructura (`db.ts`, `auth.ts`, `email.ts`, sin dueño de dominio) con lógica
+de negocio (`professionals.ts`, `search-ranking.ts`) en la misma carpeta plana — la misión que toca
+`professionals` no puede ver "su" código sin leer los archivos de las otras cuatro.
+
+```
+server/api/professionals/[id].get.ts
+server/api/professionals/[id].patch.ts
+server/api/search/index.get.ts
+server/utils/db.ts              # infraestructura transversal, no es de ningún dominio
+server/utils/auth.ts            # infraestructura transversal
+server/utils/email.ts           # infraestructura transversal
+server/utils/professionals.ts   # dominio: queries y reglas de professionals
+server/utils/search-ranking.ts  # dominio: reglas puras del ranking de search
+```
+
+**Al construir:**
+
+- Cada archivo de `server/utils/` es de un dominio (`professionals.ts`, `reviews.ts`) o es infraestructura
+  transversal (`db.ts`, `auth.ts`, `email.ts`) — nunca las dos cosas, y nunca sirve a dos dominios a la vez.
+- `server/api/` agrupa por dominio en subcarpetas (`professionals/`, `search/`) apenas exista más de un
+  endpoint por dominio — no hace falta esperar a que "duela".
+- `server/db/schema/` ya sigue este eje por convención de `CLAUDE.md` (un archivo por entidad); se
+  mantiene sin cambios.
+- `app/components/` ya agrupa por dominio en subcarpetas — `components/landing/*.vue` es el precedente.
+  Nuxt prefija el nombre del componente con la carpeta (`landing/LandingNavbar.vue` → `<LandingNavbar>`),
+  así que agregar `components/professionals/` o `components/search/` cuando el dominio aparezca sigue el
+  mismo patrón que ya existe, sin costo nuevo.
+- `app/composables/` y `app/utils/` **no siguen el mismo patrón** — por default Nuxt solo auto-importa el
+  nivel superior de esas carpetas, no subcarpetas arbitrarias. Ahí el agrupamiento por dominio va en el
+  nombre del archivo (`useProfessionalProfile.ts`, `professionals.ts` en `utils/`), no en una subcarpeta:
+  meter un composable en `composables/professionals/useProfile.ts` lo saca del auto-import sin ningún
+  error de compilación — se entera recién en runtime, con un `useProfile is not defined`. Esto ya era la
+  convención de `CLAUDE.md` (`useAlgo` por archivo); acá queda explícito el porqué.
+- `app/types/` no tiene esta restricción — los tipos se importan con `import type`, no por auto-import —
+  pero se mantiene igual de flat que `composables/` mientras no haya más de una entidad por dominio, por la
+  misma YAGNI de `CLAUDE.md`.
+
+**Alternativa descartada:** subcarpetas por dominio en cada carpeta desde el día uno
+(`server/utils/professionals/`, `server/db/schema/professionals/`) — con una sola entidad por dominio, un
+archivo ya resuelve el problema real (mezclar infraestructura y negocio); la carpeta agrega ceremonia sin
+un segundo archivo que la justifique. Reabrir esto cuando un dominio necesite más de un archivo de
+`utils/` (ej. `professionals.ts` más `professionals-verification.ts`).
+
+**Reapertura:** si `server/utils/` vuelve a mezclar infraestructura y dominio a pesar de esta regla —
+señal de que la regla no bastó y hace falta la subcarpeta.
+
 ## Dónde va cada cosa
 
 `CLAUDE.md` define la estructura de carpetas y la separación de responsabilidades del lado de la app. Esto
 completa el lado de servidor y datos, que ahí solo está esbozado.
 
-| Qué                                          | Dónde                                  |
-| -------------------------------------------- | -------------------------------------- |
-| Endpoint HTTP                                | `server/api/<recurso>.<método>.ts`     |
-| Regla de negocio o cálculo (función pura)    | `server/utils/<dominio>.ts`            |
-| Cliente de base de datos (singleton)         | `server/utils/db.ts`                   |
-| Schema de Drizzle                            | `server/db/schema/<entidad>.ts`        |
-| Políticas RLS                                | `server/db/sql/rls.sql`                |
-| Esquema de validación de entrada             | junto a su endpoint                    |
-| Secretos y config de runtime                 | `runtimeConfig` en `nuxt.config.ts`    |
-| Estado y acciones del cliente                | `app/composables/`                     |
+| Qué                                          | Dónde                                             |
+| -------------------------------------------- | ---------------------------------------------------- |
+| Endpoint HTTP                                | `server/api/<dominio>/<recurso>.<método>.ts`        |
+| Regla de negocio o cálculo (función pura)    | `server/utils/<dominio>.ts`                         |
+| Infraestructura transversal (sin dominio)    | `server/utils/db.ts`, `auth.ts`, `email.ts`         |
+| Forma pública de una entidad (DTO)           | `select` explícito en el endpoint o `server/utils/<dominio>.ts` — nunca la fila cruda de Drizzle |
+| Schema de Drizzle                            | `server/db/schema/<entidad>.ts`                     |
+| Políticas RLS                                | `server/db/sql/rls.sql`                             |
+| Esquema de validación de entrada             | junto a su endpoint                                 |
+| Secretos y config de runtime                 | `runtimeConfig` en `nuxt.config.ts`                 |
+| Estado y acciones del cliente                | `app/composables/`                                  |
 
-Dos fronteras que no se cruzan:
+Tres fronteras que no se cruzan:
 
 - **La regla de negocio no vive en el handler.** Una función pura en `server/utils/` se prueba con una
   llamada y un `expect`. La misma regla dentro de un `defineEventHandler` solo se prueba levantando Nitro y
   la base. Esto aplica a ranking, distancia, agregación de rating y reglas de verificación — no a CRUD
   simple, donde la abstracción cuesta y no rinde.
 - **El endpoint no decide presentación** y el composable no decide autorización.
+- **La forma pública de una entidad no es su fila de Drizzle** (A-005) — lo que `server/utils/` calcula y
+  lo que el handler devuelve al cliente pueden ser tipos distintos a propósito.
 
 ## Recetas concretas
 

--- a/.claude/skills/arquitectura/references/recetas.md
+++ b/.claude/skills/arquitectura/references/recetas.md
@@ -12,6 +12,7 @@ interfaz (A-004), la migración está en curso — ver la [misión 01](../../../
 - [Instalar la base de datos](#instalar-la-base-de-datos)
 - [El cliente de base de datos](#el-cliente-de-base-de-datos)
 - [Secretos y runtimeConfig](#secretos-y-runtimeconfig)
+- [`requireUser()` con `@supabase/ssr`](#requireuser-con-supabasessr)
 - [Un endpoint de lectura](#un-endpoint-de-lectura)
 - [Un endpoint de escritura, con su verificación](#un-endpoint-de-escritura-con-su-verificación)
 - [Validación de entrada derivada del schema (drizzle-zod)](#validación-de-entrada-derivada-del-schema-drizzle-zod)
@@ -91,6 +92,61 @@ NUXT_PUBLIC_SUPABASE_KEY=...
 
 **La regla que no se negocia:** todo lo que entra a `public` es legible desde el código fuente de la página.
 Antes de agregar una clave ahí, la pregunta es "¿me da lo mismo publicar esto en el README?".
+
+## `requireUser()` con `@supabase/ssr`
+
+```bash
+npm i @supabase/ssr @supabase/supabase-js
+```
+
+La sesión viaja en cookies, no en `localStorage` (ver "La sesión viaja en cookies" en A-001 de
+[`SKILL.md`](../SKILL.md)). El servidor arma su cliente con `createServerClient()`, leyendo y escribiendo
+las cookies de la request vía los helpers de `h3` — nunca con el `createClient()` plano de
+`@supabase/supabase-js`, que no sabe de cookies de servidor.
+
+```ts
+// server/utils/auth.ts
+import { createServerClient } from '@supabase/ssr'
+import { parseCookies, setCookie } from 'h3'
+import type { H3Event } from 'h3'
+
+function serverSupabase(event: H3Event) {
+  const { public: pub, supabaseSecretKey } = useRuntimeConfig()
+  return createServerClient(pub.supabaseUrl, supabaseSecretKey, {
+    cookies: {
+      getAll: () => Object.entries(parseCookies(event)).map(([name, value]) => ({ name, value })),
+      setAll: (cookies) => cookies.forEach(({ name, value, options }) => setCookie(event, name, value, options)),
+    },
+  })
+}
+
+export async function requireUser(event: H3Event) {
+  const supabase = serverSupabase(event)
+  const { data, error } = await supabase.auth.getUser()
+  if (error || !data.user) {
+    throw createError({ statusCode: 401, statusMessage: 'unauthorized' })
+  }
+  return { id: data.user.id, email: data.user.email ?? null }
+}
+```
+
+El cliente del browser usa el par que corresponde — `createBrowserClient()`, no `createClient()` — para que
+la sesión que arma el login quede en la misma cookie que el servidor sabe leer:
+
+```ts
+// app/plugins/supabase.client.ts
+import { createBrowserClient } from '@supabase/ssr'
+
+export default defineNuxtPlugin(() => {
+  const { public: pub } = useRuntimeConfig()
+  const supabase = createBrowserClient(pub.supabaseUrl, pub.supabaseKey)
+  return { provide: { supabase } }
+})
+```
+
+Mezclar los dos pares (`createClient()` en el browser con `createServerClient()` en el servidor, o
+viceversa) es el error típico: cada mitad cree que la sesión existe y ninguna la encuentra donde la otra la
+dejó.
 
 ## Un endpoint de lectura
 

--- a/.claude/skills/arquitectura/references/recetas.md
+++ b/.claude/skills/arquitectura/references/recetas.md
@@ -14,6 +14,7 @@ interfaz (A-004), la migración está en curso — ver la [misión 01](../../../
 - [Secretos y runtimeConfig](#secretos-y-runtimeconfig)
 - [Un endpoint de lectura](#un-endpoint-de-lectura)
 - [Un endpoint de escritura, con su verificación](#un-endpoint-de-escritura-con-su-verificación)
+- [Validación de entrada derivada del schema (drizzle-zod)](#validación-de-entrada-derivada-del-schema-drizzle-zod)
 - [Agregar una tabla](#agregar-una-tabla)
 - [Desplegar a Vercel](#desplegar-a-vercel)
 - [Antes de dar por terminado un endpoint](#antes-de-dar-por-terminado-un-endpoint)
@@ -24,7 +25,7 @@ interfaz (A-004), la migración está en curso — ver la [misión 01](../../../
 ```bash
 npm i drizzle-orm postgres
 npm i -D drizzle-kit
-npm i zod          # validación de entrada en los endpoints
+npm i zod drizzle-zod   # validación de entrada derivada del schema — ver receta más abajo
 ```
 
 `postgres.js` es el driver que documenta Drizzle para Supabase. No usar `node-postgres` salvo que aparezca
@@ -93,6 +94,27 @@ Antes de agregar una clave ahí, la pregunta es "¿me da lo mismo publicar esto 
 
 ## Un endpoint de lectura
 
+`findPublicProfile` no hace `select().from(professionals)` — selecciona las columnas públicas a mano.
+Es lo que materializa A-005: una columna nueva en la tabla (una nota de moderación, un score interno) es
+privada hasta que alguien la agrega acá a propósito, no por default.
+
+```ts
+// server/utils/professionals.ts
+export async function findPublicProfile(id: string) {
+  const [row] = await useDb()
+    .select({
+      id: professionals.id,
+      displayName: professionals.displayName,
+      category: professionals.category,
+      comuna: professionals.comuna,
+      // professionals.internalModerationNotes, por ejemplo, no entra acá — y por eso nunca sale
+    })
+    .from(professionals)
+    .where(eq(professionals.id, id))
+  return row
+}
+```
+
 ```ts
 // server/api/professionals/[id].get.ts
 import { z } from 'zod'
@@ -102,7 +124,7 @@ const params = z.object({ id: z.string().uuid() })
 export default defineEventHandler(async (event) => {
   const { id } = await getValidatedRouterParams(event, params.parse)
 
-  const profile = await findPublicProfile(id)   // server/utils/professionals.ts
+  const profile = await findPublicProfile(id)   // server/utils/professionals.ts — ya viene filtrado (A-005)
   if (!profile) {
     throw createError({ statusCode: 404, statusMessage: 'not_found' })
   }
@@ -150,6 +172,58 @@ export default defineEventHandler(async (event) => {
 
 Devolver `404` en vez de `403` cuando el recurso no existe evita confirmarle a un tercero que un ID es
 válido. Cuando existe pero no es suyo, `403` es correcto y más útil para depurar.
+
+## Validación de entrada derivada del schema (drizzle-zod)
+
+Escribir un `z.object()` a mano por endpoint duplica lo que el schema de Drizzle ya sabe: el tipo de cada
+columna, si es nullable, el largo de un `varchar`. Cuando el schema cambia — una columna pasa a
+`notNull()`, un `varchar(80)` pasa a `120` — el `z.object()` escrito a mano no se entera solo; sigue
+validando la regla vieja hasta que alguien lo nota, casi siempre en producción.
+
+`drizzle-zod` genera el `z.object()` desde la tabla, una vez, junto al schema:
+
+```ts
+// server/db/schema/professionals.ts
+import { pgTable, uuid, text, timestamp } from 'drizzle-orm/pg-core'
+import { createInsertSchema, createUpdateSchema } from 'drizzle-zod'
+
+export const professionals = pgTable('professionals', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  userId: uuid('user_id').notNull(),
+  displayName: text('display_name').notNull(),
+  phone: text('phone').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+})
+
+export const insertProfessionalSchema = createInsertSchema(professionals)
+export const updateProfessionalSchema = createUpdateSchema(professionals)
+```
+
+Cada endpoint lo afina con `.pick()` / `.omit()` / `.extend()` — nunca reescribiendo el tipo de un campo
+que el schema ya define:
+
+```ts
+// server/api/professionals/[id].patch.ts
+import { updateProfessionalSchema } from '../../db/schema/professionals'
+
+const body = updateProfessionalSchema
+  .pick({ displayName: true, phone: true })
+  .extend({ phone: z.string().regex(/^\+56\d{9}$/) })  // regla de negocio que Drizzle no conoce
+
+export default defineEventHandler(async (event) => {
+  const patch = await readValidatedBody(event, body.parse)
+  // ...
+})
+```
+
+`id`, `userId` y `createdAt` quedan afuera del `.pick()` — nadie los manda en el body de un `PATCH`, y no
+hace falta acordarse de omitirlos a mano en cada endpoint nuevo que toque esta tabla.
+
+**No reemplaza A-005.** `createInsertSchema`/`createUpdateSchema` validan la forma de *entrada*, que el
+schema de Drizzle ya conoce por completo. La forma *pública de salida* (qué columnas se devuelven) sigue
+siendo una decisión del endpoint — un `select` explícito, como en "Un endpoint de lectura" — porque ahí la
+pregunta no es "¿qué tipo tiene esta columna?" sino "¿debería salir del servidor?", y esa segunda pregunta
+ninguna herramienta la responde por ti.
 
 ## Agregar una tabla
 


### PR DESCRIPTION
## Resumen
- **A-005** — un endpoint nunca devuelve una fila cruda de Drizzle. La forma pública de una entidad es un `select` explícito; una columna nueva es privada por default hasta que alguien la expone a propósito. Cierra un hueco que ni A-001 (credenciales) ni A-002 (RLS, filas) cubren.
- **A-006** — `server/` se organiza por dominio (`api/<dominio>/`, `utils/<dominio>.ts` separado de infraestructura transversal como `db.ts`/`auth.ts`/`email.ts`). Documenta también la asimetría de Nuxt: `app/components/` sí soporta subcarpetas por dominio (precedente: `components/landing/`), `app/composables/` y `app/utils/` no (Nuxt solo auto-importa el nivel superior por default) — confirmado contra la documentación de Nuxt.
- Receta nueva: `drizzle-zod` para derivar la validación de entrada del schema de Drizzle en vez de escribir un `z.object()` a mano por endpoint (evita que schema y validación se desincronicen).

Nace de la conversación de arquitectura para la misión 02, antes de empezar a construir.

## Test plan
- [x] Solo documentación (`.claude/skills/arquitectura/`), no toca código