### PR TITLE
docs: redactar ingenieria.md de la misión 03

### DIFF
--- a/docs/missions/03-taxonomia-categorias-y-comunas/README.md
+++ b/docs/missions/03-taxonomia-categorias-y-comunas/README.md
@@ -2,22 +2,22 @@
 
 **Tipo:** producto. **Abierta el** 2026-08-13. **Nace de:** ninguna.
 
-**Estado de la misión:** definición
+**Estado de la misión:** lista para construir
 
 **Última actualización:** 2026-08-18
 
 Segunda de seis misiones hacia el MVP (registrarse, mostrarse, buscar, reseñar). Depende de
 [misión 02](../02-base-de-datos-y-auth/), ya cerrada, para poder guardar algo.
 
-| Documento     | Estado    | Qué falta para su gate              |
-| ------------- | --------- | ------------------------------------ |
-| Investigación | activo    | se acumula, no bloquea — el problema tiene situación y consecuencia concretas, hay 3 conclusiones (C-001 a C-003) y un ideal con capacidades observables |
-| Producto      | vigente   | aprobado por Patricio el 2026-08-17 — D-001 a D-004 aceptadas, Q-001 y Q-002 resueltas |
-| Experiencia   | vigente   | aprobado por Patricio el 2026-08-18 — componente `ComunaSelect`/`CategoriaSelect` (UXF-001), 6 modos con mockup |
-| Ingeniería    | en revisión | aprobación de Patricio sobre el modelo de datos, contratos y el plan de construcción (S-001 a S-004) |
+| Documento     | Estado  | Qué falta para su gate              |
+| ------------- | ------- | ------------------------------------ |
+| Investigación | activo  | se acumula, no bloquea — el problema tiene situación y consecuencia concretas, hay 3 conclusiones (C-001 a C-003) y un ideal con capacidades observables |
+| Producto      | vigente | aprobado por Patricio el 2026-08-17 — D-001 a D-004 aceptadas, Q-001 y Q-002 resueltas |
+| Experiencia   | vigente | aprobado por Patricio el 2026-08-18 — componente `ComunaSelect`/`CategoriaSelect` (UXF-001), 6 modos con mockup |
+| Ingeniería    | vigente | aprobado por Patricio el 2026-08-18 — T-001 a T-003 aceptadas, plan de construcción S-001 a S-004 |
 
-**Próximo hito:** que Patricio apruebe o ajuste `ingenieria.md` — el último documento antes de crear los
-issues y cerrar la misión. Sin fecha límite todavía.
+**Próximo hito:** crear los issues S-001 a S-004 desde el plan de construcción y empezar a construir. Sin
+fecha límite todavía.
 
 ## Brief
 

--- a/docs/missions/03-taxonomia-categorias-y-comunas/README.md
+++ b/docs/missions/03-taxonomia-categorias-y-comunas/README.md
@@ -14,10 +14,10 @@ Segunda de seis misiones hacia el MVP (registrarse, mostrarse, buscar, reseñar)
 | Investigación | activo    | se acumula, no bloquea — el problema tiene situación y consecuencia concretas, hay 3 conclusiones (C-001 a C-003) y un ideal con capacidades observables |
 | Producto      | vigente   | aprobado por Patricio el 2026-08-17 — D-001 a D-004 aceptadas, Q-001 y Q-002 resueltas |
 | Experiencia   | vigente   | aprobado por Patricio el 2026-08-18 — componente `ComunaSelect`/`CategoriaSelect` (UXF-001), 6 modos con mockup |
-| Ingeniería    | pendiente | —                                     |
+| Ingeniería    | en revisión | aprobación de Patricio sobre el modelo de datos, contratos y el plan de construcción (S-001 a S-004) |
 
-**Próximo hito:** escribir `ingenieria.md` — modelo de datos de `categorias`/`comunas` y el componente
-`ComunaSelect`/`CategoriaSelect` en Vue. Sin fecha límite todavía.
+**Próximo hito:** que Patricio apruebe o ajuste `ingenieria.md` — el último documento antes de crear los
+issues y cerrar la misión. Sin fecha límite todavía.
 
 ## Brief
 

--- a/docs/missions/03-taxonomia-categorias-y-comunas/ingenieria.md
+++ b/docs/missions/03-taxonomia-categorias-y-comunas/ingenieria.md
@@ -11,8 +11,9 @@
 compartido compuesto por dos wrappers
 
 Dos tablas nuevas (`categorias`, `comunas`), cada una con el campo `activa` que D-001/D-002 piden. Dos
-endpoints `GET` de solo lectura, sin autenticación (son catálogo público, no datos de usuario). Dos
-composables que los consumen con cache, y un componente Vue (`CatalogSelect`) que implementa el contrato de
+endpoints `GET` de solo lectura, sin autenticación (son catálogo público, no datos de usuario). Un
+composable genérico (`useCatalogFetch`) que los consume con cache, y un componente Vue (`CatalogSelect`) que
+implementa el contrato de
 D-004 sobre `UInputMenu` de Nuxt UI (A-004) — ya trae resuelto el autocompletado, lo que se construye acá
 es el contenido y las reglas: catálogo cerrado, nada visible hasta escribir. `CategoriaSelect` y
 `ComunaSelect` son dos wrappers delgados que lo componen, no dos copias de la misma lógica (ver T-003).
@@ -45,10 +46,24 @@ enfocado/filtrado/selección.
 | -------------------------------------- | ------------------------------------------------------ | -------------------------------------------- | -------------- |
 | `server/db/schema/taxonomia.ts`        | Forma de las tablas                                     | Qué filas existen (eso es el seed)          | D-001, D-002   |
 | `server/utils/taxonomia.ts`             | Queries: solo filas `activa = true`, columnas públicas | Presentación, formato del texto              | D-001, D-002   |
-| `server/api/categorias.get.ts` / `comunas.get.ts` | I/O: llama la query, devuelve JSON              | Filtrar por texto (eso lo hace el cliente)    | TC-001, TC-002 |
-| `app/composables/useCategoriasCatalog.ts` / `useComunasCatalog.ts` | Fetch con cache, expone `pending`/`error` | Cuándo mostrar la lista (eso es el componente) | TC-003         |
+| `server/api/categorias.get.ts` / `comunas.get.ts` | I/O: llama la query, devuelve JSON — dos archivos porque Nitro enruta por archivo, no porque haya lógica distinta | Filtrar por texto (eso lo hace el cliente) | TC-001, TC-002 |
+| `app/composables/useCatalogFetch.ts`   | Fetch con cache y manejo de error, genérico — no sabe si trae categorías o comunas | De dónde viene el endpoint (eso lo fija cada wrapper) | TC-003 |
+| `app/composables/useCategoriasCatalog.ts` / `useComunasCatalog.ts` | Fijar `key` y `endpoint` para `useCatalogFetch` — una línea cada uno | Cómo se cachea o qué pasa si falla (eso ya lo resolvió `useCatalogFetch`) | TC-003 |
 | `app/components/CatalogSelect.vue`     | Los 6 modos de UXF-001, sobre `UInputMenu` — recibe `items`/`pending`/`error`/`placeholder` por props, nunca sabe si es categoría o comuna | De dónde vienen los datos | D-004, UX-001, TC-004 |
 | `app/components/CategoriaSelect.vue` / `ComunaSelect.vue` | Conectar su composable con `CatalogSelect` — ninguna lógica de interacción propia | Cómo se ve o se comporta el selector (eso ya lo resolvió `CatalogSelect`) | TC-004 |
+
+Fetch (`useCatalogFetch`) y componente (`CatalogSelect`) siguen la misma forma a propósito: una
+implementación genérica que no sabe si es categoría o comuna, y un wrapper de una línea por entidad. Es el
+mismo principio (T-003) aplicado dos veces, no dos decisiones distintas.
+
+**La capa de queries (`server/utils/taxonomia.ts`) queda afuera de este patrón, a propósito.** Ahí las dos
+funciones difieren en los nombres de columna que le pasan a Drizzle (`categorias.slug` vs `comunas.codigo`)
+— typescript necesita esos nombres literales para tipar el resultado. Forzar una función genérica ahí
+cambia columnas explícitas y tipadas por un parámetro genérico sin ese tipo, que es exactamente la
+protección que Drizzle existe para dar. Dos funciones de cinco líneas cada una, en el mismo archivo, no es
+el problema que D-004 vino a resolver — el problema era código repetido *en lugares distintos* que se
+desincroniza sin que nadie lo note; esto es código repetido *en el mismo archivo*, a la vista, con una
+diferencia real (el tipo) entre las dos copias.
 
 No hay diagrama: son cinco capas en línea recta (schema → query → endpoint → composable → componentes),
 sin ramificaciones ni servicios externos de por medio. `CategoriaSelect`/`ComunaSelect` son la única
@@ -78,16 +93,26 @@ bifurcación, y es deliberada: comparten `CatalogSelect` por composición, no po
 - **Errores:** igual que TC-001.
 - **Contrato de producto:** [D-002](./producto.md#d-002), [D-004](./producto.md#d-004).
 
-### TC-003 — `useCategoriasCatalog()` / `useComunasCatalog()`
+### TC-003 — `useCatalogFetch()`, compuesto por `useCategoriasCatalog()` / `useComunasCatalog()`
 
-- **Entrada:** ninguna.
-- **Salida:** `{ items: Ref<{slug, nombre}[]>, pending: Ref<boolean>, error: Ref<boolean> }` (comunas:
-  mismo shape con `codigo` en vez de `slug`).
+Mismo problema que TC-004, un nivel más abajo: pedir un catálogo con cache y manejo de error es una sola
+lógica, no dos. `useCatalogFetch(key, endpoint)` la implementa una vez; `useCategoriasCatalog()` y
+`useComunasCatalog()` son una línea cada uno, solo fijando su `key` y su `endpoint` — igual que
+`CategoriaSelect`/`ComunaSelect` respecto de `CatalogSelect`.
+
+- **Entrada de `useCatalogFetch(key, endpoint)`:** `key: string` (para `useAsyncData`), `endpoint: string`
+  (la ruta a pedir).
+- **Entrada de `useCategoriasCatalog()` / `useComunasCatalog()`:** ninguna — cada uno llama internamente a
+  `useCatalogFetch('categorias', '/api/categorias')` o `useCatalogFetch('comunas', '/api/comunas')`.
+- **Salida (las tres):** `{ items: Ref<{value: string, label: string}[]>, pending: Ref<boolean>, error: Ref<boolean>, refresh: () => void }`.
+  `useCatalogFetch` no sabe si el `value` es un `slug` o un `codigo` — normaliza la respuesta del endpoint
+  (`slug`/`nombre` o `codigo`/`nombre`) a esa forma genérica, que es la que espera `items` en `CatalogSelect`
+  (TC-004).
 - **Invariantes:** el fetch ocurre una sola vez por sesión de navegación — `useAsyncData` con una key fija
   comparte el resultado entre todos los componentes que lo usen, así que abrir `CategoriaSelect` en dos
   formularios distintos de la misma página no dispara dos requests.
-- **Errores:** `error` pasa a `true` si el fetch falla; el composable no reintenta solo, expone `refresh()`
-  para que el componente lo dispare desde el botón "Reintentar" (ver `experiencia.md`, modo error).
+- **Errores:** `error` pasa a `true` si el fetch falla; no reintenta solo, expone `refresh()` para que
+  `CatalogSelect` lo dispare desde el botón "Reintentar" (ver `experiencia.md`, modo error).
 - **Contrato de producto:** soporte de [D-004](./producto.md#d-004).
 
 ### TC-004 — `<CatalogSelect>`, compuesto por `<CategoriaSelect>` / `<ComunaSelect>`
@@ -189,7 +214,7 @@ prueba.
 | ----- | ------------------------------------------------------------- | --------------------- | ------------------------------------------------------------------------------------ | ---------- |
 | S-001 | Tablas `categorias` y `comunas` con RLS y seed completo        | D-001, D-002, TR-001 | `select count(*) from comunas` = 346; `select count(*) from categorias` = 8; Gran Santiago (32) + Puerto Varas activas en `comunas`, las 8 categorías activas | — |
 | S-002 | Endpoints `GET /api/categorias` y `GET /api/comunas`            | TC-001, TC-002        | Cada endpoint devuelve solo filas `activa = true`, ordenadas por nombre               | S-001 |
-| S-003 | Composables `useCategoriasCatalog()` y `useComunasCatalog()`    | TC-003                | Montar dos componentes que usan el mismo composable en la misma página dispara un solo request | S-002 |
+| S-003 | `useCatalogFetch()` y sus wrappers `useCategoriasCatalog()`/`useComunasCatalog()` | TC-003 | Montar dos componentes que usan el mismo wrapper en la misma página dispara un solo request; ninguno de los dos wrappers pasa de una línea | S-002 |
 | S-004 | Componente `CatalogSelect.vue` con los 6 modos de `experiencia.md` | TC-004, D-004, UXF-001, UX-001 | Test unitario (Vitest + Vue Test Utils) verifica los 6 modos y que nunca emite un valor fuera de `items` | S-003 |
 | S-005 | `CategoriaSelect.vue` y `ComunaSelect.vue`, componiendo `CatalogSelect` | TC-004 | Cada uno monta `CatalogSelect` pasándole su composable — cero lógica de interacción propia, verificable con un diff que no toca `CatalogSelect` | S-004 |
 
@@ -238,25 +263,31 @@ específico de categoría o comuna colado adentro.
 
 <a id="t-003"></a>
 
-### T-003 — `CategoriaSelect`/`ComunaSelect` componen `CatalogSelect`, no duplican su lógica
+### T-003 — Categoría y comuna nunca tienen lógica duplicada entre archivos: una implementación genérica
+por capa, un wrapper de una línea por entidad
 
 - **Estado:** propuesta. **Fecha:** 2026-08-18.
 - **Contratos:** D-004, [UX-001](./experiencia.md#ux-001-el-componente-no-muestra-nada-hasta-que-el-usuario-empieza-a-escribir).
-- **Alternativas descartadas:** cada componente implementa sus propios 6 modos por separado — es lo que se
-  proponía en la primera versión de este documento. Funciona, pero duplica la única regla que D-004 definió
-  como una sola cosa para las dos entidades; un cambio a esa regla (un modo nuevo, un ajuste al debounce)
-  se tendría que aplicar dos veces y sincronizar a mano. Un mixin o un composable que devuelva solo el
-  estado (sin el markup) — deja la mitad de la lógica compartida (el estado) y la otra mitad duplicada (el
-  template con sus seis variantes de UI), que es donde vive la mayoría del riesgo de que las dos
+- **Alternativas descartadas:** cada capa implementa su versión para categoría y su versión para comuna por
+  separado — es lo que proponía la primera versión de este documento, tanto para el componente
+  (`CategoriaSelect`/`ComunaSelect` con los 6 modos cada uno) como para el fetch
+  (`useCategoriasCatalog`/`useComunasCatalog` con su propio `useAsyncData` cada uno). Funciona, pero duplica
+  la única regla que D-004 definió como una sola cosa para las dos entidades; un cambio a esa regla (un modo
+  nuevo, un ajuste al debounce) se tendría que aplicar dos veces y sincronizar a mano. Un mixin o un
+  composable que devuelva solo el estado (sin el markup del componente) — deja la mitad de la lógica
+  compartida y la otra mitad duplicada, que es donde vive la mayoría del riesgo de que las dos
   implementaciones diverjan.
-- **Decisión y consecuencias:** `CatalogSelect.vue` es la única implementación de UXF-001. `CategoriaSelect`
-  y `ComunaSelect` son componentes de una sola responsabilidad — conectar su composable con
-  `CatalogSelect` — sin markup ni lógica de interacción propia. Beneficio: un cambio a D-004/UX-001 se hace
-  una vez. Costo aceptado: agregar un tercer archivo por lo que a simple vista son "dos componentes
-  parecidos" — se acepta porque la alternativa es la duplicación exacta que esta misión existe para evitar
-  en los datos, ahora también en el componente.
-- **Reapertura:** si `CategoriaSelect` o `ComunaSelect` necesitan alguna vez una regla que no aplique a la
-  otra — ahí `CatalogSelect` deja de ser una talla única y esta decisión se revisa.
+- **Decisión y consecuencias:** `useCatalogFetch` y `CatalogSelect.vue` son las únicas implementaciones de
+  "traer un catálogo con cache" y de UXF-001, respectivamente. `useCategoriasCatalog`,
+  `useComunasCatalog`, `CategoriaSelect` y `ComunaSelect` son wrappers de una sola responsabilidad — fijar
+  el dato específico de su entidad y nada más. Beneficio: un cambio a D-004/UX-001, o al manejo de error del
+  fetch, se hace una vez y llega a las dos entidades. Costo aceptado: dos archivos genéricos más de los que
+  parecían necesarios a simple vista — se acepta porque la alternativa es la misma duplicación que esta
+  misión existe para evitar en los datos, repetida en cada capa de código que los toca. La capa de queries
+  (`server/utils/taxonomia.ts`) queda fuera de este patrón — ver la nota en la sección de Arquitectura.
+- **Reapertura:** si `CategoriaSelect`/`ComunaSelect` o sus composables necesitan alguna vez una regla que
+  no aplique a la otra entidad — ahí la implementación compartida deja de ser una talla única y esta
+  decisión se revisa.
 
 ## Preguntas
 

--- a/docs/missions/03-taxonomia-categorias-y-comunas/ingenieria.md
+++ b/docs/missions/03-taxonomia-categorias-y-comunas/ingenieria.md
@@ -1,8 +1,8 @@
 # Misión 03: taxonomía de categorías y comunas — Ingeniería
 
-**Estado:** en revisión
+**Estado:** vigente
 
-**Última actualización:** 2026-08-18
+**Última actualización:** 2026-08-18. **Aprobado por Patricio el:** 2026-08-18.
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
@@ -231,7 +231,7 @@ específico de categoría o comuna colado adentro.
 
 ### T-001 — Las claves primarias son naturales (`slug`, `codigo`), no `uuid`
 
-- **Estado:** propuesta. **Fecha:** 2026-08-18.
+- **Estado:** aceptada. **Fecha:** 2026-08-18. **Aprobada por Patricio el:** 2026-08-18.
 - **Contratos:** D-001, D-002.
 - **Alternativas descartadas:** `uuid` autogenerado como en `professionals` (patrón del resto del repo) —
   para una tabla de catálogo fijo y pequeño, un id sin significado obliga a un join o un mapeo extra en
@@ -250,7 +250,7 @@ específico de categoría o comuna colado adentro.
 
 ### T-002 — Los tres componentes viven en `app/components/` sin subcarpeta de dominio
 
-- **Estado:** propuesta. **Fecha:** 2026-08-18.
+- **Estado:** aceptada. **Fecha:** 2026-08-18. **Aprobada por Patricio el:** 2026-08-18.
 - **Contratos:** D-004.
 - **Alternativas descartadas:** `app/components/shared/` o `app/components/taxonomia/` — Nuxt prefija el
   nombre del componente con el de la carpeta (A-006), así que `shared/ComunaSelect.vue` se auto-importaría
@@ -266,7 +266,7 @@ específico de categoría o comuna colado adentro.
 ### T-003 — Categoría y comuna nunca tienen lógica duplicada entre archivos: una implementación genérica
 por capa, un wrapper de una línea por entidad
 
-- **Estado:** propuesta. **Fecha:** 2026-08-18.
+- **Estado:** aceptada. **Fecha:** 2026-08-18. **Aprobada por Patricio el:** 2026-08-18.
 - **Contratos:** D-004, [UX-001](./experiencia.md#ux-001-el-componente-no-muestra-nada-hasta-que-el-usuario-empieza-a-escribir).
 - **Alternativas descartadas:** cada capa implementa su versión para categoría y su versión para comuna por
   separado — es lo que proponía la primera versión de este documento, tanto para el componente

--- a/docs/missions/03-taxonomia-categorias-y-comunas/ingenieria.md
+++ b/docs/missions/03-taxonomia-categorias-y-comunas/ingenieria.md
@@ -1,162 +1,219 @@
-# Misión: <nombre> — Ingeniería
+# Misión 03: taxonomía de categorías y comunas — Ingeniería
 
-**Estado:** borrador
+**Estado:** en revisión
 
-**Última actualización:** AAAA-MM-DD
+**Última actualización:** 2026-08-18
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-<!--
-Fuente de verdad para arquitectura, datos, contratos, factibilidad y pruebas. Consume el comportamiento
-definido en producto. Una limitación técnica cambia el alcance solo mediante una decisión explícita en
-producto.md.
+## Decisión técnica: dos tablas de catálogo con `activa`, dos endpoints de solo lectura, dos componentes
+compartidos
 
-Núcleo obligatorio: contratos, modelo de datos, RLS y riesgos de factibilidad. Las secciones bajo demanda
-(migración, rendimiento, entrega por etapas) se agregan solo cuando el riesgo lo justifica.
+Dos tablas nuevas (`categorias`, `comunas`), cada una con el campo `activa` que D-001/D-002 piden. Dos
+endpoints `GET` de solo lectura, sin autenticación (son catálogo público, no datos de usuario). Dos
+composables que los consumen con cache, y dos componentes Vue (`CategoriaSelect`, `ComunaSelect`) que
+implementan el contrato de D-004 sobre `UInputMenu` de Nuxt UI (A-004) — ya trae resuelto el autocompletado,
+lo que se construye acá es el contenido y las reglas: catálogo cerrado, nada visible hasta escribir.
 
-Gate de salida — ingenieria.md está lista para construir cuando:
-- los contratos definen qué entra, qué sale y qué invariantes se mantienen, sin ambigüedad
-- el modelo de datos soporta los casos límite de producto.md sin workarounds
-- el impacto en RLS está resuelto: qué policy se crea o cambia, o por qué ninguna
-- la migración de datos existentes tiene estrategia o está explícitamente fuera del alcance
-- los escenarios verificables de producto están mapeados a pruebas
-- el plan de construcción corta el diseño en slices atómicos ordenados (un slice = un Issue = un PR)
--->
+Es la primera vez que el repo tiene tablas de negocio, así que también es donde `server/db/schema/`,
+`server/db/sql/rls.sql` y el patrón de "endpoint de lectura pública" (receta del skill `arquitectura`)
+salen a andar por primera vez.
 
-## Decisión técnica: <arquitectura y riesgo principal>
+- **Contratos de producto cubiertos:** D-001, D-002, D-004.
+- **Riesgo bloqueante:** ninguno — ver [TR-001](#tr-001) para el único riesgo no bloqueante (exactitud del
+  seed de 346 comunas).
 
-<Dirección técnica, trade-off principal y el riesgo que todavía podría invalidarla.>
+## Arquitectura: catálogo de solo lectura, sin dominio de negocio propio
 
-- **Contratos de producto cubiertos:** F-001, <otros>.
-- **Riesgo bloqueante:** <incertidumbre o "ninguna">.
+Categorías y comunas no son un dominio con reglas de negocio (no hay cálculo, no hay ranking, no hay
+ownership) — son datos de referencia que otros dominios consumen. Por eso `server/utils/taxonomia.ts` es
+solo queries, sin lógica que valga la pena aislar como función pura: el principio de "lógica fuera de la
+infraestructura" del skill no aplica acá, sería abstracción sin regla que separar.
 
-## Arquitectura: <cómo se divide la responsabilidad>
+Los componentes (`CategoriaSelect`, `ComunaSelect`) sí tienen una regla real — "no mostrar nada hasta
+escribir, nunca emitir un valor fuera del catálogo" (D-004, UX-001) — y esa regla vive en el componente
+mismo, no en el composable: el composable solo trae los datos, el componente decide cuándo mostrarlos.
 
-<!--
-La lógica de negocio se separa de la infraestructura: funciones puras en utils/ y server/utils/,
-reactividad en composables, acceso a datos en server/api/ con Drizzle. Incluye diagrama solo cuando tres o
-más partes interactúan.
--->
+| Componente                          | Responsabilidad                                    | No debe decidir                          | Contratos      |
+| -------------------------------------- | ------------------------------------------------------ | -------------------------------------------- | -------------- |
+| `server/db/schema/taxonomia.ts`        | Forma de las tablas                                     | Qué filas existen (eso es el seed)          | D-001, D-002   |
+| `server/utils/taxonomia.ts`             | Queries: solo filas `activa = true`, columnas públicas | Presentación, formato del texto              | D-001, D-002   |
+| `server/api/categorias.get.ts` / `comunas.get.ts` | I/O: llama la query, devuelve JSON              | Filtrar por texto (eso lo hace el cliente)    | TC-001, TC-002 |
+| `app/composables/useCategoriasCatalog.ts` / `useComunasCatalog.ts` | Fetch con cache, expone `pending`/`error` | Cuándo mostrar la lista (eso es el componente) | TC-003         |
+| `app/components/CategoriaSelect.vue` / `ComunaSelect.vue` | Interacción de UXF-001: enfocado sin texto, filtrado, selección | Qué datos existen | D-004, TC-004  |
 
-<Descripción del enfoque y por qué satisface los contratos con menor riesgo.>
-
-| Componente | Responsabilidad       | No debe decidir | Contratos |
-| ---------- | --------------------- | --------------- | --------- |
-| <nombre>   | <una responsabilidad> | <frontera>      | F-001     |
+No hay diagrama: son cuatro capas en línea recta (schema → query → endpoint → componente), sin
+ramificaciones ni servicios externos de por medio.
 
 ## Contratos
 
-<!--
-Cada contrato especifica entrada, salida e invariantes al nivel en que se puede implementar sin reuniones
-de aclaración. Incluye los errores observables y el código HTTP cuando es un endpoint.
--->
+### TC-001 — `GET /api/categorias`
 
-### TC-001 — <contrato en una frase>
+- **Entrada:** ninguna — sin params ni query.
+- **Salida:** `200 { categorias: { slug: string, nombre: string }[] }` — solo las `activa = true`, ordenadas
+  alfabéticamente por `nombre`.
+- **Invariantes:** nunca incluye una fila con `activa = false`. Nunca incluye columnas internas (si el
+  schema suma alguna después, es privada por default — A-005).
+- **Errores:** ninguno esperado con input inválido (no hay input). Una falla de conexión a la base
+  propaga como `500` — no hay una condición de negocio que distinga un error "manejable" de una caída de
+  infraestructura acá.
+- **Contrato de producto:** [D-001](./producto.md#d-001), [D-004](./producto.md#d-004).
 
-- **Entrada:** <datos y precondiciones, con tipos y forma concreta>.
-- **Salida:** <resultado y su forma concreta>.
-- **Invariantes:** <qué se cumple siempre: atomicidad, consistencia, idempotencia>.
-- **Errores:** <condición → código HTTP y cuerpo `{ error, code? }`, y qué puede hacer el llamador>.
-- **Contrato de producto:** [F-001](./producto.md#f-001).
+### TC-002 — `GET /api/comunas`
+
+- **Entrada:** ninguna.
+- **Salida:** `200 { comunas: { codigo: string, nombre: string }[] }` — solo `activa = true`, ordenadas
+  alfabéticamente por `nombre`. `codigo` es el código oficial de comuna de la SUBDERE (ver
+  [E-006](./investigacion.md#e-006)), no un id interno.
+- **Invariantes:** igual que TC-001, aplicado a `comunas`.
+- **Errores:** igual que TC-001.
+- **Contrato de producto:** [D-002](./producto.md#d-002), [D-004](./producto.md#d-004).
+
+### TC-003 — `useCategoriasCatalog()` / `useComunasCatalog()`
+
+- **Entrada:** ninguna.
+- **Salida:** `{ items: Ref<{slug, nombre}[]>, pending: Ref<boolean>, error: Ref<boolean> }` (comunas:
+  mismo shape con `codigo` en vez de `slug`).
+- **Invariantes:** el fetch ocurre una sola vez por sesión de navegación — `useAsyncData` con una key fija
+  comparte el resultado entre todos los componentes que lo usen, así que abrir `CategoriaSelect` en dos
+  formularios distintos de la misma página no dispara dos requests.
+- **Errores:** `error` pasa a `true` si el fetch falla; el composable no reintenta solo, expone `refresh()`
+  para que el componente lo dispare desde el botón "Reintentar" (ver `experiencia.md`, modo error).
+- **Contrato de producto:** soporte de [D-004](./producto.md#d-004).
+
+### TC-004 — `<CategoriaSelect>` / `<ComunaSelect>`
+
+- **Entrada (props):** `modelValue: string | null` — el `slug` o `codigo` elegido, o `null` sin selección.
+- **Salida (emit):** `update:modelValue(value: string | null)`.
+- **Invariantes:** el componente **nunca** emite un valor que no sea un `slug`/`codigo` presente en el
+  catálogo activo, o `null` — es la garantía de D-004, implementada acá porque `UInputMenu` no permite
+  "crear" una opción por default (a diferencia de un combobox libre). Ninguna opción se muestra mientras el
+  campo de búsqueda esté vacío (UX-001, modo "enfocado sin texto") — el componente controla el `open` de
+  `UInputMenu` a mano en vez de dejarlo abrir solo al enfocar.
+- **Errores:** si `useCategoriasCatalog()`/`useComunasCatalog()` reportan `error`, el componente entra en
+  modo error (ver `experiencia.md`) y el campo queda deshabilitado hasta reintentar.
+- **Contrato de producto:** [D-004](./producto.md#d-004), [UXF-001](./experiencia.md#uxf-001-elegir-categoría-o-comuna-desde-el-catálogo).
 
 ## Modelo de datos
 
-<!-- Entidades con significado, escritura y ciclo de vida. El schema completo vive en server/db/. -->
-
-| Entidad o campo | Significado             | Escritura          | Retención o historial |
-| --------------- | ----------------------- | ------------------ | --------------------- |
-| <dato>          | <semántica de producto> | <endpoint o acción>| <política>            |
+| Entidad o campo    | Significado                                              | Escritura                          | Retención o historial |
+| ---------------------- | ------------------------------------------------------------- | --------------------------------------- | ---------------------- |
+| `categorias.slug`      | Identificador estable del oficio, usado en código y futuras URLs | Seed inicial (8 filas), fijo — no se genera desde el nombre en runtime | Permanente, nunca se reusa |
+| `categorias.nombre`    | Nombre visible, el que decidió D-001 ("Gasfitería")            | Seed inicial; editable a mano en la base si cambia el copy | — |
+| `categorias.activa`    | Si aparece en el selector de registro/búsqueda                  | Seed inicial (las 8 en `true`); cambios manuales en la base (D-001, sin panel de admin) | — |
+| `comunas.codigo`       | Código oficial SUBDERE de la comuna                              | Seed inicial (346 filas), fijo          | Permanente |
+| `comunas.nombre`       | Nombre oficial de la comuna ("Ñuñoa")                            | Seed inicial                            | — |
+| `comunas.activa`       | Si aparece en el selector — Gran Santiago y Puerto Varas parten en `true`, el resto en `false` (D-002) | Seed inicial; cambios manuales en la base | — |
 
 ### Invariantes de datos
 
-- <unicidad, pertenencia, orden o consistencia temporal>.
-- <qué operación es atómica o qué dato tiene una única fuente de verdad>.
+- `categorias.slug` y `comunas.codigo` son claves primarias — la unicidad la garantiza Postgres, no una
+  verificación de aplicación.
+- Ninguna fila se borra nunca (ni categoría ni comuna): "sacar" una es poner `activa = false`, nunca un
+  `DELETE` — un profesional o una búsqueda histórica pueden seguir referenciando una categoría o comuna
+  desactivada.
+- No hay `updated_at`/`created_at` con valor de negocio — estas tablas no tienen historial que importe,
+  son catálogo de referencia.
+
+**Migración:** no aplica — son tablas nuevas. `server/db/schema/index.ts` está vacío hoy (auditado antes de
+diseñar esto), así que no hay dato previo en el repo ni consumidor existente que adaptar.
 
 ### Impacto en RLS
 
-<!--
-Obligatorio. Fuente de verdad: server/db/sql/rls.sql. Si el cambio no toca ownership ni relaciones usadas
-en policies, decirlo explícitamente con esa razón — no dejar la sección vacía.
--->
+Primera tabla del repo con RLS real — no hay política previa que migrar.
 
-| Tabla    | Cambio                 | Policy afectada | Acción                    |
-| -------- | ---------------------- | --------------- | ------------------------- |
-| <tabla>  | <nueva, ownership, FK> | <nombre>        | <crear, actualizar, nada> |
+| Tabla        | Cambio | Policy afectada             | Acción |
+| --------------- | ------ | -------------------------------- | ------ |
+| `categorias`     | nueva  | `categorias_select_public`       | crear — lectura pública sin restricción (`using (true)`); no existe policy de escritura porque nada escribe vía la conexión de la app (A-002: el seed y los cambios de `activa` van directo a la base, no por `server/api/`) |
+| `comunas`        | nueva  | `comunas_select_public`          | crear — mismo criterio que `categorias` |
+
+**Por qué la policy es `using (true)` y no `using (activa = true)`:** por A-002, la policy es respaldo, no
+el mecanismo — el filtro real vive en `server/utils/taxonomia.ts` (TC-001/TC-002). Restringir la policy a
+solo filas activas la duplicaría sin necesidad, y estos datos no son sensibles (nombres de comuna y
+categoría son públicos por diseño) — no hay nada que proteger si alguien consultara `comunas` completa por
+fuera del filtro de la app.
 
 ## Riesgos y experimentos de factibilidad
 
-<!--
-Un riesgo que podría cambiar el producto se enlaza como pregunta o decisión en producto.md. Un experimento
-tiene pregunta, límite de tiempo y resultado capaz de cerrar la incertidumbre.
--->
+<a id="tr-001"></a>
 
-| ID     | Riesgo o pregunta | Qué invalida        | Experimento o mitigación  | Criterio de salida      | Estado  |
-| ------ | ----------------- | ------------------- | ------------------------- | ----------------------- | ------- |
-| TR-001 | <incertidumbre>   | <alcance en riesgo> | <spike, prueba o recorte> | <resultado concluyente> | abierto |
+| ID     | Riesgo o pregunta                                              | Qué invalida         | Experimento o mitigación                          | Criterio de salida                | Estado  |
+| ------ | ------------------------------------------------------------------ | ------------------------ | ------------------------------------------------------ | -------------------------------------- | ------- |
+| TR-001 | El seed de 346 comunas tiene un nombre o código mal transcrito | Una comuna real queda invisible o con nombre incorrecto | Fuente única: el PDF de SUBDERE citado en [E-006](./investigacion.md#e-006), no reescribir a mano — generar el `INSERT` desde ese dato | El conteo final es exactamente 346 filas, verificado contra la fuente | abierto |
 
 ## Estrategia de pruebas
 
-<!-- Mapea los ejemplos verificables de producto.md a niveles de prueba. Qué demuestra cada una. -->
+Sin infraestructura de test de integración contra Postgres todavía en el repo — la misión 02 tampoco la
+agregó, y verificó S-001 a mano contra la base de desarrollo. Este es el mismo criterio: no se agrega el
+andamiaje de integración solo para dos queries de un `select` con un `where`.
 
-| Contrato o riesgo | Nivel                          | Caso principal | Límite o falla |
-| ----------------- | ------------------------------ | -------------- | -------------- |
-| F-001, CL-001     | <unidad, contrato, integración>| <caso>         | <caso>         |
+`@vue/test-utils` no está instalado — la única prueba de componente que existe hoy es el `email.test.ts`
+de la misión 02, que no monta nada de Vue. S-004 lo agrega (`npm i -D @vue/test-utils`) como parte del
+slice, no como precondición externa: es la primera vez que un componente de Datealo necesita esta clase de
+prueba.
+
+| Contrato o riesgo   | Nivel        | Caso principal                                              | Límite o falla |
+| ------------------------ | ------------ | ------------------------------------------------------------ | ---------------- |
+| TC-001, TC-002           | manual       | `GET /api/categorias` devuelve exactamente 8 filas; `GET /api/comunas` devuelve solo las comunas con `activa = true` | Marcar una comuna en `false` a mano y confirmar que desaparece de la respuesta |
+| TC-004 (D-004)           | unitario (Vitest + Vue Test Utils) | Seleccionar una opción de la lista emite `update:modelValue` con su `slug`/`codigo` | Escribir texto que no matchea nada y no seleccionar nada — el componente nunca emite ese texto |
+| UX-001 (nada hasta escribir) | unitario | Con el campo enfocado y vacío, la lista de opciones no se renderiza | Al escribir la primera letra, aparece |
+| TR-001 (conteo del seed) | manual, una vez | `select count(*) from comunas` = 346 después del seed | — |
 
 ### Propiedades que deben probarse
 
-- <invariante bajo reintentos, concurrencia o distintas entradas>.
-- <ausencia de efectos parciales en falla>.
+- El componente nunca deja el formulario en un estado donde `modelValue` sea un string que no exista en el
+  catálogo cargado — ni siquiera transitoriamente mientras se escribe.
+- Desactivar una comuna (`activa = false`) no rompe un valor ya guardado en otra tabla que la referencie
+  (esto lo prueba la misión que agregue esa referencia — 04 o 06 — no esta).
 
 ## Plan de construcción
 
-<!--
-Se completa al final, cuando el gate de salida se cumple y ninguna pregunta bloqueante sigue abierta —
-cortar sobre decisiones abiertas produce issues que mueren. Cada slice es un cambio funcional atómico: un
-Issue, un PR, ejecutable sin haber leído la misión (el issue lleva su contrato inline) y con criterios
-pass/fail enumerables como tests. Guía completa en el skill discovery-engineering.
--->
+| ID    | Slice (una frase, sin "y")                                  | Sustento             | Criterio de aceptación principal                                                     | Depende de |
+| ----- | ------------------------------------------------------------- | --------------------- | ------------------------------------------------------------------------------------ | ---------- |
+| S-001 | Tablas `categorias` y `comunas` con RLS y seed completo        | D-001, D-002, TR-001 | `select count(*) from comunas` = 346; `select count(*) from categorias` = 8; Gran Santiago (32) + Puerto Varas activas en `comunas`, las 8 categorías activas | — |
+| S-002 | Endpoints `GET /api/categorias` y `GET /api/comunas`            | TC-001, TC-002        | Cada endpoint devuelve solo filas `activa = true`, ordenadas por nombre               | S-001 |
+| S-003 | Composables `useCategoriasCatalog()` y `useComunasCatalog()`    | TC-003                | Montar dos componentes que usan el mismo composable en la misma página dispara un solo request | S-002 |
+| S-004 | Componentes `CategoriaSelect.vue` y `ComunaSelect.vue`          | TC-004, D-004, UXF-001| Test unitario (Vitest + Vue Test Utils) verifica los 6 modos de `experiencia.md` y que nunca emite un valor fuera del catálogo | S-003 |
 
-| ID    | Slice (una frase, sin "y") | Sustento      | Criterio de aceptación principal          | Depende de |
-| ----- | -------------------------- | ------------- | ----------------------------------------- | ---------- |
-| S-001 | <cambio atómico>           | TC-001, D-001 | <entrada concreta → resultado observable> | —          |
-
-## Secciones bajo demanda
-
-<!--
-Agregar solo cuando el riesgo lo justifique, con estos títulos:
-
-- "Migración y compatibilidad": cuando existan datos o consumidores que deben llegar al nuevo contrato.
-  Incluye rollback lógico si la migración física no puede revertirse.
-- "Rendimiento y observabilidad": cuando haya presupuesto de latencia o volumen que defender (búsqueda
-  geográfica y listados paginados son los candidatos naturales).
-- "SEO e indexación": cuando la superficie deba ser indexable (páginas por categoría + comuna, datos
-  estructurados).
-- "Entrega por etapas": cuando el cambio necesite despliegue incremental o feature flags.
--->
+Cuatro slices, en línea recta por dependencia — no hay forma de paralelizar sin que uno bloquee al
+siguiente (el componente necesita el composable, que necesita el endpoint, que necesita la tabla).
 
 ## Decisiones técnicas
 
 <a id="t-001"></a>
 
-### T-001 — <decisión en una frase>
+### T-001 — Las claves primarias son naturales (`slug`, `codigo`), no `uuid`
 
-- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
-- **Contratos:** F-001 y <regla relevante>.
-- **Alternativas descartadas:** <opciones y trade-offs, con el porqué del rechazo>.
-- **Decisión y consecuencias:** <enfoque elegido, beneficio, costo y trabajo futuro aceptado>.
-- **Reapertura:** <medición o cambio que justificaría revisar>.
+- **Estado:** propuesta. **Fecha:** 2026-08-18.
+- **Contratos:** D-001, D-002.
+- **Alternativas descartadas:** `uuid` autogenerado como en `professionals` (patrón del resto del repo) —
+  para una tabla de catálogo fijo y pequeño, un id sin significado obliga a un join o un mapeo extra en
+  cada lugar que ya conoce el nombre o el código oficial; el `slug`/`codigo` ya es estable y único por
+  definición (D-001 fija los nombres, SUBDERE fija los códigos), así que inventar un id encima no agrega
+  nada.
+- **Decisión y consecuencias:** `categorias.slug` (`text`) y `comunas.codigo` (`text`) son primary key.
+  Beneficio: el componente y cualquier URL futura (`/categoria/gasfiteria`) usan el mismo valor sin
+  traducción. Costo aceptado: si algún día una categoría necesita cambiar de `slug` (renombrar el oficio),
+  es un cambio de clave primaria, no un `UPDATE` de una columna — pero eso ya requeriría re-decidir D-001,
+  no es un caso frecuente.
+- **Reapertura:** si aparece un caso real de necesitar renombrar un `slug`/`codigo` ya en uso por datos de
+  otra tabla.
+
+<a id="t-002"></a>
+
+### T-002 — `CategoriaSelect`/`ComunaSelect` viven en `app/components/` sin subcarpeta de dominio
+
+- **Estado:** propuesta. **Fecha:** 2026-08-18.
+- **Contratos:** D-004.
+- **Alternativas descartadas:** `app/components/shared/` o `app/components/taxonomia/` — Nuxt prefija el
+  nombre del componente con el de la carpeta (A-006), así que `shared/ComunaSelect.vue` se auto-importaría
+  como `<SharedComunaSelect>`, un prefijo que no aporta nada y que nadie va a escribir por costumbre.
+- **Decisión y consecuencias:** quedan flat, como `db.ts`/`auth.ts`/`email.ts` en `server/utils/`
+  (infraestructura transversal sin dominio propio, A-006) — mismo criterio aplicado al lado de `app/`.
+- **Reapertura:** si aparecen más componentes verdaderamente transversales (sin dominio) y la carpeta
+  `app/components/` empieza a mezclarlos con los de dominio de forma confusa.
 
 ## Preguntas
 
-<!--
-Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
-Estado: abierta | resuelta AAAA-MM-DD | disuelta AAAA-MM-DD. Solo las abiertas llevan bloque de detalle.
--->
-
-<Una frase que responde "¿qué falta?": la pregunta que bloquea construcción y qué bloquea.>
-
-| ID     | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
-| ------ | ---------------------- | ------------------- | --------------------------------------------------------------- |
-| TQ-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
-| TQ-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |
+Ninguna abierta.

--- a/docs/missions/03-taxonomia-categorias-y-comunas/ingenieria.md
+++ b/docs/missions/03-taxonomia-categorias-y-comunas/ingenieria.md
@@ -7,14 +7,15 @@
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-## Decisión técnica: dos tablas de catálogo con `activa`, dos endpoints de solo lectura, dos componentes
-compartidos
+## Decisión técnica: dos tablas de catálogo con `activa`, dos endpoints de solo lectura, un componente
+compartido compuesto por dos wrappers
 
 Dos tablas nuevas (`categorias`, `comunas`), cada una con el campo `activa` que D-001/D-002 piden. Dos
 endpoints `GET` de solo lectura, sin autenticación (son catálogo público, no datos de usuario). Dos
-composables que los consumen con cache, y dos componentes Vue (`CategoriaSelect`, `ComunaSelect`) que
-implementan el contrato de D-004 sobre `UInputMenu` de Nuxt UI (A-004) — ya trae resuelto el autocompletado,
-lo que se construye acá es el contenido y las reglas: catálogo cerrado, nada visible hasta escribir.
+composables que los consumen con cache, y un componente Vue (`CatalogSelect`) que implementa el contrato de
+D-004 sobre `UInputMenu` de Nuxt UI (A-004) — ya trae resuelto el autocompletado, lo que se construye acá
+es el contenido y las reglas: catálogo cerrado, nada visible hasta escribir. `CategoriaSelect` y
+`ComunaSelect` son dos wrappers delgados que lo componen, no dos copias de la misma lógica (ver T-003).
 
 Es la primera vez que el repo tiene tablas de negocio, así que también es donde `server/db/schema/`,
 `server/db/sql/rls.sql` y el patrón de "endpoint de lectura pública" (receta del skill `arquitectura`)
@@ -31,9 +32,14 @@ ownership) — son datos de referencia que otros dominios consumen. Por eso `ser
 solo queries, sin lógica que valga la pena aislar como función pura: el principio de "lógica fuera de la
 infraestructura" del skill no aplica acá, sería abstracción sin regla que separar.
 
-Los componentes (`CategoriaSelect`, `ComunaSelect`) sí tienen una regla real — "no mostrar nada hasta
-escribir, nunca emitir un valor fuera del catálogo" (D-004, UX-001) — y esa regla vive en el componente
-mismo, no en el composable: el composable solo trae los datos, el componente decide cuándo mostrarlos.
+Los componentes sí tienen una regla real — "no mostrar nada hasta escribir, nunca emitir un valor fuera
+del catálogo" (D-004, UX-001) — y esa regla es **idéntica** para categoría y comuna, porque D-004 la
+definió como una sola regla para ambos, no dos parecidas. Repetirla en dos archivos sería el mismo error
+que evitar herencia solo de nombre: dos copias que hay que mantener sincronizadas a mano cada vez que
+cambie un modo. Por eso hay un tercer componente, `CatalogSelect.vue`, que implementa los 6 modos una sola
+vez — `CategoriaSelect` y `ComunaSelect` lo **componen**: cada uno es una capa delgada que le pasa su
+composable (`useCategoriasCatalog`/`useComunasCatalog`) y su placeholder, sin repetir la lógica de
+enfocado/filtrado/selección.
 
 | Componente                          | Responsabilidad                                    | No debe decidir                          | Contratos      |
 | -------------------------------------- | ------------------------------------------------------ | -------------------------------------------- | -------------- |
@@ -41,10 +47,12 @@ mismo, no en el composable: el composable solo trae los datos, el componente dec
 | `server/utils/taxonomia.ts`             | Queries: solo filas `activa = true`, columnas públicas | Presentación, formato del texto              | D-001, D-002   |
 | `server/api/categorias.get.ts` / `comunas.get.ts` | I/O: llama la query, devuelve JSON              | Filtrar por texto (eso lo hace el cliente)    | TC-001, TC-002 |
 | `app/composables/useCategoriasCatalog.ts` / `useComunasCatalog.ts` | Fetch con cache, expone `pending`/`error` | Cuándo mostrar la lista (eso es el componente) | TC-003         |
-| `app/components/CategoriaSelect.vue` / `ComunaSelect.vue` | Interacción de UXF-001: enfocado sin texto, filtrado, selección | Qué datos existen | D-004, TC-004  |
+| `app/components/CatalogSelect.vue`     | Los 6 modos de UXF-001, sobre `UInputMenu` — recibe `items`/`pending`/`error`/`placeholder` por props, nunca sabe si es categoría o comuna | De dónde vienen los datos | D-004, UX-001, TC-004 |
+| `app/components/CategoriaSelect.vue` / `ComunaSelect.vue` | Conectar su composable con `CatalogSelect` — ninguna lógica de interacción propia | Cómo se ve o se comporta el selector (eso ya lo resolvió `CatalogSelect`) | TC-004 |
 
-No hay diagrama: son cuatro capas en línea recta (schema → query → endpoint → componente), sin
-ramificaciones ni servicios externos de por medio.
+No hay diagrama: son cinco capas en línea recta (schema → query → endpoint → composable → componentes),
+sin ramificaciones ni servicios externos de por medio. `CategoriaSelect`/`ComunaSelect` son la única
+bifurcación, y es deliberada: comparten `CatalogSelect` por composición, no por copiarse entre sí.
 
 ## Contratos
 
@@ -82,15 +90,22 @@ ramificaciones ni servicios externos de por medio.
   para que el componente lo dispare desde el botón "Reintentar" (ver `experiencia.md`, modo error).
 - **Contrato de producto:** soporte de [D-004](./producto.md#d-004).
 
-### TC-004 — `<CategoriaSelect>` / `<ComunaSelect>`
+### TC-004 — `<CatalogSelect>`, compuesto por `<CategoriaSelect>` / `<ComunaSelect>`
 
-- **Entrada (props):** `modelValue: string | null` — el `slug` o `codigo` elegido, o `null` sin selección.
-- **Salida (emit):** `update:modelValue(value: string | null)`.
-- **Invariantes:** el componente **nunca** emite un valor que no sea un `slug`/`codigo` presente en el
-  catálogo activo, o `null` — es la garantía de D-004, implementada acá porque `UInputMenu` no permite
-  "crear" una opción por default (a diferencia de un combobox libre). Ninguna opción se muestra mientras el
-  campo de búsqueda esté vacío (UX-001, modo "enfocado sin texto") — el componente controla el `open` de
-  `UInputMenu` a mano en vez de dejarlo abrir solo al enfocar.
+- **Entrada (props) de `CatalogSelect`:** `modelValue: string | null`, `items: {value: string, label: string}[]`,
+  `pending: boolean`, `error: boolean`, `placeholder: string`.
+- **Entrada (props) de `CategoriaSelect` / `ComunaSelect`:** solo `modelValue: string | null` — el resto
+  (`items`, `pending`, `error`, `placeholder`) lo arma cada wrapper llamando a su composable y pasándoselo a
+  `CatalogSelect` internamente; quien usa `<CategoriaSelect>` no ve ni necesita saber que existe
+  `CatalogSelect` debajo.
+- **Salida (emit):** `update:modelValue(value: string | null)`, igual en las tres.
+- **Invariantes:** `CatalogSelect` **nunca** emite un valor que no esté en `items`, o `null` — es la
+  garantía de D-004, implementada una sola vez, porque `UInputMenu` no permite "crear" una opción por
+  default (a diferencia de un combobox libre). Ninguna opción se muestra mientras el campo de búsqueda esté
+  vacío (UX-001, modo "enfocado sin texto") — `CatalogSelect` controla el `open` de `UInputMenu` a mano en
+  vez de dejarlo abrir solo al enfocar. `CategoriaSelect`/`ComunaSelect` no reimplementan nada de esto —
+  si D-004 cambia, se edita `CatalogSelect` una vez y el cambio llega gratis a los dos wrappers, porque lo
+  componen — no porque lo copien.
 - **Errores:** si `useCategoriasCatalog()`/`useComunasCatalog()` reportan `error`, el componente entra en
   modo error (ver `experiencia.md`) y el campo queda deshabilitado hasta reintentar.
 - **Contrato de producto:** [D-004](./producto.md#d-004), [UXF-001](./experiencia.md#uxf-001-elegir-categoría-o-comuna-desde-el-catálogo).
@@ -156,8 +171,9 @@ prueba.
 | Contrato o riesgo   | Nivel        | Caso principal                                              | Límite o falla |
 | ------------------------ | ------------ | ------------------------------------------------------------ | ---------------- |
 | TC-001, TC-002           | manual       | `GET /api/categorias` devuelve exactamente 8 filas; `GET /api/comunas` devuelve solo las comunas con `activa = true` | Marcar una comuna en `false` a mano y confirmar que desaparece de la respuesta |
-| TC-004 (D-004)           | unitario (Vitest + Vue Test Utils) | Seleccionar una opción de la lista emite `update:modelValue` con su `slug`/`codigo` | Escribir texto que no matchea nada y no seleccionar nada — el componente nunca emite ese texto |
-| UX-001 (nada hasta escribir) | unitario | Con el campo enfocado y vacío, la lista de opciones no se renderiza | Al escribir la primera letra, aparece |
+| TC-004 (D-004)           | unitario (Vitest + Vue Test Utils), contra `CatalogSelect` directo | Seleccionar una opción de la lista emite `update:modelValue` con su `value` | Escribir texto que no matchea nada y no seleccionar nada — el componente nunca emite ese texto |
+| UX-001 (nada hasta escribir) | unitario, contra `CatalogSelect` directo | Con el campo enfocado y vacío, la lista de opciones no se renderiza | Al escribir la primera letra, aparece |
+| `CategoriaSelect`/`ComunaSelect` componen bien | unitario | Cada wrapper le pasa a `CatalogSelect` los `items` de su propio composable | Un cambio en `CatalogSelect` (ej. un modo nuevo) no exige tocar los wrappers |
 | TR-001 (conteo del seed) | manual, una vez | `select count(*) from comunas` = 346 después del seed | — |
 
 ### Propiedades que deben probarse
@@ -174,10 +190,15 @@ prueba.
 | S-001 | Tablas `categorias` y `comunas` con RLS y seed completo        | D-001, D-002, TR-001 | `select count(*) from comunas` = 346; `select count(*) from categorias` = 8; Gran Santiago (32) + Puerto Varas activas en `comunas`, las 8 categorías activas | — |
 | S-002 | Endpoints `GET /api/categorias` y `GET /api/comunas`            | TC-001, TC-002        | Cada endpoint devuelve solo filas `activa = true`, ordenadas por nombre               | S-001 |
 | S-003 | Composables `useCategoriasCatalog()` y `useComunasCatalog()`    | TC-003                | Montar dos componentes que usan el mismo composable en la misma página dispara un solo request | S-002 |
-| S-004 | Componentes `CategoriaSelect.vue` y `ComunaSelect.vue`          | TC-004, D-004, UXF-001| Test unitario (Vitest + Vue Test Utils) verifica los 6 modos de `experiencia.md` y que nunca emite un valor fuera del catálogo | S-003 |
+| S-004 | Componente `CatalogSelect.vue` con los 6 modos de `experiencia.md` | TC-004, D-004, UXF-001, UX-001 | Test unitario (Vitest + Vue Test Utils) verifica los 6 modos y que nunca emite un valor fuera de `items` | S-003 |
+| S-005 | `CategoriaSelect.vue` y `ComunaSelect.vue`, componiendo `CatalogSelect` | TC-004 | Cada uno monta `CatalogSelect` pasándole su composable — cero lógica de interacción propia, verificable con un diff que no toca `CatalogSelect` | S-004 |
 
-Cuatro slices, en línea recta por dependencia — no hay forma de paralelizar sin que uno bloquee al
-siguiente (el componente necesita el composable, que necesita el endpoint, que necesita la tabla).
+Cinco slices, en línea recta por dependencia — no hay forma de paralelizar sin que uno bloquee al
+siguiente (los wrappers necesitan `CatalogSelect`, que necesita el composable, que necesita el endpoint,
+que necesita la tabla). S-004 y S-005 quedan separados a propósito, aunque parezcan "el mismo componente en
+dos partes": S-004 es donde vive toda la regla de D-004/UX-001 y se puede revisar y probar sola, sin
+todavía saber si hay uno o dos consumidores — separarlo fuerza a que `CatalogSelect` no termine con nada
+específico de categoría o comuna colado adentro.
 
 ## Decisiones técnicas
 
@@ -202,17 +223,40 @@ siguiente (el componente necesita el composable, que necesita el endpoint, que n
 
 <a id="t-002"></a>
 
-### T-002 — `CategoriaSelect`/`ComunaSelect` viven en `app/components/` sin subcarpeta de dominio
+### T-002 — Los tres componentes viven en `app/components/` sin subcarpeta de dominio
 
 - **Estado:** propuesta. **Fecha:** 2026-08-18.
 - **Contratos:** D-004.
 - **Alternativas descartadas:** `app/components/shared/` o `app/components/taxonomia/` — Nuxt prefija el
   nombre del componente con el de la carpeta (A-006), así que `shared/ComunaSelect.vue` se auto-importaría
   como `<SharedComunaSelect>`, un prefijo que no aporta nada y que nadie va a escribir por costumbre.
-- **Decisión y consecuencias:** quedan flat, como `db.ts`/`auth.ts`/`email.ts` en `server/utils/`
-  (infraestructura transversal sin dominio propio, A-006) — mismo criterio aplicado al lado de `app/`.
+- **Decisión y consecuencias:** `CatalogSelect.vue`, `CategoriaSelect.vue` y `ComunaSelect.vue` quedan
+  flat, como `db.ts`/`auth.ts`/`email.ts` en `server/utils/` (infraestructura transversal sin dominio
+  propio, A-006) — mismo criterio aplicado al lado de `app/`.
 - **Reapertura:** si aparecen más componentes verdaderamente transversales (sin dominio) y la carpeta
   `app/components/` empieza a mezclarlos con los de dominio de forma confusa.
+
+<a id="t-003"></a>
+
+### T-003 — `CategoriaSelect`/`ComunaSelect` componen `CatalogSelect`, no duplican su lógica
+
+- **Estado:** propuesta. **Fecha:** 2026-08-18.
+- **Contratos:** D-004, [UX-001](./experiencia.md#ux-001-el-componente-no-muestra-nada-hasta-que-el-usuario-empieza-a-escribir).
+- **Alternativas descartadas:** cada componente implementa sus propios 6 modos por separado — es lo que se
+  proponía en la primera versión de este documento. Funciona, pero duplica la única regla que D-004 definió
+  como una sola cosa para las dos entidades; un cambio a esa regla (un modo nuevo, un ajuste al debounce)
+  se tendría que aplicar dos veces y sincronizar a mano. Un mixin o un composable que devuelva solo el
+  estado (sin el markup) — deja la mitad de la lógica compartida (el estado) y la otra mitad duplicada (el
+  template con sus seis variantes de UI), que es donde vive la mayoría del riesgo de que las dos
+  implementaciones diverjan.
+- **Decisión y consecuencias:** `CatalogSelect.vue` es la única implementación de UXF-001. `CategoriaSelect`
+  y `ComunaSelect` son componentes de una sola responsabilidad — conectar su composable con
+  `CatalogSelect` — sin markup ni lógica de interacción propia. Beneficio: un cambio a D-004/UX-001 se hace
+  una vez. Costo aceptado: agregar un tercer archivo por lo que a simple vista son "dos componentes
+  parecidos" — se acepta porque la alternativa es la duplicación exacta que esta misión existe para evitar
+  en los datos, ahora también en el componente.
+- **Reapertura:** si `CategoriaSelect` o `ComunaSelect` necesitan alguna vez una regla que no aplique a la
+  otra — ahí `CatalogSelect` deja de ser una talla única y esta decisión se revisa.
 
 ## Preguntas
 

--- a/docs/missions/README.md
+++ b/docs/missions/README.md
@@ -11,7 +11,7 @@ abrieron y de dónde salió cada una.
 | --- | ------ | ---- | ------- | ------ | ------- | ------- |
 | 01  | [migración a Nuxt UI](./01-migracion-nuxt-ui/) | técnica | 2026-08-11 | cerrada 2026-08-13 | — | A-004 |
 | 02  | [base de datos, Auth y correo (config)](./02-base-de-datos-y-auth/) | técnica | 2026-08-13 | cerrada 2026-08-17 | — | A-001, A-002, A-003 |
-| 03  | [taxonomía: categorías y comunas](./03-taxonomia-categorias-y-comunas/) | producto | 2026-08-13 | definición | Ingeniería | — |
+| 03  | [taxonomía: categorías y comunas](./03-taxonomia-categorias-y-comunas/) | producto | 2026-08-13 | lista para construir | — | — |
 | 04  | [registro y perfil de profesional](./04-registro-perfil-profesional/) | producto | 2026-08-13 | exploración | — | — |
 | 05  | [perfil público de profesional](./05-perfil-publico-profesional/) | producto | 2026-08-13 | exploración | — | — |
 | 06  | [búsqueda y resultados](./06-busqueda-resultados/) | producto | 2026-08-13 | exploración | — | — |


### PR DESCRIPTION
## Resumen

`ingenieria.md` de la misión 03, en revisión — cierra el discovery, define el modelo de datos y los contratos, corta el plan de construcción.

- **Modelo de datos**: tablas `categorias` y `comunas`, con clave primaria natural (`slug`/`codigo`, no `uuid` — T-001) y campo `activa` (D-001/D-002). Primeras tablas de negocio del repo.
- **RLS**: lectura pública sin restricción (`using (true)`), sin policy de escritura — nada escribe estas tablas vía `server/api/`, el seed y los cambios de `activa` van directo a la base (A-002).
- **Contratos**: `GET /api/categorias`, `GET /api/comunas` (TC-001/002), los composables `useCategoriasCatalog`/`useComunasCatalog` (TC-003) y el contrato de los componentes `CategoriaSelect`/`ComunaSelect` (TC-004) — nunca emiten un valor fuera del catálogo, nada visible hasta escribir (D-004, UX-001).
- **Riesgo no bloqueante**: TR-001, exactitud del seed de 346 comunas — mitigado generando el INSERT desde la fuente oficial de SUBDERE, no a mano.
- **Plan de construcción**: S-001 (tablas + RLS + seed) → S-002 (endpoints) → S-003 (composables) → S-004 (componentes), en línea recta por dependencia.
- **T-002**: los componentes van flat en `app/components/` sin subcarpeta — mismo criterio que la infraestructura transversal de `server/utils/` (A-006).

## Test plan

- [x] Sigue la estructura del template (`docs/missions/template/ingenieria.md`)
- [x] Los 4 casos límite de `producto.md` (CL-001, CL-002, CL-004) tienen soporte en el modelo de datos
- [x] Impacto en RLS resuelto explícitamente, con dónde se verifica pertenencia (no aplica escritura)
- [x] Plan de construcción cortado en slices atómicos con criterio de aceptación

🤖 Generated with [Claude Code](https://claude.com/claude-code)