### PR TITLE
fix(app): sacar citas a IDs de decisión de comentarios existentes

### DIFF
--- a/server/api/categorias.get.ts
+++ b/server/api/categorias.get.ts
@@ -1,7 +1,7 @@
 // El campo `activa` de cada categoría se cambia a mano en la base — no hay panel de administración
 // todavía, así que no existe un evento de escritura desde el que invalidar un caché al instante. Por
 // eso el control acá es un TTL de una hora en el CDN de Vercel (s-maxage), no una caché de aplicación:
-// es el mecanismo que Vercel documenta para cachear respuestas de sus funciones (T-004).
+// es el mecanismo que Vercel documenta para cachear respuestas de sus funciones.
 export default defineEventHandler(async (event) => {
   setResponseHeader(event, 'cache-control', 'public, s-maxage=3600, stale-while-revalidate=86400')
   return { categorias: await findActiveCategorias() }

--- a/server/api/comunas.get.ts
+++ b/server/api/comunas.get.ts
@@ -1,7 +1,7 @@
 // El campo `activa` de cada comuna se cambia a mano en la base — no hay panel de administración
 // todavía, así que no existe un evento de escritura desde el que invalidar un caché al instante. Por
 // eso el control acá es un TTL de una hora en el CDN de Vercel (s-maxage), no una caché de aplicación:
-// es el mecanismo que Vercel documenta para cachear respuestas de sus funciones (T-004).
+// es el mecanismo que Vercel documenta para cachear respuestas de sus funciones.
 export default defineEventHandler(async (event) => {
   setResponseHeader(event, 'cache-control', 'public, s-maxage=3600, stale-while-revalidate=86400')
   return { comunas: await findActiveComunas() }

--- a/server/db/schema/categorias.ts
+++ b/server/db/schema/categorias.ts
@@ -1,8 +1,7 @@
 import { boolean, pgTable, text } from 'drizzle-orm/pg-core'
 
-// slug es la clave primaria en vez de un uuid autogenerado: el catálogo es fijo y chico (8 filas), y
-// el slug ya es único y estable por definición — un id sin significado encima solo obligaría a un
-// join o un mapeo extra en cada lugar que ya conoce el nombre (T-001).
+// slug es la clave primaria: ya es el identificador natural y estable de la categoría, no hace falta
+// inventar un uuid encima.
 export const categorias = pgTable('categorias', {
   slug: text('slug').primaryKey(),
   nombre: text('nombre').notNull(),

--- a/server/db/schema/comunas.ts
+++ b/server/db/schema/comunas.ts
@@ -1,9 +1,8 @@
 import { boolean, pgTable, text } from 'drizzle-orm/pg-core'
 
 export const comunas = pgTable('comunas', {
-  // codigo es la clave primaria en vez de un uuid autogenerado — mismo criterio que categorias.ts
-  // (T-001): el catálogo es fijo, y este código oficial de comuna (Decreto Exento Nº 817, SUBDERE)
-  // ya es único y estable, así que un id interno encima no agregaría nada.
+  // codigo es la clave primaria: ya es el identificador oficial y estable de la comuna (Decreto Exento
+  // Nº 817, SUBDERE), no hace falta inventar un uuid encima.
   codigo: text('codigo').primaryKey(),
   nombre: text('nombre').notNull(),
   activa: boolean('activa').notNull().default(false),

--- a/server/db/seed/taxonomia.ts
+++ b/server/db/seed/taxonomia.ts
@@ -1,9 +1,9 @@
 // Seed de categorias y comunas. Se corre una vez por entorno: `npm run db:seed:taxonomia`.
 //
 // Conexión directa (puerto 5432), no el pooler de la app (que usa el modo transacción de Supavisor,
-// sin prepared statements) — drizzle-kit necesita la conexión directa por el mismo motivo (A-003).
+// sin prepared statements) — drizzle-kit necesita la conexión directa por el mismo motivo.
 //
-// Las 8 categorías son las que Patricio aprobó como catálogo del lanzamiento (D-001): Gasfitería,
+// Las 8 categorías son las que Patricio aprobó como catálogo del lanzamiento: Gasfitería,
 // Electricidad, Peluquería, Limpieza, Mudanzas, Pintura, Cerrajería, Jardinería — ver el array
 // `categoriasSeed` más abajo para la lista exacta.
 //
@@ -14,9 +14,9 @@
 // Activas al sembrar: las 8 categorías, más el Gran Santiago (34 comunas: las 32 de la Provincia de
 // Santiago más Puente Alto y San Bernardo, los dos conurbados que quedan fuera de esa provincia pero
 // son parte del área urbana continua — la definición administrativa "Provincia de Santiago" no
-// alcanza sola, ver D-002) y Puerto Varas — los mercados donde Patricio puede reclutar y verificar
-// profesionales directamente al lanzamiento. El resto de las comunas queda en la tabla pero
-// inactivo, listo para activarse cambiando el campo sin necesitar otro deploy.
+// alcanza sola) y Puerto Varas — los mercados donde Patricio puede reclutar y verificar profesionales
+// directamente al lanzamiento. El resto de las comunas queda en la tabla pero inactivo, listo para
+// activarse cambiando el campo sin necesitar otro deploy.
 
 import { drizzle } from 'drizzle-orm/postgres-js'
 import postgres from 'postgres'

--- a/server/utils/db.ts
+++ b/server/utils/db.ts
@@ -11,7 +11,7 @@ export function useDb() {
     // donde cada invocación abriría su propia conexión contra Postgres directo). Ese modo no soporta
     // prepared statements, que Drizzle usa por defecto — sin prepare: false esto compila y solo falla
     // en runtime contra el pooler; en local, contra una base directa, funciona igual y esconde el bug
-    // hasta producción (A-003).
+    // hasta producción.
     const client = postgres(databaseUrl, { prepare: false })
     db = drizzle({ client, schema })
   }


### PR DESCRIPTION
Aplica la regla nueva del skill `comentarios` (PR #58: nunca citar un ID de decisión en un comentario) al resto del repo. Todos los comentarios tocados ya explicaban el porqué completo en la línea — sacar la cita no pierde información, porque si la perdía es que no estaba bien escrito desde antes.

## Archivos

- `server/utils/db.ts` — sacado `(A-003)`.
- `server/api/categorias.get.ts` / `comunas.get.ts` — sacado `(T-004)`.
- `server/db/schema/categorias.ts` — sacado `(T-001)`, y de paso el número que se pudría (`8 filas`, mismo tipo de bug que ya se corrigió en #57).
- `server/db/schema/comunas.ts` — sacado `(T-001)`, mismo criterio.
- `server/db/seed/taxonomia.ts` — sacado `(A-003)`, `(D-001)`, `(D-002)`.

**`app/components/CatalogSelect.vue` queda afuera a propósito** — tiene un fix pendiente en #57 sobre esas mismas líneas; se corrige ahí para no generar un conflicto de merge entre dos PRs tocando el mismo archivo.

## Test plan

- [x] `npx nuxi typecheck` — sin errores
- [x] `npm run build` — compila

🤖 Generated with [Claude Code](https://claude.com/claude-code)