### PR TITLE
fix(db): activar Puente Alto y San Bernardo en el catálogo de comunas

### DIFF
--- a/docs/missions/03-taxonomia-categorias-y-comunas/investigacion.md
+++ b/docs/missions/03-taxonomia-categorias-y-comunas/investigacion.md
@@ -73,11 +73,16 @@ noche.
 - **Razonamiento:** la comuna es la unidad con la que la gente ya se identifica y busca ("gasfiter en
   Providencia"), y es lo bastante fina para ordenar por cercanía sin exponer la dirección exacta de nadie
   — coherente con que Datealo nunca muestra un dato de contacto sin que el profesional lo autorice.
-- **Implicación:** el modelo de datos necesita una lista cerrada de comunas, no un campo de texto libre. La
-  Provincia de Santiago (las 32 comunas del Gran Santiago) es el candidato natural para arrancar, porque es
-  donde probablemente concentra oferta y demanda inicial — pero esto es hipótesis, no dato propio.
+- **Implicación:** el modelo de datos necesita una lista cerrada de comunas, no un campo de texto libre. El
+  Gran Santiago es el candidato natural para arrancar, porque es donde probablemente concentra oferta y
+  demanda inicial — pero esto es hipótesis, no dato propio.
 - **Confianza:** media — que la comuna sea el grano correcto está bien sustentado; cuántas comunas cubrir
   al lanzamiento todavía no tiene dato propio detrás.
+- **Corrección (2026-08-19):** esta conclusión decía "la Provincia de Santiago (las 32 comunas del Gran
+  Santiago)", tratando ambos términos como sinónimos. No lo son: Gran Santiago es el área urbana continua
+  (32 comunas de la Provincia de Santiago + Puente Alto + San Bernardo, 34 en total), Provincia de
+  Santiago es una unidad administrativa más angosta que deja afuera esos dos conurbados. `producto.md`
+  (D-002) ya quedó corregido con la definición precisa.
 
 <a id="c-003"></a>
 

--- a/docs/missions/03-taxonomia-categorias-y-comunas/producto.md
+++ b/docs/missions/03-taxonomia-categorias-y-comunas/producto.md
@@ -99,9 +99,15 @@ qué se ofrece en registro y búsqueda, sin tocar código
   `activa`. Solo las comunas `activa = true` aparecen como opción en el selector de registro y de búsqueda
   — una comuna inactiva no se ofrece, no se muestra como "sin resultados". Al lanzamiento parten activas
   las comunas de Gran Santiago y Puerto Varas (los dos mercados donde Patricio puede reclutar y verificar
-  profesionales directamente); el resto existe en la tabla pero apagado. Activar una comuna nueva es
-  cambiar ese campo, sin deploy — hoy a mano en la base de datos, más adelante quizás desde un panel de
-  administración (fuera de alcance de esta misión).
+  profesionales directamente); el resto existe en la tabla pero apagado. "Gran Santiago" acá son 34
+  comunas, no las 32 de la Provincia de Santiago a secas: esa provincia más Puente Alto y San Bernardo,
+  los dos conurbados que administrativamente caen en otra provincia (Cordillera y Maipo) pero son parte
+  del área urbana continua — es la definición que usa el Área Metropolitana de Santiago para "Gran
+  Santiago" (32 + Puente Alto + San Bernardo = 34). La primera versión de esta fila activó solo las 32,
+  dejando Puente Alto y San Bernardo apagados por una lectura demasiado literal del nombre de la
+  provincia — corregido el 2026-08-19. Activar una comuna nueva es cambiar ese campo, sin deploy — hoy a
+  mano en la base de datos, más adelante quizás desde un panel de administración (fuera de alcance de esta
+  misión).
 - **Reapertura:** ninguna — el catálogo ya está completo. Lo que se revisa con el tiempo es qué comunas
   están activas, y eso no necesita reabrir esta decisión (ver [M-002](#m-002)).
 

--- a/server/db/seed/taxonomia.ts
+++ b/server/db/seed/taxonomia.ts
@@ -11,9 +11,11 @@
 // Interior), generadas desde https://github.com/knxroot/bdcut-cl en vez de transcritas a mano, para
 // no arriesgar un nombre o código mal tipeado en 346 filas.
 //
-// Activas al sembrar: las 8 categorías, más las 32 comunas de la Provincia de Santiago (Gran
-// Santiago) y Puerto Varas — los dos mercados donde Patricio puede reclutar y verificar
-// profesionales directamente al lanzamiento (D-002). El resto de las comunas queda en la tabla pero
+// Activas al sembrar: las 8 categorías, más el Gran Santiago (34 comunas: las 32 de la Provincia de
+// Santiago más Puente Alto y San Bernardo, los dos conurbados que quedan fuera de esa provincia pero
+// son parte del área urbana continua — la definición administrativa "Provincia de Santiago" no
+// alcanza sola, ver D-002) y Puerto Varas — los mercados donde Patricio puede reclutar y verificar
+// profesionales directamente al lanzamiento. El resto de las comunas queda en la tabla pero
 // inactivo, listo para activarse cambiando el campo sin necesitar otro deploy.
 
 import { drizzle } from 'drizzle-orm/postgres-js'
@@ -351,13 +353,13 @@ const comunasSeed = [
   { codigo: '13130', nombre: 'San Miguel', activa: true },
   { codigo: '13131', nombre: 'San Ramón', activa: true },
   { codigo: '13132', nombre: 'Vitacura', activa: true },
-  { codigo: '13201', nombre: 'Puente Alto', activa: false },
+  { codigo: '13201', nombre: 'Puente Alto', activa: true },
   { codigo: '13202', nombre: 'Pirque', activa: false },
   { codigo: '13203', nombre: 'San José de Maipo', activa: false },
   { codigo: '13301', nombre: 'Colina', activa: false },
   { codigo: '13302', nombre: 'Lampa', activa: false },
   { codigo: '13303', nombre: 'Tiltil', activa: false },
-  { codigo: '13401', nombre: 'San Bernardo', activa: false },
+  { codigo: '13401', nombre: 'San Bernardo', activa: true },
   { codigo: '13402', nombre: 'Buin', activa: false },
   { codigo: '13403', nombre: 'Calera de Tango', activa: false },
   { codigo: '13404', nombre: 'Paine', activa: false },


### PR DESCRIPTION
Cierra #55.

## Qué pasó

Probando el selector de comuna, Patricio notó que Puente Alto no aparecía activo. Investigando: D-002 dice que "Gran Santiago" parte activo al lanzamiento, y el seed original lo tradujo como "las 32 comunas de la Provincia de Santiago" — pero esos dos términos no son sinónimos. Puente Alto (código `13201`, la comuna más poblada de Chile) y San Bernardo (`13401`) caen administrativamente en otra provincia (Cordillera y Maipo) pero son parte del área urbana continua de Santiago. La definición estándar del Área Metropolitana de Santiago es 32 (Provincia de Santiago) + Puente Alto + San Bernardo = **34 comunas**.

## Qué cambia

- `server/db/seed/taxonomia.ts`: `13201` y `13401` pasan a `activa: true`, para que un seed nuevo en otro entorno arranque bien.
- `producto.md` (D-002) e `investigacion.md` (C-002): se precisa la definición de "Gran Santiago" con la fuente, y se deja registrado que la primera versión de esta fila fue una lectura demasiado literal del nombre de la provincia.
- La corrección ya se aplicó directo en la base de Supabase (`UPDATE comunas SET activa = true WHERE codigo IN ('13201','13401')`) — D-002 dice que activar una comuna es cambiar el campo a mano, sin deploy.

## Test plan

- [x] `UPDATE` verificado en Supabase (antes/después mostrando `activa: false → true` para ambas filas)
- [x] Seed fuente corregido para que un entorno nuevo no repita el error

🤖 Generated with [Claude Code](https://claude.com/claude-code)