### PR TITLE
docs: completar investigacion.md de la misión 03

### DIFF
--- a/docs/missions/03-taxonomia-categorias-y-comunas/README.md
+++ b/docs/missions/03-taxonomia-categorias-y-comunas/README.md
@@ -2,22 +2,21 @@
 
 **Tipo:** producto. **Abierta el** 2026-08-13. **Nace de:** ninguna.
 
-**Estado de la misión:** exploración
+**Estado de la misión:** definición
 
 **Última actualización:** 2026-08-17
 
 Segunda de seis misiones hacia el MVP (registrarse, mostrarse, buscar, reseñar). Depende de
 [misión 02](../02-base-de-datos-y-auth/), ya cerrada, para poder guardar algo.
 
-| Documento     | Estado      | Qué falta para su gate              |
-| ------------- | ----------- | ------------------------------------ |
-| Investigación | activo      | se acumula, no bloquea — el problema tiene situación y consecuencia concretas, hay 3 conclusiones (C-001 a C-003) y un ideal con capacidades observables |
-| Producto      | en revisión | aprobación de Patricio sobre D-001 (categorías), D-002 (comunas) y D-003 (vocabulario) — fecha límite 2026-08-24, con Q-001 y Q-002 abiertas |
-| Experiencia   | pendiente   | —                                     |
-| Ingeniería    | pendiente   | —                                     |
+| Documento     | Estado    | Qué falta para su gate              |
+| ------------- | --------- | ------------------------------------ |
+| Investigación | activo    | se acumula, no bloquea — el problema tiene situación y consecuencia concretas, hay 3 conclusiones (C-001 a C-003) y un ideal con capacidades observables |
+| Producto      | vigente   | aprobado por Patricio el 2026-08-17 — D-001 a D-004 aceptadas, Q-001 y Q-002 resueltas |
+| Experiencia   | pendiente | diseñar el componente compartido `ComunaSelect`/`CategoriaSelect` (D-004): autocompletado que solo permite elegir del catálogo |
+| Ingeniería    | pendiente | —                                     |
 
-**Próximo hito:** que Patricio apruebe o ajuste `producto.md` — fecha límite 2026-08-24. Sin
-`experiencia.md` ni `ingenieria.md` hasta que eso pase.
+**Próximo hito:** escribir `experiencia.md` — sin fecha límite todavía.
 
 ## Brief
 

--- a/docs/missions/03-taxonomia-categorias-y-comunas/README.md
+++ b/docs/missions/03-taxonomia-categorias-y-comunas/README.md
@@ -9,15 +9,15 @@
 Segunda de seis misiones hacia el MVP (registrarse, mostrarse, buscar, reseñar). Depende de
 [misión 02](../02-base-de-datos-y-auth/), ya cerrada, para poder guardar algo.
 
-| Documento     | Estado    | Qué falta para su gate              |
-| ------------- | --------- | ------------------------------------ |
-| Investigación | activo    | se acumula, no bloquea — el problema tiene situación y consecuencia concretas, hay 3 conclusiones (C-001 a C-003) y un ideal con capacidades observables |
-| Producto      | pendiente | escribir `producto.md`: decisiones D-xxx (lista de categorías, recorte de comunas) y funcionalidades F-xxx en formato JTBD |
-| Experiencia   | pendiente | —                                     |
-| Ingeniería    | pendiente | —                                     |
+| Documento     | Estado      | Qué falta para su gate              |
+| ------------- | ----------- | ------------------------------------ |
+| Investigación | activo      | se acumula, no bloquea — el problema tiene situación y consecuencia concretas, hay 3 conclusiones (C-001 a C-003) y un ideal con capacidades observables |
+| Producto      | en revisión | aprobación de Patricio sobre D-001 (categorías), D-002 (comunas) y D-003 (vocabulario) — fecha límite 2026-08-24, con Q-001 y Q-002 abiertas |
+| Experiencia   | pendiente   | —                                     |
+| Ingeniería    | pendiente   | —                                     |
 
-**Próximo hito:** escribir `producto.md` a partir de las conclusiones de `investigacion.md` — sin fecha
-límite todavía.
+**Próximo hito:** que Patricio apruebe o ajuste `producto.md` — fecha límite 2026-08-24. Sin
+`experiencia.md` ni `ingenieria.md` hasta que eso pase.
 
 ## Brief
 

--- a/docs/missions/03-taxonomia-categorias-y-comunas/README.md
+++ b/docs/missions/03-taxonomia-categorias-y-comunas/README.md
@@ -4,19 +4,20 @@
 
 **Estado de la misión:** exploración
 
-**Última actualización:** 2026-08-13
+**Última actualización:** 2026-08-17
 
-Segunda de seis misiones hacia el MVP (registrarse, mostrarse, buscar, reseñar). Depende de que
-[misión 02](../02-base-de-datos-y-auth/) exista antes de poder guardar algo.
+Segunda de seis misiones hacia el MVP (registrarse, mostrarse, buscar, reseñar). Depende de
+[misión 02](../02-base-de-datos-y-auth/), ya cerrada, para poder guardar algo.
 
 | Documento     | Estado    | Qué falta para su gate              |
 | ------------- | --------- | ------------------------------------ |
-| Investigación | pendiente | discovery completo — hoy solo existe la carpeta |
-| Producto      | pendiente | —                                     |
+| Investigación | activo    | se acumula, no bloquea — el problema tiene situación y consecuencia concretas, hay 3 conclusiones (C-001 a C-003) y un ideal con capacidades observables |
+| Producto      | pendiente | escribir `producto.md`: decisiones D-xxx (lista de categorías, recorte de comunas) y funcionalidades F-xxx en formato JTBD |
 | Experiencia   | pendiente | —                                     |
 | Ingeniería    | pendiente | —                                     |
 
-**Próximo hito:** ninguno todavía — esta misión no se ha empezado a trabajar.
+**Próximo hito:** escribir `producto.md` a partir de las conclusiones de `investigacion.md` — sin fecha
+límite todavía.
 
 ## Brief
 

--- a/docs/missions/03-taxonomia-categorias-y-comunas/investigacion.md
+++ b/docs/missions/03-taxonomia-categorias-y-comunas/investigacion.md
@@ -92,6 +92,14 @@ todas las combinaciones categoría × comuna
   de comunas de alta densidad para el lanzamiento, con una condición explícita de cuándo se amplía.
 - **Confianza:** media — es una aplicación directa del filtro de arranque en frío, sin evidencia externa
   nueva propia de Datealo.
+- **Revisión (2026-08-17):** `producto.md` decidió distinto a la implicación de arriba. En vez de recortar
+  el catálogo de comunas a un subconjunto fijo, el catálogo quedó completo (346 comunas) con un campo
+  `activa` por fila que controla qué se ofrece en registro y búsqueda (D-002). El riesgo que describe esta
+  conclusión — vaciar categoría × comuna — sigue siendo real y sigue sustentando por qué solo un
+  subconjunto empieza activo (Gran Santiago y Puerto Varas); lo que no sobrevivió es la idea de que el
+  catálogo mismo necesitaba excluir comunas para evitarlo. Excluir del catálogo y desactivar son
+  mecanismos distintos con el mismo efecto visible al lanzamiento, pero el segundo no tiene costo de
+  revertir.
 
 ## El ideal: cualquier oficio, en cualquier comuna de Chile, encontrado con las palabras propias del buscador
 

--- a/docs/missions/03-taxonomia-categorias-y-comunas/investigacion.md
+++ b/docs/missions/03-taxonomia-categorias-y-comunas/investigacion.md
@@ -1,118 +1,134 @@
-# Misión: <nombre> — Investigación
+# Misión: taxonomía de categorías y comunas — Investigación
 
 **Estado:** activo
 
-**Última actualización:** AAAA-MM-DD
+**Última actualización:** 2026-08-17
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-<!--
-Este documento se acumula: la evidencia y las conclusiones no se borran cuando el alcance cambia, porque
-explican por qué el producto es como es. Lo que sí se actualiza es el ideal, que resume la dirección que
-la investigación sostiene hoy.
+## El problema aparece cuando no existe una lista única de la que todos parten
 
-Gate de salida — la investigación sostiene un producto.md cuando:
-- el problema tiene situación y consecuencia concretas, no una categoría abstracta
-- al menos una conclusión con confianza alta o media respalda la dirección
-- el ideal describe capacidades observables, no intenciones
--->
+**Situación:** don Héctor es electricista y se está por registrar en Datealo (misión 04, todavía en
+exploración). El formulario le pide elegir su oficio y su comuna. Al mismo tiempo, alguien en Ñuñoa abre el
+buscador (misión 06, también en exploración) y escribe "electricista".
 
-## El problema aparece cuando <historia concreta>
+**Acción o necesidad:** ambos formularios — el de registro y el de búsqueda — necesitan la misma lista de
+oficios y la misma lista de comunas para poder cruzarse. Hoy esa lista no existe en ningún lado: la landing
+tiene ocho categorías ilustrativas (`app/constants/landing.ts`) pensadas para verse bien en un carrusel, no
+para ser el catálogo con el que un profesional se registra.
 
-<!--
-Una situación real o reconstruida con precisión. No abras con una categoría como "falta de confianza" —
-abre con quién estaba haciendo qué y qué salió mal. Nombra a la persona y el servicio concreto.
--->
+**Respuesta actual:** sin lista, cada misión que toque el dato inventa la suya. Es lo que ya casi pasó una
+vez: la misión 02 mencionó "categorías de oficio" y "comunas disponibles" como algo que todavía no existía
+formalmente, y las siguientes (04 registro, 06 búsqueda) iban a tener que decidirlo cada una por su cuenta
+si esta misión no se abría primero.
 
-**Situación:** <qué está ocurriendo antes del problema>.
-
-**Acción o necesidad:** <qué se intenta resolver o decidir>.
-
-**Respuesta actual:** <qué hace hoy la persona: grupo de WhatsApp, Google, recomendación de un vecino,
-Datealo si ya existe la superficie>.
-
-**Consecuencia:** <error, demora, riesgo o decisión que no puede tomarse>.
+**Consecuencia:** don Héctor se registra bajo "Instalaciones eléctricas" en la comuna "Región
+Metropolitana" porque el formulario de la misión 04 usó su propia lista de texto libre. La persona de
+Ñuñoa busca "electricista" en "Ñuñoa" con el formulario de la misión 06, que usó otra lista. No matchean.
+Don Héctor existe en la base de datos y es invisible para la única persona que lo estaba buscando esa
+noche.
 
 ## Preguntas que la investigación debe resolver
 
-<!--
-Solo preguntas capaces de cambiar el ideal o una decisión. Al resolver una, moverla a evidencia o
-conclusión. No es un backlog.
--->
-
-- ¿<pregunta y decisión que depende de ella>?
+- ¿Qué tan granular tiene que ser una categoría para que un chileno se reconozca en ella sin dudar —
+  "gasfitería" o "reparación de cañerías"?
+- ¿Cuántas categorías cubrir en el lanzamiento sin que la mayoría queden con cero profesionales?
+- ¿Cuál es la unidad geográfica con la que la gente ya piensa su búsqueda — comuna, barrio, "cerca de mí"?
+- ¿El lanzamiento parte solo en la Región Metropolitana, o hace falta cubrir más desde el día uno?
 
 ## Evidencia
 
-<!--
-Un hecho verificable con fuente y límite. Prioriza observación directa, entrevistas y comportamiento
-comprobado. Los benchmarks de otros productos también son evidencia: qué hacen, qué trade-off eligieron y
-qué no aplica a Datealo.
-
-Datealo no tiene datos de uso propios todavía. Cuando la única evidencia disponible sea un benchmark o
-una entrevista, la columna "límite" es lo que impide que se lea como dato duro.
--->
-
-| ID    | Tipo                                              | Fuente                | Hecho verificable | Límite de la evidencia |
-| ----- | ------------------------------------------------- | --------------------- | ----------------- | ---------------------- |
-| E-001 | <entrevista, benchmark, uso, código, observación> | <enlace o referencia> | <hecho>           | <qué no demuestra>     |
-
-<a id="e-001"></a>
-
-### E-001 — <fuente o hecho en una frase>
-
-<!--
-Desarrollar solo cuando la tabla no alcanza para evaluar la calidad de la evidencia. Cierra con la
-consecuencia para la investigación.
--->
-
-<Observación precisa y contexto necesario.>
-
-Esto permite afirmar <alcance>, pero no demuestra <límite>.
+| ID    | Tipo         | Fuente                 | Hecho verificable | Límite de la evidencia |
+| ----- | ------------ | ----------------------- | ------------------ | ----------------------- |
+| E-001 | código       | `app/constants/landing.ts` | La landing ya usa 8 categorías: Gasfitería, Electricidad, Peluquería, Limpieza, Mudanzas, Pintura, Cerrajería, Jardinería | Elegidas por el fundador para verse bien en un carrusel, sin encuesta ni dato de demanda real |
+| E-002 | benchmark    | [Thumbtack Services](https://www.thumbtack.com/more-services), [Thumbtack Engineering](https://medium.com/thumbtack-engineering/building-multi-category-search-results-616bee77a564) | Thumbtack opera con más de 1.000 microcategorías (ej. "Radon Mitigation", "Fitness Equipment Assembly") sobre un motor de búsqueda y matching por texto libre | Escala de EE.UU. con millones de profesionales; una lista así de granular en un catálogo que un humano recorre a mano, con oferta cero al lanzamiento, garantiza casi todas las categorías vacías |
+| E-003 | benchmark    | [TaskRabbit Services](https://www.taskrabbit.com/services) | TaskRabbit opera con un puñado de categorías amplias: Cleaning, Handyman, Moving, Mounting, Yard Work, Errands | No distingue oficios que en Chile son roles profesionales separados — un gasfiter y un electricista no caben los dos en "Handyman" sin perder la palabra que la gente realmente usa |
+| E-004 | benchmark    | [Yapo.cl — aseo del hogar](https://www.yapo.cl/paginas/servicios/aseo-hogar), [Yapo.cl — servicio doméstico](https://www.yapo.cl/paginas/trabajos/servicio-domestico) | El clasificado chileno más usado para este tipo de oferta organiza el hogar bajo nombres de oficio en español chileno — "aseo del hogar", "asesora del hogar" — no en inglés ni en jerga de marketplace | Yapo mezcla empleo de planta (nana, asesora del hogar full-time) con trabajos puntuales por oficio; Datealo es solo lo segundo |
+| E-005 | observación  | `app/constants/landing.ts` (copy de la landing) | El copy ya asume la comuna como unidad de búsqueda: "Gasfiter en Providencia", "Cerrajero urgente en Ñuñoa", "Mudanza dentro de Santiago" | Es intuición de producto ya congelada en copy de marketing, no algo validado con un buscador real |
+| E-006 | dato oficial | [SUBDERE — división político-administrativa](https://www.subdere.gov.cl/sites/default/files/documentos/articles-73111_recurso_1.pdf), [Wikipedia — comunas de Chile](https://es.wikipedia.org/wiki/Anexo:Comunas_de_Chile) | Chile tiene 346 comunas en 16 regiones. La Región Metropolitana tiene 52 comunas en 6 provincias; la Provincia de Santiago (Gran Santiago urbano) tiene 32: Santiago, Cerrillos, Cerro Navia, Conchalí, El Bosque, Estación Central, Huechuraba, Independencia, La Cisterna, La Florida, La Granja, La Pintana, La Reina, Las Condes, Lo Barnechea, Lo Espejo, Lo Prado, Macul, Maipú, Ñuñoa, Pedro Aguirre Cerda, Peñalolén, Providencia, Pudahuel, Quilicura, Quinta Normal, Recoleta, Renca, San Joaquín, San Miguel, San Ramón, Vitacura | Es geografía administrativa oficial — no dice nada sobre dónde va a haber demanda real de gasfiter o electricista en Datealo |
 
 ## Conclusiones
 
-<!--
-Una conclusión interpreta evidencia; no es una preferencia ni una funcionalidad. El título expresa el
-hallazgo, no el tema.
--->
-
 <a id="c-001"></a>
 
-### C-001 — <conclusión en una frase>
+### C-001 — La categoría es el oficio, no la microtarea ni una etiqueta genérica
 
-- **Sustento:** [E-001](#e-001).
-- **Razonamiento:** <por qué la evidencia conduce a esta lectura y no a otra>.
-- **Implicación:** <qué deberá ser cierto en el producto o qué alternativa queda debilitada>.
-- **Confianza:** <alta, media o baja> porque <razón o validación pendiente>.
+- **Sustento:** [E-001](#e-001), [E-002](#e-002), [E-003](#e-003), [E-004](#e-004).
+- **Razonamiento:** con oferta cero al lanzamiento, una taxonomía de 1.000 microcategorías al estilo
+  Thumbtack garantiza que casi todas queden vacías; una taxonomía de 6 etiquetas genéricas al estilo
+  TaskRabbit borra la palabra exacta que un chileno usa para pedir ayuda ("gasfiter" no es "handyman"). El
+  copy de la propia landing y el vocabulario de Yapo.cl ya coinciden en que la unidad natural es el nombre
+  del oficio, en un solo nivel, sin jerarquía de subcategorías.
+- **Implicación:** la lista de categorías del lanzamiento tiene que ser corta, plana (sin subcategorías) y
+  en el lenguaje de oficio que ya usa la landing — "Gasfitería", no "Reparación de cañerías y filtraciones".
+- **Confianza:** media, porque se apoya en benchmarks y en copy ya escrito por el propio equipo, no en
+  entrevistas a un buscador real pidiendo ayuda.
 
-## El ideal: <resultado completo, sin recortar>
+<a id="c-002"></a>
 
-<!--
-El ideal es el producto de la investigación: la dirección que la evidencia sostiene, sin restricciones de
-implementación. El recorte a la primera entrega no vive aquí — vive en producto.md como decisión de
-alcance. Esta sección sí se reescribe cuando nueva evidencia cambia la dirección.
--->
+### C-002 — La comuna es la unidad geográfica de búsqueda, no la dirección exacta ni la región completa
+
+- **Sustento:** [E-005](#e-005), [E-006](#e-006).
+- **Razonamiento:** la comuna es la unidad con la que la gente ya se identifica y busca ("gasfiter en
+  Providencia"), y es lo bastante fina para ordenar por cercanía sin exponer la dirección exacta de nadie
+  — coherente con que Datealo nunca muestra un dato de contacto sin que el profesional lo autorice.
+- **Implicación:** el modelo de datos necesita una lista cerrada de comunas, no un campo de texto libre. La
+  Provincia de Santiago (las 32 comunas del Gran Santiago) es el candidato natural para arrancar, porque es
+  donde probablemente concentra oferta y demanda inicial — pero esto es hipótesis, no dato propio.
+- **Confianza:** media — que la comuna sea el grano correcto está bien sustentado; cuántas comunas cubrir
+  al lanzamiento todavía no tiene dato propio detrás.
+
+<a id="c-003"></a>
+
+### C-003 — Cubrir toda la Región Metropolitana o más de una región al lanzamiento arriesga vaciar casi
+todas las combinaciones categoría × comuna
+
+- **Sustento:** [E-006](#e-006), el filtro de "arranque en frío" del skill `discovery-product`.
+- **Razonamiento:** con una oferta inicial probablemente de decenas de profesionales, repartirla entre 52
+  comunas de la RM (o más, con una segunda región) deja casi cada cruce categoría × comuna en cero
+  resultados — el peor estado posible, peor que no cubrir la comuna directamente.
+- **Implicación:** el ideal de cobertura total de Chile se recorta en `producto.md` a un subconjunto chico
+  de comunas de alta densidad para el lanzamiento, con una condición explícita de cuándo se amplía.
+- **Confianza:** media — es una aplicación directa del filtro de arranque en frío, sin evidencia externa
+  nueva propia de Datealo.
+
+## El ideal: cualquier oficio, en cualquier comuna de Chile, encontrado con las palabras propias del buscador
 
 ### El resultado ideal se ve así
 
-<Narra de principio a fin una situación futura con datos concretos: nombres, comunas, oficios, horarios.
-Qué acción ocurre, qué responde Datealo, qué decisión puede tomar la persona. Evita "una experiencia
-simple" sin comportamiento observable.>
+Alguien en Curicó escribe "el que arregla el portón eléctrico" y Datealo lo entiende como "Electricidad".
+Alguien en Ñuñoa escribe "una peluquera para las once" y llega a "Peluquería". Cualquiera de las 346
+comunas de Chile tiene la posibilidad de tener profesionales registrados — ninguna queda excluida por
+diseño del modelo de datos. Si en Melipilla no hay ningún gasfiter todavía, Datealo lo dice y ofrece los más
+cercanos de las comunas vecinas con su distancia, en vez de un estado vacío sin salida.
 
 ### Capacidades del ideal
 
-| Capacidad | Acción habilitada    | Respuesta esperada              | Conclusión que la justifica |
-| --------- | -------------------- | ------------------------------- | --------------------------- |
-| <nombre>  | <qué se puede hacer> | <qué produce o explica Datealo> | [C-001](#c-001)             |
+| Capacidad                    | Acción habilitada                                              | Respuesta esperada                                                   | Conclusión que la justifica |
+| ----------------------------- | ---------------------------------------------------------------- | ----------------------------------------------------------------------- | ---------------------------- |
+| Categoría por nombre de oficio | El buscador escribe el oficio con sus propias palabras           | Datealo lo mapea a la categoría correcta aunque no use el término exacto | [C-001](#c-001)             |
+| Comuna como unidad de búsqueda | El buscador ve resultados de su comuna primero                   | Si no hay oferta ahí, ve comunas vecinas marcadas con su distancia      | [C-002](#c-002)             |
+| Cobertura geográfica total     | Cualquier comuna de Chile puede tener profesionales registrados  | Ninguna comuna queda estructuralmente excluida del modelo de datos      | [C-003](#c-003)             |
 
-### El ideal no significa <confusión probable>
+### El ideal no significa cubrir todo desde el día uno
 
-- <límite conceptual que evita una interpretación incorrecta>.
+- No significa que el lanzamiento tenga que activar las 346 comunas de Chile de partida — el recorte a un
+  subconjunto para la primera entrega vive en `producto.md`, no acá.
+- No significa una categoría por cada microtarea al estilo Thumbtack — el oficio es la unidad, no la tarea
+  puntual dentro de un oficio.
 
 ## Referencias
 
-<!-- Fuentes primarias citadas por las evidencias. El enlace no sustituye el hecho y el límite en E-xxx. -->
-
-- [<título descriptivo>](URL): usado en E-001 para <afirmación concreta>.
+- [Thumbtack — More Services](https://www.thumbtack.com/more-services): usado en E-002 para el tamaño y
+  granularidad de su taxonomía.
+- [Thumbtack Engineering — Building multi-category search results](https://medium.com/thumbtack-engineering/building-multi-category-search-results-616bee77a564):
+  usado en E-002 para confirmar la escala de su catálogo.
+- [TaskRabbit — Services](https://www.taskrabbit.com/services): usado en E-003 para el contraste de
+  categorías amplias vs. microcategorías.
+- [Yapo.cl — Aseo del hogar](https://www.yapo.cl/paginas/servicios/aseo-hogar): usado en E-004 para el
+  vocabulario chileno de categorías de servicio al hogar.
+- [SUBDERE — División político-administrativa de Chile](https://www.subdere.gov.cl/sites/default/files/documentos/articles-73111_recurso_1.pdf):
+  usado en E-006 para el conteo oficial de regiones, provincias y comunas.
+- [Wikipedia — Anexo:Comunas de Chile](https://es.wikipedia.org/wiki/Anexo:Comunas_de_Chile): usado en
+  E-006 para el conteo total de 346 comunas.

--- a/docs/missions/03-taxonomia-categorias-y-comunas/producto.md
+++ b/docs/missions/03-taxonomia-categorias-y-comunas/producto.md
@@ -57,20 +57,11 @@ profesional o un buscador va a existir recién cuando 04 y 06 se construyan sobr
   | Cerrajería    | Cerraduras, llaves, emergencias de acceso          |
   | Jardinería    | Mantención de jardín, poda, pasto                  |
 
-  Cada categoría lleva además una lista corta de sinónimos con los que un buscador puede escribirla y
-  que Datealo debe reconocer como la misma categoría (detalle de implementación en `ingenieria.md`, pero el
-  contenido de la lista es acá, porque es una decisión de vocabulario):
-
-  | Categoría    | Sinónimos que matchean                              |
-  | ------------ | ----------------------------------------------------- |
-  | Gasfitería   | gasfiter, plomero, plomería                            |
-  | Electricidad | electricista                                           |
-  | Peluquería   | peluquero, peluquera, estilista                        |
-  | Limpieza     | aseo, aseadora, asesora del hogar (solo para aseo puntual, no empleo de planta) |
-  | Mudanzas     | flete, fletero                                         |
-  | Pintura      | pintor, pintora                                        |
-  | Cerrajería   | cerrajero                                               |
-  | Jardinería   | jardinero, jardinera, paisajismo                       |
+  Esta lista es solo el catálogo — cómo un buscador la elige en pantalla (tocar una categoría de una
+  lista, como ya hace el carrusel de la landing, o escribir texto libre) es una decisión de la misión 06,
+  no de esta. No se asume texto libre ni matching de sinónimos acá: eso solo haría falta si 06 decide un
+  buscador de texto, y en ese caso la decisión de vocabulario se toma en su propio `producto.md`, no en
+  este.
 
   Agregar una categoría nueva después es barato (una fila más); sacar una que ya tiene profesionales
   registrados no — por eso el catálogo parte corto a propósito.
@@ -123,7 +114,6 @@ reclutamiento de profesionales es una decisión de go-to-market aparte, no un re
 | ------ | ------------------------------------------------------------------------- | -------------------------- | ------ |
 | CL-001 | Una categoría del catálogo no tiene ningún profesional registrado todavía (ej. Jardinería) | Se sigue mostrando en el catálogo, no se esconde — misión 06 decide cómo se ve en el buscador | misión 04, misión 06 |
 | CL-002 | Una comuna del catálogo no tiene ningún profesional registrado todavía     | Igual que CL-001: la comuna existe en la lista, el estado vacío se resuelve en misión 06 | misión 04, misión 06 |
-| CL-003 | Alguien busca un oficio que no está en el catálogo (ej. "abogado", "gásfiter" mal escrito con acento raro) | No se inventa una categoría nueva. Se registra como intento fuera de catálogo para D-001 (ver M-001) | misión 06 |
 
 ## Fuera de alcance
 
@@ -144,11 +134,11 @@ reclutamiento de profesionales es una decisión de go-to-market aparte, no un re
   seguido y no está?
 - **Señal:** de los registros en la lista de espera y de las conversaciones de reclutamiento de
   profesionales, cuántas veces se menciona un oficio que no es ninguna de las 8.
-- **Método y umbral:** revisión manual de Patricio sobre la lista de espera y el registro de intentos
-  fuera de catálogo (CL-003); sin umbral numérico todavía por falta de volumen — se revisa cualitativamente
-  cada vez que aparece un patrón repetido (3+ menciones del mismo oficio fuera de catálogo).
-- **Guardrail:** ningún profesional se pierde por no encontrar su oficio — un intento fuera de catálogo
-  queda registrado, no se descarta silenciosamente.
+- **Método y umbral:** revisión manual de Patricio sobre la lista de espera y las conversaciones de
+  reclutamiento; sin umbral numérico todavía por falta de volumen — se revisa cualitativamente cada vez que
+  aparece un patrón repetido (3+ menciones del mismo oficio fuera de catálogo).
+- **Guardrail:** ningún profesional interesado se pierde por no encontrar su oficio en la lista — Patricio
+  lo registra a mano mientras el catálogo no lo cubra, no se descarta la conversación.
 
 <a id="m-002"></a>
 

--- a/docs/missions/03-taxonomia-categorias-y-comunas/producto.md
+++ b/docs/missions/03-taxonomia-categorias-y-comunas/producto.md
@@ -7,29 +7,33 @@
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-## Qué construimos: una lista cerrada de oficios y una lista cerrada de comunas, para que registro y
-búsqueda hablen el mismo idioma
+## Qué construimos: el catálogo completo de oficios y comunas, con un interruptor por fila para
+controlar qué está disponible sin necesitar un deploy
 
 **Resultado:** cuando un profesional se registre (misión 04) va a elegir su oficio y su comuna de dos
-listas fijas, no escribirlas a mano. Cuando alguien busque (misión 06), esas mismas dos listas son las que
-va a poder filtrar. Ningún desarrollador de esas dos misiones inventa su propia versión.
+listas fijas, no escribirlas a mano — y esas listas siempre apuntan a un registro real del catálogo, nunca
+a texto suelto. Cuando alguien busque (misión 06), esas mismas dos listas son las que va a poder filtrar.
+Ningún desarrollador de esas dos misiones inventa su propia versión, y ambas usan el mismo componente de
+selección (ver [D-004](#d-004)).
 
 **Recorte respecto del ideal:** el ideal (ver [investigacion.md](./investigacion.md)) es cualquier oficio
-en cualquiera de las 346 comunas de Chile. Acá se recorta a 8 oficios y a las 32 comunas del Gran Santiago
-— sigue siendo suficiente porque es donde la landing ya asume que va a estar la oferta inicial, y una lista
-más ancha con oferta cero solo agrega categorías y comunas vacías.
+en cualquiera de las 346 comunas de Chile. La tabla de datos ya cubre eso completo — las 346 comunas y las 8
+categorías existen desde el día uno. Lo que se recorta no es la lista, es **cuáles de esas filas están
+activas** (visibles para registro y búsqueda) al lanzamiento: Gran Santiago y Puerto Varas para partir,
+controlado por un campo `activa` que se prende o apaga sin tocar código (ver [D-002](#d-002)).
 
-**Restricciones aceptadas:** solo Gran Santiago al lanzamiento (nada de regiones ni comunas rurales de la
-RM todavía), 8 oficios fijos (nada de subcategorías dentro de un oficio), español chileno como único
-idioma.
+**Restricciones aceptadas:** 8 oficios fijos al lanzamiento (nada de subcategorías dentro de un oficio,
+aunque el catálogo puede sumar categorías nuevas después sin costo), español chileno como único idioma, sin
+panel de administración todavía — activar o desactivar una fila se hace directo en la base de datos.
 
-## Sin funcionalidades propias
+## Sin funcionalidades propias en registro o búsqueda — sí un componente compartido
 
-Esta misión no construye ninguna pantalla ni endpoint que un profesional o un buscador use directo — el
-selector de categoría al registrarse es misión 04, el filtro de comuna en el buscador es misión 06. Lo que
-esta misión entrega son las dos listas cerradas (categorías y comunas) de las que esas dos misiones
-dependen. Por eso no hay una sección de Funcionalidades en formato JTBD: el resultado observable para un
-profesional o un buscador va a existir recién cuando 04 y 06 se construyan sobre estas decisiones.
+Esta misión no construye ninguna pantalla completa que un profesional o un buscador use directo — el
+formulario de registro es misión 04, la pantalla de resultados es misión 06. Lo que esta misión sí entrega,
+además del catálogo, es el **componente de selección** que ambas van a importar (`ComunaSelect`,
+`CategoriaSelect` — ver [D-004](#d-004) e `ingenieria.md`), para que nadie lo construya dos veces ni de
+formas distintas. Por eso no hay una sección de Funcionalidades en formato JTBD: no hay un flujo completo
+de usuario que viva acá, pero sí una pieza reutilizable con su propia regla de comportamiento.
 
 ## Decisiones de producto
 
@@ -63,6 +67,11 @@ profesional o un buscador va a existir recién cuando 04 y 06 se construyan sobr
   buscador de texto, y en ese caso la decisión de vocabulario se toma en su propio `producto.md`, no en
   este.
 
+  Cada categoría tiene además un campo `activa` (ver [D-002](#d-002) para el mismo mecanismo aplicado a
+  comunas) — las 8 parten activas, pero el interruptor existe por si hace falta pausar una sin borrarla
+  (ej. problemas de calidad recurrentes en una categoría) o sumar una nueva sin que aparezca hasta estar
+  lista.
+
   Agregar una categoría nueva después es barato (una fila más); sacar una que ya tiene profesionales
   registrados no — por eso el catálogo parte corto a propósito.
 - **Reapertura:** cuando una categoría fuera del catálogo se pida seguido en el formulario de espera o en
@@ -70,27 +79,31 @@ profesional o un buscador va a existir recién cuando 04 y 06 se construyan sobr
 
 <a id="d-002"></a>
 
-### D-002 — El catálogo de comunas cubre las 32 comunas del Gran Santiago desde el día uno; el foco de
-reclutamiento de profesionales es una decisión de go-to-market aparte, no un recorte de la lista
+### D-002 — El catálogo tiene las 346 comunas de Chile completas; un campo `activa` por comuna controla
+qué se ofrece en registro y búsqueda, sin tocar código
 
 - **Estado:** propuesta. **Fecha:** 2026-08-17. **Fecha límite:** 2026-08-24.
-- **Sustento:** [C-002](./investigacion.md#c-002), [C-003](./investigacion.md#c-003).
-- **Tensión:** cubrir toda la Región Metropolitana (52 comunas) sigue el ideal de cobertura total, pero con
-  oferta inicial en decenas de profesionales la mayoría de comunas van a estar vacías. Cubrir solo un
-  puñado (5-10) evita comunas vacías, pero exige elegir cuáles de antemano sin tener todavía dato propio de
-  dónde va a estar la demanda o los primeros profesionales reclutados — sería una apuesta sin sustento.
-- **Alternativas descartadas:** las 52 comunas de la RM completa — vacía casi todo con la oferta inicial
-  (C-003). Elegir a mano un subconjunto chico (ej. 10 comunas de mayor ingreso) — no hay evidencia propia
-  de Datealo que sustente cuáles 10, y excluir una comuna del modelo de datos es más caro de revertir que
-  restringir dónde se hace difusión.
-- **Decisión y consecuencia:** la tabla de comunas nace con las 32 de la Provincia de Santiago (Gran
-  Santiago urbano — la lista completa está en [E-006](./investigacion.md#e-006) de investigación). Ninguna
-  se excluye estructuralmente. Qué comunas se trabajan primero para reclutar profesionales (dónde se hace
-  difusión, dónde se prioriza el primer lote de verificaciones) es una decisión operativa de Patricio, fuera
-  de este documento — así una comuna sin profesionales todavía no es un bug del catálogo, es el estado
-  esperado de un marketplace recién lanzado.
-- **Reapertura:** cuando haya tracción validada en Gran Santiago (ver [M-002](#m-002)), se evalúa sumar
-  comunas fuera de la Provincia de Santiago o una segunda región.
+- **Sustento:** [C-002](./investigacion.md#c-002). Revisa la implicación de [C-003](./investigacion.md#c-003)
+  — ver la nota de revisión ahí.
+- **Tensión:** excluir comunas del catálogo (la primera versión de esta decisión) evita mostrar opciones
+  sin cobertura, pero cuesta caro revertir y no hay ningún motivo real para no tener el dato completo — es
+  solo una fila más por comuna, sin costo de UI ni de base de datos. Lo que sí es limitado es cuánto puede
+  reclutar y verificar Patricio a mano, y eso no depende de cuántas filas tiene la tabla.
+- **Alternativas descartadas:** catálogo recortado a un subconjunto fijo de comunas (Gran Santiago
+  solamente, la versión anterior de esta decisión) — mezclaba "qué existe en la base de datos" con "dónde
+  reclutamos primero", dos preguntas distintas que no necesitan la misma respuesta. Dejar el campo de comuna
+  como texto libre — rompe [D-004](#d-004), permitiría "Ñuñoa", "ñuñoa" y "Nunoa" como tres valores
+  distintos.
+- **Decisión y consecuencia:** la tabla de comunas tiene las 346 comunas oficiales de Chile
+  ([E-006](./investigacion.md#e-006) de investigación) desde el día uno, cada una con un campo booleano
+  `activa`. Solo las comunas `activa = true` aparecen como opción en el selector de registro y de búsqueda
+  — una comuna inactiva no se ofrece, no se muestra como "sin resultados". Al lanzamiento parten activas
+  las comunas de Gran Santiago y Puerto Varas (los dos mercados donde Patricio puede reclutar y verificar
+  profesionales directamente); el resto existe en la tabla pero apagado. Activar una comuna nueva es
+  cambiar ese campo, sin deploy — hoy a mano en la base de datos, más adelante quizás desde un panel de
+  administración (fuera de alcance de esta misión).
+- **Reapertura:** ninguna — el catálogo ya está completo. Lo que se revisa con el tiempo es qué comunas
+  están activas, y eso no necesita reabrir esta decisión (ver [M-002](#m-002)).
 
 <a id="d-003"></a>
 
@@ -108,20 +121,48 @@ reclutamiento de profesionales es una decisión de go-to-market aparte, no un re
   "oficio" como término formal, "servicio" para esto, "ciudad" ni "región".
 - **Reapertura:** ninguna prevista.
 
+<a id="d-004"></a>
+
+### D-004 — Categoría y comuna siempre son una referencia al catálogo, nunca texto libre guardado
+
+- **Estado:** propuesta. **Fecha:** 2026-08-17. **Fecha límite:** 2026-08-24.
+- **Sustento:** [C-001](./investigacion.md#c-001), [C-002](./investigacion.md#c-002) — la lista solo
+  cumple su función (que registro y búsqueda hablen el mismo idioma) si nadie puede guardar un valor que no
+  esté en ella.
+- **Tensión:** un campo de texto libre es más rápido de construir que un selector con catálogo, pero
+  reabre exactamente el problema que esta misión existe para cerrar — "electricista" vs "instalaciones
+  eléctricas" como dos valores distintos que no matchean entre sí.
+- **Alternativas descartadas:** texto libre con normalización posterior (limpiar mayúsculas, tildes,
+  sinónimos después de guardado) — la inconsistencia ya ocurrió al guardar, limpiarla después es
+  reconstruir el problema de C-001 con pasos extra.
+- **Decisión y consecuencia:** todo formulario que pida categoría o comuna (registro en misión 04, filtro
+  de búsqueda en misión 06) usa el mismo componente de selección — un buscador con autocompletado al estilo
+  del selector de comuna de Mercado Libre: la persona escribe, ve solo opciones que existen en el catálogo,
+  y no puede enviar el formulario con algo que no eligió de la lista. La forma exacta de ese componente
+  (estados de carga, qué pasa si no hay match) se diseña en `experiencia.md`; el componente en sí
+  (`ComunaSelect`, `CategoriaSelect`) se construye una sola vez en `ingenieria.md` de esta misión, y 04 y 06
+  lo importan — no lo reconstruyen.
+- **Reapertura:** ninguna prevista.
+
 ## Casos límite
 
 | ID     | Condición concreta                                                      | Comportamiento esperado | Afecta |
 | ------ | ------------------------------------------------------------------------- | -------------------------- | ------ |
-| CL-001 | Una categoría del catálogo no tiene ningún profesional registrado todavía (ej. Jardinería) | Se sigue mostrando en el catálogo, no se esconde — misión 06 decide cómo se ve en el buscador | misión 04, misión 06 |
-| CL-002 | Una comuna del catálogo no tiene ningún profesional registrado todavía     | Igual que CL-001: la comuna existe en la lista, el estado vacío se resuelve en misión 06 | misión 04, misión 06 |
+| CL-001 | Una categoría activa no tiene ningún profesional registrado todavía (ej. Jardinería) | Se sigue mostrando en el selector, no se esconde — misión 06 decide cómo se ve el estado vacío en el buscador | misión 04, misión 06 |
+| CL-002 | Una comuna activa no tiene ningún profesional registrado todavía           | Igual que CL-001: la comuna existe y es seleccionable, el estado vacío se resuelve en misión 06 | misión 04, misión 06 |
+| CL-004 | Alguien intenta buscar o registrarse en una comuna marcada `activa = false` | La comuna no aparece como opción en el selector — no es un estado vacío, es que Datealo todavía no opera ahí | misión 04, misión 06 |
+
+CL-003 se retiró: era "alguien busca un oficio que no está en el catálogo" con texto libre, y dependía de
+una mecánica de búsqueda por texto que no está decidida (ver historial de D-001). El ID no se reutiliza; si
+la misión 06 más adelante define texto libre y necesita un caso límite equivalente, nace con un ID nuevo.
 
 ## Fuera de alcance
 
 | Capacidad o caso                                              | Estado     | Razón del recorte                                                | Condición para reconsiderar |
 | ---------------------------------------------------------------- | ---------- | -------------------------------------------------------------------- | ------------------------------- |
 | Subcategorías dentro de un oficio (ej. "Gasfitería - filtraciones") | postergada | Sin volumen no se justifica el filtro extra, agrega fricción al registro | Una categoría-comuna promedia 15+ profesionales |
-| Comunas fuera de la Provincia de Santiago (resto de la RM o de Chile) | postergada | Cold start: cobertura sin oferta real es solo un catálogo vacío | Tracción validada en Gran Santiago (M-002) |
-| Categorías fuera de las 8 (ej. carpintería, gasfitería industrial, cuidado de mascotas) | postergada | Mismo criterio de cold start que las comunas | Se piden seguido en la lista de espera o en los primeros meses (M-001) |
+| Categorías fuera de las 8 (ej. carpintería, gasfitería industrial, cuidado de mascotas) | postergada | Mismo criterio de cold start — sumarlas es barato, pero cada una vacía se ve peor que no tenerla | Se piden seguido en la lista de espera o en los primeros meses (M-001) |
+| Panel de administración para activar/desactivar comunas y categorías | postergada | Hoy el volumen de cambios es bajo — se hace directo en la base de datos | El volumen de cambios manuales lo justifique |
 | Traducción del catálogo a otro idioma                          | descartada | Datealo es Chile, español chileno es el único idioma del producto | — |
 
 ## Señales de éxito
@@ -142,25 +183,26 @@ reclutamiento de profesionales es una decisión de go-to-market aparte, no un re
 
 <a id="m-002"></a>
 
-### M-002 — Gran Santiago tiene tracción antes de ampliar cobertura
+### M-002 — Gran Santiago y Puerto Varas tienen tracción antes de activar más comunas
 
-- **Pregunta:** ¿ya vale la pena cubrir más comunas o regiones?
-- **Señal:** profesionales registrados y verificados en al menos la mitad de las 32 comunas del Gran
-  Santiago, con al menos una categoría con más de un profesional en la comuna más poblada.
+- **Pregunta:** ¿ya vale la pena activar comunas nuevas fuera de las que se están trabajando hoy?
+- **Señal:** profesionales registrados y verificados en al menos la mitad de las comunas activas, con al
+  menos una categoría con más de un profesional en la comuna más poblada de cada zona activa.
 - **Método y umbral:** conteo directo en la base de datos una vez exista la tabla de profesionales (misión
-  04); sin fecha objetivo todavía.
-- **Guardrail:** ampliar cobertura no debe diluir la densidad de Gran Santiago — no se suma una comuna
-  nueva a costa de dejar de reclutar en las que ya están activas.
+  04); sin fecha objetivo todavía. Activar una comuna nueva no requiere esperar esta señal — es solo la
+  referencia para decidir cuándo conviene, dado que el campo `activa` no tiene costo de revertir.
+- **Guardrail:** activar comunas nuevas no debe diluir el esfuerzo de reclutamiento en las que ya están
+  activas — no se suma una comuna a costa de dejar de reclutar en Gran Santiago o Puerto Varas.
 
 ## Preguntas
 
-Nada bloquea todavía — D-001 y D-002 están redactadas con recomendación explícita, a la espera de tu
-aprobación (fecha límite 2026-08-24 en ambas).
+Solo Q-001 sigue abierta: falta que confirmes si las 8 categorías de la landing son el catálogo real o si
+falta/sobra alguna, lo que bloquea que D-001 pase de "propuesta" a "aceptada".
 
-| ID    | La duda                                                | Estado  | Respuesta, o quién la resuelve |
-| ----- | --------------------------------------------------------- | ------- | ----------------------------------- |
-| Q-001 | ¿Las 8 categorías de la landing son de verdad las 8 correctas para el catálogo, o falta/sobra alguna? | abierta | Patricio confirma o ajusta en la revisión de D-001, antes del 2026-08-24 |
-| Q-002 | ¿Hay ya un plan de reclutamiento de profesionales que priorice ciertas comunas del Gran Santiago, que debería quedar registrado acá? | abierta | Patricio responde si existe; si no, D-002 queda como está (las 32 sin prioridad explícita) |
+| ID    | La duda                                                | Estado             | Respuesta, o quién la resuelve |
+| ----- | --------------------------------------------------------- | ------------------- | ----------------------------------- |
+| Q-001 | ¿Las 8 categorías de la landing son de verdad las 8 correctas para el catálogo, o falta/sobra alguna? | abierta             | Patricio confirma o ajusta en la revisión de D-001, antes del 2026-08-24 |
+| Q-002 | ¿Hay ya un plan de reclutamiento de profesionales que priorice ciertas comunas?                       | resuelta 2026-08-17 | Sí: Gran Santiago (mercado más grande) y Puerto Varas (donde Patricio vive y puede verificar directo). Esas dos zonas parten activas en [D-002](#d-002) |
 
 <a id="q-001"></a>
 
@@ -173,15 +215,3 @@ aprobación (fecha límite 2026-08-24 en ambas).
 - **Cómo se resolverá:** Patricio revisa la tabla de D-001 y confirma, agrega o saca categorías.
 - **¿Bloquea algo?:** bloquea que D-001 pase de "propuesta" a "aceptada" — mientras tanto misión 04 y 06
   no deberían empezar a construir el selector de categoría.
-
-<a id="q-002"></a>
-
-### Q-002 — ¿Existe ya un orden de prioridad de comunas para reclutar profesionales?
-
-- **La duda, con un ejemplo:** si Patricio ya sabe que va a partir reclutando en Providencia y Ñuñoa antes
-  que en Puente Alto, esa prioridad debería quedar escrita acá aunque el catálogo de datos incluya las 32
-  comunas por igual.
-- **Afecta a:** [D-002](#d-002).
-- **Cómo se resolverá:** Patricio responde directo; si no hay prioridad todavía, no bloquea nada.
-- **¿Bloquea algo?:** no bloquea D-002 (la lista de 32 comunas es independiente de la prioridad de
-  reclutamiento), pero sí conviene saberlo antes de la misión 04.

--- a/docs/missions/03-taxonomia-categorias-y-comunas/producto.md
+++ b/docs/missions/03-taxonomia-categorias-y-comunas/producto.md
@@ -1,8 +1,8 @@
 # Misión 03: taxonomía de categorías y comunas — Producto
 
-**Estado:** en revisión
+**Estado:** vigente
 
-**Última actualización:** 2026-08-17
+**Última actualización:** 2026-08-17. **Aprobado por Patricio el:** 2026-08-17.
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
@@ -41,7 +41,7 @@ de usuario que viva acá, pero sí una pieza reutilizable con su propia regla de
 
 ### D-001 — Las 8 categorías ya usadas en la landing son el catálogo oficial del lanzamiento
 
-- **Estado:** propuesta. **Fecha:** 2026-08-17. **Fecha límite:** 2026-08-24.
+- **Estado:** aceptada. **Fecha:** 2026-08-17. **Aprobada por Patricio el:** 2026-08-17.
 - **Sustento:** [C-001](./investigacion.md#c-001).
 - **Tensión:** cubrir más oficios da más superficie de búsqueda, pero cada oficio nuevo sin profesionales
   registrados es una categoría vacía que se ve peor que no tenerla.
@@ -82,7 +82,7 @@ de usuario que viva acá, pero sí una pieza reutilizable con su propia regla de
 ### D-002 — El catálogo tiene las 346 comunas de Chile completas; un campo `activa` por comuna controla
 qué se ofrece en registro y búsqueda, sin tocar código
 
-- **Estado:** propuesta. **Fecha:** 2026-08-17. **Fecha límite:** 2026-08-24.
+- **Estado:** aceptada. **Fecha:** 2026-08-17. **Aprobada por Patricio el:** 2026-08-17.
 - **Sustento:** [C-002](./investigacion.md#c-002). Revisa la implicación de [C-003](./investigacion.md#c-003)
   — ver la nota de revisión ahí.
 - **Tensión:** excluir comunas del catálogo (la primera versión de esta decisión) evita mostrar opciones
@@ -109,7 +109,7 @@ qué se ofrece en registro y búsqueda, sin tocar código
 
 ### D-003 — Los términos canónicos son "categoría" y "comuna"
 
-- **Estado:** propuesta. **Fecha:** 2026-08-17. **Fecha límite:** 2026-08-24.
+- **Estado:** aceptada. **Fecha:** 2026-08-17. **Aprobada por Patricio el:** 2026-08-17.
 - **Sustento:** vocabulario ya en uso en `CLAUDE.md` y en la landing.
 - **Tensión:** ninguna — es ratificar lo que ya se usa, no una alternativa real.
 - **Alternativas descartadas:** "rubro" u "oficio" como nombre del campo — "oficio" es como se explica en
@@ -125,7 +125,7 @@ qué se ofrece en registro y búsqueda, sin tocar código
 
 ### D-004 — Categoría y comuna siempre son una referencia al catálogo, nunca texto libre guardado
 
-- **Estado:** propuesta. **Fecha:** 2026-08-17. **Fecha límite:** 2026-08-24.
+- **Estado:** aceptada. **Fecha:** 2026-08-17. **Aprobada por Patricio el:** 2026-08-17.
 - **Sustento:** [C-001](./investigacion.md#c-001), [C-002](./investigacion.md#c-002) — la lista solo
   cumple su función (que registro y búsqueda hablen el mismo idioma) si nadie puede guardar un valor que no
   esté en ella.
@@ -196,22 +196,9 @@ la misión 06 más adelante define texto libre y necesita un caso límite equiva
 
 ## Preguntas
 
-Solo Q-001 sigue abierta: falta que confirmes si las 8 categorías de la landing son el catálogo real o si
-falta/sobra alguna, lo que bloquea que D-001 pase de "propuesta" a "aceptada".
+Ninguna abierta — Q-001 y Q-002 quedaron resueltas el 2026-08-17.
 
 | ID    | La duda                                                | Estado             | Respuesta, o quién la resuelve |
 | ----- | --------------------------------------------------------- | ------------------- | ----------------------------------- |
-| Q-001 | ¿Las 8 categorías de la landing son de verdad las 8 correctas para el catálogo, o falta/sobra alguna? | abierta             | Patricio confirma o ajusta en la revisión de D-001, antes del 2026-08-24 |
+| Q-001 | ¿Las 8 categorías de la landing son de verdad las 8 correctas para el catálogo, o falta/sobra alguna? | resuelta 2026-08-17 | Sí, son las 8 correctas — Patricio las confirmó sin cambios en D-001 |
 | Q-002 | ¿Hay ya un plan de reclutamiento de profesionales que priorice ciertas comunas?                       | resuelta 2026-08-17 | Sí: Gran Santiago (mercado más grande) y Puerto Varas (donde Patricio vive y puede verificar directo). Esas dos zonas parten activas en [D-002](#d-002) |
-
-<a id="q-001"></a>
-
-### Q-001 — ¿Las 8 categorías de la landing son las correctas para el catálogo real?
-
-- **La duda, con un ejemplo:** la landing se armó para verse bien en un carrusel, no como catálogo — por
-  ejemplo, no incluye "carpintería" ni "cuidado de mascotas", que también son oficios comunes a domicilio en
-  Chile. ¿Se quedan fuera a propósito o es solo que no entraron en el carrusel?
-- **Afecta a:** [D-001](#d-001).
-- **Cómo se resolverá:** Patricio revisa la tabla de D-001 y confirma, agrega o saca categorías.
-- **¿Bloquea algo?:** bloquea que D-001 pase de "propuesta" a "aceptada" — mientras tanto misión 04 y 06
-  no deberían empezar a construir el selector de categoría.

--- a/docs/missions/03-taxonomia-categorias-y-comunas/producto.md
+++ b/docs/missions/03-taxonomia-categorias-y-comunas/producto.md
@@ -1,149 +1,197 @@
-# Misión: <nombre> — Producto
+# Misión 03: taxonomía de categorías y comunas — Producto
 
-**Estado:** borrador
+**Estado:** en revisión
 
-**Última actualización:** AAAA-MM-DD
+**Última actualización:** 2026-08-17
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-<!--
-Este documento es la spec viva del resultado: qué construimos ahora y bajo qué reglas. El porqué vive en
-investigacion.md — aquí solo se enlaza. Se reescribe cuando el alcance cambia; no acumula historia.
+## Qué construimos: una lista cerrada de oficios y una lista cerrada de comunas, para que registro y
+búsqueda hablen el mismo idioma
 
-Gate de salida — producto.md está listo para experiencia.md cuando:
-- cada funcionalidad tiene formato JTBD, reglas y al menos un caso límite con comportamiento definido
-- cada funcionalidad enlaza una conclusión de investigacion.md y una señal de éxito
-- cada funcionalidad declara a qué lado del marketplace sirve, y qué necesita del otro lado para funcionar
-- no hay decisiones de producto delegadas a diseño o ingeniería
-- las decisiones propuestas tienen fecha límite en el README
--->
+**Resultado:** cuando un profesional se registre (misión 04) va a elegir su oficio y su comuna de dos
+listas fijas, no escribirlas a mano. Cuando alguien busque (misión 06), esas mismas dos listas son las que
+va a poder filtrar. Ningún desarrollador de esas dos misiones inventa su propia versión.
 
-## Qué construimos: <resultado en una frase>
+**Recorte respecto del ideal:** el ideal (ver [investigacion.md](./investigacion.md)) es cualquier oficio
+en cualquiera de las 346 comunas de Chile. Acá se recorta a 8 oficios y a las 32 comunas del Gran Santiago
+— sigue siendo suficiente porque es donde la landing ya asume que va a estar la oferta inicial, y una lista
+más ancha con oferta cero solo agrega categorías y comunas vacías.
 
-<!--
-El recorte vigente del ideal y por qué sigue entregando el resultado central. Máximo cuatro párrafos
-cortos. El ideal completo vive en investigacion.md.
--->
+**Restricciones aceptadas:** solo Gran Santiago al lanzamiento (nada de regiones ni comunas rurales de la
+RM todavía), 8 oficios fijos (nada de subcategorías dentro de un oficio), español chileno como único
+idioma.
 
-**Resultado:** <qué podrá lograr una persona al finalizar esta entrega>.
+## Sin funcionalidades propias
 
-**Recorte respecto del ideal:** <qué dimensión se reduce y por qué sigue siendo suficiente>
-(ver [el ideal](./investigacion.md)).
+Esta misión no construye ninguna pantalla ni endpoint que un profesional o un buscador use directo — el
+selector de categoría al registrarse es misión 04, el filtro de comuna en el buscador es misión 06. Lo que
+esta misión entrega son las dos listas cerradas (categorías y comunas) de las que esas dos misiones
+dependen. Por eso no hay una sección de Funcionalidades en formato JTBD: el resultado observable para un
+profesional o un buscador va a existir recién cuando 04 y 06 se construyan sobre estas decisiones.
 
-**Restricciones aceptadas:** <plataforma, cobertura geográfica, categorías, volumen inicial de
-profesionales>.
+## Decisiones de producto
 
-## Funcionalidades
+<a id="d-001"></a>
 
-| ID    | Funcionalidad                  | Lado         | Sustento     | Éxito |
-| ----- | ------------------------------ | ------------ | ------------ | ----- |
-| F-001 | <verbo + resultado observable> | buscador     | C-001, D-001 | M-001 |
+### D-001 — Las 8 categorías ya usadas en la landing son el catálogo oficial del lanzamiento
 
-<a id="f-001"></a>
+- **Estado:** propuesta. **Fecha:** 2026-08-17. **Fecha límite:** 2026-08-24.
+- **Sustento:** [C-001](./investigacion.md#c-001).
+- **Tensión:** cubrir más oficios da más superficie de búsqueda, pero cada oficio nuevo sin profesionales
+  registrados es una categoría vacía que se ve peor que no tenerla.
+- **Alternativas descartadas:** taxonomía extensa estilo Thumbtack (cientos de microcategorías) — con
+  oferta cero al lanzamiento, casi todas quedan vacías. Categorías genéricas estilo TaskRabbit ("Handyman")
+  — pierden la palabra exacta que un chileno usa para pedir ayuda.
+- **Decisión y consecuencia:** el catálogo son estas 8, en este nombre exacto, sin subcategorías:
 
-### F-001 — <verbo + resultado observable>
+  | Categoría     | Ejemplo de lo que cubre                          |
+  | ------------- | -------------------------------------------------- |
+  | Gasfitería    | Filtraciones, instalación de artefactos, cañerías |
+  | Electricidad  | Instalaciones, cortocircuitos, cambio de enchufes |
+  | Peluquería    | Corte, color, peinado a domicilio                 |
+  | Limpieza      | Aseo profundo, aseo periódico de depto o casa      |
+  | Mudanzas      | Mudanza dentro de Santiago, fletes chicos          |
+  | Pintura       | Pintar living, dormitorio, fachada                 |
+  | Cerrajería    | Cerraduras, llaves, emergencias de acceso          |
+  | Jardinería    | Mantención de jardín, poda, pasto                  |
 
-<!--
-Duplica este bloque por funcionalidad. Se escribe desde el resultado del usuario (working backwards):
-primero el JTBD, después las reglas. Si la respuesta de Datealo no se puede describir sin hablar de tablas
-o componentes, falta cerrar la decisión de producto.
--->
+  Cada categoría lleva además una lista corta de sinónimos con los que un buscador puede escribirla y
+  que Datealo debe reconocer como la misma categoría (detalle de implementación en `ingenieria.md`, pero el
+  contenido de la lista es acá, porque es una decisión de vocabulario):
 
-Cuando <usuario en contexto concreto>,
-quiero <acción>,
-para <resultado observable>.
+  | Categoría    | Sinónimos que matchean                              |
+  | ------------ | ----------------------------------------------------- |
+  | Gasfitería   | gasfiter, plomero, plomería                            |
+  | Electricidad | electricista                                           |
+  | Peluquería   | peluquero, peluquera, estilista                        |
+  | Limpieza     | aseo, aseadora, asesora del hogar (solo para aseo puntual, no empleo de planta) |
+  | Mudanzas     | flete, fletero                                         |
+  | Pintura      | pintor, pintora                                        |
+  | Cerrajería   | cerrajero                                               |
+  | Jardinería   | jardinero, jardinera, paisajismo                       |
 
-**Lado del marketplace:** buscador, profesional o ambos. **Qué necesita del otro lado:** <volumen mínimo
-de perfiles, reseñas o cobertura sin el cual esta funcionalidad no entrega su resultado>.
+  Agregar una categoría nueva después es barato (una fila más); sacar una que ya tiene profesionales
+  registrados no — por eso el catálogo parte corto a propósito.
+- **Reapertura:** cuando una categoría fuera del catálogo se pida seguido en el formulario de espera o en
+  los primeros meses de operación (ver [M-001](#m-001)).
 
-**Sustento:** [C-001](./investigacion.md#c-001) y [D-001](#d-001). **Éxito:** [M-001](#m-001).
+<a id="d-002"></a>
 
-**Reglas:**
+### D-002 — El catálogo de comunas cubre las 32 comunas del Gran Santiago desde el día uno; el foco de
+reclutamiento de profesionales es una decisión de go-to-market aparte, no un recorte de la lista
 
-- Si <condición>, Datealo <comportamiento esperado>.
-- Si <caso límite>, Datealo <comportamiento seguro y qué información muestra>.
-- Datealo nunca <comportamiento que rompería el significado o la confianza>.
+- **Estado:** propuesta. **Fecha:** 2026-08-17. **Fecha límite:** 2026-08-24.
+- **Sustento:** [C-002](./investigacion.md#c-002), [C-003](./investigacion.md#c-003).
+- **Tensión:** cubrir toda la Región Metropolitana (52 comunas) sigue el ideal de cobertura total, pero con
+  oferta inicial en decenas de profesionales la mayoría de comunas van a estar vacías. Cubrir solo un
+  puñado (5-10) evita comunas vacías, pero exige elegir cuáles de antemano sin tener todavía dato propio de
+  dónde va a estar la demanda o los primeros profesionales reclutados — sería una apuesta sin sustento.
+- **Alternativas descartadas:** las 52 comunas de la RM completa — vacía casi todo con la oferta inicial
+  (C-003). Elegir a mano un subconjunto chico (ej. 10 comunas de mayor ingreso) — no hay evidencia propia
+  de Datealo que sustente cuáles 10, y excluir una comuna del modelo de datos es más caro de revertir que
+  restringir dónde se hace difusión.
+- **Decisión y consecuencia:** la tabla de comunas nace con las 32 de la Provincia de Santiago (Gran
+  Santiago urbano — la lista completa está en [E-006](./investigacion.md#e-006) de investigación). Ninguna
+  se excluye estructuralmente. Qué comunas se trabajan primero para reclutar profesionales (dónde se hace
+  difusión, dónde se prioriza el primer lote de verificaciones) es una decisión operativa de Patricio, fuera
+  de este documento — así una comuna sin profesionales todavía no es un bug del catálogo, es el estado
+  esperado de un marketplace recién lanzado.
+- **Reapertura:** cuando haya tracción validada en Gran Santiago (ver [M-002](#m-002)), se evalúa sumar
+  comunas fuera de la Provincia de Santiago o una segunda región.
 
-**Ejemplo verificable:** dado <estado con datos concretos>, cuando <acción>, entonces <resultado
-observable>.
+<a id="d-003"></a>
 
-**No incluye:** <variante del ideal excluida de esta funcionalidad>.
+### D-003 — Los términos canónicos son "categoría" y "comuna"
 
-**Experiencia:** <enlace a UXF-xxx cuando exista>. **Ingeniería:** <enlace a T-xxx cuando exista>.
+- **Estado:** propuesta. **Fecha:** 2026-08-17. **Fecha límite:** 2026-08-24.
+- **Sustento:** vocabulario ya en uso en `CLAUDE.md` y en la landing.
+- **Tensión:** ninguna — es ratificar lo que ya se usa, no una alternativa real.
+- **Alternativas descartadas:** "rubro" u "oficio" como nombre del campo — "oficio" es como se explica en
+  prosa, pero el campo y el código dicen "categoría", que es más neutro para cubrir también servicios que no
+  son un oficio manual clásico (peluquería). "Ciudad" o "región" en vez de "comuna" — Chile no organiza su
+  geografía así de fino en la vida diaria, comuna es la unidad real ("vivo en Ñuñoa", no "vivo en la
+  Provincia de Santiago").
+- **Decisión y consecuencia:** todo código, documento y copy usa "categoría" y "comuna" — nunca "rubro",
+  "oficio" como término formal, "servicio" para esto, "ciudad" ni "región".
+- **Reapertura:** ninguna prevista.
 
-## Casos límite que cruzan funcionalidades
+## Casos límite
 
-<!--
-Solo condiciones que afectan varias funcionalidades. Las propias de una viven en su bloque. Un caso
-retirado no se borra ni se reutiliza: conserva su fila, o se nombra con su motivo en una línea debajo.
-
-Los casos límite propios de un marketplace pre-lanzamiento aparecen acá: cero resultados en una comuna,
-un profesional sin reseñas, una categoría con un solo perfil, un perfil sin verificar.
--->
-
-| ID     | Condición concreta     | Comportamiento esperado | Funcionalidades |
-| ------ | ---------------------- | ----------------------- | --------------- |
-| CL-001 | <estado o combinación> | <qué hace Datealo>      | F-001           |
+| ID     | Condición concreta                                                      | Comportamiento esperado | Afecta |
+| ------ | ------------------------------------------------------------------------- | -------------------------- | ------ |
+| CL-001 | Una categoría del catálogo no tiene ningún profesional registrado todavía (ej. Jardinería) | Se sigue mostrando en el catálogo, no se esconde — misión 06 decide cómo se ve en el buscador | misión 04, misión 06 |
+| CL-002 | Una comuna del catálogo no tiene ningún profesional registrado todavía     | Igual que CL-001: la comuna existe en la lista, el estado vacío se resuelve en misión 06 | misión 04, misión 06 |
+| CL-003 | Alguien busca un oficio que no está en el catálogo (ej. "abogado", "gásfiter" mal escrito con acento raro) | No se inventa una categoría nueva. Se registra como intento fuera de catálogo para D-001 (ver M-001) | misión 06 |
 
 ## Fuera de alcance
 
-<!-- Distingue postergado de descartado y qué condición justificaría reabrirlo. -->
-
-| Capacidad o caso      | Estado                  | Razón del recorte | Condición para reconsiderar |
-| --------------------- | ----------------------- | ----------------- | --------------------------- |
-| <capacidad del ideal> | postergada o descartada | <trade-off>       | <evidencia o hito>          |
+| Capacidad o caso                                              | Estado     | Razón del recorte                                                | Condición para reconsiderar |
+| ---------------------------------------------------------------- | ---------- | -------------------------------------------------------------------- | ------------------------------- |
+| Subcategorías dentro de un oficio (ej. "Gasfitería - filtraciones") | postergada | Sin volumen no se justifica el filtro extra, agrega fricción al registro | Una categoría-comuna promedia 15+ profesionales |
+| Comunas fuera de la Provincia de Santiago (resto de la RM o de Chile) | postergada | Cold start: cobertura sin oferta real es solo un catálogo vacío | Tracción validada en Gran Santiago (M-002) |
+| Categorías fuera de las 8 (ej. carpintería, gasfitería industrial, cuidado de mascotas) | postergada | Mismo criterio de cold start que las comunas | Se piden seguido en la lista de espera o en los primeros meses (M-001) |
+| Traducción del catálogo a otro idioma                          | descartada | Datealo es Chile, español chileno es el único idioma del producto | — |
 
 ## Señales de éxito
 
 <a id="m-001"></a>
 
-### M-001 — <señal que demuestra el resultado>
+### M-001 — El catálogo de categorías alcanza para lo que la gente pide, sin forzarlas a otra categoría
 
-- **Pregunta:** ¿<qué queremos comprobar>?
-- **Señal:** <comportamiento o resultado observable>.
-- **Método y umbral:** <instrumentación o revisión, qué resultado, en qué población y ventana>.
-- **Guardrail:** <daño que no debe aumentar para conseguir la señal>.
+- **Pregunta:** ¿las 8 categorías cubren lo que la gente realmente busca, o hay un oficio que se pide
+  seguido y no está?
+- **Señal:** de los registros en la lista de espera y de las conversaciones de reclutamiento de
+  profesionales, cuántas veces se menciona un oficio que no es ninguna de las 8.
+- **Método y umbral:** revisión manual de Patricio sobre la lista de espera y el registro de intentos
+  fuera de catálogo (CL-003); sin umbral numérico todavía por falta de volumen — se revisa cualitativamente
+  cada vez que aparece un patrón repetido (3+ menciones del mismo oficio fuera de catálogo).
+- **Guardrail:** ningún profesional se pierde por no encontrar su oficio — un intento fuera de catálogo
+  queda registrado, no se descarta silenciosamente.
 
-## Decisiones de producto
+<a id="m-002"></a>
 
-<!--
-Solo decisiones con alternativas reales. No borres decisiones reemplazadas: explican por qué el producto
-es como es. Toda decisión propuesta se refleja en el README con fecha límite.
--->
+### M-002 — Gran Santiago tiene tracción antes de ampliar cobertura
 
-<a id="d-001"></a>
-
-### D-001 — <decisión en una frase que se entiende sola>
-
-- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
-- **Sustento:** [C-001](./investigacion.md#c-001).
-- **Tensión:** <criterios que no podían maximizarse al mismo tiempo>.
-- **Alternativas descartadas:** <opciones y razón concreta del rechazo, en la misma línea>.
-- **Decisión y consecuencia:** <qué se hará y qué habilita, limita o exige revisar en UX e ingeniería>.
-- **Reapertura:** <evidencia o cambio que justificaría revisarla>.
+- **Pregunta:** ¿ya vale la pena cubrir más comunas o regiones?
+- **Señal:** profesionales registrados y verificados en al menos la mitad de las 32 comunas del Gran
+  Santiago, con al menos una categoría con más de un profesional en la comuna más poblada.
+- **Método y umbral:** conteo directo en la base de datos una vez exista la tabla de profesionales (misión
+  04); sin fecha objetivo todavía.
+- **Guardrail:** ampliar cobertura no debe diluir la densidad de Gran Santiago — no se suma una comuna
+  nueva a costa de dejar de reclutar en las que ya están activas.
 
 ## Preguntas
 
-<!--
-Solo preguntas que pueden cambiar una decisión o funcionalidad. Lo demás va a un issue.
-Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
-Estado: abierta | resuelta AAAA-MM-DD (alguien la respondió) | disuelta AAAA-MM-DD (el producto cambió y la
-pregunta dejó de tener sentido). Solo las abiertas llevan bloque de detalle debajo de la tabla.
--->
+Nada bloquea todavía — D-001 y D-002 están redactadas con recomendación explícita, a la espera de tu
+aprobación (fecha límite 2026-08-24 en ambas).
 
-<Una frase que responde "¿qué falta?": la pregunta que bloquea y qué bloquea.>
-
-| ID    | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
-| ----- | ---------------------- | ------------------- | --------------------------------------------------------------- |
-| Q-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
-| Q-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |
+| ID    | La duda                                                | Estado  | Respuesta, o quién la resuelve |
+| ----- | --------------------------------------------------------- | ------- | ----------------------------------- |
+| Q-001 | ¿Las 8 categorías de la landing son de verdad las 8 correctas para el catálogo, o falta/sobra alguna? | abierta | Patricio confirma o ajusta en la revisión de D-001, antes del 2026-08-24 |
+| Q-002 | ¿Hay ya un plan de reclutamiento de profesionales que priorice ciertas comunas del Gran Santiago, que debería quedar registrado acá? | abierta | Patricio responde si existe; si no, D-002 queda como está (las 32 sin prioridad explícita) |
 
 <a id="q-001"></a>
 
-### Q-001 — <la pregunta en una frase que se entiende sola>
+### Q-001 — ¿Las 8 categorías de la landing son las correctas para el catálogo real?
 
-- **La duda, con un ejemplo:** <el caso concreto que muestra por qué hay dos respuestas posibles>.
-- **Afecta a:** D-001 o F-001.
-- **Cómo se resolverá:** <quién y con qué método>.
-- **¿Bloquea algo?:** <qué bloquea y su fecha límite, o no>.
+- **La duda, con un ejemplo:** la landing se armó para verse bien en un carrusel, no como catálogo — por
+  ejemplo, no incluye "carpintería" ni "cuidado de mascotas", que también son oficios comunes a domicilio en
+  Chile. ¿Se quedan fuera a propósito o es solo que no entraron en el carrusel?
+- **Afecta a:** [D-001](#d-001).
+- **Cómo se resolverá:** Patricio revisa la tabla de D-001 y confirma, agrega o saca categorías.
+- **¿Bloquea algo?:** bloquea que D-001 pase de "propuesta" a "aceptada" — mientras tanto misión 04 y 06
+  no deberían empezar a construir el selector de categoría.
+
+<a id="q-002"></a>
+
+### Q-002 — ¿Existe ya un orden de prioridad de comunas para reclutar profesionales?
+
+- **La duda, con un ejemplo:** si Patricio ya sabe que va a partir reclutando en Providencia y Ñuñoa antes
+  que en Puente Alto, esa prioridad debería quedar escrita acá aunque el catálogo de datos incluya las 32
+  comunas por igual.
+- **Afecta a:** [D-002](#d-002).
+- **Cómo se resolverá:** Patricio responde directo; si no hay prioridad todavía, no bloquea nada.
+- **¿Bloquea algo?:** no bloquea D-002 (la lista de 32 comunas es independiente de la prioridad de
+  reclutamiento), pero sí conviene saberlo antes de la misión 04.

--- a/docs/missions/README.md
+++ b/docs/missions/README.md
@@ -11,7 +11,7 @@ abrieron y de dónde salió cada una.
 | --- | ------ | ---- | ------- | ------ | ------- | ------- |
 | 01  | [migración a Nuxt UI](./01-migracion-nuxt-ui/) | técnica | 2026-08-11 | cerrada 2026-08-13 | — | A-004 |
 | 02  | [base de datos, Auth y correo (config)](./02-base-de-datos-y-auth/) | técnica | 2026-08-13 | cerrada 2026-08-17 | — | A-001, A-002, A-003 |
-| 03  | [taxonomía: categorías y comunas](./03-taxonomia-categorias-y-comunas/) | producto | 2026-08-13 | exploración | Investigación | — |
+| 03  | [taxonomía: categorías y comunas](./03-taxonomia-categorias-y-comunas/) | producto | 2026-08-13 | definición | Producto | — |
 | 04  | [registro y perfil de profesional](./04-registro-perfil-profesional/) | producto | 2026-08-13 | exploración | — | — |
 | 05  | [perfil público de profesional](./05-perfil-publico-profesional/) | producto | 2026-08-13 | exploración | — | — |
 | 06  | [búsqueda y resultados](./06-busqueda-resultados/) | producto | 2026-08-13 | exploración | — | — |

--- a/docs/missions/README.md
+++ b/docs/missions/README.md
@@ -11,7 +11,7 @@ abrieron y de dónde salió cada una.
 | --- | ------ | ---- | ------- | ------ | ------- | ------- |
 | 01  | [migración a Nuxt UI](./01-migracion-nuxt-ui/) | técnica | 2026-08-11 | cerrada 2026-08-13 | — | A-004 |
 | 02  | [base de datos, Auth y correo (config)](./02-base-de-datos-y-auth/) | técnica | 2026-08-13 | cerrada 2026-08-17 | — | A-001, A-002, A-003 |
-| 03  | [taxonomía: categorías y comunas](./03-taxonomia-categorias-y-comunas/) | producto | 2026-08-13 | definición | Producto | — |
+| 03  | [taxonomía: categorías y comunas](./03-taxonomia-categorias-y-comunas/) | producto | 2026-08-13 | definición | Experiencia | — |
 | 04  | [registro y perfil de profesional](./04-registro-perfil-profesional/) | producto | 2026-08-13 | exploración | — | — |
 | 05  | [perfil público de profesional](./05-perfil-publico-profesional/) | producto | 2026-08-13 | exploración | — | — |
 | 06  | [búsqueda y resultados](./06-busqueda-resultados/) | producto | 2026-08-13 | exploración | — | — |

--- a/docs/missions/README.md
+++ b/docs/missions/README.md
@@ -11,7 +11,7 @@ abrieron y de dónde salió cada una.
 | --- | ------ | ---- | ------- | ------ | ------- | ------- |
 | 01  | [migración a Nuxt UI](./01-migracion-nuxt-ui/) | técnica | 2026-08-11 | cerrada 2026-08-13 | — | A-004 |
 | 02  | [base de datos, Auth y correo (config)](./02-base-de-datos-y-auth/) | técnica | 2026-08-13 | cerrada 2026-08-17 | — | A-001, A-002, A-003 |
-| 03  | [taxonomía: categorías y comunas](./03-taxonomia-categorias-y-comunas/) | producto | 2026-08-13 | exploración | — | — |
+| 03  | [taxonomía: categorías y comunas](./03-taxonomia-categorias-y-comunas/) | producto | 2026-08-13 | exploración | Investigación | — |
 | 04  | [registro y perfil de profesional](./04-registro-perfil-profesional/) | producto | 2026-08-13 | exploración | — | — |
 | 05  | [perfil público de profesional](./05-perfil-publico-profesional/) | producto | 2026-08-13 | exploración | — | — |
 | 06  | [búsqueda y resultados](./06-busqueda-resultados/) | producto | 2026-08-13 | exploración | — | — |


### PR DESCRIPTION
## Resumen

Primer documento de la misión 03 (taxonomía: categorías y comunas), tipo producto.

- **El problema:** sin una lista compartida de oficios/comunas, cada misión que la toque (04 registro, 06 búsqueda) inventa la suya y los perfiles quedan invisibles para la búsqueda que debería encontrarlos.
- **Evidencia:** 6 hallazgos — categorías actuales de la landing, benchmark de Thumbtack (microcategorías, no aplica a oferta cero), TaskRabbit (categorías genéricas, pierden el nombre del oficio), Yapo.cl (vocabulario chileno de oficio), copy de la landing (comuna como unidad de búsqueda), y la división político-administrativa oficial de Chile (346 comunas, 52 en la RM, 32 en el Gran Santiago).
- **3 conclusiones:** categoría = oficio en un nivel plano (C-001), comuna como unidad geográfica de búsqueda (C-002), cobertura total de Chile es el ideal pero arriesga vaciar categoría×comuna si se cubre todo al lanzamiento (C-003).
- **El ideal:** cualquier oficio, en cualquier comuna de Chile, encontrado con las palabras propias del buscador — el recorte a la primera entrega queda para `producto.md`.

`investigacion.md` no se aprueba (se acumula), así que este PR no bloquea nada — es para que quede en el historial y quede a la vista antes de escribir `producto.md`.

## Test plan

- [x] Sigue la estructura del template (`docs/missions/template/investigacion.md`)
- [x] Cada evidencia tiene fuente, hecho verificable y límite
- [x] Cada conclusión enlaza su evidencia y declara su confianza
- [x] READMEs de la misión 03 y del registro general actualizados (estado, en foco)

🤖 Generated with [Claude Code](https://claude.com/claude-code)