### PR TITLE
docs: cerrar la misión 02 y ratificar A-001, A-002 y A-003

### DIFF
--- a/.claude/skills/arquitectura/SKILL.md
+++ b/.claude/skills/arquitectura/SKILL.md
@@ -20,13 +20,13 @@ documento, verificar qué hay:
 
 | Pieza                                    | Estado                                          |
 | ---------------------------------------- | ----------------------------------------------- |
-| `server/` (endpoints, schema, RLS)       | no existe — se crea en la primera misión con datos |
-| Supabase, Drizzle, `postgres.js`         | no instalados                                   |
+| `server/` (endpoints, schema, RLS)       | plomería lista (misión 02) — `db.ts`, `auth.ts`, `email.ts`; sin tablas de negocio aún |
+| Supabase, Drizzle, `postgres.js`         | instalados y en uso (A-001, A-002, A-003, misión 02) |
 | Nuxt UI v4                               | instalado y en uso en toda la landing (A-004, misión 01) |
 
 ## A-001 — El browser nunca habla con Supabase, habla con Nitro
 
-**Estado:** propuesta. **Fecha:** 2026-08-11.
+**Estado:** aceptada (misión 02, 2026-08-17). **Fecha:** 2026-08-11.
 
 Supabase se puede usar de dos formas opuestas. Como BaaS, el browser lleva la publishable key y consulta
 PostgREST directo: ese endpoint es público por diseño y toda la seguridad recae en las policies. Como base
@@ -60,7 +60,7 @@ que Nitro no resuelva.
 
 ## A-002 — RLS es la red de seguridad, no el mecanismo de autorización
 
-**Estado:** propuesta. **Fecha:** 2026-08-11.
+**Estado:** aceptada (misión 02, 2026-08-17). **Fecha:** 2026-08-11.
 
 RLS se evalúa contra el rol de Postgres y los claims del JWT, y PostgREST los setea en cada request. **Una
 conexión de Drizzle con la cadena de conexión normal entra como rol dueño y se salta RLS por completo.**
@@ -91,7 +91,7 @@ integración, el cliente de Supabase desde el browser—, esta decisión se revi
 
 ## A-003 — La conexión va por Supavisor en modo transacción
 
-**Estado:** propuesta. **Fecha:** 2026-08-11.
+**Estado:** aceptada (misión 02, 2026-08-17). **Fecha:** 2026-08-11.
 
 Vercel corre funciones serverless y cada invocación abre su conexión. Contra Postgres directo se agota el
 límite apenas hay tráfico paralelo.

--- a/docs/missions/02-base-de-datos-y-auth/README.md
+++ b/docs/missions/02-base-de-datos-y-auth/README.md
@@ -2,29 +2,27 @@
 
 **Tipo:** técnica. **Abierta el** 2026-08-13. **Nace de:** A-001, A-002 y A-003 del skill `arquitectura`.
 
-**Estado de la misión:** lista para construir
+**Estado de la misión:** cerrada 2026-08-17
 
-**Última actualización:** 2026-08-13
+**Última actualización:** 2026-08-17
 
 Primera de seis misiones hacia el MVP (registrarse, mostrarse, buscar, reseñar). Sin `producto.md`,
 `experiencia.md` ni `investigacion.md`: es pura infraestructura, sin cambio de producto observable.
 
-**Ojo con esto al tomar la misión:** `A-001`, `A-002` y `A-003` en `arquitectura` están marcadas
-**"propuesta"**, no "aceptada" — no son un hecho consumado que esta misión solo ejecuta. Ratificarlas (o
-ajustarlas) contra una decisión real, con código de por medio, es parte del trabajo de esta misión, no algo
-que ya viene resuelto de afuera.
+`A-001`, `A-002` y `A-003` en `arquitectura` pasaron de **"propuesta"** a **"aceptada"** al cerrar esta
+misión — quedaron ratificadas con código de por medio, no solo con la recomendación original.
 
-| Documento  | Estado      | Qué falta para su gate  |
-| ---------- | ----------- | ------------------------ |
-| Ingeniería | en revisión | aprobación del dueño de producto para pasar a `vigente` |
+| Documento  | Estado  | Qué falta para su gate |
+| ---------- | ------- | ------------------------ |
+| Ingeniería | vigente | — |
 
-Issues abiertos: [#31](https://github.com/PatricioTabilo/datealo/issues/31) (S-001, Supabase + Drizzle),
+Issues: [#31](https://github.com/PatricioTabilo/datealo/issues/31) (S-001, Supabase + Drizzle),
 [#32](https://github.com/PatricioTabilo/datealo/issues/32) (S-002, auth de servidor),
 [#33](https://github.com/PatricioTabilo/datealo/issues/33) (S-003, Resend SMTP de Supabase Auth),
-[#34](https://github.com/PatricioTabilo/datealo/issues/34) (S-004, `sendEmail()`).
+[#34](https://github.com/PatricioTabilo/datealo/issues/34) (S-004, `sendEmail()`) — los cuatro cerrados.
 
-**Próximo hito:** empezar S-001 (#31) — sin fecha límite todavía. La verificación de dominio en Resend
-(TQ-001/TR-003) queda como tarea operativa de Patricio, en paralelo, sin bloquear el código.
+La verificación de dominio en Resend (TQ-001/TR-003) sigue como tarea operativa de Patricio, en paralelo,
+sin bloquear ninguna misión siguiente.
 
 ## Brief
 

--- a/docs/missions/02-base-de-datos-y-auth/ingenieria.md
+++ b/docs/missions/02-base-de-datos-y-auth/ingenieria.md
@@ -1,8 +1,8 @@
 # Misión 02: Base de datos, Auth y correo — Ingeniería
 
-**Estado:** en revisión
+**Estado:** vigente
 
-**Última actualización:** 2026-08-13
+**Última actualización:** 2026-08-17
 
 [Índice](./README.md) · [Ingeniería](./ingenieria.md)
 

--- a/docs/missions/README.md
+++ b/docs/missions/README.md
@@ -10,7 +10,7 @@ abrieron y de dónde salió cada una.
 | #   | Misión | Tipo | Abierta | Estado | En foco | Nace de |
 | --- | ------ | ---- | ------- | ------ | ------- | ------- |
 | 01  | [migración a Nuxt UI](./01-migracion-nuxt-ui/) | técnica | 2026-08-11 | cerrada 2026-08-13 | — | A-004 |
-| 02  | [base de datos, Auth y correo (config)](./02-base-de-datos-y-auth/) | técnica | 2026-08-13 | lista para construir | — | A-001, A-002, A-003 |
+| 02  | [base de datos, Auth y correo (config)](./02-base-de-datos-y-auth/) | técnica | 2026-08-13 | cerrada 2026-08-17 | — | A-001, A-002, A-003 |
 | 03  | [taxonomía: categorías y comunas](./03-taxonomia-categorias-y-comunas/) | producto | 2026-08-13 | exploración | — | — |
 | 04  | [registro y perfil de profesional](./04-registro-perfil-profesional/) | producto | 2026-08-13 | exploración | — | — |
 | 05  | [perfil público de profesional](./05-perfil-publico-profesional/) | producto | 2026-08-13 | exploración | — | — |


### PR DESCRIPTION
## Resumen

- `ingenieria.md` de la misión 02 pasa de "en revisión" a "vigente" con la aprobación del dueño de producto.
- README de la misión 02: estado a "cerrada 2026-08-17", issues S-001 a S-004 marcados cerrados.
- Registro de misiones (`docs/missions/README.md`): fila 02 a "cerrada 2026-08-17".
- Skill `arquitectura`: A-001, A-002 y A-003 pasan de "propuesta" a "aceptada", ratificadas con el código de la misión 02.

🤖 Generated with [Claude Code](https://claude.com/claude-code)