### PR TITLE
docs: redactar experiencia.md de la misión 03

### DIFF
--- a/docs/missions/03-taxonomia-categorias-y-comunas/README.md
+++ b/docs/missions/03-taxonomia-categorias-y-comunas/README.md
@@ -4,7 +4,7 @@
 
 **Estado de la misión:** definición
 
-**Última actualización:** 2026-08-17
+**Última actualización:** 2026-08-18
 
 Segunda de seis misiones hacia el MVP (registrarse, mostrarse, buscar, reseñar). Depende de
 [misión 02](../02-base-de-datos-y-auth/), ya cerrada, para poder guardar algo.
@@ -13,10 +13,11 @@ Segunda de seis misiones hacia el MVP (registrarse, mostrarse, buscar, reseñar)
 | ------------- | --------- | ------------------------------------ |
 | Investigación | activo    | se acumula, no bloquea — el problema tiene situación y consecuencia concretas, hay 3 conclusiones (C-001 a C-003) y un ideal con capacidades observables |
 | Producto      | vigente   | aprobado por Patricio el 2026-08-17 — D-001 a D-004 aceptadas, Q-001 y Q-002 resueltas |
-| Experiencia   | en revisión | aprobación de Patricio sobre el diseño del componente `ComunaSelect`/`CategoriaSelect` (UXF-001), con mockup de sus 6 modos |
-| Ingeniería    | pendiente   | —                                     |
+| Experiencia   | vigente   | aprobado por Patricio el 2026-08-18 — componente `ComunaSelect`/`CategoriaSelect` (UXF-001), 6 modos con mockup |
+| Ingeniería    | pendiente | —                                     |
 
-**Próximo hito:** que Patricio apruebe o ajuste `experiencia.md` — sin fecha límite todavía.
+**Próximo hito:** escribir `ingenieria.md` — modelo de datos de `categorias`/`comunas` y el componente
+`ComunaSelect`/`CategoriaSelect` en Vue. Sin fecha límite todavía.
 
 ## Brief
 

--- a/docs/missions/03-taxonomia-categorias-y-comunas/README.md
+++ b/docs/missions/03-taxonomia-categorias-y-comunas/README.md
@@ -13,10 +13,10 @@ Segunda de seis misiones hacia el MVP (registrarse, mostrarse, buscar, reseñar)
 | ------------- | --------- | ------------------------------------ |
 | Investigación | activo    | se acumula, no bloquea — el problema tiene situación y consecuencia concretas, hay 3 conclusiones (C-001 a C-003) y un ideal con capacidades observables |
 | Producto      | vigente   | aprobado por Patricio el 2026-08-17 — D-001 a D-004 aceptadas, Q-001 y Q-002 resueltas |
-| Experiencia   | pendiente | diseñar el componente compartido `ComunaSelect`/`CategoriaSelect` (D-004): autocompletado que solo permite elegir del catálogo |
-| Ingeniería    | pendiente | —                                     |
+| Experiencia   | en revisión | aprobación de Patricio sobre el diseño del componente `ComunaSelect`/`CategoriaSelect` (UXF-001), con mockup de sus 6 modos |
+| Ingeniería    | pendiente   | —                                     |
 
-**Próximo hito:** escribir `experiencia.md` — sin fecha límite todavía.
+**Próximo hito:** que Patricio apruebe o ajuste `experiencia.md` — sin fecha límite todavía.
 
 ## Brief
 

--- a/docs/missions/03-taxonomia-categorias-y-comunas/design-mockups/comuna-select.html
+++ b/docs/missions/03-taxonomia-categorias-y-comunas/design-mockups/comuna-select.html
@@ -1,0 +1,198 @@
+<!doctype html>
+<html lang="es-CL">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>C-001 ComunaSelect / CategoriaSelect — misión 03</title>
+
+    <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+    <link
+      href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&family=Plus+Jakarta+Sans:wght@600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../../design/datealo-mockup-kit.css" />
+    <style type="text/tailwindcss">
+      @theme {
+        --color-primary: var(--ui-primary);
+        --color-secondary: var(--ui-secondary);
+        --color-success: var(--ui-success);
+        --color-error: var(--ui-error);
+      }
+    </style>
+    <style>
+      .field-shell {
+        border: 1px solid var(--ui-border);
+        border-radius: var(--ui-radius, 0.5rem);
+        background: var(--ui-bg);
+      }
+      .option-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0.75rem 1rem;
+        font-size: 0.9375rem;
+        color: var(--ui-text-highlighted);
+        border-bottom: 1px solid var(--ui-border-muted);
+      }
+      .option-row:last-child {
+        border-bottom: none;
+      }
+      .skeleton-line {
+        height: 0.9rem;
+        border-radius: 0.375rem;
+        background: var(--ui-bg-accented);
+      }
+    </style>
+  </head>
+
+  <body>
+    <div class="frames">
+      <!-- 1. cerrado, sin valor -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          C-001 · modo cerrado, sin valor
+          <small>ComunaSelect embebido en un formulario genérico — el formulario real lo diseña la misión 04/06</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="p-5">
+            <label class="mb-2 block text-sm font-semibold" style="color: var(--ui-text-highlighted)">Comuna</label>
+            <div class="field-shell flex items-center justify-between px-4 py-3.5">
+              <span style="color: var(--ui-text-dimmed)">¿Qué comuna buscas?</span>
+              <span style="color: var(--ui-text-dimmed)">▾</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- 2. abierto sin texto — lista completa -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          C-001 · modo abierto sin texto
+          <small>tocó el campo — aparece el catálogo activo completo, sin escribir nada</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="p-5">
+            <label class="mb-2 block text-sm font-semibold" style="color: var(--ui-text-highlighted)">Comuna</label>
+            <div class="field-shell px-4 py-3.5" style="border-color: var(--ui-primary)">
+              <input
+                type="text"
+                placeholder="¿Qué comuna buscas?"
+                class="w-full bg-transparent text-[0.9375rem] outline-none"
+                style="color: var(--ui-text-highlighted)"
+              />
+            </div>
+            <div class="field-shell mt-2 overflow-hidden">
+              <div class="option-row"><span>Cerrillos</span></div>
+              <div class="option-row"><span>Cerro Navia</span></div>
+              <div class="option-row"><span>Estación Central</span></div>
+              <div class="option-row"><span>Las Condes</span></div>
+              <div class="option-row" style="background: var(--ui-bg-accented)"><span>Ñuñoa</span></div>
+              <div class="option-row"><span>Providencia</span></div>
+              <div class="option-row"><span>Puerto Varas</span></div>
+              <div class="option-row"><span>Vitacura</span></div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- 3. abierto con coincidencias -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          C-001 · modo abierto con coincidencias
+          <small>escribió "nun" — filtra en vivo, sin distinguir tildes ni mayúsculas</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="p-5">
+            <label class="mb-2 block text-sm font-semibold" style="color: var(--ui-text-highlighted)">Comuna</label>
+            <div class="field-shell px-4 py-3.5" style="border-color: var(--ui-primary)">
+              <span class="text-[0.9375rem]" style="color: var(--ui-text-highlighted)">nun</span>
+            </div>
+            <div class="field-shell mt-2 overflow-hidden">
+              <div class="option-row" style="background: var(--ui-bg-accented)">
+                <span><strong style="color: var(--ui-primary)">Ñuñ</strong>oa</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- 4. sin coincidencias -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          C-001 · modo sin coincidencias
+          <small>escribió "nunoaa" — no matchea, pero el catálogo completo sigue disponible debajo</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="p-5">
+            <label class="mb-2 block text-sm font-semibold" style="color: var(--ui-text-highlighted)">Comuna</label>
+            <div class="field-shell px-4 py-3.5" style="border-color: var(--ui-primary)">
+              <span class="text-[0.9375rem]" style="color: var(--ui-text-highlighted)">nunoaa</span>
+            </div>
+            <p class="mt-2 px-1 text-sm" style="color: var(--ui-text-muted)">No encontramos "nunoaa"</p>
+            <div class="field-shell mt-2 overflow-hidden">
+              <div class="option-row"><span>Cerrillos</span></div>
+              <div class="option-row"><span>Cerro Navia</span></div>
+              <div class="option-row"><span>Estación Central</span></div>
+              <div class="option-row"><span>Las Condes</span></div>
+              <div class="option-row"><span>Ñuñoa</span></div>
+              <div class="option-row"><span>Providencia</span></div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- 5. cargando -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          C-001 · modo cargando
+          <small>primera carga del catálogo en la sesión — skeleton, no spinner</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="p-5">
+            <label class="mb-2 block text-sm font-semibold" style="color: var(--ui-text-highlighted)">Comuna</label>
+            <div class="field-shell px-4 py-3.5" style="border-color: var(--ui-primary)">
+              <span class="text-[0.9375rem]" style="color: var(--ui-text-dimmed)">¿Qué comuna buscas?</span>
+            </div>
+            <div class="field-shell mt-2 space-y-3 p-4">
+              <div class="skeleton-line" style="width: 70%"></div>
+              <div class="skeleton-line" style="width: 55%"></div>
+              <div class="skeleton-line" style="width: 65%"></div>
+              <div class="skeleton-line" style="width: 45%"></div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- 6. error -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          C-001 · modo error
+          <small>falló la carga del catálogo — reintentar vuelve a modo cargando</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="p-5">
+            <label class="mb-2 block text-sm font-semibold" style="color: var(--ui-text-highlighted)">Comuna</label>
+            <div class="field-shell px-4 py-3.5" style="border-color: var(--ui-primary)">
+              <span class="text-[0.9375rem]" style="color: var(--ui-text-dimmed)">¿Qué comuna buscas?</span>
+            </div>
+            <div class="field-shell mt-2 p-4 text-center">
+              <p class="text-sm" style="color: var(--ui-text-muted)">No pudimos cargar las comunas.</p>
+              <button
+                class="mt-3 rounded-xl px-5 py-2 text-sm font-bold text-white"
+                style="background: var(--ui-primary)"
+              >
+                Reintentar
+              </button>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  </body>
+</html>

--- a/docs/missions/03-taxonomia-categorias-y-comunas/design-mockups/comuna-select.html
+++ b/docs/missions/03-taxonomia-categorias-y-comunas/design-mockups/comuna-select.html
@@ -65,11 +65,11 @@
         </div>
       </section>
 
-      <!-- 2. abierto sin texto — lista completa -->
+      <!-- 2. enfocado sin texto — nada visible, como Mercado Libre -->
       <section class="frame frame-mobile">
         <div class="frame-label">
-          C-001 · modo abierto sin texto
-          <small>tocó el campo — aparece el catálogo activo completo, sin escribir nada</small>
+          C-001 · modo enfocado sin texto
+          <small>tocó el campo — no aparece ninguna lista todavía, igual que Mercado Libre; el catálogo se precarga en silencio</small>
         </div>
         <div class="frame-viewport">
           <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
@@ -82,16 +82,7 @@
                 class="w-full bg-transparent text-[0.9375rem] outline-none"
                 style="color: var(--ui-text-highlighted)"
               />
-            </div>
-            <div class="field-shell mt-2 overflow-hidden">
-              <div class="option-row"><span>Cerrillos</span></div>
-              <div class="option-row"><span>Cerro Navia</span></div>
-              <div class="option-row"><span>Estación Central</span></div>
-              <div class="option-row"><span>Las Condes</span></div>
-              <div class="option-row" style="background: var(--ui-bg-accented)"><span>Ñuñoa</span></div>
-              <div class="option-row"><span>Providencia</span></div>
-              <div class="option-row"><span>Puerto Varas</span></div>
-              <div class="option-row"><span>Vitacura</span></div>
+              <span class="animate-pulse" style="color: var(--ui-primary)">|</span>
             </div>
           </div>
         </div>
@@ -123,7 +114,7 @@
       <section class="frame frame-mobile">
         <div class="frame-label">
           C-001 · modo sin coincidencias
-          <small>escribió "nunoaa" — no matchea, pero el catálogo completo sigue disponible debajo</small>
+          <small>escribió "nunoaa" — no matchea nada; sin lista debajo, el catálogo nunca se muestra completo</small>
         </div>
         <div class="frame-viewport">
           <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
@@ -133,14 +124,6 @@
               <span class="text-[0.9375rem]" style="color: var(--ui-text-highlighted)">nunoaa</span>
             </div>
             <p class="mt-2 px-1 text-sm" style="color: var(--ui-text-muted)">No encontramos "nunoaa"</p>
-            <div class="field-shell mt-2 overflow-hidden">
-              <div class="option-row"><span>Cerrillos</span></div>
-              <div class="option-row"><span>Cerro Navia</span></div>
-              <div class="option-row"><span>Estación Central</span></div>
-              <div class="option-row"><span>Las Condes</span></div>
-              <div class="option-row"><span>Ñuñoa</span></div>
-              <div class="option-row"><span>Providencia</span></div>
-            </div>
           </div>
         </div>
       </section>
@@ -149,14 +132,14 @@
       <section class="frame frame-mobile">
         <div class="frame-label">
           C-001 · modo cargando
-          <small>primera carga del catálogo en la sesión — skeleton, no spinner</small>
+          <small>escribió antes de que la precarga en silencio terminara — skeleton, no spinner</small>
         </div>
         <div class="frame-viewport">
           <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
           <div class="p-5">
             <label class="mb-2 block text-sm font-semibold" style="color: var(--ui-text-highlighted)">Comuna</label>
             <div class="field-shell px-4 py-3.5" style="border-color: var(--ui-primary)">
-              <span class="text-[0.9375rem]" style="color: var(--ui-text-dimmed)">¿Qué comuna buscas?</span>
+              <span class="text-[0.9375rem]" style="color: var(--ui-text-highlighted)">nun</span>
             </div>
             <div class="field-shell mt-2 space-y-3 p-4">
               <div class="skeleton-line" style="width: 70%"></div>

--- a/docs/missions/03-taxonomia-categorias-y-comunas/experiencia.md
+++ b/docs/missions/03-taxonomia-categorias-y-comunas/experiencia.md
@@ -1,8 +1,8 @@
 # Misión 03: taxonomía de categorías y comunas — Experiencia
 
-**Estado:** en revisión
+**Estado:** vigente
 
-**Última actualización:** 2026-08-18
+**Última actualización:** 2026-08-18. **Aprobado por Patricio el:** 2026-08-18.
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
@@ -29,7 +29,7 @@ reglas.
 ## Componente — no es una vista propia
 
 - **C-001 — `ComunaSelect` / `CategoriaSelect`** · móvil / desktop · resuelve D-004 · flujo UXF-001 ·
-  en revisión
+  vigente
   - modo **cerrado** — el campo muestra el valor elegido (si hay uno) o el placeholder; nada más en
     pantalla.
   - modo **enfocado sin texto** — el usuario tocó el campo; el cursor queda activo, pero no aparece

--- a/docs/missions/03-taxonomia-categorias-y-comunas/experiencia.md
+++ b/docs/missions/03-taxonomia-categorias-y-comunas/experiencia.md
@@ -2,7 +2,7 @@
 
 **Estado:** en revisión
 
-**Última actualización:** 2026-08-17
+**Última actualización:** 2026-08-18
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
@@ -32,10 +32,11 @@ reglas.
   en revisión
   - modo **cerrado** — el campo muestra el valor elegido (si hay uno) o el placeholder; nada más en
     pantalla.
-  - modo **abierto sin texto** — el usuario tocó el campo; aparece debajo la lista completa de opciones
-    disponibles (comunas `activa = true`, o las 8 categorías), sin necesitar escribir nada.
-  - modo **abierto con coincidencias** — el usuario escribió algo; la lista se filtra en vivo a las
-    opciones que contienen el texto, sin distinguir mayúsculas ni tildes.
+  - modo **enfocado sin texto** — el usuario tocó el campo; el cursor queda activo, pero no aparece
+    ninguna lista todavía — igual que el selector de comuna de Mercado Libre, no se muestra nada hasta
+    que se empieza a escribir.
+  - modo **abierto con coincidencias** — el usuario escribió al menos una letra; aparece debajo la lista
+    filtrada a las opciones que contienen el texto, sin distinguir mayúsculas ni tildes.
   - modo **sin coincidencias** — lo que escribió no matchea ninguna opción del catálogo.
   - modo **cargando** — primera carga del catálogo (solo la primera vez que se abre el campo en la sesión).
   - modo **error** — la carga del catálogo falló.
@@ -48,13 +49,14 @@ alrededor de 33: Gran Santiago + Puerto Varas) y el placeholder.
 
 | Desde                   | Acción                              | Queda en                | Qué pasa con el trabajo                          |
 | ------------------------ | ------------------------------------ | ------------------------ | -------------------------------------------------- |
-| cerrado                  | toca el campo                        | abierto sin texto        | si ya había un valor, queda precargado como texto para editar |
-| abierto sin texto        | escribe una letra                    | abierto con coincidencias o sin coincidencias | el texto tipeado se conserva mientras escribe |
+| cerrado                  | toca el campo                        | enfocado sin texto       | si ya había un valor, queda precargado como texto para editar; el catálogo empieza a cargar en silencio, sin mostrar nada |
+| enfocado sin texto       | escribe una letra, catálogo ya disponible | abierto con coincidencias o sin coincidencias | el texto tipeado se conserva mientras escribe |
+| enfocado sin texto       | escribe una letra, catálogo aún cargando | cargando                | el texto tipeado se conserva; el filtro se aplica apenas termine de cargar |
 | abierto con coincidencias | toca/selecciona una opción           | cerrado                  | el valor elegido queda guardado con su id de catálogo |
-| sin coincidencias         | borra el texto                       | abierto sin texto        | vuelve a mostrar el catálogo completo               |
-| sin coincidencias         | toca una opción de la lista completa debajo del mensaje | cerrado | igual que seleccionar con coincidencias — el catálogo completo sigue visible aunque no matchee lo escrito |
+| sin coincidencias         | borra el texto hasta dejarlo vacío  | enfocado sin texto       | la lista desaparece, igual que al enfocar por primera vez |
 | abierto (cualquier modo) | toca fuera del campo, sin seleccionar | cerrado                 | si ya había un valor previo, se restaura; si no, queda vacío — el texto tipeado sin seleccionar se descarta |
-| cargando                 | termina la carga                     | abierto sin texto        | ninguno — recién ahí aparece la lista               |
+| cargando                 | termina la carga, sin texto tipeado mientras esperaba | enfocado sin texto | ninguno — el catálogo queda listo para filtrar en cuanto se escriba |
+| cargando                 | termina la carga, con texto ya tipeado mientras esperaba | abierto con coincidencias o sin coincidencias | se aplica el filtro sobre el texto que ya estaba escrito |
 | error                    | toca "Reintentar"                    | cargando                 | ninguno                                             |
 
 ## UXF-001 — Elegir categoría o comuna desde el catálogo
@@ -85,16 +87,16 @@ hover queda visualmente distinta del resto de la lista.
 
 | Paso | Acción                                    | Respuesta del sistema                                                | Información visible |
 | ---- | ------------------------------------------- | ------------------------------------------------------------------------ | ---------------------- |
-| 1    | Toca el campo (vacío o con un valor previo) | Se abre la lista completa de opciones disponibles debajo del campo       | Todas las opciones del catálogo activo, en orden alfabético |
-| 2    | Escribe (opcional)                          | La lista se filtra en vivo a las opciones que contienen el texto, sin distinguir mayúsculas ni tildes | Solo las opciones que matchean, resaltando la parte del texto que coincide |
+| 1    | Toca el campo (vacío o con un valor previo) | El cursor queda activo; no aparece ninguna lista todavía. El catálogo empieza a cargar en silencio | Si había un valor previo, queda como texto editable; si no, el placeholder |
+| 2    | Escribe al menos una letra                  | Aparece debajo la lista filtrada a las opciones que contienen el texto, sin distinguir mayúsculas ni tildes | Solo las opciones que matchean, resaltando la parte del texto que coincide |
 | 3    | Toca/selecciona una opción                  | El campo se cierra mostrando ese valor; aparece un ícono para volver a abrirlo | El valor elegido, en texto legible |
 
 ### Variantes y recuperación
 
 | Condición                             | Qué cambia                                              | Cómo se entiende                                  | Cómo se recupera |
 | ---------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------ | -------------------- |
-| Lo que escribió no matchea nada          | Aparece "No encontramos '<texto>'" arriba de la lista completa | El mensaje nombra exactamente lo que se escribió, no un genérico | Puede seguir escribiendo o tocar cualquier opción de la lista completa que sigue debajo |
-| El catálogo activo es chico (hoy ~33 comunas, 8 categorías) | La lista completa cabe sin scroll largo | No aplica — es el caso normal, no un estado especial | No aplica |
+| Lo que escribió no matchea nada          | Aparece "No encontramos '<texto>'" — sin lista debajo, el catálogo no se muestra completo en ningún momento | El mensaje nombra exactamente lo que se escribió, no un genérico | Puede seguir escribiendo o borrar para volver a "enfocado sin texto" |
+| Escribe antes de que el catálogo termine de cargar | El campo queda en modo cargando con el texto conservado | Skeleton de 4 líneas en vez de la lista filtrada | El filtro se aplica solo al terminar de cargar, sin que el usuario tenga que volver a escribir |
 | Conexión lenta al cargar el catálogo por primera vez | Skeleton de 4 líneas con la forma de una opción, no spinner | El skeleton ocupa el mismo espacio que la lista real, para que no salte el layout | Se resuelve solo cuando termina la carga |
 | Falla la carga del catálogo              | El campo muestra "No pudimos cargar las comunas" con botón "Reintentar" | Mensaje visible en el lugar donde iría la lista | Tocar "Reintentar" vuelve a modo cargando |
 | Intenta continuar el formulario sin seleccionar nada | El botón de acción principal del formulario permanece deshabilitado | El botón se ve visualmente inactivo, no aparece un error al tocarlo | Completar la selección habilita el botón |
@@ -114,8 +116,9 @@ hover queda visualmente distinta del resto de la lista.
 | ------------------------ | --------------------------------------------------------------------- | ---------------------------------------- |
 | cerrado, sin valor        | Placeholder: "¿Qué comuna buscas?" (ComunaSelect) o "¿Qué necesitas?" (CategoriaSelect) | Tocar para abrir |
 | cerrado, con valor        | El nombre elegido, ej. "Ñuñoa" o "Gasfitería"                        | Tocar para cambiar                       |
-| abierto, lista completa   | Todas las opciones activas, orden alfabético, ej. "Cerrillos", "Conchalí", "Estación Central"... | Escribir o tocar una opción |
-| abierto, sin coincidencias | "No encontramos 'nunoaa'" + la lista completa debajo                | Seguir escribiendo o tocar una opción del catálogo |
+| enfocado, sin texto       | Nada debajo del campo — ni lista ni mensaje, solo el cursor activo   | Escribir                                 |
+| abierto, con coincidencias | Las opciones que matchean lo escrito, con la coincidencia resaltada  | Tocar una opción o seguir escribiendo    |
+| abierto, sin coincidencias | "No encontramos 'nunoaa'" — sin lista debajo                        | Seguir escribiendo o borrar               |
 | carga                    | Skeleton de 4 líneas con la forma de una opción                      | Ninguna                                  |
 | error                    | "No pudimos cargar las comunas. Inténtalo de nuevo."                 | Botón "Reintentar"                       |
 
@@ -129,22 +132,27 @@ hover queda visualmente distinta del resto de la lista.
 
 | Decisión | Flujo   | Estados cubiertos                                                 | Estado  |
 | --------- | ------- | --------------------------------------------------------------------- | ------- |
-| D-004     | UXF-001 | cerrado, abierto sin texto, abierto con coincidencias, sin coincidencias, carga, error | vigente |
+| D-004     | UXF-001 | cerrado, enfocado sin texto, abierto con coincidencias, sin coincidencias, carga, error | vigente |
 
 ## Decisiones de experiencia
 
 <a id="ux-001"></a>
 
-### UX-001 — El componente muestra el catálogo completo al abrir, no espera a que se escriba algo
+### UX-001 — El componente no muestra nada hasta que el usuario empieza a escribir
 
-- **Estado:** aceptada. **Fecha:** 2026-08-17.
-- **Sustento:** D-002 — con solo ~33 comunas activas y 8 categorías, obligar a escribir antes de ver
-  cualquier opción agrega un paso sin necesidad; el catálogo es chico a propósito (cold start).
-- **Alternativas descartadas:** no mostrar nada hasta que el usuario escriba al menos una letra (patrón
-  común en catálogos grandes tipo Thumbtack) — tiene sentido con miles de opciones, no con 33; acá solo
-  agrega fricción a alguien que quiere tocar y elegir de una lista corta y reconocible.
-- **Decisión y consecuencia:** tocar el campo, sin escribir nada, ya muestra la lista completa de opciones
-  activas. Escribir es un atajo para achicarla, no un requisito para verla.
+- **Estado:** aceptada. **Fecha:** 2026-08-18.
+- **Sustento:** D-004 — el modelo de interacción ya declarado ahí es "al estilo del selector de comuna de
+  Mercado Libre", y ese selector no abre ninguna lista hasta que se escribe la primera letra. La primera
+  versión de esta decisión (mostrar el catálogo completo al enfocar) se apartaba de esa referencia sin un
+  motivo de Datealo que lo justificara — era una preferencia mía, no algo pedido.
+- **Alternativas descartadas:** mostrar el catálogo completo al enfocar, sin esperar texto (la primera
+  versión de esta decisión) — parecía razonable con un catálogo chico (~33 comunas activas, 8 categorías),
+  pero se apartaba sin necesidad del patrón de referencia que D-004 ya fijó, y agrega una lista completa en
+  pantalla en el primer toque cuando la mayoría de las veces la persona ya sabe qué va a escribir.
+- **Decisión y consecuencia:** tocar el campo no muestra nada — ni lista ni mensaje, solo el cursor activo.
+  El catálogo se precarga en silencio en ese momento (ver mapa de estados) para que, apenas se escriba la
+  primera letra, filtrar sea instantáneo la mayoría de las veces — el modo "cargando" solo aparece si esa
+  precarga no alcanzó a terminar.
 - **Impacto en producto:** ninguno — es una decisión de interacción, no cambia D-001/D-002/D-004.
 
 ## Preguntas

--- a/docs/missions/03-taxonomia-categorias-y-comunas/experiencia.md
+++ b/docs/missions/03-taxonomia-categorias-y-comunas/experiencia.md
@@ -1,183 +1,152 @@
-# Misión: <nombre> — Experiencia
+# Misión 03: taxonomía de categorías y comunas — Experiencia
 
-**Estado:** borrador
+**Estado:** en revisión
 
-**Última actualización:** AAAA-MM-DD
+**Última actualización:** 2026-08-17
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-<!--
-Fuente de verdad para flujos, estados, contenido e interacción. No redefine reglas de producto: si el
-diseño descubre una regla nueva o invalida una, abre o actualiza una decisión en producto.md.
+## Decisión de experiencia: un componente de búsqueda con catálogo cerrado, no una pantalla
 
-Núcleo obligatorio: vistas, mapa de estados, flujos críticos y estados por superficie. Las secciones bajo
-demanda (modelo mental, jerarquía de información, validación) se agregan solo cuando una decisión las
-necesita.
+Esta misión no tiene una vista propia — no hay una URL a la que alguien navegue. Lo que `producto.md`
+(D-004) pide es un **componente** que se embebe donde haga falta elegir categoría o comuna: el formulario
+de registro (misión 04) y el filtro de búsqueda (misión 06). Por eso esta sección reemplaza "Vistas y
+flujos de pantalla completa" por el diseño del componente mismo — sus modos son los mismos sin importar
+dónde se use.
 
-Gate de salida — experiencia.md está lista para ingenieria.md cuando:
-- cada flujo crítico tiene secuencia, variantes, recuperación y criterio de término
-- cada estado tiene contenido concreto (texto real, información visible, acción disponible)
-- cada vista lista sus modos, y el mapa de estados cubre todas las transiciones entre ellos
-- cada modo tiene su indicador permanente de estado, y cada flujo tiene todas sus salidas documentadas
-- los casos límite de producto.md tienen flujo o estado mapeado
-- cada flujo crítico está mockeado en móvil (390px), y en desktop si también vive ahí
-- ninguna pantalla queda descrita como "similar a X" sin especificar qué cambia
--->
+El modelo de interacción es un campo de búsqueda con autocompletado, al estilo del selector de comuna de
+Mercado Libre que mencionaste: se escribe, aparecen coincidencias del catálogo debajo, se elige una — nunca
+queda un valor sin elegir de la lista. En Nuxt UI (A-004) esto es `UInputMenu`, que ya trae el
+comportamiento de búsqueda resuelto — no hay que inventar la mecánica, solo especificar el contenido y las
+reglas.
 
-## Decisión de experiencia: <qué cambia para quien usa el producto>
+- **Decisiones cubiertas:** [D-004](./producto.md#d-004) (categoría/comuna siempre son referencia al
+  catálogo), [D-001](./producto.md#d-001) y [D-002](./producto.md#d-002) (qué contiene cada catálogo, el
+  campo `activa`).
+- **Pendiente bloqueante:** ninguna.
 
-<Modelo de interacción elegido, flujo más importante y la incertidumbre que sigue abierta.>
+## Componente — no es una vista propia
 
-- **Funcionalidades cubiertas:** F-001, <otras>.
-- **Pendiente bloqueante:** <pregunta o "ninguna">.
+- **C-001 — `ComunaSelect` / `CategoriaSelect`** · móvil / desktop · resuelve D-004 · flujo UXF-001 ·
+  en revisión
+  - modo **cerrado** — el campo muestra el valor elegido (si hay uno) o el placeholder; nada más en
+    pantalla.
+  - modo **abierto sin texto** — el usuario tocó el campo; aparece debajo la lista completa de opciones
+    disponibles (comunas `activa = true`, o las 8 categorías), sin necesitar escribir nada.
+  - modo **abierto con coincidencias** — el usuario escribió algo; la lista se filtra en vivo a las
+    opciones que contienen el texto, sin distinguir mayúsculas ni tildes.
+  - modo **sin coincidencias** — lo que escribió no matchea ninguna opción del catálogo.
+  - modo **cargando** — primera carga del catálogo (solo la primera vez que se abre el campo en la sesión).
+  - modo **error** — la carga del catálogo falló.
 
-## Vistas
-
-<!--
-El listado de pantallas que define la experiencia — el mapa que se entrega antes de los flujos. Una línea
-por vista, sin tabla, con sus modos anidados debajo. Una vista es un destino: se llega a ella. Un modo es
-un estado de esa vista que cambia qué se puede hacer y qué se ve — se anida, nunca se lista como vista
-hermana.
-
-El porqué de cada vista, su trade-off o su justificación no van aquí: viven en su flujo (UXF) o en una
-decisión (UX-xxx). Regla de formato para todo el documento: las tablas se reservan para índices de celdas
-cortas; lo que lleva justificación extensa va en secciones con header + bullets, nunca en una celda.
--->
-
-- **V-001 — <vista>** · móvil / desktop · resuelve F-001 · flujos UXF-001 · pendiente
-  - modo **<nombre>** — <qué lo distingue y qué se puede hacer en él>
-  - modo **<nombre>** — <ídem>
+Los dos componentes (`ComunaSelect`, `CategoriaSelect`) comparten estos seis modos — la única diferencia es
+el tamaño del catálogo que filtran (8 categorías siempre activas vs. las comunas `activa = true`, hoy
+alrededor de 33: Gran Santiago + Puerto Varas) y el placeholder.
 
 ## Mapa de estados
 
-<!--
-Vistas y flujos son listas, y una lista no muestra un camino. Esta tabla conecta los modos: qué acción
-lleva de uno a otro y qué pasa con el trabajo del usuario en cada salto. Cada fila que falte es una
-pregunta que ingeniería resuelve inventando.
--->
+| Desde                   | Acción                              | Queda en                | Qué pasa con el trabajo                          |
+| ------------------------ | ------------------------------------ | ------------------------ | -------------------------------------------------- |
+| cerrado                  | toca el campo                        | abierto sin texto        | si ya había un valor, queda precargado como texto para editar |
+| abierto sin texto        | escribe una letra                    | abierto con coincidencias o sin coincidencias | el texto tipeado se conserva mientras escribe |
+| abierto con coincidencias | toca/selecciona una opción           | cerrado                  | el valor elegido queda guardado con su id de catálogo |
+| sin coincidencias         | borra el texto                       | abierto sin texto        | vuelve a mostrar el catálogo completo               |
+| sin coincidencias         | toca una opción de la lista completa debajo del mensaje | cerrado | igual que seleccionar con coincidencias — el catálogo completo sigue visible aunque no matchee lo escrito |
+| abierto (cualquier modo) | toca fuera del campo, sin seleccionar | cerrado                 | si ya había un valor previo, se restaura; si no, queda vacío — el texto tipeado sin seleccionar se descarta |
+| cargando                 | termina la carga                     | abierto sin texto        | ninguno — recién ahí aparece la lista               |
+| error                    | toca "Reintentar"                    | cargando                 | ninguno                                             |
 
-| Desde  | Acción             | Queda en | Qué pasa con el trabajo              |
-| ------ | ------------------ | -------- | ------------------------------------ |
-| <modo> | <acción concreta>  | <modo>   | <qué se aplicó, qué quedó pendiente> |
-| <modo> | <salir sin cerrar> | <modo>   | <qué se pierde o se conserva>        |
+## UXF-001 — Elegir categoría o comuna desde el catálogo
 
-## UXF-001 — <flujo principal en verbo>
+**Objetivo:** que la persona termine con un valor de categoría o comuna válido, sin poder guardar texto que
+no exista en el catálogo. **Contrato:** [D-004](./producto.md#d-004).
 
-<!--
-Duplica por flujo crítico. Cada paso describe acción → respuesta al nivel de "el usuario toca X → Datealo
-muestra Y". Un mockup no reemplaza la secuencia porque no explica estados ni recuperación.
--->
+**Punto de entrada:** cualquier formulario que necesite un valor de categoría o comuna. Hoy no hay ninguno
+construido — este documento especifica el componente para que la misión 04 (registro) y la misión 06
+(búsqueda) lo embeban igual, sin diseñarlo cada una por su lado.
 
-**Objetivo:** <qué se completa o comprende>. **Contrato:** [F-001](./producto.md#f-001).
+**Criterio de término:** el campo tiene un valor elegido de la lista, identificado por su id de catálogo —
+no basta con que el texto visible coincida con el nombre de una opción.
 
-**Punto de entrada:** <estado y superficie inicial, y qué acción trae al usuario hasta acá>.
-
-**Criterio de término:** <estado observable que confirma que el flujo terminó bien>.
-
-**Cómo sabe el usuario dónde está:** <el elemento concreto y permanente en pantalla que se lo dice, por
-cada modo que toca este flujo>.
+**Cómo sabe el usuario dónde está:** el campo cerrado muestra el valor elegido como texto legible (el
+nombre de la categoría o comuna, nunca un id). Mientras está abierto, la opción resaltada por teclado o por
+hover queda visualmente distinta del resto de la lista.
 
 ### Salidas
 
-<!--
-Todas las formas de irse, no solo terminar bien. El criterio de término cubre la salida buena; las otras
-son las que el usuario encuentra primero. Un modo del que no se sabe salir es un modo donde el usuario se
-pierde.
--->
-
-| Salida                | Cómo se ejecuta       | Qué queda del trabajo           |
-| --------------------- | --------------------- | ------------------------------- |
-| <termina bien>        | <acción>              | <qué se aplicó y dónde>         |
-| <descarta>            | <acción, Esc, cerrar> | <nada, ni a medias>             |
-| <abandona sin cerrar> | <navega a otra parte> | <se conserva, se pierde, avisa> |
+| Salida                              | Cómo se ejecuta                          | Qué queda del trabajo                            |
+| ------------------------------------ | ------------------------------------------ | --------------------------------------------------- |
+| Termina bien                        | toca/selecciona una opción de la lista    | el valor queda aplicado en el campo, cerrado        |
+| Descarta sin seleccionar            | toca fuera del campo (blur), tecla Esc    | vuelve al valor que tenía antes, o queda vacío — nunca guarda el texto tipeado |
+| Abandona sin cerrar (navega afuera) | cierra la pestaña, va a otra pantalla     | lo maneja el formulario que contiene el componente (misión 04/06), no este documento |
 
 ### Secuencia principal
 
-| Paso | Acción            | Respuesta del sistema         | Información visible |
-| ---- | ----------------- | ----------------------------- | ------------------- |
-| 1    | <acción concreta> | <feedback o cambio de estado> | <dato y jerarquía>  |
+| Paso | Acción                                    | Respuesta del sistema                                                | Información visible |
+| ---- | ------------------------------------------- | ------------------------------------------------------------------------ | ---------------------- |
+| 1    | Toca el campo (vacío o con un valor previo) | Se abre la lista completa de opciones disponibles debajo del campo       | Todas las opciones del catálogo activo, en orden alfabético |
+| 2    | Escribe (opcional)                          | La lista se filtra en vivo a las opciones que contienen el texto, sin distinguir mayúsculas ni tildes | Solo las opciones que matchean, resaltando la parte del texto que coincide |
+| 3    | Toca/selecciona una opción                  | El campo se cierra mostrando ese valor; aparece un ícono para volver a abrirlo | El valor elegido, en texto legible |
 
 ### Variantes y recuperación
 
-| Condición          | Qué cambia              | Cómo se entiende    | Cómo se recupera             |
-| ------------------ | ----------------------- | ------------------- | ---------------------------- |
-| <sin resultados>   | <estado>                | <mensaje concreto>  | <acción disponible>          |
-| <sin permiso de ubicación> | <comportamiento> | <indicador visible> | <alternativa manual>         |
-| <conexión lenta>   | <skeleton, no spinner>  | <qué se ve mientras>| <qué pasa si falla>          |
+| Condición                             | Qué cambia                                              | Cómo se entiende                                  | Cómo se recupera |
+| ---------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------ | -------------------- |
+| Lo que escribió no matchea nada          | Aparece "No encontramos '<texto>'" arriba de la lista completa | El mensaje nombra exactamente lo que se escribió, no un genérico | Puede seguir escribiendo o tocar cualquier opción de la lista completa que sigue debajo |
+| El catálogo activo es chico (hoy ~33 comunas, 8 categorías) | La lista completa cabe sin scroll largo | No aplica — es el caso normal, no un estado especial | No aplica |
+| Conexión lenta al cargar el catálogo por primera vez | Skeleton de 4 líneas con la forma de una opción, no spinner | El skeleton ocupa el mismo espacio que la lista real, para que no salte el layout | Se resuelve solo cuando termina la carga |
+| Falla la carga del catálogo              | El campo muestra "No pudimos cargar las comunas" con botón "Reintentar" | Mensaje visible en el lugar donde iría la lista | Tocar "Reintentar" vuelve a modo cargando |
+| Intenta continuar el formulario sin seleccionar nada | El botón de acción principal del formulario permanece deshabilitado | El botón se ve visualmente inactivo, no aparece un error al tocarlo | Completar la selección habilita el botón |
 
 ### Decisiones que no deben quedar implícitas
 
-- <qué ocurre al cancelar, volver atrás, reintentar o confirmar>.
-- <qué cambio se guarda inmediato y cuál necesita confirmación>.
+- Si ya había un valor elegido y el usuario vuelve a tocar el campo, el valor previo se precarga como
+  texto editable — no se borra a ciegas ni obliga a escribir desde cero.
+- El componente nunca ofrece "crear" una opción que no está en el catálogo — a diferencia de un combobox
+  genérico que a veces agrega "crear '<texto>'", acá esa opción no existe, es la garantía de D-004.
+- Una comuna con `activa = false` no aparece en absoluto en la lista — no se muestra deshabilitada ni con
+  una nota, simplemente no está (ver [CL-004](./producto.md) de producto).
 
 ## Estados por superficie
 
-<!--
-El contenido es concreto: texto real, no "mensaje apropiado". El estado vacío de un marketplace
-pre-lanzamiento no es un detalle: para muchas búsquedas será el estado principal durante meses.
--->
-
-| Estado  | Qué se muestra (texto e información real) | Acción disponible                   |
-| ------- | ----------------------------------------- | ----------------------------------- |
-| inicial | <contenido>                               | <acción>                            |
-| vacío   | <por qué está vacío, con texto concreto>  | <cómo avanzar, o ninguna y por qué> |
-| carga   | <skeleton de qué forma>                   | <ninguna>                           |
-| error   | <causa útil y alcance>                    | <recuperación>                      |
+| Estado                 | Qué se muestra (texto e información real)                         | Acción disponible                     |
+| ------------------------ | --------------------------------------------------------------------- | ---------------------------------------- |
+| cerrado, sin valor        | Placeholder: "¿Qué comuna buscas?" (ComunaSelect) o "¿Qué necesitas?" (CategoriaSelect) | Tocar para abrir |
+| cerrado, con valor        | El nombre elegido, ej. "Ñuñoa" o "Gasfitería"                        | Tocar para cambiar                       |
+| abierto, lista completa   | Todas las opciones activas, orden alfabético, ej. "Cerrillos", "Conchalí", "Estación Central"... | Escribir o tocar una opción |
+| abierto, sin coincidencias | "No encontramos 'nunoaa'" + la lista completa debajo                | Seguir escribiendo o tocar una opción del catálogo |
+| carga                    | Skeleton de 4 líneas con la forma de una opción                      | Ninguna                                  |
+| error                    | "No pudimos cargar las comunas. Inténtalo de nuevo."                 | Botón "Reintentar"                       |
 
 ## Mockups
 
-<!--
-Los mockups viven en design-mockups/ como HTML (ver el skill discovery-ux y docs/design/README.md).
-Exploran o materializan una decisión; no son fuente de verdad de reglas de producto.
--->
-
-| Mockup   | Cubre   | Estado                 | Ruta                              |
-| -------- | ------- | ---------------------- | --------------------------------- |
-| <nombre> | UXF-001 | exploración o validado | `./design-mockups/<archivo>.html` |
+| Mockup         | Cubre   | Estado    | Ruta                                            |
+| ---------------- | ------- | --------- | -------------------------------------------------- |
+| Selector de comuna | UXF-001 | validado | `./design-mockups/comuna-select.html`             |
 
 ## Cobertura
 
-<!-- Detecta huecos antes de construir. Una funcionalidad sin pantalla nueva igual tiene estados. -->
-
-| Funcionalidad | Flujo   | Estados cubiertos       | Estado    |
-| ------------- | ------- | ----------------------- | --------- |
-| F-001         | UXF-001 | principal, vacío, error | pendiente |
-
-## Secciones bajo demanda
-
-<!--
-Agregar solo cuando una decisión las necesite, con estos títulos:
-
-- "Modelo mental y lenguaje": cuando un concepto de producto pueda confundirse en la interfaz.
-- "Jerarquía de información": cuando una superficie densa exija decidir qué se ve primero (una card de
-  resultado con foto, rating, distancia, precio y disponibilidad es exactamente ese caso).
-- "Validación (UXV-xxx)": cuando una incertidumbre de diseño necesite prueba con usuarios.
-- "Accesibilidad y adaptación": cuando el contexto de uso cambie el flujo o la representación.
--->
+| Decisión | Flujo   | Estados cubiertos                                                 | Estado  |
+| --------- | ------- | --------------------------------------------------------------------- | ------- |
+| D-004     | UXF-001 | cerrado, abierto sin texto, abierto con coincidencias, sin coincidencias, carga, error | vigente |
 
 ## Decisiones de experiencia
 
 <a id="ux-001"></a>
 
-### UX-001 — <decisión en una frase>
+### UX-001 — El componente muestra el catálogo completo al abrir, no espera a que se escriba algo
 
-- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
-- **Sustento:** F-001 o <hallazgo>.
-- **Alternativas descartadas:** <opciones relevantes y trade-off, con el porqué del rechazo>.
-- **Decisión y consecuencia:** <qué flujo o superficie cambia>.
-- **Impacto en producto:** <ninguno o enlace a D-xxx/F-xxx actualizado>.
+- **Estado:** aceptada. **Fecha:** 2026-08-17.
+- **Sustento:** D-002 — con solo ~33 comunas activas y 8 categorías, obligar a escribir antes de ver
+  cualquier opción agrega un paso sin necesidad; el catálogo es chico a propósito (cold start).
+- **Alternativas descartadas:** no mostrar nada hasta que el usuario escriba al menos una letra (patrón
+  común en catálogos grandes tipo Thumbtack) — tiene sentido con miles de opciones, no con 33; acá solo
+  agrega fricción a alguien que quiere tocar y elegir de una lista corta y reconocible.
+- **Decisión y consecuencia:** tocar el campo, sin escribir nada, ya muestra la lista completa de opciones
+  activas. Escribir es un atajo para achicarla, no un requisito para verla.
+- **Impacto en producto:** ninguno — es una decisión de interacción, no cambia D-001/D-002/D-004.
 
 ## Preguntas
 
-<!--
-Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
-Estado: abierta | resuelta AAAA-MM-DD | disuelta AAAA-MM-DD. Solo las abiertas llevan bloque de detalle.
--->
-
-<Una frase que responde "¿qué falta?": la pregunta que bloquea construcción y qué bloquea.>
-
-| ID      | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
-| ------- | ---------------------- | ------------------- | --------------------------------------------------------------- |
-| UXQ-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
-| UXQ-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |
+Ninguna abierta.

--- a/docs/missions/README.md
+++ b/docs/missions/README.md
@@ -11,7 +11,7 @@ abrieron y de dónde salió cada una.
 | --- | ------ | ---- | ------- | ------ | ------- | ------- |
 | 01  | [migración a Nuxt UI](./01-migracion-nuxt-ui/) | técnica | 2026-08-11 | cerrada 2026-08-13 | — | A-004 |
 | 02  | [base de datos, Auth y correo (config)](./02-base-de-datos-y-auth/) | técnica | 2026-08-13 | cerrada 2026-08-17 | — | A-001, A-002, A-003 |
-| 03  | [taxonomía: categorías y comunas](./03-taxonomia-categorias-y-comunas/) | producto | 2026-08-13 | definición | Experiencia | — |
+| 03  | [taxonomía: categorías y comunas](./03-taxonomia-categorias-y-comunas/) | producto | 2026-08-13 | definición | Ingeniería | — |
 | 04  | [registro y perfil de profesional](./04-registro-perfil-profesional/) | producto | 2026-08-13 | exploración | — | — |
 | 05  | [perfil público de profesional](./05-perfil-publico-profesional/) | producto | 2026-08-13 | exploración | — | — |
 | 06  | [búsqueda y resultados](./06-busqueda-resultados/) | producto | 2026-08-13 | exploración | — | — |


### PR DESCRIPTION
## Resumen

`experiencia.md` de la misión 03, en revisión — diseña el componente compartido `ComunaSelect`/`CategoriaSelect` que D-004 (producto.md) exige: un selector con catálogo cerrado, nunca texto libre.

- **6 modos**: cerrado, abierto sin texto (catálogo completo visible al tocar, sin necesitar escribir), abierto con coincidencias, sin coincidencias, cargando, error.
- **UXF-001**: flujo completo con punto de entrada, secuencia, salidas (termina bien / descarta / abandona) y recuperación de cada variante.
- **UX-001**: decisión de mostrar el catálogo completo al abrir el campo en vez de esperar a que se escriba algo — tiene sentido con ~33 comunas activas y 8 categorías, no aplicaría con un catálogo de miles.
- **Mockup**: los 6 modos en `design-mockups/comuna-select.html`, también publicado como artifact para revisión rápida: https://claude.ai/code/artifact/30c37078-f15c-4cbb-82b5-dd2ddc52aeb7

## Test plan

- [x] Sigue la estructura del template (`docs/missions/template/experiencia.md`)
- [x] Cada modo del componente tiene mockup (los 6, en un frame por modo)
- [x] Casos límite de `producto.md` (CL-001, CL-002, CL-004) tienen comportamiento mapeado
- [x] README de la misión 03 actualizado

🤖 Generated with [Claude Code](https://claude.com/claude-code)