### PR TITLE
docs: completar ingenieria.md de la misión 02 y su plan de construcción

### DIFF
--- a/docs/missions/02-base-de-datos-y-auth/README.md
+++ b/docs/missions/02-base-de-datos-y-auth/README.md
@@ -2,7 +2,7 @@
 
 **Tipo:** técnica. **Abierta el** 2026-08-13. **Nace de:** A-001, A-002 y A-003 del skill `arquitectura`.
 
-**Estado de la misión:** exploración
+**Estado de la misión:** lista para construir
 
 **Última actualización:** 2026-08-13
 
@@ -14,11 +14,17 @@ Primera de seis misiones hacia el MVP (registrarse, mostrarse, buscar, reseñar)
 ajustarlas) contra una decisión real, con código de por medio, es parte del trabajo de esta misión, no algo
 que ya viene resuelto de afuera.
 
-| Documento  | Estado    | Qué falta para su gate  |
-| ---------- | --------- | ------------------------ |
-| Ingeniería | pendiente | discovery completo — hoy solo existe la carpeta |
+| Documento  | Estado      | Qué falta para su gate  |
+| ---------- | ----------- | ------------------------ |
+| Ingeniería | en revisión | aprobación del dueño de producto para pasar a `vigente` |
 
-**Próximo hito:** ninguno todavía — esta misión no se ha empezado a trabajar.
+Issues abiertos: [#31](https://github.com/PatricioTabilo/datealo/issues/31) (S-001, Supabase + Drizzle),
+[#32](https://github.com/PatricioTabilo/datealo/issues/32) (S-002, auth de servidor),
+[#33](https://github.com/PatricioTabilo/datealo/issues/33) (S-003, Resend SMTP de Supabase Auth),
+[#34](https://github.com/PatricioTabilo/datealo/issues/34) (S-004, `sendEmail()`).
+
+**Próximo hito:** empezar S-001 (#31) — sin fecha límite todavía. La verificación de dominio en Resend
+(TQ-001/TR-003) queda como tarea operativa de Patricio, en paralelo, sin bloquear el código.
 
 ## Brief
 

--- a/docs/missions/02-base-de-datos-y-auth/ingenieria.md
+++ b/docs/missions/02-base-de-datos-y-auth/ingenieria.md
@@ -73,7 +73,13 @@ documenta la receta de "endpoint de escritura" en `arquitectura/references/recet
 - **Entrada:** el `H3Event` de la request. Nunca confía en un `userId` que venga del body o la query.
 - **Salida:** `{ id: string, email: string | null }` del usuario autenticado.
 - **Invariantes:** valida el JWT de Supabase contra la secret key del servidor, no contra la publishable
-  key del cliente — un JWT expirado o manipulado nunca resuelve a un usuario válido.
+  key del cliente — un JWT expirado o manipulado nunca resuelve a un usuario válido. **La sesión viaja en
+  cookies, no en `localStorage`**: el cliente se arma con `createServerClient()` de `@supabase/ssr` leyendo
+  las cookies de la request, nunca con el `createClient()` plano de `@supabase/supabase-js` — ese guarda la
+  sesión en `localStorage`, invisible para el servidor, y el síntoma es silencioso (login "funciona" en el
+  browser, cualquier endpoint protegido devuelve `401` siempre). El cliente del browser usa el par que
+  corresponde, `createBrowserClient()`, para que ambos lados lean la misma cookie. Receta completa en
+  [`recetas.md`](../../../.claude/skills/arquitectura/references/recetas.md#requireuser-con-supabasessr).
 - **Errores:** sin sesión o sesión inválida → `401 { error: 'unauthorized' }`. El llamador decide si eso
   termina la request (recurso privado) o si sigue como anónimo (recurso público).
 - **Contrato de producto:** A-002.

--- a/docs/missions/02-base-de-datos-y-auth/ingenieria.md
+++ b/docs/missions/02-base-de-datos-y-auth/ingenieria.md
@@ -1,162 +1,231 @@
-# Misión: <nombre> — Ingeniería
+# Misión 02: Base de datos, Auth y correo — Ingeniería
 
-**Estado:** borrador
+**Estado:** en revisión
 
-**Última actualización:** AAAA-MM-DD
+**Última actualización:** 2026-08-13
 
-[Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
-[Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
+[Índice](./README.md) · [Ingeniería](./ingenieria.md)
 
-<!--
-Fuente de verdad para arquitectura, datos, contratos, factibilidad y pruebas. Consume el comportamiento
-definido en producto. Una limitación técnica cambia el alcance solo mediante una decisión explícita en
-producto.md.
+## Decisión técnica: Supabase (Postgres + Auth) vía Drizzle, con Resend como transporte de correo en dos roles
 
-Núcleo obligatorio: contratos, modelo de datos, RLS y riesgos de factibilidad. Las secciones bajo demanda
-(migración, rendimiento, entrega por etapas) se agregan solo cuando el riesgo lo justifica.
+Ratifica A-001, A-002 y A-003 del skill `arquitectura` (hoy "propuesta") con la evaluación real que les
+faltaba, y agrega dos decisiones nuevas que no estaban cubiertas ahí: qué usar para autenticación y qué
+usar para correo transaccional.
 
-Gate de salida — ingenieria.md está lista para construir cuando:
-- los contratos definen qué entra, qué sale y qué invariantes se mantienen, sin ambigüedad
-- el modelo de datos soporta los casos límite de producto.md sin workarounds
-- el impacto en RLS está resuelto: qué policy se crea o cambia, o por qué ninguna
-- la migración de datos existentes tiene estrategia o está explícitamente fuera del alcance
-- los escenarios verificables de producto están mapeados a pruebas
-- el plan de construcción corta el diseño en slices atómicos ordenados (un slice = un Issue = un PR)
--->
+La base de datos es Postgres administrado por Supabase, accedido solo desde `server/api/` vía Drizzle
+(A-001) contra el pooler Supavisor en modo transacción (A-003). La identidad de ambos lados del
+marketplace la resuelve Supabase Auth, con su sesión viviendo en el browser por necesidad y la
+autorización real verificada en cada endpoint (A-002) — nunca solo en la policy RLS. El correo lo maneja
+Resend en dos roles distintos: como transporte SMTP custom de Supabase Auth (para los correos que el
+propio sistema de auth dispara: confirmación de cuenta, magic link, reset de contraseña) y como
+`sendEmail()` genérico en `server/utils/` para el correo de negocio que cada misión futura va a disparar
+con su propio contenido.
 
-## Decisión técnica: <arquitectura y riesgo principal>
+- **Contratos de producto cubiertos:** A-001, A-002, A-003 (skill `arquitectura`).
+- **Riesgo bloqueante:** ninguno para la arquitectura en sí. El riesgo real es operativo — ver TR-001 — y
+  depende de una decisión de negocio que no es de esta misión (el dominio de envío, TQ-001).
 
-<Dirección técnica, trade-off principal y el riesgo que todavía podría invalidarla.>
+## Arquitectura: cuatro piezas, cada una con una sola responsabilidad
 
-- **Contratos de producto cubiertos:** F-001, <otros>.
-- **Riesgo bloqueante:** <incertidumbre o "ninguna">.
+```
+Browser ──(sesión Supabase Auth, publishable key)──> Supabase Auth
+Browser ──(fetch a /api/*, mismo origen)────────────> Nitro (server/api/)
+                                                          │
+                                          requireUser() ──┤── useDb() ──> Postgres (Supavisor :6543)
+                                                          │
+                                                    sendEmail() ──> Resend API
+                                                          
+Supabase Auth ──(SMTP custom)──> Resend SMTP ──> bandeja del usuario
+```
 
-## Arquitectura: <cómo se divide la responsabilidad>
+El browser nunca ve la cadena de conexión de Postgres ni la secret key de Supabase (A-001): solo la
+publishable key, porque la sesión de Auth tiene que vivir ahí. Nitro es el único que habla con Postgres y
+con la API de Resend. Supabase Auth es el único que habla con el transporte SMTP — eso lo configura el
+dashboard de Supabase, no código de la app.
 
-<!--
-La lógica de negocio se separa de la infraestructura: funciones puras en utils/ y server/utils/,
-reactividad en composables, acceso a datos en server/api/ con Drizzle. Incluye diagrama solo cuando tres o
-más partes interactúan.
--->
+| Componente                      | Responsabilidad                                              | No debe decidir                        | Contratos     |
+| -------------------------------- | -------------------------------------------------------------- | ----------------------------------------- | -------------- |
+| `useDb()` (`server/utils/db.ts`) | Conexión singleton a Postgres vía Drizzle                    | Autorización, forma de la respuesta       | A-001, A-003  |
+| `requireUser()` (`server/utils/auth.ts`) | Validar la sesión de Supabase Auth en el servidor      | Si el usuario es dueño del recurso pedido | A-002         |
+| SMTP custom de Supabase Auth      | Entregar los correos que el propio sistema de auth dispara   | Contenido de negocio                      | T-002, T-003  |
+| `sendEmail()` (`server/utils/email.ts`) | Enviar correo de negocio vía la API de Resend            | Copy o template — eso lo define quien lo llama | T-003    |
 
-<Descripción del enfoque y por qué satisface los contratos con menor riesgo.>
-
-| Componente | Responsabilidad       | No debe decidir | Contratos |
-| ---------- | --------------------- | --------------- | --------- |
-| <nombre>   | <una responsabilidad> | <frontera>      | F-001     |
+La pertenencia de un recurso (¿es tuyo?) nunca la decide `requireUser()` — solo confirma que hay una
+sesión válida y quién es. Cada endpoint de misiones futuras hace esa segunda verificación, como ya
+documenta la receta de "endpoint de escritura" en `arquitectura/references/recetas.md`.
 
 ## Contratos
 
-<!--
-Cada contrato especifica entrada, salida e invariantes al nivel en que se puede implementar sin reuniones
-de aclaración. Incluye los errores observables y el código HTTP cuando es un endpoint.
--->
+### TC-001 — `useDb()` entrega un cliente Drizzle listo para consultar
 
-### TC-001 — <contrato en una frase>
+- **Entrada:** ninguna — lee `databaseUrl` de `runtimeConfig` en el primer llamado.
+- **Salida:** instancia de Drizzle tipada contra `server/db/schema`, reutilizada en llamados siguientes
+  dentro del mismo proceso (singleton perezoso).
+- **Invariantes:** la conexión se abre una sola vez por contenedor serverless caliente; se abre siempre
+  con `prepare: false` — sin ese flag compila pero falla en runtime contra Supavisor en modo transacción
+  (A-003), un error que no aparece en local contra una base directa.
+- **Errores:** una `databaseUrl` inválida o el pooler caído propaga el error del driver `postgres.js` sin
+  envolverlo — cada endpoint que lo llama decide cómo mapearlo a una respuesta HTTP.
+- **Contrato de producto:** A-001, A-003.
 
-- **Entrada:** <datos y precondiciones, con tipos y forma concreta>.
-- **Salida:** <resultado y su forma concreta>.
-- **Invariantes:** <qué se cumple siempre: atomicidad, consistencia, idempotencia>.
-- **Errores:** <condición → código HTTP y cuerpo `{ error, code? }`, y qué puede hacer el llamador>.
-- **Contrato de producto:** [F-001](./producto.md#f-001).
+### TC-002 — `requireUser(event)` verifica la sesión de Supabase Auth en el servidor
+
+- **Entrada:** el `H3Event` de la request. Nunca confía en un `userId` que venga del body o la query.
+- **Salida:** `{ id: string, email: string | null }` del usuario autenticado.
+- **Invariantes:** valida el JWT de Supabase contra la secret key del servidor, no contra la publishable
+  key del cliente — un JWT expirado o manipulado nunca resuelve a un usuario válido.
+- **Errores:** sin sesión o sesión inválida → `401 { error: 'unauthorized' }`. El llamador decide si eso
+  termina la request (recurso privado) o si sigue como anónimo (recurso público).
+- **Contrato de producto:** A-002.
+
+### TC-003 — `sendEmail()` entrega correo de negocio vía Resend
+
+- **Entrada:** `{ to: string, subject: string, html: string }`. El contenido y el copy los arma quien
+  llama — este contrato no sabe de profesionales, reseñas ni registro.
+- **Salida:** `{ id: string }` con el ID de mensaje que devuelve Resend.
+- **Invariantes:** el contrato no sabe ni le importa qué dominio respalda `emailFrom` — recibe
+  `resendApiKey` y `emailFrom` desde `runtimeConfig` (variables `NUXT_RESEND_API_KEY` y `NUXT_EMAIL_FROM`,
+  igual que `databaseUrl` en la receta de `arquitectura`), así que verificar el dominio en el dashboard de
+  Resend no exige ningún cambio de código, solo cambiar el valor de la variable de entorno.
+- **Errores:** el error del SDK de Resend (dominio no verificado, rate limit, destinatario inválido) se
+  propaga con su mensaje original — no un `500` genérico que oculte cuál de las tres causas fue.
+- **Contrato de producto:** T-003.
 
 ## Modelo de datos
 
-<!-- Entidades con significado, escritura y ciclo de vida. El schema completo vive en server/db/. -->
+Ninguna tabla de negocio nueva — el brief de esta misión es "cero tablas de negocio, cero pantallas, cero
+flujo de usuario" y se mantiene: instalar la plomería, no modelar nada que le pertenezca a una misión de
+producto.
 
-| Entidad o campo | Significado             | Escritura          | Retención o historial |
-| --------------- | ----------------------- | ------------------ | --------------------- |
-| <dato>          | <semántica de producto> | <endpoint o acción>| <política>            |
+Supabase Auth crea y administra su propio schema `auth` (empezando por `auth.users`) fuera de las
+migraciones de Drizzle — `drizzle-kit` nunca genera ni toca ese schema. Las misiones 03 a 07 son las que
+van a agregar sus tablas de negocio con un `user_id uuid` que referencia `auth.users.id`, no esta.
 
 ### Invariantes de datos
 
-- <unicidad, pertenencia, orden o consistencia temporal>.
-- <qué operación es atómica o qué dato tiene una única fuente de verdad>.
+- `auth.users` es la única fuente de verdad de identidad (email, password hash, metadata de sesión).
+  Ninguna tabla de `public` duplica email o password.
+- El schema `auth` es propiedad de Supabase Auth. Un cambio ahí se hace desde el dashboard o la API de
+  Supabase, nunca con una migración de `drizzle-kit`.
 
 ### Impacto en RLS
 
-<!--
-Obligatorio. Fuente de verdad: server/db/sql/rls.sql. Si el cambio no toca ownership ni relaciones usadas
-en policies, decirlo explícitamente con esa razón — no dejar la sección vacía.
--->
+| Tabla | Cambio | Policy afectada | Acción |
+| ----- | ------ | ---------------- | ------ |
+| — | ninguna | — | ninguna |
 
-| Tabla    | Cambio                 | Policy afectada | Acción                    |
-| -------- | ---------------------- | --------------- | ------------------------- |
-| <tabla>  | <nueva, ownership, FK> | <nombre>        | <crear, actualizar, nada> |
+Ninguna tabla nueva de negocio → ninguna policy nueva. `auth.users` ya trae RLS gestionado por Supabase,
+fuera del alcance de `server/db/sql/rls.sql`. Esa fuente de verdad sigue vacía hasta la primera tabla de
+negocio (misión 03).
 
 ## Riesgos y experimentos de factibilidad
 
-<!--
-Un riesgo que podría cambiar el producto se enlaza como pregunta o decisión en producto.md. Un experimento
-tiene pregunta, límite de tiempo y resultado capaz de cerrar la incertidumbre.
--->
-
-| ID     | Riesgo o pregunta | Qué invalida        | Experimento o mitigación  | Criterio de salida      | Estado  |
-| ------ | ----------------- | ------------------- | ------------------------- | ----------------------- | ------- |
-| TR-001 | <incertidumbre>   | <alcance en riesgo> | <spike, prueba o recorte> | <resultado concluyente> | abierto |
+| ID     | Riesgo o pregunta | Qué invalida | Experimento o mitigación | Criterio de salida | Estado |
+| ------ | ----------------- | ------------ | ------------------------- | -------------------- | ------ |
+| TR-001 | El proveedor de correo por defecto de Supabase Auth entrega máximo 2 correos/hora **por proyecto** (no por usuario), sin SLA, y rechaza destinatarios fuera del equipo del proyecto — inutilizable ni para probar el flujo de registro | Cualquier prueba real de confirmación de cuenta, y producción por completo | Configurar Resend como SMTP custom en el dashboard de Supabase (Authentication → Emails → SMTP Settings) como parte de S-003, usando la API key de Resend que llega por variable de entorno — el dominio que respalda esa key es indiferente para este mecanismo | Un signup de prueba contra el destinatario verificado disponible en ese momento (cuenta propia en Resend, o el dominio final una vez verificado) recibe la confirmación, sin tocar el límite (que sube a 30/hora con SMTP custom) | abierto |
+| TR-002 | Supavisor en modo transacción no soporta prepared statements; si `prepare: false` se pierde en algún punto, la app compila y solo falla en runtime, y no se nota en local contra una base directa | Cualquier request que toque `useDb()` en producción | Un endpoint de salud (`/api/health/db`, temporal, se borra o se deja como healthcheck real) hace un `SELECT 1` desplegado en Vercel, no solo en local, antes de cerrar S-001 | El healthcheck responde 200 en al menos dos requests concurrentes contra el deploy de Vercel | abierto |
+| TR-003 | La verificación de dominio en Resend (SPF, DKIM, DMARC) es un cambio de DNS externo a este repo, y `sendEmail()`/el SMTP de Supabase no distinguen en código qué dominio los respalda | Ninguno para el código de esta misión — sí para que un correo real le llegue a un usuario que no sea Patricio, mientras el dominio no esté verificado | Patricio configura el dominio y la verificación DNS en el dashboard de Resend por su cuenta, en paralelo a esta misión y sin bloquearla; mientras tanto S-003/S-004 se verifican contra el destinatario de prueba que Resend permita sin dominio verificado | El dominio real queda verificado en Resend antes de que cualquier misión de producto (03 a 07) dependa de un correo llegándole a un usuario real que no sea de prueba | abierto — sin fecha, fuera del código de esta misión |
 
 ## Estrategia de pruebas
 
-<!-- Mapea los ejemplos verificables de producto.md a niveles de prueba. Qué demuestra cada una. -->
-
-| Contrato o riesgo | Nivel                          | Caso principal | Límite o falla |
-| ----------------- | ------------------------------ | -------------- | -------------- |
-| F-001, CL-001     | <unidad, contrato, integración>| <caso>         | <caso>         |
+| Contrato o riesgo | Nivel | Caso principal | Límite o falla |
+| ------------------ | ----- | --------------- | ---------------- |
+| TC-001 | integración | Una query real contra un proyecto Supabase de prueba hace round-trip | `databaseUrl` inválida propaga el error del driver, no cuelga |
+| TC-002 | unidad | Sesión válida resuelve `{ id, email }` | Sin sesión, JWT expirado y JWT manipulado devuelven `401` los tres |
+| TC-003 | unidad + integración manual | SDK de Resend mockeado: el payload sale con la forma correcta | Dominio no verificado y rate limit se propagan como errores distintos, no un `500` genérico; un envío real contra el dominio sandbox de Resend se corre una vez por slice, no en cada CI |
+| TR-002 | integración desplegada | Healthcheck contra el deploy real de Vercel, no local | Dos requests concurrentes no agotan el pool |
 
 ### Propiedades que deben probarse
 
-- <invariante bajo reintentos, concurrencia o distintas entradas>.
-- <ausencia de efectos parciales en falla>.
+- `useDb()` no abre una conexión nueva por request dentro del mismo contenedor caliente — reutiliza el
+  singleton.
+- `requireUser()` nunca resuelve un usuario a partir de datos que vengan del cliente (body, query, headers
+  que no sean el JWT de sesión).
+- Un fallo de `sendEmail()` no revienta el endpoint que lo llama con un `500` sin contexto — el llamador
+  puede distinguir "el correo falló" de "la operación de negocio falló".
 
 ## Plan de construcción
 
-<!--
-Se completa al final, cuando el gate de salida se cumple y ninguna pregunta bloqueante sigue abierta —
-cortar sobre decisiones abiertas produce issues que mueren. Cada slice es un cambio funcional atómico: un
-Issue, un PR, ejecutable sin haber leído la misión (el issue lleva su contrato inline) y con criterios
-pass/fail enumerables como tests. Guía completa en el skill discovery-engineering.
--->
+Corte por pieza de infraestructura: cada slice deja algo verificable de punta a punta (no solo "el
+paquete quedó instalado"). S-001 es la base — nada más funciona sin la conexión a Postgres. S-002 y S-003
+no dependen entre sí pero ambos necesitan S-001 para `runtimeConfig`. S-004 depende de que Resend ya esté
+integrado (S-003 verifica el mecanismo de envío).
 
-| ID    | Slice (una frase, sin "y") | Sustento      | Criterio de aceptación principal          | Depende de |
-| ----- | -------------------------- | ------------- | ----------------------------------------- | ---------- |
-| S-001 | <cambio atómico>           | TC-001, D-001 | <entrada concreta → resultado observable> | —          |
+Ninguno de los cuatro slices depende de qué dominio respalda las credenciales de Resend (TQ-001,
+resuelta): el código consume `resendApiKey` y `emailFrom` como variables de entorno, y la verificación de
+dominio en el dashboard de Resend es un paso operativo de Patricio, en paralelo a esta misión, sin bloquear
+ningún merge. El único efecto de hacerlo después es que hasta entonces el correo real solo le llega a
+destinatarios que Resend permita sin dominio verificado (ver TR-003).
 
-## Secciones bajo demanda
-
-<!--
-Agregar solo cuando el riesgo lo justifique, con estos títulos:
-
-- "Migración y compatibilidad": cuando existan datos o consumidores que deben llegar al nuevo contrato.
-  Incluye rollback lógico si la migración física no puede revertirse.
-- "Rendimiento y observabilidad": cuando haya presupuesto de latencia o volumen que defender (búsqueda
-  geográfica y listados paginados son los candidatos naturales).
-- "SEO e indexación": cuando la superficie deba ser indexable (páginas por categoría + comuna, datos
-  estructurados).
-- "Entrega por etapas": cuando el cambio necesite despliegue incremental o feature flags.
--->
+| ID    | Slice (una frase, sin "y") | Sustento | Criterio de aceptación principal | Depende de | Issue |
+| ----- | --------------------------- | -------- | ----------------------------------- | ---------- | ----- |
+| S-001 | Instalar y conectar Supabase + Drizzle | A-001, A-003, TC-001 | `useDb()` existe en `server/utils/db.ts`; `/api/health/db` desplegado en Vercel responde 200 con un `SELECT 1` contra el pooler, con `prepare: false` | — | [#31](https://github.com/PatricioTabilo/datealo/issues/31) |
+| S-002 | Autenticación de servidor con Supabase Auth | A-002, TC-002 | `requireUser()` existe en `server/utils/auth.ts`; un endpoint de prueba responde `401` sin sesión y `200` con una sesión real de un usuario de prueba | S-001 | [#32](https://github.com/PatricioTabilo/datealo/issues/32) |
+| S-003 | Configurar Resend como SMTP custom de Supabase Auth | T-002, T-003, TR-001 | El dashboard de Supabase Auth queda apuntando al SMTP de Resend con la API key de `NUXT_RESEND_API_KEY`; un signup de prueba dispara el correo de confirmación y llega a un destinatario válido para la cuenta de Resend usada, sin tocar el límite de 2/hora por defecto | S-001 | [#33](https://github.com/PatricioTabilo/datealo/issues/33) |
+| S-004 | `sendEmail()` genérico sobre la API de Resend | TC-003 | Llamar `sendEmail()` con un template mínimo entrega el correo usando `resendApiKey`/`emailFrom` de `runtimeConfig`; una API key inválida o un rate limit se propagan como error legible, no un `500` genérico | S-001, S-003 | [#34](https://github.com/PatricioTabilo/datealo/issues/34) |
 
 ## Decisiones técnicas
 
 <a id="t-001"></a>
 
-### T-001 — <decisión en una frase>
+### T-001 — Supabase (Postgres) + Drizzle sobre Supavisor en modo transacción
 
-- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
-- **Contratos:** F-001 y <regla relevante>.
-- **Alternativas descartadas:** <opciones y trade-offs, con el porqué del rechazo>.
-- **Decisión y consecuencias:** <enfoque elegido, beneficio, costo y trabajo futuro aceptado>.
-- **Reapertura:** <medición o cambio que justificaría revisar>.
+- **Estado:** propuesta. **Fecha:** 2026-08-13.
+- **Contratos:** A-001, A-003.
+- **Alternativas descartadas:** Neon — mejor DX de branching por rama de Postgres puro, pero sin Auth
+  nativo: sumaría un segundo proveedor solo para identidad, dos sistemas que mantener en vez de uno.
+  Postgres self-hosted en un VPS — control total, pero para un producto pre-lanzamiento sin equipo de
+  infra el costo operativo (backups, parches, HA) no se justifica contra lo que resuelve. PlanetScale —
+  MySQL, no Postgres: no es "más simple", es un motor distinto con su propio costo de aprendizaje y sin
+  RLS nativo, que es parte de A-002.
+- **Decisión y consecuencias:** Postgres administrado por Supabase, accedido solo por Drizzle desde
+  `server/api/`. El costo aceptado es la dependencia de un solo proveedor para datos e identidad — mitigado
+  porque Postgres es portable (dump/restore a cualquier otro Postgres) si algún día hace falta migrar.
+- **Reapertura:** si el volumen de datos o el presupuesto de latencia exige control fino sobre el
+  hardware que Supabase no expone en su tier, se revisa contra Neon o self-hosted con una medición real.
+
+### T-002 — Supabase Auth para ambos lados del marketplace
+
+- **Estado:** propuesta. **Fecha:** 2026-08-13.
+- **Contratos:** A-001, A-002.
+- **Alternativas descartadas:** Clerk — mejor DX de componentes prearmados y soporte nativo de
+  organizaciones/SSO, pero Datealo no tiene organizaciones ni requisitos B2B: pagaría por una superficie
+  que no usa, y la fuente de verdad de usuarios quedaría fuera de Postgres, duplicando identidad entre dos
+  sistemas. `@sidebase/nuxt-auth` / Better Auth self-hosted — sin costo por usuario activo y control
+  total, pero sin Supabase ya resuelto como base de datos no hay ninguna razón para mantener a mano un
+  segundo sistema de sesiones en un equipo de una persona.
+- **Decisión y consecuencias:** Supabase Auth, con la sesión en el browser (única excepción a A-001) y la
+  autorización real verificada en cada endpoint (A-002). El costo aceptado es que Supabase Auth por
+  defecto no manda correo utilizable en producción — de ahí sale T-003.
+- **Reapertura:** si aparece un requisito de negocio real de organizaciones o SSO (poco probable para un
+  marketplace de hogar B2C), se revisa contra Clerk o WorkOS con ese requisito concreto, no en abstracto.
+
+### T-003 — Resend como proveedor de correo, en dos roles
+
+- **Estado:** propuesta. **Fecha:** 2026-08-13.
+- **Contratos:** T-002, TC-003, TR-001.
+- **Alternativas descartadas:** dejar el proveedor por defecto de Supabase — 2 correos/hora por proyecto
+  entero, sin SLA, inviable incluso para pruebas (TR-001). Postmark — mejor reputación de entregabilidad y
+  logging, pero al volumen de un producto pre-lanzamiento el pricing 2026 no le gana a Resend, y el
+  atractivo real de Postmark (soporte, deliverability a escala) importa recién con volumen que Datealo no
+  tiene todavía. AWS SES — el más barato por email a escala (~$0.10 por 1.000), pero exige manejar bounces,
+  reputación de IP y sandbox a mano: costo de operación que no se justifica sin equipo de infra.
+- **Decisión y consecuencias:** Resend en dos roles — SMTP custom de Supabase Auth para los correos del
+  propio sistema de auth, y `sendEmail()` genérico sobre su API para correo de negocio. El costo aceptado
+  es depender de un proveedor con menos años de operación que Postmark o SES; se acepta porque el volumen
+  actual es cero y la integración es la más simple de las tres.
+- **Reapertura:** si el volumen supera ~40-50k correos/mes o la deliverability se vuelve un problema
+  medible (bounces, marcado como spam), se revisa contra Postmark o SES con datos reales de esta misma
+  cuenta, no con una intuición.
 
 ## Preguntas
 
-<!--
-Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
-Estado: abierta | resuelta AAAA-MM-DD | disuelta AAAA-MM-DD. Solo las abiertas llevan bloque de detalle.
--->
+Ninguna pregunta abierta bloquea construcción. TQ-001 se resolvió desacoplando el código del dominio real
+(el contrato TC-003 y la config de SMTP solo dependen de variables de entorno); TQ-002 no bloquea esta
+misión porque no le importa a ninguno de los cuatro slices qué método de auth use cada lado del
+marketplace — eso lo decide la misión 04.
 
-<Una frase que responde "¿qué falta?": la pregunta que bloquea construcción y qué bloquea.>
-
-| ID     | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
-| ------ | ---------------------- | ------------------- | --------------------------------------------------------------- |
-| TQ-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
-| TQ-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |
+| ID     | La duda | Estado | Respuesta, o quién la resuelve |
+| ------ | ------- | ------ | -------------------------------- |
+| TQ-001 | ¿Qué dominio verifica el envío en Resend — `datealo.cl`, un subdominio como `mail.datealo.cl`, u otro? | resuelta 2026-08-13 | No bloquea el slicing: el código consume `resendApiKey`/`emailFrom` como variables de entorno, indiferente a qué dominio las respalda. Patricio configura y verifica el dominio en el dashboard de Resend por su cuenta, en paralelo, sin fecha límite (ver TR-003). |
+| TQ-002 | ¿Con qué método se autentican los profesionales — email/password, magic link, OTP por teléfono? | abierta | No bloquea esta misión: cualquiera de los tres usa el mismo SMTP custom de Supabase Auth que configura S-003. Lo resuelve la misión 04 (registro de profesional) al diseñar su propio flujo. |

--- a/docs/missions/02-base-de-datos-y-auth/ingenieria.md
+++ b/docs/missions/02-base-de-datos-y-auth/ingenieria.md
@@ -43,7 +43,7 @@ publishable key, porque la sesión de Auth tiene que vivir ahí. Nitro es el ún
 con la API de Resend. Supabase Auth es el único que habla con el transporte SMTP — eso lo configura el
 dashboard de Supabase, no código de la app.
 
-| Componente                      | Responsabilidad                                              | No debe decidir                        | Contratos     |
+| Componente                      | Responsabilidad                                              | No debe decidir                        | Sustento      |
 | -------------------------------- | -------------------------------------------------------------- | ----------------------------------------- | -------------- |
 | `useDb()` (`server/utils/db.ts`) | Conexión singleton a Postgres vía Drizzle                    | Autorización, forma de la respuesta       | A-001, A-003  |
 | `requireUser()` (`server/utils/auth.ts`) | Validar la sesión de Supabase Auth en el servidor      | Si el usuario es dueño del recurso pedido | A-002         |
@@ -147,22 +147,33 @@ negocio (misión 03).
 ## Plan de construcción
 
 Corte por pieza de infraestructura: cada slice deja algo verificable de punta a punta (no solo "el
-paquete quedó instalado"). S-001 es la base — nada más funciona sin la conexión a Postgres. S-002 y S-003
-no dependen entre sí pero ambos necesitan S-001 para `runtimeConfig`. S-004 depende de que Resend ya esté
-integrado (S-003 verifica el mecanismo de envío).
+paquete quedó instalado"). **Los cuatro son independientes entre sí y se pueden construir y mergear en
+paralelo** — ninguno toca código que otro necesite:
 
-Ninguno de los cuatro slices depende de qué dominio respalda las credenciales de Resend (TQ-001,
+- S-001 (Postgres/Drizzle) y S-002 (Auth) son integraciones distintas de Supabase que no se tocan: `useDb()`
+  usa el driver de Postgres, `requireUser()` usa `@supabase/supabase-js` con la secret key. Ninguno de los
+  dos lee lo que el otro escribe en `runtimeConfig` — cada uno agrega sus propias claves.
+- S-003 (SMTP custom en el dashboard de Supabase) no toca código de este repo en absoluto.
+- S-004 (`sendEmail()`) usa la API HTTP de Resend, un camino completamente distinto del SMTP que configura
+  S-003 — comparten la cuenta de Resend, no código. Su única precondición real es que exista la API key de
+  Resend, que es un dato externo, no un slice.
+
+Ninguno de los cuatro depende tampoco de qué dominio respalda las credenciales de Resend (TQ-001,
 resuelta): el código consume `resendApiKey` y `emailFrom` como variables de entorno, y la verificación de
 dominio en el dashboard de Resend es un paso operativo de Patricio, en paralelo a esta misión, sin bloquear
 ningún merge. El único efecto de hacerlo después es que hasta entonces el correo real solo le llega a
 destinatarios que Resend permita sin dominio verificado (ver TR-003).
 
+**S-003 es el único que no produce un PR** — es configuración de dashboard, no código. Se cierra con un
+comentario de confirmación en el issue, no con un merge; es la excepción al patrón "un Issue = un PR" del
+resto del repo, no un error de corte.
+
 | ID    | Slice (una frase, sin "y") | Sustento | Criterio de aceptación principal | Depende de | Issue |
 | ----- | --------------------------- | -------- | ----------------------------------- | ---------- | ----- |
-| S-001 | Instalar y conectar Supabase + Drizzle | A-001, A-003, TC-001 | `useDb()` existe en `server/utils/db.ts`; `/api/health/db` desplegado en Vercel responde 200 con un `SELECT 1` contra el pooler, con `prepare: false` | — | [#31](https://github.com/PatricioTabilo/datealo/issues/31) |
-| S-002 | Autenticación de servidor con Supabase Auth | A-002, TC-002 | `requireUser()` existe en `server/utils/auth.ts`; un endpoint de prueba responde `401` sin sesión y `200` con una sesión real de un usuario de prueba | S-001 | [#32](https://github.com/PatricioTabilo/datealo/issues/32) |
-| S-003 | Configurar Resend como SMTP custom de Supabase Auth | T-002, T-003, TR-001 | El dashboard de Supabase Auth queda apuntando al SMTP de Resend con la API key de `NUXT_RESEND_API_KEY`; un signup de prueba dispara el correo de confirmación y llega a un destinatario válido para la cuenta de Resend usada, sin tocar el límite de 2/hora por defecto | S-001 | [#33](https://github.com/PatricioTabilo/datealo/issues/33) |
-| S-004 | `sendEmail()` genérico sobre la API de Resend | TC-003 | Llamar `sendEmail()` con un template mínimo entrega el correo usando `resendApiKey`/`emailFrom` de `runtimeConfig`; una API key inválida o un rate limit se propagan como error legible, no un `500` genérico | S-001, S-003 | [#34](https://github.com/PatricioTabilo/datealo/issues/34) |
+| S-001 | Conectar Supabase vía Drizzle | A-001, A-003, TC-001 | `useDb()` existe en `server/utils/db.ts`; `/api/health/db` desplegado en Vercel responde 200 con un `SELECT 1` contra el pooler, con `prepare: false` | — | [#31](https://github.com/PatricioTabilo/datealo/issues/31) |
+| S-002 | Exponer la sesión de Supabase Auth en el servidor | A-002, TC-002 | `requireUser()` existe en `server/utils/auth.ts`; `GET /api/auth/me` responde `401` sin sesión y `200 { id, email }` con una sesión real de un usuario de prueba — queda como endpoint permanente, no de descarte, porque el frontend lo necesita para saber si hay sesión activa | — | [#32](https://github.com/PatricioTabilo/datealo/issues/32) |
+| S-003 | Configurar Resend como SMTP custom de Supabase Auth | T-002, T-003, TR-001 | El dashboard de Supabase Auth queda apuntando al SMTP de Resend con su API key; un `curl -X POST` contra `POST /auth/v1/signup` de Supabase (no hay código de la app que dispare signup todavía — eso es la misión 04) hace llegar el correo de confirmación a un destinatario válido para la cuenta de Resend usada, sin tocar el límite de 2/hora por defecto | — | [#33](https://github.com/PatricioTabilo/datealo/issues/33) |
+| S-004 | `sendEmail()` genérico sobre la API de Resend | TC-003 | `sendEmail()` existe en `server/utils/email.ts`; test unitario con el SDK de Resend mockeado verifica la forma del payload y el mapeo de errores; un envío real de una vez (script local, no código que se mergea) contra el sandbox de Resend confirma que llega, usando `resendApiKey`/`emailFrom` de `runtimeConfig` | requiere que exista la API key de Resend (precondición externa, no un slice) | [#34](https://github.com/PatricioTabilo/datealo/issues/34) |
 
 ## Decisiones técnicas
 

--- a/docs/missions/README.md
+++ b/docs/missions/README.md
@@ -10,7 +10,7 @@ abrieron y de dónde salió cada una.
 | #   | Misión | Tipo | Abierta | Estado | En foco | Nace de |
 | --- | ------ | ---- | ------- | ------ | ------- | ------- |
 | 01  | [migración a Nuxt UI](./01-migracion-nuxt-ui/) | técnica | 2026-08-11 | cerrada 2026-08-13 | — | A-004 |
-| 02  | [base de datos, Auth y correo (config)](./02-base-de-datos-y-auth/) | técnica | 2026-08-13 | exploración | — | A-001, A-002, A-003 |
+| 02  | [base de datos, Auth y correo (config)](./02-base-de-datos-y-auth/) | técnica | 2026-08-13 | lista para construir | — | A-001, A-002, A-003 |
 | 03  | [taxonomía: categorías y comunas](./03-taxonomia-categorias-y-comunas/) | producto | 2026-08-13 | exploración | — | — |
 | 04  | [registro y perfil de profesional](./04-registro-perfil-profesional/) | producto | 2026-08-13 | exploración | — | — |
 | 05  | [perfil público de profesional](./05-perfil-publico-profesional/) | producto | 2026-08-13 | exploración | — | — |


### PR DESCRIPTION
## Resumen
- `ingenieria.md` de la misión 02 pasa de plantilla vacía a completo, estado `en revisión`: contratos (`useDb()`, `requireUser()`, `sendEmail()`), tres decisiones técnicas con alternativas descartadas (T-001 Supabase+Drizzle, T-002 Supabase Auth, T-003 Resend en doble rol) y plan de construcción de 4 slices.
- Hallazgo que sustenta T-003: el proveedor de correo por defecto de Supabase Auth entrega máximo 2 correos/hora **por proyecto**, sin SLA — inutilizable incluso para probar el flujo de registro. Por eso Resend va como SMTP custom de Supabase Auth, no solo como proveedor de correo de negocio.
- El código queda desacoplado de qué dominio verifica el envío (TQ-001, resuelta): solo depende de `resendApiKey`/`emailFrom` por variable de entorno. La verificación de dominio en Resend queda como tarea operativa aparte, sin bloquear ningún slice.
- Estado de la misión pasa a `lista para construir`; se actualiza el registro en `docs/missions/README.md`.

Issues generados desde el plan de construcción: #31, #32, #33, #34.

## Test plan
- [x] Solo documentación de la misión, no toca código todavía (eso es S-001 en adelante)