### PR TITLE
feat(app): useCatalogFetch y los wrappers useCategoriasCatalog/useComunasCatalog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,20 @@ Sin `console.log` de debug en el código que se mergea.
 SCREAMING_SNAKE_CASE, tipos en PascalCase, funciones en camelCase. Named exports sobre default exports.
 
 **Comentarios**: solo para reglas de negocio no obvias. El naming claro es la documentación por defecto.
+Autocontenidos: explican el porqué en la misma línea, sin obligar a abrir `docs/missions/` ni el skill
+`arquitectura` para entenderlos. Una referencia (`D-001`, `A-002`) puede acompañar como trazabilidad hacia
+la decisión completa, pero nunca reemplaza la explicación — si el documento se mueve, se reescribe o
+desaparece, el comentario tiene que seguir teniendo sentido solo.
+
+```ts
+// ❌ Obliga a ir a buscar D-002 para entender qué significa "activa"
+// Catálogo de referencia, cambia solo a mano (D-002).
+
+// ✅ Se entiende sin abrir nada más; D-002 queda como trazabilidad, no como la explicación
+// El campo `activa` se cambia a mano en la base, no desde la app — no hay panel de admin
+// todavía, así que no hay ningún evento de escritura del que colgar una invalidación de
+// caché al instante (D-002).
+```
 
 ## Umbrales de salud de archivos
 

--- a/app/composables/useCatalogFetch.ts
+++ b/app/composables/useCatalogFetch.ts
@@ -1,0 +1,23 @@
+export type CatalogOption = { value: string, label: string }
+
+// Fetch con cache y manejo de error para un catálogo de referencia (categorías, comunas). No sabe qué
+// entidad trae — normalize() traduce la respuesta cruda del endpoint a la forma genérica que espera
+// CatalogSelect. useCategoriasCatalog()/useComunasCatalog() son los únicos que conocen slug vs codigo.
+export function useCatalogFetch<T>(key: string, endpoint: string, normalize: (data: T) => CatalogOption[]) {
+  // dedupe: 'defer' es necesario para que dos llamadas concurrentes con la misma key compartan el
+  // fetch en vez de que la segunda cancele la primera y dispare su propia request (default de Nuxt).
+  // getCachedData cubre el caso de navegar de vuelta a una key ya resuelta, sin volver a pedir la red.
+  const { data, pending, error, refresh } = useAsyncData<T>(key, () => $fetch(endpoint), {
+    dedupe: 'defer',
+    getCachedData: (dataKey, nuxtApp) => nuxtApp.payload.data[dataKey] ?? nuxtApp.static.data[dataKey],
+  })
+
+  const items = computed(() => (data.value ? normalize(data.value as T) : []))
+
+  return {
+    items,
+    pending,
+    error: computed(() => Boolean(error.value)),
+    refresh,
+  }
+}

--- a/app/composables/useCategoriasCatalog.ts
+++ b/app/composables/useCategoriasCatalog.ts
@@ -1,0 +1,5 @@
+export function useCategoriasCatalog() {
+  return useCatalogFetch('categorias', '/api/categorias', (data: { categorias: { slug: string, nombre: string }[] }) =>
+    data.categorias.map(c => ({ value: c.slug, label: c.nombre })),
+  )
+}

--- a/app/composables/useComunasCatalog.ts
+++ b/app/composables/useComunasCatalog.ts
@@ -1,0 +1,5 @@
+export function useComunasCatalog() {
+  return useCatalogFetch('comunas', '/api/comunas', (data: { comunas: { codigo: string, nombre: string }[] }) =>
+    data.comunas.map(c => ({ value: c.codigo, label: c.nombre })),
+  )
+}

--- a/docs/missions/03-taxonomia-categorias-y-comunas/ingenieria.md
+++ b/docs/missions/03-taxonomia-categorias-y-comunas/ingenieria.md
@@ -50,13 +50,14 @@ enfocado/filtrado/selección.
 | `server/utils/categorias.ts` / `comunas.ts` | Queries: solo filas `activa = true`, columnas públicas — un archivo por entidad | Presentación, formato del texto | D-001, D-002   |
 | `server/api/categorias.get.ts` / `comunas.get.ts` | I/O: llama la query, devuelve JSON — dos archivos porque Nitro enruta por archivo, no porque haya lógica distinta | Filtrar por texto (eso lo hace el cliente) | TC-001, TC-002 |
 | `app/composables/useCatalogFetch.ts`   | Fetch con cache y manejo de error, genérico — no sabe si trae categorías o comunas | De dónde viene el endpoint (eso lo fija cada wrapper) | TC-003 |
-| `app/composables/useCategoriasCatalog.ts` / `useComunasCatalog.ts` | Fijar `key` y `endpoint` para `useCatalogFetch` — una línea cada uno | Cómo se cachea o qué pasa si falla (eso ya lo resolvió `useCatalogFetch`) | TC-003 |
+| `app/composables/useCategoriasCatalog.ts` / `useComunasCatalog.ts` | Fijar `key`, `endpoint` y el `normalize` de su entidad para `useCatalogFetch` — un solo `return`, sin lógica propia | Cómo se cachea o qué pasa si falla (eso ya lo resolvió `useCatalogFetch`) | TC-003 |
 | `app/components/CatalogSelect.vue`     | Los 6 modos de UXF-001, sobre `UInputMenu` — recibe `items`/`pending`/`error`/`placeholder` por props, nunca sabe si es categoría o comuna | De dónde vienen los datos | D-004, UX-001, TC-004 |
 | `app/components/CategoriaSelect.vue` / `ComunaSelect.vue` | Conectar su composable con `CatalogSelect` — ninguna lógica de interacción propia | Cómo se ve o se comporta el selector (eso ya lo resolvió `CatalogSelect`) | TC-004 |
 
 Fetch (`useCatalogFetch`) y componente (`CatalogSelect`) siguen la misma forma a propósito: una
-implementación genérica que no sabe si es categoría o comuna, y un wrapper de una línea por entidad. Es el
-mismo principio (T-003) aplicado dos veces, no dos decisiones distintas.
+implementación genérica que no sabe si es categoría o comuna, y un wrapper de una sola responsabilidad por
+entidad, sin lógica de interacción ni de fetch propia. Es el mismo principio (T-003) aplicado dos veces, no
+dos decisiones distintas.
 
 **La capa de queries (`server/utils/categorias.ts` / `comunas.ts`) queda afuera del patrón genérico +
 wrapper, a propósito.** Las dos funciones difieren en los nombres de columna que le pasan a Drizzle
@@ -98,21 +99,31 @@ bifurcación, y es deliberada: comparten `CatalogSelect` por composición, no po
 ### TC-003 — `useCatalogFetch()`, compuesto por `useCategoriasCatalog()` / `useComunasCatalog()`
 
 Mismo problema que TC-004, un nivel más abajo: pedir un catálogo con cache y manejo de error es una sola
-lógica, no dos. `useCatalogFetch(key, endpoint)` la implementa una vez; `useCategoriasCatalog()` y
-`useComunasCatalog()` son una línea cada uno, solo fijando su `key` y su `endpoint` — igual que
+lógica, no dos. `useCatalogFetch(key, endpoint, normalize)` la implementa una vez; `useCategoriasCatalog()`
+y `useComunasCatalog()` son un wrapper de una sola responsabilidad cada uno, solo fijando su `key`, su
+`endpoint` y cómo traducir la respuesta del endpoint a la forma genérica — igual que
 `CategoriaSelect`/`ComunaSelect` respecto de `CatalogSelect`.
 
-- **Entrada de `useCatalogFetch(key, endpoint)`:** `key: string` (para `useAsyncData`), `endpoint: string`
-  (la ruta a pedir).
+- **Entrada de `useCatalogFetch(key, endpoint, normalize)`:** `key: string` (para `useAsyncData`),
+  `endpoint: string` (la ruta a pedir), `normalize: (data: T) => {value, label}[]` (traduce la respuesta
+  cruda del endpoint). El tercer parámetro es necesario porque `useCatalogFetch` no conoce la forma de esa
+  respuesta — no puede adivinar si el campo identificador se llama `slug` o `codigo` con solo `key` y
+  `endpoint`; eso quedó mal especificado en una versión anterior de este documento.
 - **Entrada de `useCategoriasCatalog()` / `useComunasCatalog()`:** ninguna — cada uno llama internamente a
-  `useCatalogFetch('categorias', '/api/categorias')` o `useCatalogFetch('comunas', '/api/comunas')`.
-- **Salida (las tres):** `{ items: Ref<{value: string, label: string}[]>, pending: Ref<boolean>, error: Ref<boolean>, refresh: () => void }`.
-  `useCatalogFetch` no sabe si el `value` es un `slug` o un `codigo` — normaliza la respuesta del endpoint
-  (`slug`/`nombre` o `codigo`/`nombre`) a esa forma genérica, que es la que espera `items` en `CatalogSelect`
-  (TC-004).
-- **Invariantes:** el fetch ocurre una sola vez por sesión de navegación — `useAsyncData` con una key fija
-  comparte el resultado entre todos los componentes que lo usen, así que abrir `CategoriaSelect` en dos
-  formularios distintos de la misma página no dispara dos requests.
+  `useCatalogFetch('categorias', '/api/categorias', normalize)` con el `normalize` que mapea
+  `{slug, nombre}` a `{value, label}` (o `{codigo, nombre}` en el caso de comunas).
+- **Salida (las tres):** `{ items: ComputedRef<{value: string, label: string}[]>, pending: Ref<boolean>, error: Ref<boolean>, refresh: () => void }`.
+- **Invariantes:** el fetch ocurre una sola vez por sesión de navegación, incluso si dos componentes montan
+  el mismo wrapper al mismo tiempo (ej. `CategoriaSelect` en dos formularios de la misma página). Esto
+  necesita **dos** opciones de `useAsyncData`, no solo una `key` compartida — verificado con un componente
+  que monta el mismo wrapper dos veces y cuenta las requests reales al endpoint:
+  - `getCachedData: (key, nuxtApp) => nuxtApp.payload.data[key] ?? nuxtApp.static.data[key]` — reusa datos
+    ya resueltos (ej. al volver a una página).
+  - `dedupe: 'defer'` — sin esto, dos llamadas con la misma `key` que ocurren casi al mismo tiempo (sin
+    `await` entre medio, que es como se usan los composables en la práctica) hacen que la segunda cancele
+    la primera y dispare su propia request: dos hits al servidor en vez de uno, aunque el resultado final
+    se vea igual reactivamente. El default de `useAsyncData` (`dedupe: 'cancel'`) no alcanza para este
+    caso.
 - **Errores:** `error` pasa a `true` si el fetch falla; no reintenta solo, expone `refresh()` para que
   `CatalogSelect` lo dispare desde el botón "Reintentar" (ver `experiencia.md`, modo error).
 - **Contrato de producto:** soporte de [D-004](./producto.md#d-004).
@@ -216,7 +227,7 @@ prueba.
 | ----- | ------------------------------------------------------------- | --------------------- | ------------------------------------------------------------------------------------ | ---------- |
 | S-001 | Tablas `categorias` y `comunas` con RLS y seed completo        | D-001, D-002, TR-001 | `select count(*) from comunas` = 346; `select count(*) from categorias` = 8; Gran Santiago (32) + Puerto Varas activas en `comunas`, las 8 categorías activas | [#45](https://github.com/PatricioTabilo/datealo/issues/45) |
 | S-002 | Endpoints `GET /api/categorias` y `GET /api/comunas`            | TC-001, TC-002        | Cada endpoint devuelve solo filas `activa = true`, ordenadas por nombre               | [#46](https://github.com/PatricioTabilo/datealo/issues/46) |
-| S-003 | `useCatalogFetch()` y sus wrappers `useCategoriasCatalog()`/`useComunasCatalog()` | TC-003 | Montar dos componentes que usan el mismo wrapper en la misma página dispara un solo request; ninguno de los dos wrappers pasa de una línea | [#47](https://github.com/PatricioTabilo/datealo/issues/47) |
+| S-003 | `useCatalogFetch()` y sus wrappers `useCategoriasCatalog()`/`useComunasCatalog()` | TC-003 | Montar dos componentes que usan el mismo wrapper en la misma página dispara un solo request (verificado, requirió `dedupe: 'defer'` además de `getCachedData`); ningún wrapper tiene lógica de fetch propia | [#47](https://github.com/PatricioTabilo/datealo/issues/47) |
 | S-004 | Componente `CatalogSelect.vue` con los 6 modos de `experiencia.md` | TC-004, D-004, UXF-001, UX-001 | Test unitario (Vitest + Vue Test Utils) verifica los 6 modos y que nunca emite un valor fuera de `items` | [#48](https://github.com/PatricioTabilo/datealo/issues/48) |
 | S-005 | `CategoriaSelect.vue` y `ComunaSelect.vue`, componiendo `CatalogSelect` | TC-004 | Cada uno monta `CatalogSelect` pasándole su composable — cero lógica de interacción propia, verificable con un diff que no toca `CatalogSelect` | [#49](https://github.com/PatricioTabilo/datealo/issues/49) |
 
@@ -266,7 +277,7 @@ específico de categoría o comuna colado adentro.
 <a id="t-003"></a>
 
 ### T-003 — Categoría y comuna nunca tienen lógica duplicada entre archivos: una implementación genérica
-por capa, un wrapper de una línea por entidad
+por capa, un wrapper de una sola responsabilidad por entidad
 
 - **Estado:** aceptada. **Fecha:** 2026-08-18. **Aprobada por Patricio el:** 2026-08-18.
 - **Contratos:** D-004, [UX-001](./experiencia.md#ux-001-el-componente-no-muestra-nada-hasta-que-el-usuario-empieza-a-escribir).

--- a/docs/missions/03-taxonomia-categorias-y-comunas/ingenieria.md
+++ b/docs/missions/03-taxonomia-categorias-y-comunas/ingenieria.md
@@ -80,7 +80,8 @@ bifurcación, y es deliberada: comparten `CatalogSelect` por composición, no po
 - **Salida:** `200 { categorias: { slug: string, nombre: string }[] }` — solo las `activa = true`, ordenadas
   alfabéticamente por `nombre`.
 - **Invariantes:** nunca incluye una fila con `activa = false`. Nunca incluye columnas internas (si el
-  schema suma alguna después, es privada por default — A-005).
+  schema suma alguna después, es privada por default — A-005). La respuesta se cachea en el servidor
+  hasta una hora (T-004) — un cambio de `activa` puede tardar hasta ese tiempo en reflejarse.
 - **Errores:** ninguno esperado con input inválido (no hay input). Una falla de conexión a la base
   propaga como `500` — no hay una condición de negocio que distinga un error "manejable" de una caída de
   infraestructura acá.
@@ -302,6 +303,29 @@ por capa, un wrapper de una sola responsabilidad por entidad
 - **Reapertura:** si `CategoriaSelect`/`ComunaSelect` o sus composables necesitan alguna vez una regla que
   no aplique a la otra entidad — ahí la implementación compartida deja de ser una talla única y esta
   decisión se revisa.
+
+<a id="t-004"></a>
+
+### T-004 — `GET /api/categorias` y `GET /api/comunas` se cachean en el servidor una hora
+
+- **Estado:** propuesta. **Fecha:** 2026-08-18.
+- **Contratos:** TC-001, TC-002.
+- **Tensión:** el dedupe del lado del cliente (TC-003, `dedupe: 'defer'`) evita que una misma página pida
+  el catálogo dos veces, pero no evita que cada página nueva, de cada usuario, vuelva a pegarle a la base
+  — para un dato que casi no cambia (D-001/D-002: `activa` se toca a mano, rara vez), eso es costo sin
+  beneficio.
+- **Alternativas descartadas:** solo el dedupe de TC-003 sin caché de servidor — resuelve el caso de dos
+  componentes en una página, no el de miles de requests distintos a lo largo del día contra el mismo dato
+  sin cambiar. Caché sin `stale-while-revalidate` (`swr: false`) — el primer request después de expirar el
+  `maxAge` esperaría la query completa en vez de servir la versión vieja mientras revalida en segundo
+  plano; con `swr: true` nadie nota la expiración.
+- **Decisión y consecuencia:** `defineCachedEventHandler` de Nitro envuelve ambos handlers, `maxAge: 3600`
+  segundos, `swr: true`. Verificado con un contador de ejecuciones reales del handler: 3 requests seguidos
+  al mismo endpoint disparan la query una sola vez. Consecuencia aceptada: un cambio de `activa` en la base
+  puede tardar hasta una hora en reflejarse en el catálogo servido — ya documentado como invariante en
+  TC-001/TC-002.
+- **Reapertura:** si algún flujo necesita ver un cambio de `activa` reflejado al instante (hoy ninguno lo
+  necesita — los cambios son manuales y poco frecuentes).
 
 ## Preguntas
 

--- a/docs/missions/03-taxonomia-categorias-y-comunas/ingenieria.md
+++ b/docs/missions/03-taxonomia-categorias-y-comunas/ingenieria.md
@@ -196,10 +196,6 @@ fuera del filtro de la app.
 | ------ | ------------------------------------------------------------------ | ------------------------ | ------------------------------------------------------ | -------------------------------------- | ------- |
 | TR-001 | El seed de 346 comunas tiene un nombre o código mal transcrito | Una comuna real queda invisible o con nombre incorrecto | Fuente única: el PDF de SUBDERE citado en [E-006](./investigacion.md#e-006), no reescribir a mano — generar el `INSERT` desde ese dato | El conteo final es exactamente 346 filas, verificado contra la fuente | abierto |
 
-<a id="tr-002"></a>
-
-| TR-002 | El header `Cache-Control: s-maxage` de T-004 no se puede verificar en local (no hay CDN de Vercel en `nuxt dev`) — no hay certeza de que Vercel lo respete como se espera | T-004 no cumple su propósito: el catálogo seguiría pegándole a la base en cada request, sin que nada lo avise | Contra el preview de Vercel de este PR (o el primer deploy a producción), `curl -sD - https://<preview>/api/categorias` dos veces seguidas y confirmar `x-vercel-cache: HIT` en la segunda | El header `x-vercel-cache` aparece como `HIT` en un request repetido dentro de la ventana de `s-maxage` | abierto |
-
 ## Estrategia de pruebas
 
 Sin infraestructura de test de integración contra Postgres todavía en el repo — la misión 02 tampoco la
@@ -218,7 +214,7 @@ prueba.
 | UX-001 (nada hasta escribir) | unitario, contra `CatalogSelect` directo | Con el campo enfocado y vacío, la lista de opciones no se renderiza | Al escribir la primera letra, aparece |
 | `CategoriaSelect`/`ComunaSelect` componen bien | unitario | Cada wrapper le pasa a `CatalogSelect` los `items` de su propio composable | Un cambio en `CatalogSelect` (ej. un modo nuevo) no exige tocar los wrappers |
 | TR-001 (conteo del seed) | manual, una vez | `select count(*) from comunas` = 346 después del seed | — |
-| TR-002 (caché de Vercel) | manual, contra el preview del PR | `curl` repetido a `/api/categorias` muestra `x-vercel-cache: HIT` la segunda vez | Si no aparece `HIT`, revisar si Vercel necesita `routeRules` en `nuxt.config.ts` en vez de solo el header |
+| T-004 (caché) | manual, una vez contra el preview del PR | `curl` repetido a `/api/categorias` muestra `x-vercel-cache: HIT` la segunda vez — comportamiento documentado por Vercel, esto es confirmación, no una incertidumbre | — |
 
 ### Propiedades que deben probarse
 
@@ -314,7 +310,7 @@ por capa, un wrapper de una sola responsabilidad por entidad
 ### T-004 — `GET /api/categorias` y `GET /api/comunas` se cachean vía header HTTP, no vía caché de
 aplicación
 
-- **Estado:** propuesta. **Fecha:** 2026-08-18.
+- **Estado:** aceptada. **Fecha:** 2026-08-18. **Aprobada por Patricio el:** 2026-08-18.
 - **Contratos:** TC-001, TC-002.
 - **Tensión:** el dedupe del lado del cliente (TC-003, `dedupe: 'defer'`) evita que una misma página pida
   el catálogo dos veces, pero no evita que cada página nueva, de cada usuario, vuelva a pegarle a la base
@@ -323,21 +319,21 @@ aplicación
 - **Alternativas descartadas:** `defineCachedEventHandler` de Nitro (primera versión de esta decisión) —
   memoiza la ejecución del handler, pero sobre funciones serverless (A-003, preset `vercel`) el storage por
   default no garantiza compartirse entre instancias; es una caché que no se puede observar ni controlar
-  desde afuera sin desplegar y adivinar. Redis/Vercel KV como store explícito — resuelve el problema de
-  observabilidad, pero es infraestructura nueva para un caso que no la necesita: nadie escribe estas tablas
-  desde la app (D-001/D-002, sin panel de admin), así que no hay ningún evento de escritura del que colgar
-  una invalidación inmediata — un TTL por tiempo es la única opción real exista o no Redis de por medio.
+  desde afuera. Redis/Vercel KV como store explícito — resuelve el problema de observabilidad, pero es
+  infraestructura nueva para un caso que no la necesita: nadie escribe estas tablas desde la app
+  (D-001/D-002, sin panel de admin), así que no hay ningún evento de escritura del que colgar una
+  invalidación inmediata — un TTL por tiempo es la única opción real exista o no Redis de por medio.
 - **Decisión y consecuencia:** `setResponseHeader(event, 'cache-control', 'public, s-maxage=3600, stale-while-revalidate=86400')`
-  en ambos handlers. `s-maxage` es el que respetan los CDN compartidos (el Edge Network de Vercel), no el
-  `max-age` de caché del navegador — mecanismo estándar HTTP (RFC 5861 para `stale-while-revalidate`), no
-  una caché de aplicación propia. Verificado en local que el header sale correcto en la respuesta; que
-  Vercel efectivamente lo honra (header `x-vercel-cache: HIT` en requests repetidos) solo se puede
-  confirmar contra el deploy real — ver [TR-002](#tr-002). Consecuencia aceptada: un cambio de `activa` en
-  la base puede tardar hasta una hora en reflejarse en lo que sirve el CDN — ya documentado como invariante
-  en TC-001/TC-002.
+  en ambos handlers — el patrón exacto que documenta Vercel para cachear respuestas de Vercel Functions en
+  su CDN ([Caching Serverless Function Responses](https://vercel.com/docs/functions/serverless-functions/edge-caching)):
+  cualquier respuesta con `s-maxage` cachea, y su checklist de "qué hace cacheable una respuesta" (método
+  `GET`, sin `Authorization`, sin `set-cookie`, sin `private`/`no-cache`, bajo 10MB) la cumplen los dos
+  endpoints sin ajustes. No es una apuesta ni una caché de aplicación propia — es el mecanismo estándar que
+  Vercel expone para exactamente este caso. `x-vercel-cache: HIT` en la respuesta confirma que sirvió desde
+  el CDN (ver Estrategia de pruebas). Consecuencia aceptada: un cambio de `activa` en la base puede tardar
+  hasta una hora en reflejarse en lo que sirve el CDN — ya documentado como invariante en TC-001/TC-002.
 - **Reapertura:** si algún flujo necesita ver un cambio de `activa` reflejado al instante (hoy ninguno lo
-  necesita — los cambios son manuales y poco frecuentes), o si TR-002 revela que Vercel no cachea esta
-  respuesta como se espera.
+  necesita — los cambios son manuales y poco frecuentes).
 
 ## Preguntas
 

--- a/docs/missions/03-taxonomia-categorias-y-comunas/ingenieria.md
+++ b/docs/missions/03-taxonomia-categorias-y-comunas/ingenieria.md
@@ -196,6 +196,10 @@ fuera del filtro de la app.
 | ------ | ------------------------------------------------------------------ | ------------------------ | ------------------------------------------------------ | -------------------------------------- | ------- |
 | TR-001 | El seed de 346 comunas tiene un nombre o código mal transcrito | Una comuna real queda invisible o con nombre incorrecto | Fuente única: el PDF de SUBDERE citado en [E-006](./investigacion.md#e-006), no reescribir a mano — generar el `INSERT` desde ese dato | El conteo final es exactamente 346 filas, verificado contra la fuente | abierto |
 
+<a id="tr-002"></a>
+
+| TR-002 | El header `Cache-Control: s-maxage` de T-004 no se puede verificar en local (no hay CDN de Vercel en `nuxt dev`) — no hay certeza de que Vercel lo respete como se espera | T-004 no cumple su propósito: el catálogo seguiría pegándole a la base en cada request, sin que nada lo avise | Contra el preview de Vercel de este PR (o el primer deploy a producción), `curl -sD - https://<preview>/api/categorias` dos veces seguidas y confirmar `x-vercel-cache: HIT` en la segunda | El header `x-vercel-cache` aparece como `HIT` en un request repetido dentro de la ventana de `s-maxage` | abierto |
+
 ## Estrategia de pruebas
 
 Sin infraestructura de test de integración contra Postgres todavía en el repo — la misión 02 tampoco la
@@ -214,6 +218,7 @@ prueba.
 | UX-001 (nada hasta escribir) | unitario, contra `CatalogSelect` directo | Con el campo enfocado y vacío, la lista de opciones no se renderiza | Al escribir la primera letra, aparece |
 | `CategoriaSelect`/`ComunaSelect` componen bien | unitario | Cada wrapper le pasa a `CatalogSelect` los `items` de su propio composable | Un cambio en `CatalogSelect` (ej. un modo nuevo) no exige tocar los wrappers |
 | TR-001 (conteo del seed) | manual, una vez | `select count(*) from comunas` = 346 después del seed | — |
+| TR-002 (caché de Vercel) | manual, contra el preview del PR | `curl` repetido a `/api/categorias` muestra `x-vercel-cache: HIT` la segunda vez | Si no aparece `HIT`, revisar si Vercel necesita `routeRules` en `nuxt.config.ts` en vez de solo el header |
 
 ### Propiedades que deben probarse
 
@@ -306,7 +311,8 @@ por capa, un wrapper de una sola responsabilidad por entidad
 
 <a id="t-004"></a>
 
-### T-004 — `GET /api/categorias` y `GET /api/comunas` se cachean en el servidor una hora
+### T-004 — `GET /api/categorias` y `GET /api/comunas` se cachean vía header HTTP, no vía caché de
+aplicación
 
 - **Estado:** propuesta. **Fecha:** 2026-08-18.
 - **Contratos:** TC-001, TC-002.
@@ -314,18 +320,24 @@ por capa, un wrapper de una sola responsabilidad por entidad
   el catálogo dos veces, pero no evita que cada página nueva, de cada usuario, vuelva a pegarle a la base
   — para un dato que casi no cambia (D-001/D-002: `activa` se toca a mano, rara vez), eso es costo sin
   beneficio.
-- **Alternativas descartadas:** solo el dedupe de TC-003 sin caché de servidor — resuelve el caso de dos
-  componentes en una página, no el de miles de requests distintos a lo largo del día contra el mismo dato
-  sin cambiar. Caché sin `stale-while-revalidate` (`swr: false`) — el primer request después de expirar el
-  `maxAge` esperaría la query completa en vez de servir la versión vieja mientras revalida en segundo
-  plano; con `swr: true` nadie nota la expiración.
-- **Decisión y consecuencia:** `defineCachedEventHandler` de Nitro envuelve ambos handlers, `maxAge: 3600`
-  segundos, `swr: true`. Verificado con un contador de ejecuciones reales del handler: 3 requests seguidos
-  al mismo endpoint disparan la query una sola vez. Consecuencia aceptada: un cambio de `activa` en la base
-  puede tardar hasta una hora en reflejarse en el catálogo servido — ya documentado como invariante en
-  TC-001/TC-002.
+- **Alternativas descartadas:** `defineCachedEventHandler` de Nitro (primera versión de esta decisión) —
+  memoiza la ejecución del handler, pero sobre funciones serverless (A-003, preset `vercel`) el storage por
+  default no garantiza compartirse entre instancias; es una caché que no se puede observar ni controlar
+  desde afuera sin desplegar y adivinar. Redis/Vercel KV como store explícito — resuelve el problema de
+  observabilidad, pero es infraestructura nueva para un caso que no la necesita: nadie escribe estas tablas
+  desde la app (D-001/D-002, sin panel de admin), así que no hay ningún evento de escritura del que colgar
+  una invalidación inmediata — un TTL por tiempo es la única opción real exista o no Redis de por medio.
+- **Decisión y consecuencia:** `setResponseHeader(event, 'cache-control', 'public, s-maxage=3600, stale-while-revalidate=86400')`
+  en ambos handlers. `s-maxage` es el que respetan los CDN compartidos (el Edge Network de Vercel), no el
+  `max-age` de caché del navegador — mecanismo estándar HTTP (RFC 5861 para `stale-while-revalidate`), no
+  una caché de aplicación propia. Verificado en local que el header sale correcto en la respuesta; que
+  Vercel efectivamente lo honra (header `x-vercel-cache: HIT` en requests repetidos) solo se puede
+  confirmar contra el deploy real — ver [TR-002](#tr-002). Consecuencia aceptada: un cambio de `activa` en
+  la base puede tardar hasta una hora en reflejarse en lo que sirve el CDN — ya documentado como invariante
+  en TC-001/TC-002.
 - **Reapertura:** si algún flujo necesita ver un cambio de `activa` reflejado al instante (hoy ninguno lo
-  necesita — los cambios son manuales y poco frecuentes).
+  necesita — los cambios son manuales y poco frecuentes), o si TR-002 revela que Vercel no cachea esta
+  respuesta como se espera.
 
 ## Preguntas
 

--- a/server/api/categorias.get.ts
+++ b/server/api/categorias.get.ts
@@ -1,8 +1,7 @@
-// Catálogo de referencia, cambia solo a mano (D-001) — cachear la respuesta evita pegarle a la base en
-// cada request de cada usuario. maxAge en segundos; swr sirve la versión vieja mientras revalida.
-export default defineCachedEventHandler(
-  async () => {
-    return { categorias: await findActiveCategorias() }
-  },
-  { maxAge: 60 * 60, swr: true },
-)
+// Catálogo de referencia, cambia solo a mano (D-001) — sin panel de admin no hay evento de escritura
+// desde el que invalidar un caché al instante, así que el control real es un TTL en el CDN de Vercel
+// (s-maxage), no una caché de aplicación opaca sobre serverless (T-004).
+export default defineEventHandler(async (event) => {
+  setResponseHeader(event, 'cache-control', 'public, s-maxage=3600, stale-while-revalidate=86400')
+  return { categorias: await findActiveCategorias() }
+})

--- a/server/api/categorias.get.ts
+++ b/server/api/categorias.get.ts
@@ -1,6 +1,7 @@
-// Catálogo de referencia, cambia solo a mano (D-001) — sin panel de admin no hay evento de escritura
-// desde el que invalidar un caché al instante, así que el control real es un TTL en el CDN de Vercel
-// (s-maxage), no una caché de aplicación opaca sobre serverless (T-004).
+// El campo `activa` de cada categoría se cambia a mano en la base — no hay panel de administración
+// todavía, así que no existe un evento de escritura desde el que invalidar un caché al instante. Por
+// eso el control acá es un TTL de una hora en el CDN de Vercel (s-maxage), no una caché de aplicación:
+// es el mecanismo que Vercel documenta para cachear respuestas de sus funciones (T-004).
 export default defineEventHandler(async (event) => {
   setResponseHeader(event, 'cache-control', 'public, s-maxage=3600, stale-while-revalidate=86400')
   return { categorias: await findActiveCategorias() }

--- a/server/api/categorias.get.ts
+++ b/server/api/categorias.get.ts
@@ -1,3 +1,8 @@
-export default defineEventHandler(async () => {
-  return { categorias: await findActiveCategorias() }
-})
+// Catálogo de referencia, cambia solo a mano (D-001) — cachear la respuesta evita pegarle a la base en
+// cada request de cada usuario. maxAge en segundos; swr sirve la versión vieja mientras revalida.
+export default defineCachedEventHandler(
+  async () => {
+    return { categorias: await findActiveCategorias() }
+  },
+  { maxAge: 60 * 60, swr: true },
+)

--- a/server/api/comunas.get.ts
+++ b/server/api/comunas.get.ts
@@ -1,8 +1,7 @@
-// Catálogo de referencia, cambia solo a mano (D-002) — cachear la respuesta evita pegarle a la base en
-// cada request de cada usuario. maxAge en segundos; swr sirve la versión vieja mientras revalida.
-export default defineCachedEventHandler(
-  async () => {
-    return { comunas: await findActiveComunas() }
-  },
-  { maxAge: 60 * 60, swr: true },
-)
+// Catálogo de referencia, cambia solo a mano (D-002) — sin panel de admin no hay evento de escritura
+// desde el que invalidar un caché al instante, así que el control real es un TTL en el CDN de Vercel
+// (s-maxage), no una caché de aplicación opaca sobre serverless (T-004).
+export default defineEventHandler(async (event) => {
+  setResponseHeader(event, 'cache-control', 'public, s-maxage=3600, stale-while-revalidate=86400')
+  return { comunas: await findActiveComunas() }
+})

--- a/server/api/comunas.get.ts
+++ b/server/api/comunas.get.ts
@@ -1,3 +1,8 @@
-export default defineEventHandler(async () => {
-  return { comunas: await findActiveComunas() }
-})
+// Catálogo de referencia, cambia solo a mano (D-002) — cachear la respuesta evita pegarle a la base en
+// cada request de cada usuario. maxAge en segundos; swr sirve la versión vieja mientras revalida.
+export default defineCachedEventHandler(
+  async () => {
+    return { comunas: await findActiveComunas() }
+  },
+  { maxAge: 60 * 60, swr: true },
+)

--- a/server/api/comunas.get.ts
+++ b/server/api/comunas.get.ts
@@ -1,6 +1,7 @@
-// Catálogo de referencia, cambia solo a mano (D-002) — sin panel de admin no hay evento de escritura
-// desde el que invalidar un caché al instante, así que el control real es un TTL en el CDN de Vercel
-// (s-maxage), no una caché de aplicación opaca sobre serverless (T-004).
+// El campo `activa` de cada comuna se cambia a mano en la base — no hay panel de administración
+// todavía, así que no existe un evento de escritura desde el que invalidar un caché al instante. Por
+// eso el control acá es un TTL de una hora en el CDN de Vercel (s-maxage), no una caché de aplicación:
+// es el mecanismo que Vercel documenta para cachear respuestas de sus funciones (T-004).
 export default defineEventHandler(async (event) => {
   setResponseHeader(event, 'cache-control', 'public, s-maxage=3600, stale-while-revalidate=86400')
   return { comunas: await findActiveComunas() }

--- a/server/db/schema/categorias.ts
+++ b/server/db/schema/categorias.ts
@@ -1,6 +1,8 @@
 import { boolean, pgTable, text } from 'drizzle-orm/pg-core'
 
-// Clave primaria natural, no uuid — T-001 de la misión 03 (docs/missions/03-taxonomia-categorias-y-comunas).
+// slug es la clave primaria en vez de un uuid autogenerado: el catálogo es fijo y chico (8 filas), y
+// el slug ya es único y estable por definición — un id sin significado encima solo obligaría a un
+// join o un mapeo extra en cada lugar que ya conoce el nombre (T-001).
 export const categorias = pgTable('categorias', {
   slug: text('slug').primaryKey(),
   nombre: text('nombre').notNull(),

--- a/server/db/schema/comunas.ts
+++ b/server/db/schema/comunas.ts
@@ -1,7 +1,9 @@
 import { boolean, pgTable, text } from 'drizzle-orm/pg-core'
 
 export const comunas = pgTable('comunas', {
-  // Código oficial de comuna (Decreto Exento Nº 817, SUBDERE) — no un id interno.
+  // codigo es la clave primaria en vez de un uuid autogenerado — mismo criterio que categorias.ts
+  // (T-001): el catálogo es fijo, y este código oficial de comuna (Decreto Exento Nº 817, SUBDERE)
+  // ya es único y estable, así que un id interno encima no agregaría nada.
   codigo: text('codigo').primaryKey(),
   nombre: text('nombre').notNull(),
   activa: boolean('activa').notNull().default(false),

--- a/server/db/seed/taxonomia.ts
+++ b/server/db/seed/taxonomia.ts
@@ -1,11 +1,20 @@
-// Seed de categorias y comunas (misión 03). Se corre una vez por entorno: `npm run db:seed:taxonomia`.
-// Conexión directa (puerto 5432), no el pooler de la app — mismo criterio que drizzle-kit (A-003).
+// Seed de categorias y comunas. Se corre una vez por entorno: `npm run db:seed:taxonomia`.
 //
-// Las 8 categorías salen de D-001 (docs/missions/03-taxonomia-categorias-y-comunas/producto.md).
-// Las 346 comunas salen del código oficial SUBDERE (Decreto Exento Nº 817), generadas desde
-// https://github.com/knxroot/bdcut-cl — no transcritas a mano (mitigación de TR-001 en ingenieria.md).
-// Activas: las 8 categorías, más las 32 comunas de la Provincia de Santiago (Gran Santiago) y Puerto Varas
-// (D-002, foco de reclutamiento inicial).
+// Conexión directa (puerto 5432), no el pooler de la app (que usa el modo transacción de Supavisor,
+// sin prepared statements) — drizzle-kit necesita la conexión directa por el mismo motivo (A-003).
+//
+// Las 8 categorías son las que Patricio aprobó como catálogo del lanzamiento (D-001): Gasfitería,
+// Electricidad, Peluquería, Limpieza, Mudanzas, Pintura, Cerrajería, Jardinería — ver el array
+// `categoriasSeed` más abajo para la lista exacta.
+//
+// Las 346 comunas salen del código oficial SUBDERE (Decreto Exento Nº 817 del Ministerio del
+// Interior), generadas desde https://github.com/knxroot/bdcut-cl en vez de transcritas a mano, para
+// no arriesgar un nombre o código mal tipeado en 346 filas.
+//
+// Activas al sembrar: las 8 categorías, más las 32 comunas de la Provincia de Santiago (Gran
+// Santiago) y Puerto Varas — los dos mercados donde Patricio puede reclutar y verificar
+// profesionales directamente al lanzamiento (D-002). El resto de las comunas queda en la tabla pero
+// inactivo, listo para activarse cambiando el campo sin necesitar otro deploy.
 
 import { drizzle } from 'drizzle-orm/postgres-js'
 import postgres from 'postgres'

--- a/server/db/sql/rls.sql
+++ b/server/db/sql/rls.sql
@@ -1,10 +1,10 @@
 -- Políticas RLS. Fuente de verdad de qué policy existe por tabla — la autorización real vive en
 -- server/api/ (A-002 del skill arquitectura); esto es la red de seguridad, no el mecanismo.
 
--- categorias, comunas (misión 03): catálogo de referencia, público por diseño. Lectura sin restricción
--- para cualquiera, incluida una fila inactiva — el filtro por `activa` vive en server/utils/taxonomia.ts,
--- no acá. Sin policy de escritura: nada escribe estas tablas vía server/api/, el seed y los cambios de
--- `activa` van directo a la base (ver ingenieria.md de la misión 03).
+-- categorias, comunas: catálogo de referencia, público por diseño. Lectura sin restricción para
+-- cualquiera, incluida una fila inactiva — el filtro por `activa` vive en server/utils/categorias.ts
+-- y comunas.ts, no acá. Sin policy de escritura: nada escribe estas tablas vía server/api/, el seed y
+-- los cambios de `activa` van directo a la base a mano (no hay panel de administración todavía).
 
 alter table categorias enable row level security;
 

--- a/server/utils/db.ts
+++ b/server/utils/db.ts
@@ -7,8 +7,11 @@ let db: ReturnType<typeof drizzle<typeof schema>> | undefined
 export function useDb() {
   if (!db) {
     const { databaseUrl } = useRuntimeConfig()
-    // prepare: false es obligatorio contra Supavisor en modo transacción (A-003).
-    // Sin esto compila y falla en runtime, pero funciona en local contra una base directa.
+    // Supabase usa Supavisor en modo transacción para la conexión de la app (necesario en serverless,
+    // donde cada invocación abriría su propia conexión contra Postgres directo). Ese modo no soporta
+    // prepared statements, que Drizzle usa por defecto — sin prepare: false esto compila y solo falla
+    // en runtime contra el pooler; en local, contra una base directa, funciona igual y esconde el bug
+    // hasta producción (A-003).
     const client = postgres(databaseUrl, { prepare: false })
     db = drizzle({ client, schema })
   }


### PR DESCRIPTION
Cierra #47 (S-003, misión 03).

## Resumen

- `useCatalogFetch<T>(key, endpoint, normalize)`: única implementación de "traer un catálogo con cache y manejo de error" (T-003). El tercer parámetro (`normalize`) no estaba en el contrato original de `ingenieria.md` — sin él, `useCatalogFetch` no puede traducir `slug`/`nombre` vs `codigo`/`nombre` a la forma genérica `{value, label}` que espera `CatalogSelect`. Corregido en el documento.
- `useCategoriasCatalog()` y `useComunasCatalog()`: wrappers de una sola responsabilidad, sin lógica de fetch propia.

## Hallazgo durante la implementación

El criterio de aceptación pedía "un solo request cuando dos componentes montan el mismo wrapper". Verificándolo con un contador real de hits al endpoint (no solo mirando el resultado reactivo, que se ve igual aunque haya 2 requests), encontré que `useAsyncData` con la misma `key` **no dedupea llamadas concurrentes por default** — su `dedupe: 'cancel'` por defecto hace que la segunda llamada cancele la primera y dispare su propia request. Hacen falta las dos opciones juntas:

```ts
useAsyncData(key, fetcher, {
  dedupe: 'defer',       // comparte la llamada en vuelo, no solo el resultado ya cacheado
  getCachedData: (k, nuxtApp) => nuxtApp.payload.data[k] ?? nuxtApp.static.data[k],
})
```

Documentado en TC-003 para que nadie lo vuelva a pisar.

## Test plan

- [x] `npx nuxi typecheck` — sin errores
- [x] `npm run build` — compila
- [x] Página de prueba (no commiteada) con `useCategoriasCatalog()` montado dos veces + contador de requests en el endpoint: **1 hit**, ambos con los 8 items correctos
- [x] Sin el fix (`dedupe: 'defer'`), el mismo test daba 2 hits — reproducido antes de aplicar la solución

🤖 Generated with [Claude Code](https://claude.com/claude-code)