### PR TITLE
fix(app): CatalogSelect como input de texto normal, sin combobox de Nuxt UI

### DIFF
--- a/app/components/CatalogSelect.test.ts
+++ b/app/components/CatalogSelect.test.ts
@@ -11,12 +11,14 @@ import CatalogSelect from './CatalogSelect.vue'
 // UInputMenu, que es de Nuxt UI y no de este componente.
 const UInputMenuStub = {
   props: ['modelValue', 'searchTerm', 'items', 'open', 'loading', 'disabled', 'placeholder'],
-  emits: ['update:modelValue', 'update:searchTerm'],
+  emits: ['update:modelValue', 'update:searchTerm', 'focus', 'blur'],
   template: `
     <div>
       <input
         :value="searchTerm"
         @input="$emit('update:searchTerm', $event.target.value)"
+        @focus="$emit('focus')"
+        @blur="$emit('blur')"
       />
       <div v-if="open" data-testid="dropdown">
         <slot v-for="item in items" :key="item.value" name="item" :item="item" />
@@ -110,5 +112,28 @@ describe('CatalogSelect', () => {
     await wrapper.find('input').setValue('a')
     await wrapper.find('[data-testid="retry-button"]').trigger('click')
     expect(wrapper.emitted('retry')).toBeTruthy()
+  })
+
+  it('sin showAllOnFocus (comunas): enfocar sin escribir no abre la lista', async () => {
+    const wrapper = mountCatalogSelect()
+    await wrapper.find('input').trigger('focus')
+    expect(wrapper.find('[data-testid="dropdown"]').exists()).toBe(false)
+  })
+
+  it('con showAllOnFocus (categorías): enfocar sin escribir muestra el catálogo completo', async () => {
+    const wrapper = mountCatalogSelect({ showAllOnFocus: true })
+    await wrapper.find('input').trigger('focus')
+
+    expect(wrapper.find('[data-testid="dropdown"]').exists()).toBe(true)
+    for (const item of items) {
+      expect(wrapper.find(`[data-testid="option-${item.value}"]`).isVisible()).toBe(true)
+    }
+  })
+
+  it('con showAllOnFocus: al salir sin seleccionar, la lista se vuelve a cerrar', async () => {
+    const wrapper = mountCatalogSelect({ showAllOnFocus: true })
+    await wrapper.find('input').trigger('focus')
+    await wrapper.find('input').trigger('blur')
+    expect(wrapper.find('[data-testid="dropdown"]').exists()).toBe(false)
   })
 })

--- a/app/components/CatalogSelect.test.ts
+++ b/app/components/CatalogSelect.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import CatalogSelect from './CatalogSelect.vue'
+
+// UInputMenu es de Nuxt UI (auto-importado en la app real, no disponible fuera de un contexto Nuxt) —
+// se stubea con algo mínimo que expone lo que CatalogSelect necesita: v-model, search-term y el slot
+// `#item` por cada elemento de `items` (CatalogSelect siempre le pasa el catálogo completo, sin
+// recortar — ver T-004/T-005 y el comentario en CatalogSelect.vue sobre por qué). Lo que se prueba
+// acá es la lógica de CatalogSelect (qué se ve, qué se emite), no el comportamiento interno de
+// UInputMenu, que es de Nuxt UI y no de este componente.
+const UInputMenuStub = {
+  props: ['modelValue', 'searchTerm', 'items', 'open', 'loading', 'disabled', 'placeholder'],
+  emits: ['update:modelValue', 'update:searchTerm'],
+  template: `
+    <div>
+      <input
+        :value="searchTerm"
+        @input="$emit('update:searchTerm', $event.target.value)"
+      />
+      <div v-if="open" data-testid="dropdown">
+        <slot v-for="item in items" :key="item.value" name="item" :item="item" />
+        <slot name="content-bottom" />
+      </div>
+    </div>
+  `,
+}
+
+const UButtonStub = {
+  props: ['size'],
+  emits: ['click'],
+  template: '<button v-bind="$attrs" @click="$emit(\'click\')"><slot /></button>',
+  inheritAttrs: false,
+}
+
+const items = [
+  { value: 'gasfiteria', label: 'Gasfitería' },
+  { value: 'electricidad', label: 'Electricidad' },
+  { value: 'jardineria', label: 'Jardinería' },
+]
+
+function mountCatalogSelect(props: Partial<InstanceType<typeof CatalogSelect>['$props']> = {}) {
+  return mount(CatalogSelect, {
+    props: {
+      items,
+      pending: false,
+      error: false,
+      placeholder: '¿Qué necesitas?',
+      errorMessage: 'No pudimos cargar el catálogo.',
+      ...props,
+    },
+    global: {
+      stubs: { UInputMenu: UInputMenuStub, UButton: UButtonStub },
+    },
+  })
+}
+
+describe('CatalogSelect', () => {
+  it('modo enfocado sin texto: no muestra ninguna opción hasta escribir', async () => {
+    const wrapper = mountCatalogSelect()
+    expect(wrapper.find('[data-testid="dropdown"]').exists()).toBe(false)
+  })
+
+  it('modo con coincidencias: filtra sin distinguir mayúsculas ni tildes, sin sacar el resto del DOM', async () => {
+    const wrapper = mountCatalogSelect()
+    await wrapper.find('input').setValue('electric')
+
+    const match = wrapper.find('[data-testid="option-electricidad"]')
+    const nonMatch = wrapper.find('[data-testid="option-gasfiteria"]')
+    expect(match.isVisible()).toBe(true)
+    // Sigue en el árbol (nunca se saca del array — ver comentario de CatalogSelect.vue), solo oculto.
+    expect(nonMatch.exists()).toBe(true)
+    expect(nonMatch.isVisible()).toBe(false)
+  })
+
+  it('matchea "gasfiteria" escrito sin tilde contra "Gasfitería"', async () => {
+    const wrapper = mountCatalogSelect()
+    await wrapper.find('input').setValue('gasfiteria')
+    expect(wrapper.find('[data-testid="option-gasfiteria"]').isVisible()).toBe(true)
+  })
+
+  it('seleccionar una opción emite update:modelValue con su value, nunca con el texto escrito', async () => {
+    const wrapper = mountCatalogSelect()
+    await wrapper.find('input').setValue('gasfi')
+    await wrapper.find('[data-testid="option-gasfiteria"]').trigger('click')
+
+    const emitted = wrapper.emitted('update:modelValue')
+    expect(emitted).toBeTruthy()
+    expect(emitted![0]).toEqual(['gasfiteria'])
+  })
+
+  it('seleccionar la opción correcta no emite el value de otra, aunque esté oculta en el mismo array', async () => {
+    const wrapper = mountCatalogSelect()
+    await wrapper.find('input').setValue('electric')
+    await wrapper.find('[data-testid="option-electricidad"]').trigger('click')
+
+    const emitted = wrapper.emitted('update:modelValue')
+    expect(emitted![0]).toEqual(['electricidad'])
+    expect(emitted![0]).not.toEqual(['gasfiteria'])
+  })
+
+  it('escribir texto que no matchea nada no emite ningún valor', async () => {
+    const wrapper = mountCatalogSelect()
+    await wrapper.find('input').setValue('algo que no existe')
+    expect(wrapper.emitted('update:modelValue')).toBeFalsy()
+  })
+
+  it('modo error: el botón "Reintentar" emite retry', async () => {
+    const wrapper = mountCatalogSelect({ error: true })
+    await wrapper.find('input').setValue('a')
+    await wrapper.find('[data-testid="retry-button"]').trigger('click')
+    expect(wrapper.emitted('retry')).toBeTruthy()
+  })
+})

--- a/app/components/CatalogSelect.test.ts
+++ b/app/components/CatalogSelect.test.ts
@@ -1,32 +1,35 @@
 // @vitest-environment jsdom
 import { mount } from '@vue/test-utils'
+import { defineComponent, ref } from 'vue'
 import { describe, expect, it } from 'vitest'
 import CatalogSelect from './CatalogSelect.vue'
 
-// UInputMenu es de Nuxt UI (auto-importado en la app real, no disponible fuera de un contexto Nuxt) —
-// se stubea con algo mínimo que expone lo que CatalogSelect necesita: v-model, search-term y el slot
-// `#item` por cada elemento de `items` (CatalogSelect siempre le pasa el catálogo completo, sin
-// recortar — ver T-004/T-005 y el comentario en CatalogSelect.vue sobre por qué). Lo que se prueba
-// acá es la lógica de CatalogSelect (qué se ve, qué se emite), no el comportamiento interno de
-// UInputMenu, que es de Nuxt UI y no de este componente.
-const UInputMenuStub = {
-  props: ['modelValue', 'searchTerm', 'items', 'open', 'loading', 'disabled', 'placeholder'],
-  emits: ['update:modelValue', 'update:searchTerm', 'focus', 'blur'],
+// UInput/UButton son de Nuxt UI (auto-importados en la app real, no disponibles fuera de un contexto
+// Nuxt) — se stubean con lo mínimo real: un <input> de verdad y un <button> de verdad, porque
+// CatalogSelect ya no delega nada de su comportamiento a un componente de combobox — el filtrado, la
+// apertura y la selección son 100% propios (ver el comentario en CatalogSelect.vue sobre por qué se
+// abandonó el modo combobox de UInputMenu).
+//
+// Expone `inputRef` igual que el UInput real (node_modules/@nuxt/ui/dist/runtime/components/Input.vue)
+// porque CatalogSelect lo usa directo para limpiar el campo al tipear sobre un label ya elegido.
+const UInputStub = defineComponent({
+  props: ['modelValue', 'placeholder', 'readonly'],
+  emits: ['update:modelValue'],
+  setup(_props, { expose }) {
+    const inputRef = ref<HTMLInputElement | null>(null)
+    expose({ inputRef })
+    return { inputRef }
+  },
   template: `
-    <div>
-      <input
-        :value="searchTerm"
-        @input="$emit('update:searchTerm', $event.target.value)"
-        @focus="$emit('focus')"
-        @blur="$emit('blur')"
-      />
-      <div v-if="open" data-testid="dropdown">
-        <slot v-for="item in items" :key="item.value" name="item" :item="item" />
-        <slot name="content-bottom" />
-      </div>
-    </div>
+    <input
+      ref="inputRef"
+      :value="modelValue"
+      :placeholder="placeholder"
+      :readonly="readonly"
+      @input="$emit('update:modelValue', $event.target.value)"
+    />
   `,
-}
+})
 
 const UButtonStub = {
   props: ['size'],
@@ -52,7 +55,7 @@ function mountCatalogSelect(props: Partial<InstanceType<typeof CatalogSelect>['$
       ...props,
     },
     global: {
-      stubs: { UInputMenu: UInputMenuStub, UButton: UButtonStub },
+      stubs: { UInput: UInputStub, UButton: UButtonStub },
     },
   })
 }
@@ -60,29 +63,29 @@ function mountCatalogSelect(props: Partial<InstanceType<typeof CatalogSelect>['$
 describe('CatalogSelect', () => {
   it('modo enfocado sin texto: no muestra ninguna opción hasta escribir', async () => {
     const wrapper = mountCatalogSelect()
-    expect(wrapper.find('[data-testid="dropdown"]').exists()).toBe(false)
+    await wrapper.find('input').trigger('focusin')
+    expect(wrapper.find('[data-testid^="option-"]').exists()).toBe(false)
   })
 
-  it('modo con coincidencias: filtra sin distinguir mayúsculas ni tildes, sin sacar el resto del DOM', async () => {
+  it('modo con coincidencias: filtra sin distinguir mayúsculas ni tildes, sacando las que no matchean', async () => {
     const wrapper = mountCatalogSelect()
+    await wrapper.find('input').trigger('focusin')
     await wrapper.find('input').setValue('electric')
 
-    const match = wrapper.find('[data-testid="option-electricidad"]')
-    const nonMatch = wrapper.find('[data-testid="option-gasfiteria"]')
-    expect(match.isVisible()).toBe(true)
-    // Sigue en el árbol (nunca se saca del array — ver comentario de CatalogSelect.vue), solo oculto.
-    expect(nonMatch.exists()).toBe(true)
-    expect(nonMatch.isVisible()).toBe(false)
+    expect(wrapper.find('[data-testid="option-electricidad"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="option-gasfiteria"]').exists()).toBe(false)
   })
 
   it('matchea "gasfiteria" escrito sin tilde contra "Gasfitería"', async () => {
     const wrapper = mountCatalogSelect()
+    await wrapper.find('input').trigger('focusin')
     await wrapper.find('input').setValue('gasfiteria')
-    expect(wrapper.find('[data-testid="option-gasfiteria"]').isVisible()).toBe(true)
+    expect(wrapper.find('[data-testid="option-gasfiteria"]').exists()).toBe(true)
   })
 
   it('seleccionar una opción emite update:modelValue con su value, nunca con el texto escrito', async () => {
     const wrapper = mountCatalogSelect()
+    await wrapper.find('input').trigger('focusin')
     await wrapper.find('input').setValue('gasfi')
     await wrapper.find('[data-testid="option-gasfiteria"]').trigger('click')
 
@@ -91,8 +94,9 @@ describe('CatalogSelect', () => {
     expect(emitted![0]).toEqual(['gasfiteria'])
   })
 
-  it('seleccionar la opción correcta no emite el value de otra, aunque esté oculta en el mismo array', async () => {
+  it('seleccionar la opción correcta no emite el value de otra que ya no está en la lista filtrada', async () => {
     const wrapper = mountCatalogSelect()
+    await wrapper.find('input').trigger('focusin')
     await wrapper.find('input').setValue('electric')
     await wrapper.find('[data-testid="option-electricidad"]').trigger('click')
 
@@ -103,37 +107,105 @@ describe('CatalogSelect', () => {
 
   it('escribir texto que no matchea nada no emite ningún valor', async () => {
     const wrapper = mountCatalogSelect()
+    await wrapper.find('input').trigger('focusin')
     await wrapper.find('input').setValue('algo que no existe')
     expect(wrapper.emitted('update:modelValue')).toBeFalsy()
   })
 
   it('modo error: el botón "Reintentar" emite retry', async () => {
     const wrapper = mountCatalogSelect({ error: true })
+    await wrapper.find('input').trigger('focusin')
     await wrapper.find('input').setValue('a')
     await wrapper.find('[data-testid="retry-button"]').trigger('click')
     expect(wrapper.emitted('retry')).toBeTruthy()
   })
 
+  it('modo cargando: muestra el skeleton, no la lista', async () => {
+    const wrapper = mountCatalogSelect({ pending: true })
+    await wrapper.find('input').trigger('focusin')
+    await wrapper.find('input').setValue('a')
+    expect(wrapper.find('[data-testid="loading-skeleton"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid^="option-"]').exists()).toBe(false)
+  })
+
   it('sin showAllOnFocus (comunas): enfocar sin escribir no abre la lista', async () => {
     const wrapper = mountCatalogSelect()
-    await wrapper.find('input').trigger('focus')
-    expect(wrapper.find('[data-testid="dropdown"]').exists()).toBe(false)
+    await wrapper.find('input').trigger('focusin')
+    expect(wrapper.find('[data-testid^="option-"]').exists()).toBe(false)
   })
 
   it('con showAllOnFocus (categorías): enfocar sin escribir muestra el catálogo completo', async () => {
     const wrapper = mountCatalogSelect({ showAllOnFocus: true })
-    await wrapper.find('input').trigger('focus')
+    await wrapper.find('input').trigger('focusin')
 
-    expect(wrapper.find('[data-testid="dropdown"]').exists()).toBe(true)
     for (const item of items) {
-      expect(wrapper.find(`[data-testid="option-${item.value}"]`).isVisible()).toBe(true)
+      expect(wrapper.find(`[data-testid="option-${item.value}"]`).exists()).toBe(true)
     }
   })
 
   it('con showAllOnFocus: al salir sin seleccionar, la lista se vuelve a cerrar', async () => {
     const wrapper = mountCatalogSelect({ showAllOnFocus: true })
-    await wrapper.find('input').trigger('focus')
-    await wrapper.find('input').trigger('blur')
-    expect(wrapper.find('[data-testid="dropdown"]').exists()).toBe(false)
+    await wrapper.find('input').trigger('focusin')
+    await wrapper.find('input').trigger('focusout')
+    expect(wrapper.find('[data-testid^="option-"]').exists()).toBe(false)
+  })
+
+  it('al reenfocar un campo con selección, sigue mostrando el label elegido (no en blanco)', async () => {
+    const wrapper = mountCatalogSelect({ modelValue: 'gasfiteria' })
+    expect(wrapper.find('input').element.value).toBe('Gasfitería')
+    await wrapper.find('input').trigger('focusin')
+    expect(wrapper.find('input').element.value).toBe('Gasfitería')
+  })
+
+  // Comportamiento verificado sobre el selector de comuna real de mercadolibre.cl: reenfocar un campo ya
+  // elegido no abre la lista ni toca el texto — recién al escribir se abre y filtra.
+  it('reenfocar un campo ya elegido no abre la lista (solo abre al escribir)', async () => {
+    const wrapper = mountCatalogSelect({ modelValue: 'electricidad' })
+    await wrapper.find('input').trigger('focusin')
+    expect(wrapper.find('[data-testid^="option-"]').exists()).toBe(false)
+
+    await wrapper.find('input').setValue('gasfi')
+    expect(wrapper.find('[data-testid="option-gasfiteria"]').exists()).toBe(true)
+  })
+
+  it('con una selección hecha, la lista no queda filtrada por su propio label', async () => {
+    const wrapper = mountCatalogSelect({ modelValue: 'electricidad', showAllOnFocus: true })
+    await wrapper.find('input').trigger('focusin')
+
+    // Sin esto, el campo filtraría por "Electricidad" y mostraría una lista de un solo elemento,
+    // dejando sin salida a quien quiere cambiar de opción.
+    for (const item of items) {
+      expect(wrapper.find(`[data-testid="option-${item.value}"]`).exists()).toBe(true)
+    }
+  })
+
+  it('salir sin elegir descarta el texto a medio escribir y restaura el label elegido (D-004)', async () => {
+    const wrapper = mountCatalogSelect({ modelValue: 'electricidad' })
+    await wrapper.find('input').trigger('focusin')
+    await wrapper.find('input').setValue('texto suelto')
+    await wrapper.find('input').trigger('focusout')
+
+    expect(wrapper.find('input').element.value).toBe('Electricidad')
+  })
+
+  it('salir sin elegir y sin selección previa deja el campo vacío, no el texto suelto', async () => {
+    const wrapper = mountCatalogSelect()
+    await wrapper.find('input').trigger('focusin')
+    await wrapper.find('input').setValue('texto suelto')
+    await wrapper.find('input').trigger('focusout')
+
+    expect(wrapper.find('input').element.value).toBe('')
+  })
+
+  it('seleccionar una opción no dispara focusout (click dentro del propio contenedor)', async () => {
+    const wrapper = mountCatalogSelect()
+    await wrapper.find('input').trigger('focusin')
+    await wrapper.find('input').setValue('gasfi')
+    // focusout con relatedTarget apuntando a la opción, como pasaría en un browser real al clickearla
+    const option = wrapper.find('[data-testid="option-gasfiteria"]').element
+    await wrapper.find('input').trigger('focusout', { relatedTarget: option })
+    await wrapper.find('[data-testid="option-gasfiteria"]').trigger('click')
+
+    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual(['gasfiteria'])
   })
 })

--- a/app/components/CatalogSelect.vue
+++ b/app/components/CatalogSelect.vue
@@ -3,8 +3,15 @@
 // los 6 modos del selector de catálogo. No sabe si trabaja con categorías o comunas — quien lo usa
 // (CategoriaSelect, ComunaSelect) le pasa los datos, el copy y `showAllOnFocus`. Nunca emite un valor
 // que no esté en `items`.
-// ref/computed importados explícitos (no solo auto-import de Nuxt): así el componente se puede
-// montar en un test con Vitest + Vue Test Utils plano, sin levantar un contexto de Nuxt completo.
+//
+// No usa el modo combobox de UInputMenu: probado en un browser real, la combinación de items
+// controlados + selección interna de Reka UI no resolvía de forma confiable qué opción se había
+// clickeado, y a veces no abría la lista en absoluto. Es un `UInput` simple (input de texto, sin
+// comportamiento propio de combobox) más una lista propia debajo — selección, filtrado y apertura
+// 100% manejados acá, sin depender de que una librería de combobox adivine la intención correcta.
+//
+// ref/computed importados explícitos (no solo auto-import de Nuxt): así el componente se puede montar
+// en un test con Vitest + Vue Test Utils plano, sin levantar un contexto de Nuxt completo.
 import { computed, ref, watch } from 'vue'
 
 export type CatalogOption = { value: string, label: string }
@@ -25,7 +32,30 @@ const emit = defineEmits<{ retry: [] }>()
 
 const modelValue = defineModel<string | null>({ default: null })
 
-const searchTerm = ref('')
+const containerRef = ref<HTMLElement | null>(null)
+// UInput expone su <input> nativo como `inputRef` (node_modules/@nuxt/ui/dist/runtime/components/Input.vue)
+const uInputRef = ref<{ inputRef?: HTMLInputElement | null } | null>(null)
+
+const selectedLabel = computed(() => props.items.find(item => item.value === modelValue.value)?.label ?? null)
+
+// El texto que se ve en el campo, y la única fuente de verdad de lo que dice el input. Al elegir una
+// opción pasa a ser su label, así que el campo se comporta como un input de texto común y corriente: el
+// cursor cae donde se hace click, lo escrito se inserta ahí, y nada se autoselecciona ni se borra solo.
+// Es exactamente lo que hace el selector de comuna de Mercado Libre (verificado sobre el sitio real).
+const searchTerm = ref(selectedLabel.value ?? '')
+
+const focused = ref(false)
+// Distingue "enfocado pero sin tocar nada" de "está buscando". La lista solo filtra cuando de verdad se
+// escribió algo — si no, reenfocar un campo ya elegido filtraría por su propio label y dejaría una lista
+// de un solo elemento, que no ayuda a cambiar de opción.
+const hasTyped = ref(false)
+
+// Mantiene el campo en sintonía cuando el valor cambia desde afuera (v-model seteado por el formulario,
+// catálogo que termina de cargar y recién ahí puede resolver el label). No pisa lo que se está
+// escribiendo en ese momento.
+watch(selectedLabel, (label) => {
+  if (!hasTyped.value) searchTerm.value = label ?? ''
+})
 
 // Sin distinguir mayúsculas ni tildes, como pide UXF-001 — "nunoa" tiene que encontrar "Ñuñoa".
 function normalize(value: string) {
@@ -36,85 +66,121 @@ function normalize(value: string) {
 }
 
 function matchesSearch(item: CatalogOption) {
-  if (!searchTerm.value) return true
+  if (!hasTyped.value || !searchTerm.value) return true
   return normalize(item.label).includes(normalize(searchTerm.value))
 }
 
-// El array que se le pasa a UInputMenu es siempre el catálogo completo, sin recortar — nunca cambia
-// de referencia ni de orden entre teclas. Probado en el browser: reasignar `items` a un subconjunto
-// en cada tecla (con `ignoreFilter`) hacía que un click en la única opción visible seleccionara otra
-// distinta — la que ocupaba esa misma posición en el catálogo original. Qué se ve filtrado y qué no
-// se controla visualmente en el slot `#item` (v-show, no v-if — nunca se saca del array).
-const focused = ref(false)
+const visibleItems = computed(() => props.items.filter(matchesSearch))
 
-const isOpen = computed(() => searchTerm.value.length > 0 || Boolean(props.showAllOnFocus && focused.value))
-
-const hasNoMatches = computed(
-  () => isOpen.value && !props.pending && !props.error && !props.items.some(matchesSearch),
-)
-
-// Reka UI resetea el searchTerm al seleccionar por default (resetSearchTermOnSelect) — como `open`
-// está controlado y depende de `searchTerm`, ese reset cerraba el dropdown a mitad del click y la
-// selección se perdía. Se desactiva ese reset automático (ver template) y se hace acá, reactivo,
-// después de que la selección ya se aplicó — nunca a mitad de un click.
-watch(modelValue, () => {
-  searchTerm.value = ''
+// La lista se abre al escribir, no al enfocar — reenfocar un campo ya elegido no dispara nada, igual que
+// en Mercado Libre. Dos excepciones: `showAllOnFocus` (categorías, UX-002) y el modo error, que si no se
+// mostrara apenas hay foco quedaría inalcanzable — el campo de solo lectura no deja escribir para verlo.
+const isOpen = computed(() => {
+  if (!focused.value) return false
+  if (props.error) return true
+  return hasTyped.value || Boolean(props.showAllOnFocus)
 })
 
-// Al salir del campo sin seleccionar (ej. escribió algo que no matchea y hizo click afuera), el
-// searchTerm queda con ese texto inválido — y como el label del valor elegido solo se resuelve
-// cuando matchesSearch lo deja visible, el campo ya cerrado no podía mostrarlo. Se limpia acá
-// también, no solo al seleccionar.
-function handleBlur() {
-  searchTerm.value = ''
-  focused.value = false
+const hasNoMatches = computed(
+  () => isOpen.value && !props.pending && !props.error && visibleItems.value.length === 0,
+)
+
+function handleInput(value: string | number) {
+  searchTerm.value = String(value)
+  hasTyped.value = true
 }
 
-function handleFocus() {
+function handleFocusIn() {
   focused.value = true
 }
 
-// Selección 100% propia — nunca se confía en que UInputMenu resuelva qué se clickeó.
+// focusout (no blur) a nivel del contenedor: permite distinguir "el foco se fue a otra opción de la
+// misma lista" (relatedTarget adentro del contenedor, no hacer nada) de "el foco se fue afuera de
+// verdad" (ahí sí cerrar). Sin esto, tocar una opción dispara blur del input antes que su propio
+// click, y la selección se pierde — el mismo problema de fondo que forzó a abandonar el combobox de
+// Reka, resuelto acá con un patrón estándar en vez de pelear contra una librería.
+function handleFocusOut(event: FocusEvent) {
+  const related = event.relatedTarget
+  if (containerRef.value && related instanceof Node && containerRef.value.contains(related)) {
+    return
+  }
+  focused.value = false
+  hasTyped.value = false
+  // Al salir sin elegir nada, el texto a medio escribir se descarta y vuelve el label elegido (o queda
+  // vacío): el campo nunca puede quedar mostrando algo que no está en el catálogo (D-004).
+  searchTerm.value = selectedLabel.value ?? ''
+}
+
 function selectItem(item: CatalogOption) {
   modelValue.value = item.value
+  searchTerm.value = item.label
+  hasTyped.value = false
+  focused.value = false
+  // Sin esto, el <input> real del browser puede seguir enfocado (clickear el botón de la opción no
+  // siempre le quita el foco al input, depende del browser/SO) — y con foco real todavía puesto ahí,
+  // el label recién seleccionado no se termina de ver como texto del campo.
+  uInputRef.value?.inputRef?.blur()
+}
+
+function retry() {
+  emit('retry')
 }
 </script>
 
 <template>
-  <UInputMenu
-    :model-value="modelValue ?? undefined"
-    v-model:search-term="searchTerm"
-    :open="isOpen"
-    :items="props.items"
-    :loading="pending"
-    :disabled="error"
-    value-key="value"
-    label-key="label"
-    ignore-filter
-    :create-item="false"
-    :reset-search-term-on-select="false"
-    :placeholder="placeholder"
-    @blur="handleBlur"
-    @focus="handleFocus"
-  >
-    <template #item="{ item }">
-      <div
-        v-show="matchesSearch(item)"
-        class="flex w-full cursor-pointer items-center rounded-md px-2 py-1.5 text-sm hover:bg-elevated"
-        :data-testid="`option-${item.value}`"
-        @click.stop.prevent="selectItem(item)"
-      >
-        {{ item.label }}
-      </div>
-    </template>
-    <template #content-bottom>
-      <div v-if="error" class="flex flex-col items-center gap-2 px-2 py-2 text-center">
-        <p class="text-sm text-muted">{{ errorMessage }}</p>
-        <UButton size="sm" data-testid="retry-button" @click="emit('retry')">Reintentar</UButton>
-      </div>
-      <p v-else-if="hasNoMatches" class="px-2 py-2 text-sm text-muted">
-        No encontramos "{{ searchTerm }}"
-      </p>
-    </template>
-  </UInputMenu>
+  <div ref="containerRef" class="relative" @focusin="handleFocusIn" @focusout="handleFocusOut">
+    <UInput
+      ref="uInputRef"
+      :model-value="searchTerm"
+      :placeholder="placeholder"
+      :readonly="error"
+      trailing-icon="i-lucide-chevron-down"
+      class="w-full"
+      @update:model-value="handleInput"
+    />
+
+    <div
+      v-if="isOpen"
+      class="absolute inset-x-0 top-full z-10 mt-2 max-h-72 overflow-auto rounded-md border p-1 shadow-lg"
+      style="background: var(--ui-bg); border-color: var(--ui-border)"
+    >
+      <template v-if="error">
+        <div class="flex flex-col items-center gap-2 px-2 py-3 text-center">
+          <p class="text-sm" style="color: var(--ui-text-muted)">{{ errorMessage }}</p>
+          <UButton size="sm" data-testid="retry-button" @click="retry">Reintentar</UButton>
+        </div>
+      </template>
+      <template v-else-if="pending">
+        <div class="space-y-2 p-2" data-testid="loading-skeleton">
+          <div class="h-3 w-3/4 animate-pulse rounded" style="background: var(--ui-bg-elevated)" />
+          <div class="h-3 w-1/2 animate-pulse rounded" style="background: var(--ui-bg-elevated)" />
+          <div class="h-3 w-2/3 animate-pulse rounded" style="background: var(--ui-bg-elevated)" />
+        </div>
+      </template>
+      <template v-else-if="hasNoMatches">
+        <p class="px-2 py-3 text-sm" style="color: var(--ui-text-muted)">No encontramos "{{ searchTerm }}"</p>
+      </template>
+      <template v-else>
+        <button
+          v-for="item in visibleItems"
+          :key="item.value"
+          type="button"
+          :data-testid="`option-${item.value}`"
+          class="catalog-option flex w-full cursor-pointer items-center rounded-md px-2 py-1.5 text-left text-sm"
+          @click="selectItem(item)"
+        >
+          {{ item.label }}
+        </button>
+      </template>
+    </div>
+  </div>
 </template>
+
+<style scoped>
+.catalog-option {
+  color: var(--ui-text-highlighted);
+}
+.catalog-option:hover {
+  background: var(--ui-bg-elevated);
+}
+</style>

--- a/app/components/CatalogSelect.vue
+++ b/app/components/CatalogSelect.vue
@@ -1,0 +1,109 @@
+<script setup lang="ts">
+// Única implementación de UXF-001 (docs/missions/03-taxonomia-categorias-y-comunas/experiencia.md):
+// los 6 modos del selector de catálogo. No sabe si trabaja con categorías o comunas — quien lo usa
+// (CategoriaSelect, ComunaSelect) le pasa los datos y el copy. Nunca emite un valor que no esté en
+// `items`, y no muestra ninguna opción hasta que se escribe la primera letra (estilo Mercado Libre),
+// en vez de mostrar el catálogo completo al enfocar.
+// ref/computed importados explícitos (no solo auto-import de Nuxt): así el componente se puede
+// montar en un test con Vitest + Vue Test Utils plano, sin levantar un contexto de Nuxt completo.
+import { computed, ref, watch } from 'vue'
+
+export type CatalogOption = { value: string, label: string }
+
+const props = defineProps<{
+  items: CatalogOption[]
+  pending: boolean
+  error: boolean
+  placeholder: string
+  errorMessage: string
+}>()
+
+const emit = defineEmits<{ retry: [] }>()
+
+const modelValue = defineModel<string | null>({ default: null })
+
+const searchTerm = ref('')
+
+// Sin distinguir mayúsculas ni tildes, como pide UXF-001 — "nunoa" tiene que encontrar "Ñuñoa".
+function normalize(value: string) {
+  return value
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLowerCase()
+}
+
+function matchesSearch(item: CatalogOption) {
+  if (!searchTerm.value) return true
+  return normalize(item.label).includes(normalize(searchTerm.value))
+}
+
+// El array que se le pasa a UInputMenu es siempre el catálogo completo, sin recortar — nunca cambia
+// de referencia ni de orden entre teclas. Probado en el browser: reasignar `items` a un subconjunto
+// en cada tecla (con `ignoreFilter`) hacía que un click en la única opción visible seleccionara otra
+// distinta — la que ocupaba esa misma posición en el catálogo original. Qué se ve filtrado y qué no
+// se controla visualmente en el slot `#item` (v-show, no v-if — nunca se saca del array).
+const isOpen = computed(() => searchTerm.value.length > 0)
+
+const hasNoMatches = computed(
+  () => isOpen.value && !props.pending && !props.error && !props.items.some(matchesSearch),
+)
+
+// Reka UI resetea el searchTerm al seleccionar por default (resetSearchTermOnSelect) — como `open`
+// está controlado y depende de `searchTerm`, ese reset cerraba el dropdown a mitad del click y la
+// selección se perdía. Se desactiva ese reset automático (ver template) y se hace acá, reactivo,
+// después de que la selección ya se aplicó — nunca a mitad de un click.
+watch(modelValue, () => {
+  searchTerm.value = ''
+})
+
+// Al salir del campo sin seleccionar (ej. escribió algo que no matchea y hizo click afuera), el
+// searchTerm queda con ese texto inválido — y como el label del valor elegido solo se resuelve
+// cuando matchesSearch lo deja visible, el campo ya cerrado no podía mostrarlo. Se limpia acá
+// también, no solo al seleccionar.
+function handleBlur() {
+  searchTerm.value = ''
+}
+
+// Selección 100% propia — nunca se confía en que UInputMenu resuelva qué se clickeó.
+function selectItem(item: CatalogOption) {
+  modelValue.value = item.value
+}
+</script>
+
+<template>
+  <UInputMenu
+    :model-value="modelValue ?? undefined"
+    v-model:search-term="searchTerm"
+    :open="isOpen"
+    :items="props.items"
+    :loading="pending"
+    :disabled="error"
+    value-key="value"
+    label-key="label"
+    ignore-filter
+    :create-item="false"
+    :reset-search-term-on-select="false"
+    :placeholder="placeholder"
+    @blur="handleBlur"
+  >
+    <template #item="{ item }">
+      <div
+        v-show="matchesSearch(item)"
+        class="flex w-full cursor-pointer items-center rounded-md px-2 py-1.5 text-sm hover:bg-elevated"
+        :data-testid="`option-${item.value}`"
+        @click.stop.prevent="selectItem(item)"
+      >
+        {{ item.label }}
+      </div>
+    </template>
+    <template #content-bottom>
+      <div v-if="error" class="flex flex-col items-center gap-2 px-2 py-2 text-center">
+        <p class="text-sm text-muted">{{ errorMessage }}</p>
+        <UButton size="sm" data-testid="retry-button" @click="emit('retry')">Reintentar</UButton>
+      </div>
+      <p v-else-if="hasNoMatches" class="px-2 py-2 text-sm text-muted">
+        No encontramos "{{ searchTerm }}"
+      </p>
+    </template>
+  </UInputMenu>
+</template>

--- a/app/components/CatalogSelect.vue
+++ b/app/components/CatalogSelect.vue
@@ -1,9 +1,8 @@
 <script setup lang="ts">
 // Única implementación de UXF-001 (docs/missions/03-taxonomia-categorias-y-comunas/experiencia.md):
 // los 6 modos del selector de catálogo. No sabe si trabaja con categorías o comunas — quien lo usa
-// (CategoriaSelect, ComunaSelect) le pasa los datos y el copy. Nunca emite un valor que no esté en
-// `items`, y no muestra ninguna opción hasta que se escribe la primera letra (estilo Mercado Libre),
-// en vez de mostrar el catálogo completo al enfocar.
+// (CategoriaSelect, ComunaSelect) le pasa los datos, el copy y `showAllOnFocus`. Nunca emite un valor
+// que no esté en `items`.
 // ref/computed importados explícitos (no solo auto-import de Nuxt): así el componente se puede
 // montar en un test con Vitest + Vue Test Utils plano, sin levantar un contexto de Nuxt completo.
 import { computed, ref, watch } from 'vue'
@@ -16,6 +15,10 @@ const props = defineProps<{
   error: boolean
   placeholder: string
   errorMessage: string
+  // Con pocas opciones (categorías: 8) mostrar todo al enfocar no cuesta nada y ahorra un toque. Con
+  // muchas (comunas: 346, ~33 activas) esperar a que se escriba es el patrón de Mercado Libre que ya
+  // se validó — mostrar 33 opciones de entrada es más ruido que ayuda. UX-002 en experiencia.md.
+  showAllOnFocus?: boolean
 }>()
 
 const emit = defineEmits<{ retry: [] }>()
@@ -42,7 +45,9 @@ function matchesSearch(item: CatalogOption) {
 // en cada tecla (con `ignoreFilter`) hacía que un click en la única opción visible seleccionara otra
 // distinta — la que ocupaba esa misma posición en el catálogo original. Qué se ve filtrado y qué no
 // se controla visualmente en el slot `#item` (v-show, no v-if — nunca se saca del array).
-const isOpen = computed(() => searchTerm.value.length > 0)
+const focused = ref(false)
+
+const isOpen = computed(() => searchTerm.value.length > 0 || Boolean(props.showAllOnFocus && focused.value))
 
 const hasNoMatches = computed(
   () => isOpen.value && !props.pending && !props.error && !props.items.some(matchesSearch),
@@ -62,6 +67,11 @@ watch(modelValue, () => {
 // también, no solo al seleccionar.
 function handleBlur() {
   searchTerm.value = ''
+  focused.value = false
+}
+
+function handleFocus() {
+  focused.value = true
 }
 
 // Selección 100% propia — nunca se confía en que UInputMenu resuelva qué se clickeó.
@@ -85,6 +95,7 @@ function selectItem(item: CatalogOption) {
     :reset-search-term-on-select="false"
     :placeholder="placeholder"
     @blur="handleBlur"
+    @focus="handleFocus"
   >
     <template #item="{ item }">
       <div

--- a/docs/missions/03-taxonomia-categorias-y-comunas/experiencia.md
+++ b/docs/missions/03-taxonomia-categorias-y-comunas/experiencia.md
@@ -138,9 +138,9 @@ hover queda visualmente distinta del resto de la lista.
 
 <a id="ux-001"></a>
 
-### UX-001 — El componente no muestra nada hasta que el usuario empieza a escribir
+### UX-001 — Por default, el componente no muestra nada hasta que el usuario empieza a escribir
 
-- **Estado:** aceptada. **Fecha:** 2026-08-18.
+- **Estado:** aceptada. **Fecha:** 2026-08-18. Acotada por UX-002 (categorías son la excepción).
 - **Sustento:** D-004 — el modelo de interacción ya declarado ahí es "al estilo del selector de comuna de
   Mercado Libre", y ese selector no abre ninguna lista hasta que se escribe la primera letra. La primera
   versión de esta decisión (mostrar el catálogo completo al enfocar) se apartaba de esa referencia sin un
@@ -152,8 +152,29 @@ hover queda visualmente distinta del resto de la lista.
 - **Decisión y consecuencia:** tocar el campo no muestra nada — ni lista ni mensaje, solo el cursor activo.
   El catálogo se precarga en silencio en ese momento (ver mapa de estados) para que, apenas se escriba la
   primera letra, filtrar sea instantáneo la mayoría de las veces — el modo "cargando" solo aparece si esa
-  precarga no alcanzó a terminar.
+  precarga no alcanzó a terminar. Este es el comportamiento de `ComunaSelect` — `CategoriaSelect` no lo
+  usa, ver UX-002.
 - **Impacto en producto:** ninguno — es una decisión de interacción, no cambia D-001/D-002/D-004.
+
+<a id="ux-002"></a>
+
+### UX-002 — `CategoriaSelect` sí muestra el catálogo completo al enfocar; `ComunaSelect` no
+
+- **Estado:** aceptada. **Fecha:** 2026-08-19.
+- **Sustento:** D-001 (8 categorías fijas) vs. D-002 (346 comunas, ~33 activas) — la razón que sostiene
+  UX-001 (una lista larga en pantalla al primer toque es más ruido que ayuda) no aplica con solo 8
+  opciones: cabe entera sin scroll y ahorra un toque a alguien que igual iba a abrir la lista para mirar
+  las opciones antes de escribir.
+- **Alternativas descartadas:** la misma regla para las dos (UX-001 sin excepción) — trataba igual dos
+  catálogos con un orden de magnitud de diferencia en tamaño por el valor de no tener una regla especial,
+  no porque la experiencia fuera mejor así para categorías.
+- **Decisión y consecuencia:** `CatalogSelect` recibe un prop `showAllOnFocus` (booleano, default `false`)
+  — `CategoriaSelect` lo pasa en `true`, `ComunaSelect` no lo pasa (queda en `false`, el comportamiento de
+  UX-001). Con `showAllOnFocus`, tocar el campo sin escribir muestra las 8 categorías completas; escribir
+  sigue filtrando igual que siempre. `CatalogSelect` sigue sin saber qué entidad es — el prop lo decide
+  cada wrapper, no una condición interna sobre cuántos `items` llegaron.
+- **Impacto en producto:** ninguno — sigue siendo D-004 (catálogo cerrado), solo cambia cuándo se ve la
+  lista completa.
 
 ## Preguntas
 

--- a/docs/missions/03-taxonomia-categorias-y-comunas/experiencia.md
+++ b/docs/missions/03-taxonomia-categorias-y-comunas/experiencia.md
@@ -17,9 +17,11 @@ dónde se use.
 
 El modelo de interacción es un campo de búsqueda con autocompletado, al estilo del selector de comuna de
 Mercado Libre que mencionaste: se escribe, aparecen coincidencias del catálogo debajo, se elige una — nunca
-queda un valor sin elegir de la lista. En Nuxt UI (A-004) esto es `UInputMenu`, que ya trae el
-comportamiento de búsqueda resuelto — no hay que inventar la mecánica, solo especificar el contenido y las
-reglas.
+queda un valor sin elegir de la lista. El campo se comporta como un input de texto normal, tal cual el de
+Mercado Libre (medido sobre el sitio real): al elegir una opción su label queda como texto del campo, al
+volver a enfocarlo el cursor cae donde se hizo click sin autoseleccionar ni borrar nada, y la lista se abre
+al escribir — no al enfocar. La mecánica se construye en el componente y no sobre el combobox de Nuxt UI;
+el porqué está en [T-005](./ingenieria.md#t-005).
 
 - **Decisiones cubiertas:** [D-004](./producto.md#d-004) (categoría/comuna siempre son referencia al
   catálogo), [D-001](./producto.md#d-001) y [D-002](./producto.md#d-002) (qué contiene cada catálogo, el
@@ -107,6 +109,9 @@ hover queda visualmente distinta del resto de la lista.
   texto editable — no se borra a ciegas ni obliga a escribir desde cero.
 - El componente nunca ofrece "crear" una opción que no está en el catálogo — a diferencia de un combobox
   genérico que a veces agrega "crear '<texto>'", acá esa opción no existe, es la garantía de D-004.
+- Si el usuario sale del campo con texto escrito a medias y sin elegir nada, ese texto se descarta y vuelve
+  el label de lo que ya estaba seleccionado (o el campo queda vacío si no había nada). El campo nunca queda
+  mostrando algo que no está en el catálogo, aunque no se haya enviado el formulario todavía (D-004).
 - Una comuna con `activa = false` no aparece en absoluto en la lista — no se muestra deshabilitada ni con
   una nota, simplemente no está (ver [CL-004](./producto.md) de producto).
 

--- a/docs/missions/03-taxonomia-categorias-y-comunas/ingenieria.md
+++ b/docs/missions/03-taxonomia-categorias-y-comunas/ingenieria.md
@@ -13,10 +13,9 @@ compartido compuesto por dos wrappers
 Dos tablas nuevas (`categorias`, `comunas`), cada una con el campo `activa` que D-001/D-002 piden. Dos
 endpoints `GET` de solo lectura, sin autenticación (son catálogo público, no datos de usuario). Un
 composable genérico (`useCatalogFetch`) que los consume con cache, y un componente Vue (`CatalogSelect`) que
-implementa el contrato de
-D-004 sobre `UInputMenu` de Nuxt UI (A-004) — ya trae resuelto el autocompletado, lo que se construye acá
-es el contenido y las reglas: catálogo cerrado, nada visible hasta escribir. `CategoriaSelect` y
-`ComunaSelect` son dos wrappers delgados que lo componen, no dos copias de la misma lógica (ver T-003).
+implementa el contrato de D-004 sobre un `UInput` de Nuxt UI (A-004) más una lista propia: catálogo
+cerrado, nada visible hasta escribir. `CategoriaSelect` y `ComunaSelect` son dos wrappers delgados que lo
+componen, no dos copias de la misma lógica (ver T-003).
 
 Es la primera vez que el repo tiene tablas de negocio, así que también es donde `server/db/schema/`,
 `server/db/sql/rls.sql` y el patrón de "endpoint de lectura pública" (receta del skill `arquitectura`)
@@ -51,7 +50,7 @@ enfocado/filtrado/selección.
 | `server/api/categorias.get.ts` / `comunas.get.ts` | I/O: llama la query, devuelve JSON — dos archivos porque Nitro enruta por archivo, no porque haya lógica distinta | Filtrar por texto (eso lo hace el cliente) | TC-001, TC-002 |
 | `app/composables/useCatalogFetch.ts`   | Fetch con cache y manejo de error, genérico — no sabe si trae categorías o comunas | De dónde viene el endpoint (eso lo fija cada wrapper) | TC-003 |
 | `app/composables/useCategoriasCatalog.ts` / `useComunasCatalog.ts` | Fijar `key`, `endpoint` y el `normalize` de su entidad para `useCatalogFetch` — un solo `return`, sin lógica propia | Cómo se cachea o qué pasa si falla (eso ya lo resolvió `useCatalogFetch`) | TC-003 |
-| `app/components/CatalogSelect.vue`     | Los 6 modos de UXF-001, sobre `UInputMenu` — recibe `items`/`pending`/`error`/`placeholder` por props, nunca sabe si es categoría o comuna | De dónde vienen los datos | D-004, UX-001, TC-004 |
+| `app/components/CatalogSelect.vue`     | Los 6 modos de UXF-001, sobre `UInput` + lista propia — recibe `items`/`pending`/`error`/`placeholder` por props, nunca sabe si es categoría o comuna | De dónde vienen los datos | D-004, UX-001, TC-004 |
 | `app/components/CategoriaSelect.vue` / `ComunaSelect.vue` | Conectar su composable con `CatalogSelect` — ninguna lógica de interacción propia | Cómo se ve o se comporta el selector (eso ya lo resolvió `CatalogSelect`) | TC-004 |
 
 Fetch (`useCatalogFetch`) y componente (`CatalogSelect`) siguen la misma forma a propósito: una
@@ -141,16 +140,18 @@ y `useComunasCatalog()` son un wrapper de una sola responsabilidad cada uno, sol
   lo pasa (queda en `false`).
 - **Salida (emit):** `update:modelValue(value: string | null)`, igual en las tres.
 - **Invariantes:** `CatalogSelect` **nunca** emite un valor que no esté en `items`, o `null` — es la
-  garantía de D-004, implementada una sola vez, porque `UInputMenu` no permite "crear" una opción por
-  default (a diferencia de un combobox libre). Con `showAllOnFocus: false` (default, `ComunaSelect`),
-  ninguna opción se muestra mientras el campo de búsqueda esté vacío (UX-001); con `showAllOnFocus: true`
-  (`CategoriaSelect`), el catálogo completo se muestra apenas se enfoca, sin esperar texto (UX-002).
-  `CatalogSelect` sigue sin saber qué entidad es — decide según el prop, nunca según cuántos `items`
-  recibió. `CategoriaSelect`/`ComunaSelect` no reimplementan nada de esto — si D-004/UX-001/UX-002 cambian,
-  se edita `CatalogSelect` una vez y el cambio llega gratis a los dos wrappers, porque lo componen — no
-  porque lo copien.
+  garantía de D-004, implementada una sola vez: el único camino que escribe `modelValue` es elegir una
+  opción de la lista, y al salir del campo sin elegir, el texto tipeado se descarta y vuelve el label de lo
+  que ya estaba seleccionado (o queda vacío), así que el campo nunca queda mostrando algo fuera del
+  catálogo. Con `showAllOnFocus: false` (default, `ComunaSelect`), ninguna opción se muestra hasta que se
+  escribe (UX-001); con `showAllOnFocus: true` (`CategoriaSelect`), el catálogo completo se muestra apenas
+  se enfoca (UX-002). `CatalogSelect` sigue sin saber qué entidad es — decide según el prop, nunca según
+  cuántos `items` recibió. `CategoriaSelect`/`ComunaSelect` no reimplementan nada de esto — si
+  D-004/UX-001/UX-002 cambian, se edita `CatalogSelect` una vez y el cambio llega gratis a los dos
+  wrappers, porque lo componen — no porque lo copien.
 - **Errores:** si `useCategoriasCatalog()`/`useComunasCatalog()` reportan `error`, el componente entra en
-  modo error (ver `experiencia.md`) y el campo queda deshabilitado hasta reintentar.
+  modo error (ver `experiencia.md`): el campo queda de solo lectura (no deshabilitado — un campo
+  deshabilitado no recibe foco, y sin foco el mensaje de error nunca llegaría a verse) hasta reintentar.
 - **Contrato de producto:** [D-004](./producto.md#d-004), [UXF-001](./experiencia.md#uxf-001-elegir-categoría-o-comuna-desde-el-catálogo).
 
 ## Modelo de datos
@@ -339,6 +340,34 @@ aplicación
   hasta una hora en reflejarse en lo que sirve el CDN — ya documentado como invariante en TC-001/TC-002.
 - **Reapertura:** si algún flujo necesita ver un cambio de `activa` reflejado al instante (hoy ninguno lo
   necesita — los cambios son manuales y poco frecuentes).
+
+<a id="t-005"></a>
+
+### T-005 — `CatalogSelect` no usa el modo combobox de `UInputMenu`: es un `UInput` más una lista propia
+
+- **Estado:** aceptada. **Fecha:** 2026-08-19. **Aprobada por Patricio el:** 2026-08-19.
+- **Contratos:** TC-004.
+- **Tensión:** `UInputMenu` (A-004) ya trae autocompletado resuelto y era la opción por default de esta
+  misión — construir la interacción a mano es más código propio del que el principio YAGNI querría. Pero
+  probado en un browser real, no funcionaba: al filtrar la lista por lo escrito, clickear una opción
+  seleccionaba otra (la que ocupaba ese índice en el array sin filtrar), y a veces la lista no abría.
+- **Alternativas descartadas:** parchar `UInputMenu` — se intentó con `by="value"`, sacando `ignoreFilter`,
+  y con un slot `#item` con handler manual sobre la lista ya filtrada; ninguna resolvió el problema de
+  fondo, que es que Reka UI resuelve internamente qué ítem se eligió y esa resolución no coincide con una
+  lista de items controlada desde afuera. Mantener los items estables y ocultar los que no matchean con
+  `v-show` sí pasaba los tests unitarios, pero seguía fallando en el browser del usuario — señal de que se
+  estaba construyendo alrededor de un comportamiento que no se controla, no sobre uno entendido.
+- **Decisión y consecuencia:** `CatalogSelect` usa `UInput` (input de texto, sin comportamiento propio de
+  combobox) más una lista propia debajo; apertura, filtrado y selección se manejan en el componente. El
+  cierre al hacer click en una opción usa `focusout` + `relatedTarget` contenido en el contenedor, que es
+  el patrón estándar para no perder el click por el blur del input. El comportamiento del campo se calcó
+  del selector de comuna de mercadolibre.cl, medido sobre el sitio real (D-004 lo cita como referencia):
+  es un input de texto normal — al elegir una opción su label queda como texto, al volver a enfocarlo el
+  cursor cae donde se hizo click sin autoseleccionar nada, y la lista se abre al escribir, no al enfocar.
+  Consecuencia aceptada: la interacción es código propio de Datealo y hay que mantenerla; a cambio es
+  código que se entiende entero y que se puede testear sin depender de la resolución interna de Reka.
+- **Reapertura:** si una versión futura de Nuxt UI resuelve el caso de items controlados + filtrado
+  externo, conviene volver a evaluar `UInputMenu` y borrar esta implementación.
 
 ## Preguntas
 

--- a/docs/missions/03-taxonomia-categorias-y-comunas/ingenieria.md
+++ b/docs/missions/03-taxonomia-categorias-y-comunas/ingenieria.md
@@ -132,19 +132,23 @@ y `useComunasCatalog()` son un wrapper de una sola responsabilidad cada uno, sol
 ### TC-004 — `<CatalogSelect>`, compuesto por `<CategoriaSelect>` / `<ComunaSelect>`
 
 - **Entrada (props) de `CatalogSelect`:** `modelValue: string | null`, `items: {value: string, label: string}[]`,
-  `pending: boolean`, `error: boolean`, `placeholder: string`.
+  `pending: boolean`, `error: boolean`, `placeholder: string`, `showAllOnFocus?: boolean` (default `false`
+  — ver UX-002).
 - **Entrada (props) de `CategoriaSelect` / `ComunaSelect`:** solo `modelValue: string | null` — el resto
-  (`items`, `pending`, `error`, `placeholder`) lo arma cada wrapper llamando a su composable y pasándoselo a
-  `CatalogSelect` internamente; quien usa `<CategoriaSelect>` no ve ni necesita saber que existe
-  `CatalogSelect` debajo.
+  (`items`, `pending`, `error`, `placeholder`, `showAllOnFocus`) lo arma cada wrapper llamando a su
+  composable y pasándoselo a `CatalogSelect` internamente; quien usa `<CategoriaSelect>` no ve ni necesita
+  saber que existe `CatalogSelect` debajo. `CategoriaSelect` pasa `showAllOnFocus: true`; `ComunaSelect` no
+  lo pasa (queda en `false`).
 - **Salida (emit):** `update:modelValue(value: string | null)`, igual en las tres.
 - **Invariantes:** `CatalogSelect` **nunca** emite un valor que no esté en `items`, o `null` — es la
   garantía de D-004, implementada una sola vez, porque `UInputMenu` no permite "crear" una opción por
-  default (a diferencia de un combobox libre). Ninguna opción se muestra mientras el campo de búsqueda esté
-  vacío (UX-001, modo "enfocado sin texto") — `CatalogSelect` controla el `open` de `UInputMenu` a mano en
-  vez de dejarlo abrir solo al enfocar. `CategoriaSelect`/`ComunaSelect` no reimplementan nada de esto —
-  si D-004 cambia, se edita `CatalogSelect` una vez y el cambio llega gratis a los dos wrappers, porque lo
-  componen — no porque lo copien.
+  default (a diferencia de un combobox libre). Con `showAllOnFocus: false` (default, `ComunaSelect`),
+  ninguna opción se muestra mientras el campo de búsqueda esté vacío (UX-001); con `showAllOnFocus: true`
+  (`CategoriaSelect`), el catálogo completo se muestra apenas se enfoca, sin esperar texto (UX-002).
+  `CatalogSelect` sigue sin saber qué entidad es — decide según el prop, nunca según cuántos `items`
+  recibió. `CategoriaSelect`/`ComunaSelect` no reimplementan nada de esto — si D-004/UX-001/UX-002 cambian,
+  se edita `CatalogSelect` una vez y el cambio llega gratis a los dos wrappers, porque lo componen — no
+  porque lo copien.
 - **Errores:** si `useCategoriasCatalog()`/`useComunasCatalog()` reportan `error`, el componente entra en
   modo error (ver `experiencia.md`) y el campo queda deshabilitado hasta reintentar.
 - **Contrato de producto:** [D-004](./producto.md#d-004), [UXF-001](./experiencia.md#uxf-001-elegir-categoría-o-comuna-desde-el-catálogo).
@@ -212,6 +216,7 @@ prueba.
 | TC-001, TC-002           | manual       | `GET /api/categorias` devuelve exactamente 8 filas; `GET /api/comunas` devuelve solo las comunas con `activa = true` | Marcar una comuna en `false` a mano y confirmar que desaparece de la respuesta |
 | TC-004 (D-004)           | unitario (Vitest + Vue Test Utils), contra `CatalogSelect` directo | Seleccionar una opción de la lista emite `update:modelValue` con su `value` | Escribir texto que no matchea nada y no seleccionar nada — el componente nunca emite ese texto |
 | UX-001 (nada hasta escribir) | unitario, contra `CatalogSelect` directo | Con el campo enfocado y vacío, la lista de opciones no se renderiza | Al escribir la primera letra, aparece |
+| UX-002 (categorías muestran todo al enfocar) | unitario, contra `CatalogSelect` directo | Con `showAllOnFocus: true`, enfocar sin escribir muestra el catálogo completo | Con `showAllOnFocus: false` (default), enfocar sin escribir no muestra nada |
 | `CategoriaSelect`/`ComunaSelect` componen bien | unitario | Cada wrapper le pasa a `CatalogSelect` los `items` de su propio composable | Un cambio en `CatalogSelect` (ej. un modo nuevo) no exige tocar los wrappers |
 | TR-001 (conteo del seed) | manual, una vez | `select count(*) from comunas` = 346 después del seed | — |
 | T-004 (caché) | manual, una vez contra el preview del PR | `curl` repetido a `/api/categorias` muestra `x-vercel-cache: HIT` la segunda vez — comportamiento documentado por Vercel, esto es confirmación, no una incertidumbre | — |

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,10 @@
       },
       "devDependencies": {
         "@types/node": "^26.2.0",
+        "@vitejs/plugin-vue": "^6.0.8",
+        "@vue/test-utils": "^2.4.11",
         "drizzle-kit": "^0.31.10",
+        "jsdom": "^29.1.1",
         "tsx": "^4.23.12",
         "typescript": "^6.0.3",
         "vitest": "^4.1.10",
@@ -52,6 +55,57 @@
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -481,6 +535,19 @@
         }
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@capsizecss/unpack": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@capsizecss/unpack/-/unpack-4.0.1.tgz",
@@ -535,6 +602,146 @@
       "resolved": "https://registry.npmjs.org/@colordx/core/-/core-5.5.0.tgz",
       "integrity": "sha512-3PxTH8itZzltK0U9jTwVVnjLXvnDYuq3m+QXsHkENxWiPRh4WaoLcs1SQjqgZ55kS+QyirpH5BVwzP2gMVG6EQ==",
       "license": "MIT"
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.0.tgz",
+      "integrity": "sha512-5+5LEmFuY1AjXdYhmgjTJogtQnP1evJ1zrBZGUNZ0thkpwnnmKxcHdAMn/OtFjAb25zA+jKDVYVRl+5G7rjv1A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.1",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.8.tgz",
+      "integrity": "sha512-CpMLjAvwQg3BL5S0IeqsZNMH7EQrEWi0kLKOC13ZBF0ZwERiLWlibNPJr8G1kdU3Ms/r2KiNrF81pUh2HwAHdg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
     },
     "node_modules/@drizzle-team/brocli": {
       "version": "0.10.2",
@@ -1425,6 +1632,24 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@floating-ui/core": {
@@ -2449,6 +2674,13 @@
         "pkg-types": "^2.3.1",
         "semver": "^7.8.1"
       }
+    },
+    "node_modules/@one-ini/wasm": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
+      "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@oxc-project/types": {
       "version": "0.144.0",
@@ -4889,6 +5121,27 @@
       "integrity": "sha512-IOnwSCma8j+9xJT6b8H0dEYidC80NsYmNMlZxRsukYcSoGaDBohog5hDxzeUXdFeGWFA++vWvxqOmrr96VlqMA==",
       "license": "MIT"
     },
+    "node_modules/@vue/test-utils": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.4.11.tgz",
+      "integrity": "sha512-GDqaqZsA6m2E5vNzej0aYiIb6BX8xV9pNSbbbXKOfEYwg7ZNblVX8suyqmUBThq8VIrgAJNxn+z72hVtUeiWHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-beautify": "^1.14.9",
+        "vue-component-type-helpers": "^3.0.0"
+      },
+      "peerDependencies": {
+        "@vue/compiler-dom": "3.x",
+        "@vue/server-renderer": "3.x",
+        "vue": "3.x"
+      },
+      "peerDependenciesMeta": {
+        "@vue/server-renderer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vueuse/core": {
       "version": "14.4.0",
       "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-14.4.0.tgz",
@@ -5468,6 +5721,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -5817,6 +6080,24 @@
       "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
       "license": "MIT"
     },
+    "node_modules/config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
+    "node_modules/config-chain/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/consola": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
@@ -6091,6 +6372,58 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/db0": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/db0/-/db0-0.3.4.tgz",
@@ -6141,6 +6474,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
@@ -6986,6 +7326,68 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "license": "MIT"
     },
+    "node_modules/editorconfig": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.7.tgz",
+      "integrity": "sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@one-ini/wasm": "0.1.1",
+        "commander": "^10.0.0",
+        "minimatch": "^9.0.1",
+        "semver": "^7.5.3"
+      },
+      "bin": {
+        "editorconfig": "bin/editorconfig"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/editorconfig/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/editorconfig/node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/editorconfig/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/editorconfig/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -7823,6 +8225,19 @@
       "integrity": "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==",
       "license": "MIT"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -8127,6 +8542,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-reference": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
@@ -8210,11 +8632,244 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/js-beautify": {
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.15.4.tgz",
+      "integrity": "sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "config-chain": "^1.1.13",
+        "editorconfig": "^1.0.4",
+        "glob": "^10.4.2",
+        "js-cookie": "^3.0.5",
+        "nopt": "^7.2.1"
+      },
+      "bin": {
+        "css-beautify": "js/bin/css-beautify.js",
+        "html-beautify": "js/bin/html-beautify.js",
+        "js-beautify": "js/bin/js-beautify.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/js-beautify/node_modules/abbrev": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/js-beautify/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-beautify/node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/js-beautify/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/js-beautify/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-beautify/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/js-beautify/node_modules/nopt": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
+      "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^2.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/js-beautify/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.8.tgz",
+      "integrity": "sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
       "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -10091,6 +10746,32 @@
       "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
       "license": "MIT"
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -10862,6 +11543,23 @@
         "prosemirror-transform": "^1.1.0"
       }
     },
+    "node_modules/proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/quansync": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
@@ -11045,6 +11743,16 @@
       },
       "peerDependencies": {
         "vue": ">= 3.4.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resend": {
@@ -11340,6 +12048,19 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scule": {
@@ -11848,6 +12569,13 @@
         "node": ">=16"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tagged-tag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
@@ -12053,6 +12781,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.10.tgz",
+      "integrity": "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.10"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
+      "integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -12081,6 +12829,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -14048,6 +14809,19 @@
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -14059,6 +14833,16 @@
       "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
       "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
       "license": "MIT"
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -14255,6 +15039,23 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y-protocols": {
       "version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,10 @@
   },
   "devDependencies": {
     "@types/node": "^26.2.0",
+    "@vitejs/plugin-vue": "^6.0.8",
+    "@vue/test-utils": "^2.4.11",
     "drizzle-kit": "^0.31.10",
+    "jsdom": "^29.1.1",
     "tsx": "^4.23.12",
     "typescript": "^6.0.3",
     "vitest": "^4.1.10",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,8 @@
+import vue from '@vitejs/plugin-vue'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
+  plugins: [vue()],
   test: {
     environment: 'node',
   },


### PR DESCRIPTION
Cierra #48 (S-004, misión 03).

## Resumen

`CatalogSelect.vue`: los 6 modos de UXF-001 (cerrado, enfocado sin texto, con coincidencias, sin coincidencias, cargando, error), con filtrado propio sin distinguir mayúsculas ni tildes (D-004, UX-001) y `showAllOnFocus` para que categorías se vean completas al enfocar (UX-002).

## No usa el combobox de Nuxt UI, y por qué (T-005)

La primera versión iba sobre `UInputMenu`. Probado en el browser, **clickear una opción seleccionaba otra distinta** — la que ocupaba ese índice en el array sin filtrar — y a veces la lista no abría. Se intentó parchar con `by="value"`, sacando `ignoreFilter`, y con un slot `#item` con handler manual; ninguna lo resolvió. Una versión con los items estables + `v-show` llegó a pasar los tests unitarios pero **seguía fallando en el browser de Patricio**, que es la señal de que se estaba construyendo alrededor de un comportamiento que no controlamos.

Ahora es un `UInput` (texto plano) más una lista propia: apertura, filtrado y selección se manejan en el componente. El cierre al clickear una opción usa `focusout` + `relatedTarget` contenido, el patrón estándar para no perder el click contra el blur del input.

## El comportamiento del campo está medido, no supuesto

Después de varios intentos fallidos de adivinar la interacción, fui al selector de comuna real de mercadolibre.cl (la referencia que cita D-004) y **medí qué hace**:

| Acción | Mercado Libre (medido) |
| --- | --- |
| Seleccionar una opción | El input queda con el label completo |
| Volver a hacer click | `selectionStart == selectionEnd` → cursor donde clickeaste, sin selección |
| Escribir una tecla | Inserta en el cursor, no borra nada |
| Volver a enfocar | La lista **no** se abre; solo abre al escribir |

Es un input de texto normal. Todo lo que le había agregado antes (autoseleccionar al enfocar, limpiar en la primera tecla, interceptar `mousedown`) era invención y por eso se sentía raro en cada iteración. Se eliminó.

Dos reglas propias que sí se mantienen, porque son nuestras y no de ML:

- **`showAllOnFocus`** (categorías, UX-002). Al reenfocar con algo ya elegido la lista muestra todo, no filtrada por su propio label — si no, quedaba una lista de un solo ítem y sin salida para cambiar de opción.
- **Al salir sin elegir**, el texto a medio escribir se descarta y vuelve el label elegido. ML deja el texto libre ahí; nosotros no podemos por D-004.

También: en modo error el campo queda `readonly`, no `disabled` — un campo deshabilitado no recibe foco, y sin foco el mensaje de error y el botón "Reintentar" eran inalcanzables.

## Docs actualizadas

`ingenieria.md` (TC-004, tabla de arquitectura, nuevo **T-005**) y `experiencia.md` ya no describen el enfoque `UInputMenu` que se abandonó.

## Test plan

- [x] `npx nuxi typecheck` — sin errores
- [x] `npm run build` — compila
- [x] 17 tests unitarios (Vitest + `@vue/test-utils`), incluidos los que fijan el comportamiento medido en ML: reenfocar no abre la lista, la lista no queda filtrada por su propio label, y salir sin elegir restaura el label
- [x] **Verificado a mano por Patricio en el browser** — los intentos anteriores pasaban tests pero fallaban en uso real, así que esta vez la confirmación vino de probarlo de verdad

🤖 Generated with [Claude Code](https://claude.com/claude-code)
