### PR TITLE
docs: skill comentarios — nunca citar IDs de decisión, fuente única de verdad

### DIFF
--- a/.claude/skills/comentarios/SKILL.md
+++ b/.claude/skills/comentarios/SKILL.md
@@ -39,6 +39,10 @@ Un comentario largo casi nunca arregla un diseño confuso, solo lo documenta.
   no puede cargar solo — la razón, la restricción, el caso límite.
 - **Usa palabras distintas a las del nombre.** Si el comentario es la prop/función/variable traducida a
   prosa, no agrega información — es ruido con forma de explicación.
+- **Ancla en los identificadores reales, no en verbos sueltos.** "Reenfocar un campo" no es una acción que
+  exista en el código si lo que hay es un ref `focused` y una función `handleFocusIn` — nombralos. Un
+  comentario que parafrasea con palabras propias en vez de citar lo que el código realmente hace es más
+  difícil de verificar contra el código, y más fácil que quede mal descrito.
 - **No lo dupliques.** Si la misma razón ya está explicada donde vive el dato o la prop, no la repitas en
   cada lugar que la usa — una copia, no N que se pueden desincronizar.
 - **En positivo, nunca en negativo.** Qué hace, qué extiende, dónde vive la lógica relacionada — nunca "no
@@ -121,6 +125,29 @@ no `CategoriaOComunaSelect`), sus props sin nada de categoría ni comuna, y la e
 de cualquier extracción de componente, no un insight de esta decisión puntual.
 
 ✅ Sin comentario — la estructura de archivos ya lo dice.
+
+❌ Verbos sueltos que no corresponden a nada del código — encontrado en `CatalogSelect.vue`:
+
+```ts
+const focused = ref(false)
+// Distingue "enfocado pero sin tocar nada" de "está buscando". La lista solo filtra cuando de verdad se
+// escribió algo — si no, reenfocar un campo ya elegido filtraría por su propio label...
+const hasTyped = ref(false)
+```
+
+"Enfocar" y "reenfocar un campo" no son acciones que existan en el código — lo que hay es un ref
+`focused` y una función `handleInput`. Parafrasear con palabras propias en vez de citar lo que el código
+realmente hace es más difícil de verificar, y más fácil que quede mal descrito.
+
+✅ Ancla en los identificadores reales:
+
+```ts
+const focused = ref(false)
+// searchTerm ya arranca con el label elegido (ver más abajo) — sin hasTyped, matchesSearch usaría ese
+// texto para filtrar apenas focused se pone en true, mostrando una lista de un solo resultado en vez de
+// dejar cambiar de opción. hasTyped solo se prende con un keystroke real, en handleInput.
+const hasTyped = ref(false)
+```
 
 ## Al revisar un comentario existente
 

--- a/.claude/skills/comentarios/SKILL.md
+++ b/.claude/skills/comentarios/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: comentarios
-description: Cuándo escribir un comentario de código en Datealo y cómo no dejarlo pudrirse — evita comentarios que restan el porqué a favor del qué, negativos ("no hace X"), duplicados entre archivos, con números que se desactualizan, o que citan una decisión (D-001, T-003, UX-002) sin explicar nada en la misma línea. Usar antes de escribir cualquier comentario nuevo, o al revisar si uno existente debería reescribirse o borrarse.
+description: Cuándo escribir un comentario de código en Datealo y cómo no dejarlo pudrirse — evita comentarios que restan el porqué a favor del qué, negativos ("no hace X"), duplicados entre archivos, con números que se desactualizan, o que citan un ID de decisión (D-001, T-003, UX-002) en vez de explicar. Usar antes de escribir cualquier comentario nuevo, o al revisar si uno existente debería reescribirse o borrarse.
 ---
 
 # Comentarios en Datealo
@@ -38,10 +38,11 @@ Un comentario largo casi nunca arregla un diseño confuso, solo lo documenta.
 - **Sin números ni hechos que se pudren solos.** Si el valor puede cambiar sin que el comentario se
   entere, no lo hardcodees — describí la forma cualitativa ("catálogo chico" vs. "catálogo grande"), el
   valor exacto vive en el código o los datos.
-- **Una referencia a una decisión (D-001, T-003, UX-002) acompaña, nunca reemplaza.** Si al sacar la cita
-  el comentario deja de tener sentido, todavía no estaba explicando nada.
+- **Nunca cites un ID de decisión (D-001, T-003, UX-002).** Si la explicación no se sostiene sola sin la
+  cita, todavía no explica nada — y si se sostiene sola, la cita no agrega nada. Trazabilidad hacia la
+  decisión completa se resuelve con `git blame` o los docs de la misión, no desde el comentario.
 
-## Ejemplo real de este repo
+## Ejemplos reales de este repo
 
 ❌ Cita sin explicar — encontrado en `server/db/seed/taxonomia.ts` antes de corregirse:
 
@@ -51,11 +52,11 @@ Un comentario largo casi nunca arregla un diseño confuso, solo lo documenta.
 
 Obliga a ir a buscar D-002 para entender qué significa que el catálogo "cambie a mano".
 
-✅ La razón vive en la línea, D-002 queda como trazabilidad:
+✅ La razón vive en la línea, sin cita:
 
 ```ts
 // El campo `activa` se cambia a mano en la base, no desde la app — no hay panel de admin todavía, así
-// que no hay ningún evento de escritura del que colgar una invalidación de caché al instante (D-002).
+// que no hay ningún evento de escritura del que colgar una invalidación de caché al instante.
 ```
 
 ❌ Negativo + duplicado + con un número que ya estaba mal el día que se escribió — encontrado en
@@ -69,12 +70,32 @@ Obliga a ir a buscar D-002 para entender qué significa que el catálogo "cambie
 ```
 
 ✅ Cero comentario en el wrapper — el prop `show-all-on-focus="true"` ya es el hecho, y la razón vive una
-sola vez donde la prop se declara (`CatalogSelect.vue`), sin número exacto:
+sola vez donde la prop se declara (`CatalogSelect.vue`), sin número exacto ni cita:
 
 ```ts
 // Catálogo chico (categorías): mostrar todo al enfocar no cuesta nada. Catálogo grande (comunas): esperar
 // a que se escriba, el patrón ya validado de Mercado Libre — mostrar todas las opciones de entrada es
-// más ruido que ayuda. UX-002 en experiencia.md.
+// más ruido que ayuda.
+```
+
+❌ Explicación completa pero con relleno y una cita que no agregaba nada — encontrado en
+`server/db/schema/categorias.ts`:
+
+```ts
+// slug es la clave primaria en vez de un uuid autogenerado: el catálogo es fijo y chico (8 filas), y
+// el slug ya es único y estable por definición — un id sin significado encima solo obligaría a un
+// join o un mapeo extra en cada lugar que ya conoce el nombre (T-001).
+```
+
+Tres problemas: "(8 filas)" es un número que se pudre (D-001 dice explícitamente que sumar categorías
+después es esperado), "fijo y chico" y "por definición" son relleno que no agrega razón, y T-001 no
+resolvía ningún matiz que la frase no dijera ya.
+
+✅ La razón real en una frase, sin relleno ni cita:
+
+```ts
+// slug es la clave primaria: ya es el identificador natural y estable de la categoría, no hace falta
+// inventar un uuid encima.
 ```
 
 ## Al revisar un comentario existente

--- a/.claude/skills/comentarios/SKILL.md
+++ b/.claude/skills/comentarios/SKILL.md
@@ -1,41 +1,49 @@
 ---
 name: comentarios
-description: Cuándo escribir un comentario de código en Datealo y cómo no dejarlo pudrirse — evita comentarios negativos ("no hace X"), duplicados entre archivos, con números que se desactualizan, o que citan una decisión (D-001, T-003, UX-002) sin explicar el porqué en la misma línea. Usar antes de escribir cualquier comentario nuevo, o al revisar si uno existente debería reescribirse o borrarse.
+description: Cuándo escribir un comentario de código en Datealo y cómo no dejarlo pudrirse — evita comentarios que restan el porqué a favor del qué, negativos ("no hace X"), duplicados entre archivos, con números que se desactualizan, o que citan una decisión (D-001, T-003, UX-002) sin explicar nada en la misma línea. Usar antes de escribir cualquier comentario nuevo, o al revisar si uno existente debería reescribirse o borrarse.
 ---
 
 # Comentarios en Datealo
 
-**Fuentes**: [Stack Overflow Engineering — Best practices for writing code
-comments](https://stackoverflow.blog/2021/12/23/best-practices-for-writing-code-comments/) ("code tells you
-how, comments tell you why"; comentarios que duplican el código tienen valor negativo — ensucian y hay que
-mantenerlos). Sección "Comentarios" de `CLAUDE.md` (regla de autocontención del repo).
+**Fuentes:** [Google eng-practices — What to look for in a code
+review](https://google.github.io/eng-practices/review/reviewer/looking-for.html) ("comments are useful
+when they explain why some code exists, and should not be explaining what... if code isn't clear enough
+to explain itself, then the code should be made simpler"). [Ousterhout, *A Philosophy of Software
+Design*](https://www.goodreads.com/work/quotes/61938796) ("a first step towards writing good comments is
+to use different words in the comment from those in the name of the entity being described"). [Stack
+Overflow Engineering — Best practices for writing code
+comments](https://stackoverflow.blog/2021/12/23/best-practices-for-writing-code-comments/) (comentarios
+que duplican el código o un hecho que cambia tienen valor negativo: ensucian y hay que mantenerlos).
 
-Este skill nació de dos vueltas de feedback reales en la misma tarea (PR #57, `CategoriaSelect.vue`): la
-primera corrigió comentarios que citaban una decisión sin explicar nada; la segunda encontró que el
-comentario "corregido" seguía siendo duplicado y con un número que ya estaba mal el mismo día que se
-escribió. Los ejemplos de abajo son ese caso real.
+## El test
 
-## Antes de escribir un comentario, en este orden
+**Un comentario vale la pena solo si dice algo que el código no puede decir por sí solo:** la razón detrás
+de una decisión, una restricción no obvia, o un caso límite. Si lo único que hace es repetir en prosa lo
+que el nombre de la variable, función o prop ya dice, no suma nada — bórralo.
 
-1. **¿El código ya lo dice solo?** Un wrapper de 4 líneas con un solo componente adentro no necesita un
-   comentario que diga "esto es un wrapper que no hace nada propio" — eso ya se lee en el código. No
-   comentar.
-2. **¿Esta explicación ya vive en otro archivo?** No la repitas. Que viva una sola vez, donde el dato o la
-   prop se define — todo lo demás son N copias que se pueden desincronizar.
-3. **¿Es positiva o negativa?** Describe qué hace, qué extiende, o dónde vive la lógica relevante — nunca
-   qué NO hace. "No reimplementa X" no ayuda a nadie a entender el código; "X vive en Y" sí.
-4. **¿Tiene un número o hecho que puede cambiar sin que el comentario se entere?** Sacalo. Describe la
-   forma cualitativa ("catálogo chico" vs. "catálogo grande"), no el valor exacto ("8" vs. "346") — el
-   valor exacto vive en el código o los datos, no en un comentario que nadie va a actualizar cuando cambie.
-5. **¿Cita un ID de decisión (D-001, T-003, UX-002) sin explicar el porqué en la misma línea?** La cita
-   acompaña como trazabilidad hacia la decisión completa — nunca reemplaza la explicación. Si al sacar el
-   ID el comentario deja de tener sentido, todavía no explica nada.
+**Si te cuesta escribirlo en una o dos líneas claras, la señal no es "necesito un comentario más largo" —
+es que el código mismo es demasiado complicado y conviene simplificarlo primero** (Google eng-practices).
+Un comentario largo casi nunca arregla un diseño confuso, solo lo documenta.
 
-Si la respuesta a la 1 es sí, no hay comentario. Si sobrevive las cinco, es un comentario que vale la pena.
+## Reglas, una vez que el comentario pasó el test
 
-## Ejemplos reales de este repo
+- **Explica el porqué, no el qué.** El código ya dice qué hace; el comentario existe para lo que el código
+  no puede cargar solo — la razón, la restricción, el caso límite.
+- **Usa palabras distintas a las del nombre.** Si el comentario es la prop/función/variable traducida a
+  prosa, no agrega información — es ruido con forma de explicación.
+- **No lo dupliques.** Si la misma razón ya está explicada donde vive el dato o la prop, no la repitas en
+  cada lugar que la usa — una copia, no N que se pueden desincronizar.
+- **En positivo, nunca en negativo.** Qué hace, qué extiende, dónde vive la lógica relacionada — nunca "no
+  hace X". Decir qué no pasa no ayuda a entender qué sí pasa.
+- **Sin números ni hechos que se pudren solos.** Si el valor puede cambiar sin que el comentario se
+  entere, no lo hardcodees — describí la forma cualitativa ("catálogo chico" vs. "catálogo grande"), el
+  valor exacto vive en el código o los datos.
+- **Una referencia a una decisión (D-001, T-003, UX-002) acompaña, nunca reemplaza.** Si al sacar la cita
+  el comentario deja de tener sentido, todavía no estaba explicando nada.
 
-❌ Cita sin explicar (encontrado en `server/db/seed/taxonomia.ts`, antes de corregirse):
+## Ejemplo real de este repo
+
+❌ Cita sin explicar — encontrado en `server/db/seed/taxonomia.ts` antes de corregirse:
 
 ```ts
 // Catálogo de referencia, cambia solo a mano (D-002).
@@ -43,15 +51,15 @@ Si la respuesta a la 1 es sí, no hay comentario. Si sobrevive las cinco, es un 
 
 Obliga a ir a buscar D-002 para entender qué significa que el catálogo "cambie a mano".
 
-✅ Corregido — la razón vive en la línea, D-002 es trazabilidad:
+✅ La razón vive en la línea, D-002 queda como trazabilidad:
 
 ```ts
 // El campo `activa` se cambia a mano en la base, no desde la app — no hay panel de admin todavía, así
 // que no hay ningún evento de escritura del que colgar una invalidación de caché al instante (D-002).
 ```
 
-❌ Negativo + duplicado + número que se pudre (encontrado en `CategoriaSelect.vue`, dos vueltas de
-feedback antes de esta versión):
+❌ Negativo + duplicado + con un número que ya estaba mal el día que se escribió — encontrado en
+`CategoriaSelect.vue` (PR #57), aun después de una primera corrección:
 
 ```ts
 // No reimplementa nada de la interacción (filtrado, apertura, selección) — eso vive una sola vez en
@@ -60,27 +68,17 @@ feedback antes de esta versión):
 // Categorías son solo 8 — mostrarlas todas al enfocar no es ruido, por eso showAllOnFocus (UX-002).
 ```
 
-Tres problemas a la vez: describe qué NO hace (regla 3), la razón de `showAllOnFocus` ya estaba explicada
-en `CatalogSelect.vue` junto a la prop (regla 2), y "son solo 8" es un hecho que cambia — el mismo
-comentario decía en otra versión "~33 comunas activas" y ya estaba desactualizado el día que se escribió
-(regla 4).
-
-✅ Corregido — cero comentarios en el wrapper (el prop ya es el hecho), la razón vive una sola vez donde se
-declara la prop:
+✅ Cero comentario en el wrapper — el prop `show-all-on-focus="true"` ya es el hecho, y la razón vive una
+sola vez donde la prop se declara (`CatalogSelect.vue`), sin número exacto:
 
 ```ts
-// CatalogSelect.vue, junto a la prop:
 // Catálogo chico (categorías): mostrar todo al enfocar no cuesta nada. Catálogo grande (comunas): esperar
 // a que se escriba, el patrón ya validado de Mercado Libre — mostrar todas las opciones de entrada es
 // más ruido que ayuda. UX-002 en experiencia.md.
 ```
 
-```vue
-<!-- CategoriaSelect.vue: sin comentario, el prop ya lo dice -->
-<CatalogSelect ... :show-all-on-focus="true" />
-```
-
 ## Al revisar un comentario existente
 
-Si estás editando un archivo y pasás por un comentario que no cumple las cinco reglas, corregilo ahí mismo
-— no hace falta una tarea aparte para eso, es parte de dejar el código mejor de como lo encontraste.
+Si estás editando un archivo y pasás por un comentario que no pasa el test o rompe alguna regla,
+corregilo ahí mismo — no hace falta una tarea aparte, es parte de dejar el código mejor de como lo
+encontraste.

--- a/.claude/skills/comentarios/SKILL.md
+++ b/.claude/skills/comentarios/SKILL.md
@@ -21,6 +21,14 @@ que duplican el código o un hecho que cambia tienen valor negativo: ensucian y 
 de una decisión, una restricción no obvia, o un caso límite. Si lo único que hace es repetir en prosa lo
 que el nombre de la variable, función o prop ya dice, no suma nada — bórralo.
 
+**"Explica el porqué" no es un pase automático.** Un porqué puede seguir siendo redundante si ya se
+infiere de la estructura del archivo — su nombre, sus props, o la existencia de otros archivos que lo
+rodean. "Este componente es genérico para evitar lógica duplicada entre sus dos wrappers" es la
+justificación de manual para cualquier extracción de componente compartido — si el nombre del archivo, sus
+props sin nada específico de ningún caso de uso, y la existencia de esos wrappers ya cuentan esa historia,
+repetirla en prosa no agrega nada. Preguntá no solo "¿explica el porqué?" sino "¿ese porqué ya era
+inferible sin el comentario?".
+
 **Si te cuesta escribirlo en una o dos líneas claras, la señal no es "necesito un comentario más largo" —
 es que el código mismo es demasiado complicado y conviene simplificarlo primero** (Google eng-practices).
 Un comentario largo casi nunca arregla un diseño confuso, solo lo documenta.
@@ -97,6 +105,22 @@ resolvía ningún matiz que la frase no dijera ya.
 // slug es la clave primaria: ya es el identificador natural y estable de la categoría, no hace falta
 // inventar un uuid encima.
 ```
+
+❌ Porqué correcto en forma, pero redundante con lo que la estructura de archivos ya dice — encontrado en
+`CatalogSelect.vue`:
+
+```ts
+// CategoriaSelect y ComunaSelect necesitan exactamente el mismo comportamiento de selección — que viva
+// una sola vez acá, en vez de copiado en cada wrapper, evita que con el tiempo terminen comportándose
+// distinto sin que nadie lo note.
+```
+
+Pasa el test de "explica el porqué, no el qué" — y aun así sobra: el nombre del archivo (`CatalogSelect`,
+no `CategoriaOComunaSelect`), sus props sin nada de categoría ni comuna, y la existencia de
+`CategoriaSelect.vue`/`ComunaSelect.vue` ya cuentan que es un componente compartido. Es la razón esperable
+de cualquier extracción de componente, no un insight de esta decisión puntual.
+
+✅ Sin comentario — la estructura de archivos ya lo dice.
 
 ## Al revisar un comentario existente
 

--- a/.claude/skills/comentarios/SKILL.md
+++ b/.claude/skills/comentarios/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: comentarios
+description: Cuándo escribir un comentario de código en Datealo y cómo no dejarlo pudrirse — evita comentarios negativos ("no hace X"), duplicados entre archivos, con números que se desactualizan, o que citan una decisión (D-001, T-003, UX-002) sin explicar el porqué en la misma línea. Usar antes de escribir cualquier comentario nuevo, o al revisar si uno existente debería reescribirse o borrarse.
+---
+
+# Comentarios en Datealo
+
+**Fuentes**: [Stack Overflow Engineering — Best practices for writing code
+comments](https://stackoverflow.blog/2021/12/23/best-practices-for-writing-code-comments/) ("code tells you
+how, comments tell you why"; comentarios que duplican el código tienen valor negativo — ensucian y hay que
+mantenerlos). Sección "Comentarios" de `CLAUDE.md` (regla de autocontención del repo).
+
+Este skill nació de dos vueltas de feedback reales en la misma tarea (PR #57, `CategoriaSelect.vue`): la
+primera corrigió comentarios que citaban una decisión sin explicar nada; la segunda encontró que el
+comentario "corregido" seguía siendo duplicado y con un número que ya estaba mal el mismo día que se
+escribió. Los ejemplos de abajo son ese caso real.
+
+## Antes de escribir un comentario, en este orden
+
+1. **¿El código ya lo dice solo?** Un wrapper de 4 líneas con un solo componente adentro no necesita un
+   comentario que diga "esto es un wrapper que no hace nada propio" — eso ya se lee en el código. No
+   comentar.
+2. **¿Esta explicación ya vive en otro archivo?** No la repitas. Que viva una sola vez, donde el dato o la
+   prop se define — todo lo demás son N copias que se pueden desincronizar.
+3. **¿Es positiva o negativa?** Describe qué hace, qué extiende, o dónde vive la lógica relevante — nunca
+   qué NO hace. "No reimplementa X" no ayuda a nadie a entender el código; "X vive en Y" sí.
+4. **¿Tiene un número o hecho que puede cambiar sin que el comentario se entere?** Sacalo. Describe la
+   forma cualitativa ("catálogo chico" vs. "catálogo grande"), no el valor exacto ("8" vs. "346") — el
+   valor exacto vive en el código o los datos, no en un comentario que nadie va a actualizar cuando cambie.
+5. **¿Cita un ID de decisión (D-001, T-003, UX-002) sin explicar el porqué en la misma línea?** La cita
+   acompaña como trazabilidad hacia la decisión completa — nunca reemplaza la explicación. Si al sacar el
+   ID el comentario deja de tener sentido, todavía no explica nada.
+
+Si la respuesta a la 1 es sí, no hay comentario. Si sobrevive las cinco, es un comentario que vale la pena.
+
+## Ejemplos reales de este repo
+
+❌ Cita sin explicar (encontrado en `server/db/seed/taxonomia.ts`, antes de corregirse):
+
+```ts
+// Catálogo de referencia, cambia solo a mano (D-002).
+```
+
+Obliga a ir a buscar D-002 para entender qué significa que el catálogo "cambie a mano".
+
+✅ Corregido — la razón vive en la línea, D-002 es trazabilidad:
+
+```ts
+// El campo `activa` se cambia a mano en la base, no desde la app — no hay panel de admin todavía, así
+// que no hay ningún evento de escritura del que colgar una invalidación de caché al instante (D-002).
+```
+
+❌ Negativo + duplicado + número que se pudre (encontrado en `CategoriaSelect.vue`, dos vueltas de
+feedback antes de esta versión):
+
+```ts
+// No reimplementa nada de la interacción (filtrado, apertura, selección) — eso vive una sola vez en
+// CatalogSelect... (T-003)
+//
+// Categorías son solo 8 — mostrarlas todas al enfocar no es ruido, por eso showAllOnFocus (UX-002).
+```
+
+Tres problemas a la vez: describe qué NO hace (regla 3), la razón de `showAllOnFocus` ya estaba explicada
+en `CatalogSelect.vue` junto a la prop (regla 2), y "son solo 8" es un hecho que cambia — el mismo
+comentario decía en otra versión "~33 comunas activas" y ya estaba desactualizado el día que se escribió
+(regla 4).
+
+✅ Corregido — cero comentarios en el wrapper (el prop ya es el hecho), la razón vive una sola vez donde se
+declara la prop:
+
+```ts
+// CatalogSelect.vue, junto a la prop:
+// Catálogo chico (categorías): mostrar todo al enfocar no cuesta nada. Catálogo grande (comunas): esperar
+// a que se escriba, el patrón ya validado de Mercado Libre — mostrar todas las opciones de entrada es
+// más ruido que ayuda. UX-002 en experiencia.md.
+```
+
+```vue
+<!-- CategoriaSelect.vue: sin comentario, el prop ya lo dice -->
+<CatalogSelect ... :show-all-on-focus="true" />
+```
+
+## Al revisar un comentario existente
+
+Si estás editando un archivo y pasás por un comentario que no cumple las cinco reglas, corregilo ahí mismo
+— no hace falta una tarea aparte para eso, es parte de dejar el código mejor de como lo encontraste.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,6 +233,7 @@ Skills propios del repo en `.claude/skills/`:
 | `discovery-ux`            | Iterar `experiencia.md`: vistas, flujos, estados, mockups          |
 | `discovery-engineering`   | Iterar `ingenieria.md`: contratos, datos, slicing en issues        |
 | `vue-composition`         | Extraer componentes o composables; auditoría de salud de archivos  |
+| `comentarios`             | Antes de escribir o revisar cualquier comentario de código          |
 
 Skills de terceros pre-instalados en `.agents/skills/` (ver `skills-lock.json`): `nuxt`, `vue`,
 `drizzle-orm`, `frontend-design`, `ui-ux-pro-max`, `web-design-guidelines`, `marketing-psychology`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,21 +141,8 @@ Sin `console.log` de debug en el código que se mergea.
 **Naming**: archivos en kebab-case, componentes en PascalCase, composables `useAlgo`, constantes en
 SCREAMING_SNAKE_CASE, tipos en PascalCase, funciones en camelCase. Named exports sobre default exports.
 
-**Comentarios**: solo para reglas de negocio no obvias. El naming claro es la documentación por defecto.
-Autocontenidos: explican el porqué en la misma línea, sin obligar a abrir `docs/missions/` ni el skill
-`arquitectura` para entenderlos. Una referencia (`D-001`, `A-002`) puede acompañar como trazabilidad hacia
-la decisión completa, pero nunca reemplaza la explicación — si el documento se mueve, se reescribe o
-desaparece, el comentario tiene que seguir teniendo sentido solo.
-
-```ts
-// ❌ Obliga a ir a buscar D-002 para entender qué significa "activa"
-// Catálogo de referencia, cambia solo a mano (D-002).
-
-// ✅ Se entiende sin abrir nada más; D-002 queda como trazabilidad, no como la explicación
-// El campo `activa` se cambia a mano en la base, no desde la app — no hay panel de admin
-// todavía, así que no hay ningún evento de escritura del que colgar una invalidación de
-// caché al instante (D-002).
-```
+**Comentarios**: ver el skill `comentarios` — cuándo escribir uno, cómo evitar que se pudra, ejemplos
+reales de este repo. Es la fuente de verdad, no se repite acá.
 
 ## Umbrales de salud de archivos
 


### PR DESCRIPTION
## Por qué

Cuarto round de feedback en el mismo eje (comentarios de `CategoriaSelect.vue`/`categorias.ts`, este ciclo):

1. Comentarios citando una decisión (T-003) sin explicar el porqué en la línea.
2. El "fix" seguía sin servir: negativo, duplicado, con un número ya desactualizado.
3. El skill que documentó lo anterior era un checklist ad-hoc de una sola fuente — pulido con Google eng-practices y Ousterhout.
4. Aun con explicación completa, la cita (T-001) no agregaba nada — Patricio: "se supone que son autocontenidos... siento que es mucha justificación". Se define la regla final: **nunca citar un ID de decisión**. Si la explicación no se sostiene sola sin la cita, todavía no explica nada; si se sostiene sola, la cita no agrega nada. Trazabilidad hacia la decisión completa se resuelve con `git blame` o los docs de la misión, no desde el comentario.
5. Patricio también notó que `CLAUDE.md` repetía la regla que ya vive en el skill — exactamente la duplicación que el skill prohíbe. `CLAUDE.md` queda como un puntero de una línea; el skill es la fuente de verdad.

## Qué agrega/cambia

- `.claude/skills/comentarios/SKILL.md` (proyecto) y `~/.claude/skills/comentarios/SKILL.md` (global, fuera de este repo) actualizados: nunca citar IDs de decisión/tickets, con el ejemplo real de `categorias.ts`.
- `CLAUDE.md`: la sección "Comentarios" pasa de ~15 líneas con ejemplo a un puntero al skill.

**Nota de proceso:** `.claude/rules/skills.global.md` pide pasar por `claude-toolkit:skill-detector`/`skill-classifier`/`verify-skill-generic`. Ese plugin no está habilitado en esta máquina — Patricio confirmó que es de otro proyecto y que se salte el gate.

Ver también el PR de barrido que aplica esta regla al resto del repo.

## Test plan

- [x] Aplicado en el momento sobre el caso real que lo motivó
- [x] Sin código ejecutable — solo documentación de skill, no aplica typecheck/build

🤖 Generated with [Claude Code](https://claude.com/claude-code)