### PR TITLE
chore(server): exponer la sesión de Supabase Auth en el servidor

### DIFF
--- a/.claude/skills/arquitectura/references/recetas.md
+++ b/.claude/skills/arquitectura/references/recetas.md
@@ -104,6 +104,11 @@ La sesión viaja en cookies, no en `localStorage` (ver "La sesión viaja en cook
 las cookies de la request vía los helpers de `h3` — nunca con el `createClient()` plano de
 `@supabase/supabase-js`, que no sabe de cookies de servidor.
 
+**La key es la publishable, no la secret.** Este cliente representa al usuario de la sesión, no un acceso
+admin — con la secret key cualquier query hecha por este cliente saltaría RLS por completo. No hace falta
+para validar la sesión: `getUser()` (nunca `getSession()`, que no revalida) manda el JWT al servidor de
+Supabase Auth y lo valida ahí, sin importar qué key identifica al proyecto en el header.
+
 ```ts
 // server/utils/auth.ts
 import { createServerClient } from '@supabase/ssr'
@@ -111,8 +116,8 @@ import { parseCookies, setCookie } from 'h3'
 import type { H3Event } from 'h3'
 
 function serverSupabase(event: H3Event) {
-  const { public: pub, supabaseSecretKey } = useRuntimeConfig()
-  return createServerClient(pub.supabaseUrl, supabaseSecretKey, {
+  const { public: pub } = useRuntimeConfig()
+  return createServerClient(pub.supabaseUrl, pub.supabaseKey, {
     cookies: {
       getAll: () => Object.entries(parseCookies(event)).map(([name, value]) => ({ name, value })),
       setAll: (cookies) => cookies.forEach(({ name, value, options }) => setCookie(event, name, value, options)),

--- a/docs/missions/02-base-de-datos-y-auth/ingenieria.md
+++ b/docs/missions/02-base-de-datos-y-auth/ingenieria.md
@@ -72,14 +72,17 @@ documenta la receta de "endpoint de escritura" en `arquitectura/references/recet
 
 - **Entrada:** el `H3Event` de la request. Nunca confía en un `userId` que venga del body o la query.
 - **Salida:** `{ id: string, email: string | null }` del usuario autenticado.
-- **Invariantes:** valida el JWT de Supabase contra la secret key del servidor, no contra la publishable
-  key del cliente — un JWT expirado o manipulado nunca resuelve a un usuario válido. **La sesión viaja en
-  cookies, no en `localStorage`**: el cliente se arma con `createServerClient()` de `@supabase/ssr` leyendo
-  las cookies de la request, nunca con el `createClient()` plano de `@supabase/supabase-js` — ese guarda la
-  sesión en `localStorage`, invisible para el servidor, y el síntoma es silencioso (login "funciona" en el
-  browser, cualquier endpoint protegido devuelve `401` siempre). El cliente del browser usa el par que
-  corresponde, `createBrowserClient()`, para que ambos lados lean la misma cookie. Receta completa en
-  [`recetas.md`](../../../.claude/skills/arquitectura/references/recetas.md#requireuser-con-supabasessr).
+- **Invariantes:** usa `supabase.auth.getUser()`, nunca `getSession()` — `getUser()` revalida el JWT contra
+  el servidor de Supabase Auth en cada llamado, `getSession()` puede devolver una sesión de la cookie sin
+  revalidar. El cliente se arma con la **publishable key** (no la secret key: con la secret key este
+  cliente saltaría RLS por completo si algún día se reusa para una query, y no hace falta para validar la
+  sesión — `getUser()` ya revalida server-side sin importar qué key identifique al proyecto). **La sesión
+  viaja en cookies, no en `localStorage`**: el cliente se arma con `createServerClient()` de `@supabase/ssr`
+  leyendo las cookies de la request, nunca con el `createClient()` plano de `@supabase/supabase-js` — ese
+  guarda la sesión en `localStorage`, invisible para el servidor, y el síntoma es silencioso (login
+  "funciona" en el browser, cualquier endpoint protegido devuelve `401` siempre). El cliente del browser usa
+  el par que corresponde, `createBrowserClient()`, para que ambos lados lean la misma cookie. Receta completa
+  en [`recetas.md`](../../../.claude/skills/arquitectura/references/recetas.md#requireuser-con-supabasessr).
 - **Errores:** sin sesión o sesión inválida → `401 { error: 'unauthorized' }`. El llamador decide si eso
   termina la request (recurso privado) o si sigue como anónimo (recurso público).
 - **Contrato de producto:** A-002.

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -14,7 +14,11 @@ export default defineNuxtConfig({
     // Privado: solo servidor. Nunca llega al bundle del cliente (A-001).
     databaseUrl: '',
 
-    public: {},
+    public: {
+      // Público por diseño: la publishable key no es un secreto (A-001).
+      supabaseUrl: '',
+      supabaseKey: '',
+    },
   },
 
   app: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "dependencies": {
         "@lucide/vue": "^1.31.0",
         "@nuxt/ui": "^4.10.0",
+        "@supabase/ssr": "^0.12.4",
+        "@supabase/supabase-js": "^2.112.3",
         "drizzle-orm": "^0.45.2",
         "drizzle-zod": "^0.8.3",
         "nuxt": "^4.5.2",
@@ -3319,6 +3321,110 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.112.3",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.112.3.tgz",
+      "integrity": "sha512-NA0rsgAlWZPvbhw8aUdmgfpHVgUAcd8zK5ov43l++o1bLIPXZhRiAlRobhwF5AatQuovpqxsMH50F4oyyV4XZw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.112.3",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.112.3.tgz",
+      "integrity": "sha512-gfv481mTOVWtZIJgXupxZpni2V2UWPf6jeF/jOK7HdMHdH+mt6sU0sHHwf0POsPip8ltlulu9OUHgwVzl5ddRw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.5.tgz",
+      "integrity": "sha512-aAn9H9ovVyeApKy11OWOrrOGq8DV68yWeH4ud2lN9fzn4aO8Zb5GLL9m1pUg9nLqIcT+ZDfAcsZe0E/nqdv2lw==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.112.3",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.112.3.tgz",
+      "integrity": "sha512-+Mf6uCpzr00bqxwX8hTK2X2L9eAL/1vuOjdEjx6upz9ulb0RmQT16XeU/JkMUlVHw/B46ZnPa2busY4Kd9YCzw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.112.3",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.112.3.tgz",
+      "integrity": "sha512-E6wljXWs7DUOloyIB69i3YFInWE6IyCvgTAbQ0KYxOHv26FdA1KzEXTuzxrYEdf70t406Z9BRwUlGyclGF2FXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "0.4.5",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/ssr": {
+      "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.12.4.tgz",
+      "integrity": "sha512-xHzcgI8cC1TpBKSwJcR5Yd8CCwfIq0SBc5yb4yz/YFw5tbCrEQ0QT3a+2jymCxHgQWLfzwN93HZ6eRbcoMkOlA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.2"
+      },
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.111.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.112.3",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.112.3.tgz",
+      "integrity": "sha512-oSK61tzlUvg+BWPqpKQCu9qqonsO26btaoAR9D6Gest2aj7xUqToj9rKyaoYOJczkhg9BjqA1REbYy9tPI4bDA==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.112.3",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.112.3.tgz",
+      "integrity": "sha512-Jv1bxVQmEJNkjvPEhFaKjPzsh+Ozyew6lWGD+SoYcsclDEP1z7yEvKvfUQfzy0DkxRIQnZNxmmWtAzw5XLTQoA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.112.3",
+        "@supabase/functions-js": "2.112.3",
+        "@supabase/postgrest-js": "2.112.3",
+        "@supabase/realtime-js": "2.112.3",
+        "@supabase/storage-js": "2.112.3"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.23",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
@@ -5555,6 +5661,19 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cookie-es": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.3.tgz",
@@ -7573,6 +7692,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16.17.0"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/ieee754": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
   "dependencies": {
     "@lucide/vue": "^1.31.0",
     "@nuxt/ui": "^4.10.0",
+    "@supabase/ssr": "^0.12.4",
+    "@supabase/supabase-js": "^2.112.3",
     "drizzle-orm": "^0.45.2",
     "drizzle-zod": "^0.8.3",
     "nuxt": "^4.5.2",

--- a/server/api/auth/me.get.ts
+++ b/server/api/auth/me.get.ts
@@ -1,0 +1,3 @@
+export default defineEventHandler(async (event) => {
+  return await requireUser(event)
+})

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -1,0 +1,25 @@
+import { createServerClient } from '@supabase/ssr'
+import { parseCookies, setCookie } from 'h3'
+import type { H3Event } from 'h3'
+
+function serverSupabase(event: H3Event) {
+  const { public: pub } = useRuntimeConfig()
+  // La publishable key, no la secret key: este cliente representa al usuario de la sesión, no un
+  // acceso admin. Con la secret key cualquier query por este cliente saltaría RLS por completo.
+  return createServerClient(pub.supabaseUrl, pub.supabaseKey, {
+    cookies: {
+      getAll: () => Object.entries(parseCookies(event)).map(([name, value]) => ({ name, value })),
+      setAll: (cookies) =>
+        cookies.forEach(({ name, value, options }) => setCookie(event, name, value, options)),
+    },
+  })
+}
+
+export async function requireUser(event: H3Event) {
+  const supabase = serverSupabase(event)
+  const { data, error } = await supabase.auth.getUser()
+  if (error || !data.user) {
+    throw createError({ statusCode: 401, statusMessage: 'unauthorized' })
+  }
+  return { id: data.user.id, email: data.user.email ?? null }
+}


### PR DESCRIPTION
Closes #32

## Resumen
- `requireUser()` en `server/utils/auth.ts` — sesión en cookies vía `@supabase/ssr` (`createServerClient`), nunca `localStorage`.
- `GET /api/auth/me` — endpoint permanente (no descartable): `401` sin sesión, `200 { id, email }` con sesión real.
- **Corrección encontrada al implementar** (ya reflejada en `ingenieria.md`, la receta de `arquitectura` y el issue #32): el cliente server-side usa la **publishable key**, no la secret key. Con la secret key ese cliente saltaría RLS por completo si algún día se reusa para una query; no hace falta para validar la sesión porque `auth.getUser()` revalida server-side contra Supabase Auth sin importar qué key identifica al proyecto.

## Test plan
- [x] `npx nuxi typecheck` — cero errores
- [x] `npm run build` — limpio
- [x] Local: `GET /api/auth/me` sin cookie → `401`
- [x] Local: usuario de prueba creado vía admin API, sesión real firmada con `@supabase/ssr`, `GET /api/auth/me` con esa cookie → `200 { id, email }` (usuario de prueba borrado al terminar)
- [x] Ningún secreto de Supabase llega a `runtimeConfig.public`

Sustento: A-002, TC-002.