### PR TITLE
feat(docs): instalar skills de ingeniería y wirearlos a discovery-engineering

### DIFF
--- a/.claude/skills/clean-architecture/SKILL.md
+++ b/.claude/skills/clean-architecture/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: clean-architecture
+description: 'Structure software around the Dependency Rule: source code dependencies point inward from frameworks to use cases to entities. Use when the user mentions "architecture layers", "dependency rule", "ports and adapters (hexagonal)", "onion architecture", "screaming architecture", "where should business logic go", "decouple from the database", "swap the framework without a rewrite", or "keep business rules independent". Also trigger when deciding which layer code belongs in, isolating core logic from infrastructure, defining module boundaries, or debating whether the framework should call your code or the reverse. Covers component principles, boundaries, and SOLID. For code-level quality, see clean-code. For domain modeling, see domain-driven-design.'
+license: MIT
+metadata:
+  author: wondelai
+  version: "1.4.0"
+---
+
+# Clean Architecture Framework
+
+A disciplined approach to structuring software so that business rules remain independent of frameworks, databases, and delivery mechanisms. Apply these principles when designing system architecture, reviewing module boundaries, or advising on dependency management.
+
+## Core Principle
+
+**Source code dependencies must point inward — toward higher-level policies.** Nothing in an inner circle can know anything about an outer circle. This single rule produces systems that are testable and independent of frameworks, UI, database, and any external agency. Business rules are what matter; databases, web frameworks, and delivery mechanisms are details — when details depend on policies, you can defer decisions, swap implementations, and test business logic in isolation.
+
+## Scoring
+
+**Goal: 10/10.** Score one point for each of the seven Quick Diagnostic rows the architecture satisfies (0-7), then map to a 0-10 band: 6-7 satisfied = **9-10** (Dependency Rule holds, business logic is framework- and DB-independent); 4-5 = **6-8** (core is testable but some details leak inward); 2-3 = **3-5** (framework or persistence dictates structure); 0-1 = **0-2** (no boundaries — business rules live in controllers and ORM models). Report the score, the failed diagnostic rows, and the specific inversion needed to fix each.
+
+### 1. Dependency Rule and Concentric Circles
+
+**Core concept:** Organize the architecture as concentric circles — Entities (enterprise business rules) innermost, then Use Cases (application business rules), then Interface Adapters, with Frameworks and Drivers outermost. Source code dependencies always point inward.
+
+**Why it works:** When high-level policies don't depend on low-level details, you can swap the database, web framework, or API style without touching business logic — the system becomes resilient to the most volatile parts of the stack.
+
+**Key insights:**
+- Inner circles cannot mention outer circle names — no classes, functions, variables, or data formats from outside
+- Data crossing a boundary must be in the form most convenient for the inner circle, never dictated by the outer
+- Dependency Inversion (interfaces defined inward, implemented outward) is the mechanism that enforces the rule
+- The number of circles is not fixed — four is typical; the rule stays the same
+- Frameworks are details, not architecture — they belong in the outermost circle
+
+**Code applications:**
+
+| Context | Pattern | Example |
+|---------|---------|---------|
+| **Layer direction** | Inner circles define interfaces; outer implement | `UserRepository` interface in Use Cases; `PostgresUserRepository` in Adapters |
+| **Data crossing** | DTOs cross boundaries, not ORM entities | Use Case returns `UserResponse` DTO, not an ActiveRecord model |
+| **Dependency direction** | Import arrows always point inward | Controller imports Use Case; Use Case never imports Controller |
+
+See [references/dependency-rule.md](references/dependency-rule.md) when an inner-circle import points outward and you need the four-circle code walkthrough, the data-crossing rules, and the four-step dependency-inversion procedure to fix it.
+
+### 2. Entities and Use Cases
+
+**Core concept:** Entities encapsulate enterprise-wide business rules — rules that would exist even without software. Use Cases contain application-specific rules that orchestrate the flow of data to and from Entities.
+
+**Why it works:** Separating what the business does (Entities) from how the application orchestrates it (Use Cases) lets you reuse Entities across applications and change application behavior without altering core business rules.
+
+**Key insights:**
+- Entities are not database rows — they are objects or pure functions encapsulating critical business rules
+- Use Cases accept Request Models and return Response Models — never framework objects
+- Each Use Case is a single application operation (`CreateOrder`, `ApproveExpense`)
+- The Interactor pattern: a Use Case class implements an input boundary interface and calls an output boundary interface
+- Changes to a Use Case should never affect an Entity; Entity changes may ripple to Use Cases
+
+**Code applications:**
+
+| Context | Pattern | Example |
+|---------|---------|---------|
+| **Entity design** | Critical business rules, zero framework dependencies | `Order.calculateTotal()` applies tax rules; knows nothing about HTTP |
+| **Request/Response** | Simple data structures cross the boundary | `CreateOrderRequest { items, customerId }` — no ORM models |
+| **Single responsibility** | One Use Case per operation | `PlaceOrder`, `CancelOrder`, `RefundOrder` as separate classes |
+| **Interactor** | Implements Input Port, calls Output Port | `PlaceOrderInteractor implements PlaceOrderInput` |
+
+See [references/entities-use-cases.md](references/entities-use-cases.md) when designing an Interactor or deciding what belongs in an Entity versus a Use Case — full Enterprise vs. Application Business Rules treatment with request/response model examples.
+
+### 3. Interface Adapters and Frameworks
+
+**Core concept:** Interface Adapters convert data between the form convenient for Use Cases/Entities and the form required by external agencies. Frameworks and Drivers are the outermost layer — glue code to the outside world.
+
+**Why it works:** When the web framework, ORM, or message queue is confined to the outer circles, replacing any of them is a localized change. The database is a detail; the web is a detail; details should be plugins to your business rules, not the skeleton of the application.
+
+**Key insights:**
+- Controllers translate HTTP into Use Case input; Presenters translate Use Case output into view models
+- Gateways implement repository interfaces defined by Use Cases — the inner circle defines the contract, the outer fulfills it
+- Business rules never know whether data lives in SQL, NoSQL, or flat files, or that delivery is HTTP
+- Treat frameworks with suspicion — they want you to couple to them; keep them at arm's length
+
+**Code applications:**
+
+| Context | Pattern | Example |
+|---------|---------|---------|
+| **Controller** | Delivery mechanism → Use Case input | `OrderController.create(req)` builds `CreateOrderRequest`, calls Interactor |
+| **Presenter** | Use Case output → view model | `OrderPresenter.present(response)` formats for JSON/HTML |
+| **Gateway** | Repository interface implemented per DB | `SqlOrderRepository implements OrderRepository` |
+| **Framework boundary** | Framework calls inward, never the reverse | Express route handler calls Controller; Controller never imports Express |
+
+See [references/adapters-frameworks.md](references/adapters-frameworks.md) when wiring controllers, presenters, or gateways, or arguing that the database/web is a detail — covers plugin architecture and how to confine a framework to the edges.
+
+### 4. Component Principles
+
+**Core concept:** Components are the units of deployment. Three cohesion principles govern what goes inside a component; three coupling principles govern relationships between components.
+
+**Why it works:** Poorly composed components create ripple effects where one change forces redeployment of unrelated code; the principles keep changes localized and releases independent.
+
+**Key insights:**
+- REP (Reuse/Release Equivalence): classes in a component must be versionable and releasable as a unit
+- CCP (Common Closure): classes that change for the same reason at the same time belong together — SRP for components
+- CRP (Common Reuse): don't force users to depend on classes they don't use
+- ADP (Acyclic Dependencies): the component graph must have no cycles — break them with DIP or a new component
+- SDP (Stable Dependencies): depend in the direction of stability
+- SAP (Stable Abstractions): stable components should be abstract; unstable ones concrete
+
+**Code applications:**
+
+| Context | Pattern | Example |
+|---------|---------|---------|
+| **Component grouping** | Group classes that change together (CCP) | All order-related Use Cases in one component |
+| **Breaking cycles** | Apply DIP to invert a dependency edge | Extract an interface into a new component to break the cycle |
+| **Stability metrics** | Instability I = Ce / (Ca + Ce) | Many incoming, no outgoing deps → I near 0 (stable) |
+
+See [references/component-principles.md](references/component-principles.md) when grouping classes into deployable components or breaking a dependency cycle — each of REP, CCP, CRP, ADP, SDP, SAP worked through with the instability metric.
+
+### 5. SOLID Principles
+
+**Core concept:** Five class-and-module-level principles — Single Responsibility, Open-Closed, Liskov Substitution, Interface Segregation, Dependency Inversion — the mid-level building blocks that make the Dependency Rule possible.
+
+**Why it works:** Each principle addresses a specific way dependencies go wrong, preventing the rigidity, fragility, and immobility that turn codebases into legacy nightmares.
+
+**Key insights:**
+- SRP: a module has one reason to change — it serves one actor (not "does one thing")
+- OCP: extend behavior by adding new code, not modifying existing code — strategy and plugin patterns
+- LSP: subtypes must be usable through the base interface without the client knowing — violated by unexpected exceptions or ignored methods
+- ISP: clients should not depend on methods they don't use — fat interfaces create needless coupling
+- DIP: high-level modules and low-level modules both depend on abstractions defined by the high-level module
+
+**Code applications:**
+
+| Context | Pattern | Example |
+|---------|---------|---------|
+| **SRP violation** | Class serves multiple actors | `Employee` handles pay (CFO), reporting (COO), persistence (CTO) |
+| **OCP via strategy** | New behavior through new classes | Add `ExpressShipping` implementing `ShippingStrategy`; `Order` untouched |
+| **LSP violation** | Subtype changes expected behavior | `Square extends Rectangle` breaks the `setWidth()`/`setHeight()` contract |
+| **ISP application** | Split fat interfaces into role interfaces | `Printer`, `Scanner`, `Fax` instead of one `MultiFunctionDevice` |
+| **DIP wiring** | High-level defines interface; low-level implements | `OrderService` depends on `PaymentGateway`, not `StripeClient` |
+
+See [references/solid-principles.md](references/solid-principles.md) when applying SRP/OCP/LSP/ISP/DIP to a specific class or diagnosing a violation — each principle worked through with code examples and the smell it prevents.
+
+### 6. Boundaries and Boundary Anatomy
+
+**Core concept:** A boundary is a line between things that matter and things that are details, implemented through polymorphism: dependencies cross pointing inward while control flow may cross either way.
+
+**Why it works:** Every boundary buys the option to defer a decision or swap an implementation; strategic boundary placement determines whether a system is a joy or a pain to maintain over years.
+
+**Key insights:**
+- Full boundaries use reciprocal interfaces on both sides; partial boundaries use a simpler strategy or facade
+- Humble Object pattern: split boundary code into a hard-to-test part (close to the boundary) and an easy-to-test part (the logic)
+- Services are not automatically architectural boundaries — a microservice with a fat shared data model is a monolith with network calls
+- Tests are the most isolated component: they depend inward, nothing depends on them
+- Premature boundaries are expensive, but so are missing ones — draw them at points of likely volatility
+
+**Code applications:**
+
+| Context | Pattern | Example |
+|---------|---------|---------|
+| **Full vs. partial boundary** | Reciprocal ports, or a lone strategy | Use Case defines `PlaceOrderInput`/`PlaceOrderOutput`; simpler cases take a `ShippingStrategy` |
+| **Humble Object** | Separate testable logic from infrastructure | `PresenterLogic` (testable) produces `ViewModel`; `View` (humble) renders it |
+| **Main as plugin** | Composition root assembles the system | `main()` wires all concrete implementations and starts the app |
+
+See [references/boundaries.md](references/boundaries.md) when deciding where to draw a boundary, choosing full vs. partial, or applying the Humble Object pattern — also covers services as boundaries, test boundaries, and Main as the ultimate plugin.
+
+## Common Mistakes
+
+| Mistake | Why It Fails | Fix |
+|---------|-------------|-----|
+| **ORM leaking into business logic** | Entities couple to the schema; DB changes rewrite business rules | Separate domain entities from persistence models; map at the adapter layer |
+| **Business rules in controllers** | Untestable without HTTP; duplicated across endpoints | Move logic into Use Case Interactors; controllers only translate and delegate |
+| **Framework-first architecture** | Framework dictates structure; swapping means a rewrite | Treat the framework as a plugin; structure code by business capability |
+| **Circular component dependencies** | Changes ripple unpredictably; no independent releases | Apply DIP or extract a shared abstraction component |
+| **One giant Use Case per feature** | Bloated thousand-line orchestrators | Split into focused single-operation Use Cases |
+| **Skipping boundaries "because it's simple"** | Coupling accumulates silently until the cost is enormous | Draw boundaries proactively at points of likely volatility |
+| **Microservices as automatic good architecture** | A distributed monolith is worse than a clean monolith | Apply the Dependency Rule within and across services; services are deployment boundaries, not architectural ones |
+
+## Quick Diagnostic
+
+| Question | If No | Action |
+|----------|-------|--------|
+| Can you test business rules without DB, web server, or framework? | Rules coupled to infrastructure | Extract entities and use cases behind interfaces; mock outer layers |
+| Do all source dependencies point inward? | Dependency Rule violated | Introduce boundary interfaces; invert the offending dependency |
+| Can you swap the database without touching business logic? | Persistence leaking inward | Repository pattern; isolate persistence in adapters |
+| Are Use Cases independent of delivery mechanism? | Use Cases know HTTP/CLI/queues | Use plain DTOs in Use Case signatures |
+| Is the framework confined to the outermost circle? | Framework is your architecture | Wrap framework calls behind interfaces; push to the edges |
+| Is the component graph cycle-free? | Circular dependencies exist | Apply ADP: DIP or new components to break every cycle |
+| Does Main (composition root) wire all dependencies? | Concrete classes instantiated in inner circles | Move construction to Main; use DI or factories |
+
+## Further Reading
+
+Based on Robert C. Martin's definitive guide to software architecture:
+
+- [*"Clean Architecture: A Craftsman's Guide to Software Structure and Design"*](https://www.amazon.com/Clean-Architecture-Craftsmans-Software-Structure/dp/0134494164?tag=wondelai00-20) by Robert C. Martin
+
+## About the Author
+
+**Robert C. Martin ("Uncle Bob")** is a software engineer programming since 1970, a founding signatory of the Agile Manifesto, and the author of *Clean Code*, *The Clean Coder*, *Clean Architecture*, and *Clean Agile*. His SOLID principles are foundational vocabulary in object-oriented design, and his work argues that architecture is about managing dependencies and keeping business rules independent of infrastructure details.

--- a/.claude/skills/clean-architecture/references/adapters-frameworks.md
+++ b/.claude/skills/clean-architecture/references/adapters-frameworks.md
@@ -1,0 +1,358 @@
+# Interface Adapters and Frameworks
+
+Interface Adapters and Frameworks & Drivers form the two outermost circles of Clean Architecture. Interface Adapters translate data between the forms convenient for Use Cases and Entities and the forms convenient for external agencies. Frameworks and Drivers are the glue code that connects the system to the outside world. Together, these layers contain all the volatile, technology-specific decisions -- the parts most likely to change over the life of a system.
+
+This reference covers controllers, presenters, gateways, the nature of frameworks as details, database and web as details, keeping frameworks at arm's length, and the plugin architecture.
+
+
+## Table of Contents
+1. [Interface Adapters](#interface-adapters)
+2. [Frameworks as Details](#frameworks-as-details)
+3. [The Database Is a Detail](#the-database-is-a-detail)
+4. [The Web Is a Detail](#the-web-is-a-detail)
+5. [Plugin Architecture](#plugin-architecture)
+6. [Keeping Frameworks at Arm's Length](#keeping-frameworks-at-arms-length)
+
+---
+
+## Interface Adapters
+
+### Controllers
+
+A Controller is an adapter that translates input from the delivery mechanism (HTTP, CLI, message queue, gRPC) into a form that the Use Case can understand. It constructs a Request Model and calls the Use Case's Input Port.
+
+**Responsibilities of a Controller:**
+- Parse and extract data from the delivery mechanism's native format
+- Construct the Use Case's Request Model
+- Call the Use Case's Input Port
+- Handle delivery-mechanism-specific concerns (authentication, rate limiting) BEFORE calling the Use Case
+
+**What a Controller must NOT do:**
+- Contain business logic
+- Directly access the database
+- Format output for the response (that's the Presenter's job)
+- Know about other controllers
+
+```python
+# Controller in the Adapters circle
+class OrderController:
+    def __init__(self, place_order: PlaceOrderInput):
+        self._place_order = place_order
+
+    def create(self, http_request: dict) -> None:
+        # Translate HTTP data to Use Case request
+        request = PlaceOrderRequest(
+            customer_id=http_request["customer_id"],
+            items=[
+                OrderItemRequest(
+                    product_id=item["product_id"],
+                    quantity=item["quantity"],
+                    unit_price=item["unit_price"],
+                )
+                for item in http_request["items"]
+            ],
+            shipping_address=AddressRequest(
+                street=http_request["address"]["street"],
+                city=http_request["address"]["city"],
+                zip_code=http_request["address"]["zip"],
+            ),
+        )
+        # Delegate to the Use Case
+        self._place_order.execute(request)
+```
+
+The Controller knows about HTTP data format and knows about `PlaceOrderRequest`. It translates between the two. The Use Case never sees HTTP.
+
+### Presenters
+
+A Presenter translates Use Case output into a form suitable for the delivery mechanism. It implements the Use Case's Output Port and produces a View Model.
+
+**The Presenter pattern separates two concerns:**
+1. The Use Case decides WHAT data to present
+2. The Presenter decides HOW to format it for display
+
+```python
+# Output Port defined in Use Case circle
+class PlaceOrderOutput(ABC):
+    @abstractmethod
+    def present_success(self, response: OrderResponse) -> None:
+        pass
+
+    @abstractmethod
+    def present_failure(self, message: str) -> None:
+        pass
+
+# Presenter in the Adapters circle
+class JsonOrderPresenter(PlaceOrderOutput):
+    def __init__(self):
+        self.view_model: dict = {}
+        self.status_code: int = 200
+
+    def present_success(self, response: OrderResponse) -> None:
+        self.status_code = 201
+        self.view_model = {
+            "data": {
+                "id": response.order_id,
+                "total": f"${response.total}",
+                "status": response.status.capitalize(),
+                "estimated_delivery": response.estimated_delivery,
+            }
+        }
+
+    def present_failure(self, message: str) -> None:
+        self.status_code = 400
+        self.view_model = {"error": {"message": message}}
+```
+
+The Presenter knows about JSON structure, status codes, and string formatting. The Use Case knows nothing about any of this.
+
+### Gateways
+
+A Gateway implements a repository or service interface defined by the Use Case circle using a specific technology. It is the adapter between the abstract port and the concrete implementation.
+
+```python
+# Interface defined in Use Case circle
+class OrderRepository(ABC):
+    @abstractmethod
+    def save(self, order: Order) -> None:
+        pass
+
+    @abstractmethod
+    def find_by_id(self, order_id: str) -> Order | None:
+        pass
+
+# Gateway in the Adapters circle
+class PostgresOrderRepository(OrderRepository):
+    def __init__(self, connection_pool):
+        self._pool = connection_pool
+
+    def save(self, order: Order) -> None:
+        with self._pool.connection() as conn:
+            conn.execute(
+                "INSERT INTO orders (id, customer_id, total, status) VALUES (%s, %s, %s, %s)",
+                (order.id, order.customer_id, str(order.calculate_total()), order.status.value),
+            )
+            for item in order.items:
+                conn.execute(
+                    "INSERT INTO order_items (order_id, product_id, quantity, price) VALUES (%s, %s, %s, %s)",
+                    (order.id, item.product_id, item.quantity, str(item.price)),
+                )
+
+    def find_by_id(self, order_id: str) -> Order | None:
+        with self._pool.connection() as conn:
+            row = conn.execute("SELECT * FROM orders WHERE id = %s", (order_id,)).fetchone()
+            if row is None:
+                return None
+            items = conn.execute("SELECT * FROM order_items WHERE order_id = %s", (order_id,)).fetchall()
+            return self._to_domain(row, items)
+
+    def _to_domain(self, row, item_rows) -> Order:
+        # Map database rows back to domain entity
+        items = [OrderItem(r["product_id"], r["quantity"], Money(r["price"])) for r in item_rows]
+        return Order(order_id=row["id"], items=items, customer_id=row["customer_id"])
+```
+
+Notice the `_to_domain` method: it maps between the persistence format (database rows) and the domain format (entity objects). This mapping is the gateway's core responsibility.
+
+### Adapter Types Summary
+
+| Adapter | Translates From | Translates To | Direction |
+|---------|----------------|---------------|-----------|
+| **Controller** | External input (HTTP, CLI, event) | Use Case Request Model | Inward |
+| **Presenter** | Use Case Response Model | View Model (JSON, HTML, CLI output) | Outward |
+| **Gateway** | Repository/Service Interface | Concrete technology (SQL, API, file) | Outward |
+| **Mapper** | Domain Entity | Persistence Model (ORM, document) | Both directions |
+
+## Frameworks as Details
+
+### The Framework Trap
+
+Frameworks are powerful tools. They provide routing, dependency injection, ORM, template rendering, and dozens of other features. The temptation is to build your system on top of the framework -- to let the framework be the architecture.
+
+This is a trap. When the framework IS the architecture:
+- You cannot test business logic without the framework running
+- You cannot change the framework without rewriting the application
+- Framework bugs become your bugs, in your most critical code
+- Framework upgrades force changes throughout the system
+- Your code becomes an accessory to the framework rather than the framework serving your code
+
+### Frameworks Want Marriage, You Want a Fling
+
+Frameworks are authored by people who have a use case for them. They provide massive power and convenience -- but they ask for commitment. They want you to:
+
+- Inherit from their base classes
+- Put their annotations on your code
+- Store your data in their preferred format
+- Structure your project their way
+
+Each of these is a coupling point. The more you comply, the harder it is to separate.
+
+**The Clean Architecture approach:**
+- Don't derive business objects from framework base classes
+- Don't put framework annotations on domain entities
+- Don't let the framework dictate your project structure
+- Treat the framework as a tool in the outermost circle, not as the foundation
+
+### Practical Framework Isolation
+
+| Framework Feature | Coupled Approach | Decoupled Approach |
+|-------------------|-----------------|-------------------|
+| **Routing** | Business logic in route handlers | Route handlers call Controllers; Controllers call Use Cases |
+| **ORM** | Domain entities ARE ORM models | Separate domain entities; map to/from ORM models in gateways |
+| **Validation** | Framework validation decorators on entities | Validation in Use Case or domain layer using plain code |
+| **Dependency injection** | `@Inject` annotations on domain classes | Constructor injection; wiring in Main component |
+| **Configuration** | `Settings.get("key")` in business logic | Inject config values as constructor parameters |
+| **Logging** | Framework logger called directly in Use Cases | Inject a logger interface; implement with framework in outer circle |
+
+## The Database Is a Detail
+
+The database is a detail. It is a mechanism for storing and retrieving data. From the perspective of the business rules, it doesn't matter whether data lives in PostgreSQL, MongoDB, flat files, or an in-memory data structure.
+
+### Why It Matters
+
+When business rules know about the database:
+- Testing requires a database (slow, fragile tests)
+- Database schema changes ripple into business logic
+- Migrating to a different database means rewriting business rules
+- The data model is driven by database capabilities rather than business needs
+
+### Repository Pattern
+
+The repository pattern is the primary mechanism for keeping the database at arm's length:
+
+1. **Define the interface in the Use Case circle** -- it describes WHAT operations the business needs, not HOW data is stored
+2. **Implement the interface in the Adapter circle** -- this is where SQL, ORM calls, and database-specific code live
+3. **Inject the implementation at startup** -- Main wires the concrete repository into the use case
+
+### ORM Considerations
+
+ORMs are useful tools, but they must be contained in the outer circles:
+
+**The two-model approach:**
+- **Domain model**: Pure business entities with business methods and rules. No ORM annotations. Lives in the Entity circle.
+- **Persistence model**: ORM-annotated classes that map to database tables. Lives in the Adapter circle. The gateway maps between the two.
+
+This duplication is intentional and valuable. The domain model evolves with business rules; the persistence model evolves with the database schema. They change for different reasons at different times.
+
+## The Web Is a Detail
+
+The web is a delivery mechanism -- a way to transport data between the user and the application. The business rules should not know whether they are being accessed through a web browser, a mobile app, a CLI, or a message queue.
+
+### Delivery Mechanism Independence
+
+When use cases are independent of the delivery mechanism, you can:
+- Serve the same business logic through REST, GraphQL, gRPC, CLI, and WebSocket simultaneously
+- Test business logic without HTTP
+- Migrate from one web framework to another by rewriting only the outer circle
+
+### Multiple Delivery Mechanisms
+
+```
+REST Controller ----\
+                     \
+GraphQL Resolver ------> Use Case Interactor ---> Entity
+                     /
+CLI Command --------/
+Message Handler ---/
+```
+
+Each delivery mechanism is an adapter in the outer circle. They all call the same Use Case Input Port. The business logic is written once and exposed through as many delivery mechanisms as needed.
+
+## Plugin Architecture
+
+The ultimate expression of Clean Architecture is the plugin architecture: the business rules are the core application, and everything else (database, web framework, external services, UI) is a plugin that connects to the core.
+
+### How Plugins Work
+
+1. **The core defines interfaces** (ports) that describe what it needs from the outside world
+2. **Plugins implement those interfaces** using specific technologies
+3. **Main assembles the plugins** and injects them into the core at startup
+4. **The core never knows which plugins are attached** -- it only knows the interfaces
+
+### The Main Component
+
+Main is the dirtiest, most concrete component in the system. It knows about everything because it must instantiate and wire all the pieces together. But nothing depends on Main.
+
+```python
+# main.py -- the composition root
+def create_app():
+    # Concrete infrastructure
+    db_pool = create_connection_pool(os.environ["DATABASE_URL"])
+    email_client = SendGridClient(os.environ["SENDGRID_API_KEY"])
+
+    # Gateways (implement interfaces)
+    order_repo = PostgresOrderRepository(db_pool)
+    email_service = SendGridEmailService(email_client)
+
+    # Presenters
+    order_presenter = JsonOrderPresenter()
+
+    # Use Cases (wired with concrete dependencies)
+    place_order = PlaceOrderInteractor(order_repo, order_presenter)
+    cancel_order = CancelOrderInteractor(order_repo, email_service, order_presenter)
+
+    # Controllers (wired with use cases)
+    order_controller = OrderController(place_order, cancel_order)
+
+    # Framework wiring
+    app = Flask(__name__)
+    app.route("/orders", methods=["POST"])(order_controller.create)
+    app.route("/orders/<id>/cancel", methods=["POST"])(order_controller.cancel)
+
+    return app
+```
+
+Main is the only place where the concrete classes from all circles come together. If you want to swap PostgreSQL for DynamoDB, you change Main and add a `DynamoOrderRepository`. No other file changes.
+
+### Plugin Swappability in Practice
+
+| Plugin | Interface | Implementation A | Implementation B |
+|--------|-----------|-----------------|-----------------|
+| **Persistence** | `OrderRepository` | `PostgresOrderRepository` | `DynamoOrderRepository` |
+| **Email** | `EmailService` | `SendGridEmailService` | `SesEmailService` |
+| **Payment** | `PaymentGateway` | `StripeGateway` | `BraintreeGateway` |
+| **Search** | `ProductSearch` | `ElasticsearchProductSearch` | `AlgoliaProductSearch` |
+| **Cache** | `CacheStore` | `RedisCacheStore` | `MemcachedCacheStore` |
+| **File storage** | `FileStore` | `S3FileStore` | `LocalFileStore` |
+
+Each swap is a single line change in Main plus a new implementation class. No business logic changes. No use case changes. No entity changes. This is the power of treating frameworks and infrastructure as plugins.
+
+## Keeping Frameworks at Arm's Length
+
+### The Wrapper Strategy
+
+When a framework provides something useful but you don't want to couple to it directly, wrap it:
+
+```python
+# Interface in inner circle
+class Clock(ABC):
+    @abstractmethod
+    def now(self) -> datetime:
+        pass
+
+# Wrapper in outer circle
+class SystemClock(Clock):
+    def now(self) -> datetime:
+        return datetime.utcnow()
+
+# Test double
+class FakeClock(Clock):
+    def __init__(self, fixed_time: datetime):
+        self._time = fixed_time
+
+    def now(self) -> datetime:
+        return self._time
+```
+
+Now your business logic depends on `Clock` (an interface you control), not on `datetime.utcnow()` (a library call you don't control). You can test time-dependent logic deterministically.
+
+### When NOT to Wrap
+
+Not everything needs a wrapper. Apply the rule pragmatically:
+
+- **Standard library types** (strings, lists, dates as data): Don't wrap. They are stable and ubiquitous.
+- **Utility functions with no side effects**: Don't wrap `math.ceil()` or `json.dumps()`.
+- **Anything with I/O or side effects** (database, network, filesystem, clock, random): Wrap it.
+- **Anything from a framework you might swap**: Wrap it.
+
+The test is: "Would I need to mock this in a test?" If yes, wrap it behind an interface.

--- a/.claude/skills/clean-architecture/references/boundaries.md
+++ b/.claude/skills/clean-architecture/references/boundaries.md
@@ -1,0 +1,431 @@
+# Boundaries and Boundary Anatomy
+
+Boundaries are the lines that separate software elements. In Clean Architecture, boundaries separate policies from details, stable code from volatile code, and high-level concerns from low-level mechanisms. How you draw boundaries, where you place them, and how you implement them determines whether a system remains maintainable over decades or degrades into an unmaintainable monolith.
+
+This reference covers boundary anatomy, boundary crossing mechanisms, the Humble Object pattern, partial boundaries, layers and boundaries, services as boundaries, test boundaries, and the Main component as the ultimate plugin.
+
+
+## Table of Contents
+1. [Boundary Anatomy](#boundary-anatomy)
+2. [Boundary Crossing](#boundary-crossing)
+3. [The Humble Object Pattern](#the-humble-object-pattern)
+4. [Partial Boundaries](#partial-boundaries)
+5. [Services as Boundaries](#services-as-boundaries)
+6. [Test Boundaries](#test-boundaries)
+7. [The Main Component as a Plugin](#the-main-component-as-a-plugin)
+
+---
+
+## Boundary Anatomy
+
+### What Is a Boundary?
+
+A boundary is a separation between two groups of code where one side should not know about the other. At its core, a boundary is an interface plus a dependency inversion: the inner side defines an abstraction, and the outer side provides a concrete implementation.
+
+### The Structure of a Full Boundary
+
+A full boundary has components on both sides, connected through polymorphism:
+
+```
+[Client Side]                    [Boundary]                    [Implementation Side]
+                                     |
+Controller ----calls----> InputPort (interface)
+                                     |
+                              Interactor (implements InputPort)
+                                     |
+                              Interactor ----calls----> OutputPort (interface)
+                                     |
+                                                          Presenter (implements OutputPort)
+```
+
+**Both interfaces are defined on the inner side.** The Controller depends on `InputPort` (inward). The Presenter implements `OutputPort` (inward). The Interactor knows about neither the Controller nor the Presenter directly.
+
+### Boundary Components
+
+| Component | Circle | Role |
+|-----------|--------|------|
+| **Input Port** | Use Case | Interface that defines what the use case accepts |
+| **Output Port** | Use Case | Interface that defines what the use case produces |
+| **Interactor** | Use Case | Implements Input Port; calls Output Port |
+| **Controller** | Adapter | Calls Input Port; translates from delivery mechanism |
+| **Presenter** | Adapter | Implements Output Port; translates to display format |
+| **Data Transfer Objects** | Use Case | Simple structures that carry data across the boundary |
+| **Gateway Interface** | Use Case | Abstraction for data persistence or external services |
+| **Gateway Implementation** | Adapter | Concrete persistence or service access |
+
+## Boundary Crossing
+
+### How Data Flows Across Boundaries
+
+Data crosses boundaries as simple data structures -- DTOs, structs, or primitives. Never as framework objects, ORM entities, or complex objects that carry dependencies.
+
+**Inbound crossing (Controller to Use Case):**
+
+```python
+# Controller creates a simple DTO and passes it inward
+@dataclass(frozen=True)
+class TransferFundsRequest:
+    source_account_id: str
+    destination_account_id: str
+    amount: str  # String to avoid float precision issues
+    currency: str
+
+# Controller
+class TransferController:
+    def handle(self, http_body: dict) -> None:
+        request = TransferFundsRequest(
+            source_account_id=http_body["from"],
+            destination_account_id=http_body["to"],
+            amount=http_body["amount"],
+            currency=http_body["currency"],
+        )
+        self._transfer_use_case.execute(request)
+```
+
+**Outbound crossing (Use Case to Presenter):**
+
+```python
+# Use Case creates a response DTO and passes it outward through the Output Port
+@dataclass(frozen=True)
+class TransferFundsResponse:
+    transfer_id: str
+    new_source_balance: str
+    timestamp: str
+
+# In the Interactor:
+response = TransferFundsResponse(
+    transfer_id=transfer.id,
+    new_source_balance=str(source_account.balance),
+    timestamp=transfer.created_at.isoformat(),
+)
+self._presenter.present_success(response)
+```
+
+### Flow of Control vs. Direction of Dependency
+
+This is a subtle but critical distinction:
+
+- **Flow of control:** Controller --> Interactor --> Presenter (left to right, outward at the end)
+- **Source code dependency:** Controller --> InputPort <-- Interactor --> OutputPort <-- Presenter
+
+The dependencies point inward on both sides of the Interactor. Control flows outward to the Presenter, but the dependency is inverted: the Presenter depends on (implements) an interface defined by the Use Case.
+
+## The Humble Object Pattern
+
+### The Problem
+
+Some code is inherently hard to test because it's close to a boundary with something difficult to control -- a GUI, a database connection, a network socket. The Humble Object pattern splits such code into two parts:
+
+1. **The Humble Object:** Contains the hard-to-test code, stripped of all logic. It's so simple that testing is unnecessary (or trivially easy).
+2. **The Testable Object:** Contains all the logic, extracted from the hard-to-test context so it can be tested in isolation.
+
+### Pattern Structure
+
+```
+[Testable Logic]              [Humble Object]
+PresenterLogic    -produces->  ViewModel
+(easy to test)                 (simple data)
+                                    |
+                                    v
+                               View/Template
+                               (hard to test, but so simple it doesn't matter)
+```
+
+### Examples of Humble Objects
+
+**1. View (GUI boundary):**
+
+```python
+# Testable: Presenter that produces a ViewModel
+class OrderPresenterLogic:
+    def present(self, response: OrderResponse) -> OrderViewModel:
+        return OrderViewModel(
+            title=f"Order #{response.order_id}",
+            total=f"${response.total:.2f}",
+            status_color="green" if response.status == "completed" else "yellow",
+            items=[f"{i.name} x{i.qty}" for i in response.items],
+        )
+
+# Humble: View that just renders the ViewModel (no logic to test)
+class OrderView:
+    def render(self, vm: OrderViewModel) -> str:
+        return self._template.render(vm)  # Template rendering only
+```
+
+The Presenter is easily testable -- give it a response, assert the ViewModel. The View is humble -- it just passes the ViewModel to a template engine. No logic, no decisions.
+
+**2. Database Gateway (persistence boundary):**
+
+```python
+# Testable: Use Case logic that decides what to persist
+class ApproveExpenseInteractor:
+    def execute(self, request: ApproveExpenseRequest) -> None:
+        expense = self._repo.find_by_id(request.expense_id)
+        expense.approve(request.approver_id)  # Business logic -- testable
+        self._repo.save(expense)
+
+# Humble: Repository that just maps and persists (minimal logic)
+class SqlExpenseRepository:
+    def save(self, expense: Expense) -> None:
+        self._conn.execute(
+            "UPDATE expenses SET status = %s, approved_by = %s WHERE id = %s",
+            (expense.status.value, expense.approver_id, expense.id),
+        )
+```
+
+The Interactor contains the decision logic (testable with a mock repo). The Repository is humble -- it just maps entity state to SQL parameters.
+
+**3. Service Gateway (external service boundary):**
+
+```python
+# Testable: Logic that decides whether and how to send notifications
+class NotificationService:
+    def __init__(self, sender: NotificationSender):
+        self._sender = sender
+
+    def notify_order_shipped(self, order: Order) -> None:
+        if order.customer_prefers_email():
+            self._sender.send_email(
+                to=order.customer_email,
+                subject=f"Order {order.id} shipped",
+                body=self._format_shipping_message(order),
+            )
+
+# Humble: Just sends the message (hard to test, but no logic)
+class SmtpNotificationSender(NotificationSender):
+    def send_email(self, to: str, subject: str, body: str) -> None:
+        self._smtp.sendmail(self._from_addr, to, self._build_mime(subject, body))
+```
+
+### Where Humble Objects Appear in Clean Architecture
+
+| Boundary | Humble Object | Testable Partner |
+|----------|--------------|-----------------|
+| GUI/View | Template renderer, React component | Presenter logic that produces ViewModel |
+| Database | SQL execution, ORM save/load | Use Case logic, mapping logic |
+| External API | HTTP client wrapper | Service logic that decides what to send |
+| Filesystem | File read/write operations | Logic that decides what to read/write |
+| Clock/Random | System clock, random generator | Logic that uses injected clock/random |
+
+## Partial Boundaries
+
+### When Full Boundaries Are Too Expensive
+
+Full boundaries require interfaces on both sides (Input Port and Output Port), separate DTOs, and careful dependency management. Sometimes the anticipated need for a boundary doesn't justify the cost. In these cases, use a partial boundary.
+
+### Three Forms of Partial Boundaries
+
+**1. Skip the last step (prepare for full boundary later):**
+
+Create the interfaces and separate the components, but deploy them together in the same package. You've done the intellectual work of separation but deferred the deployment separation.
+
+```python
+# Same package, but clearly separated with interfaces
+# Can be split into separate packages later with minimal effort
+class OrderService:
+    def __init__(self, repo: OrderRepository):  # Interface exists
+        self._repo = repo
+
+class InMemoryOrderRepository(OrderRepository):  # Implementation exists
+    ...
+
+# Both live in the same package for now
+```
+
+**2. Strategy pattern (one-sided boundary):**
+
+```python
+# Only the outbound side has an interface
+class ReportGenerator:
+    def __init__(self, formatter: ReportFormatter):
+        self._formatter = formatter
+
+    def generate(self, data: ReportData) -> str:
+        # Logic here
+        return self._formatter.format(processed_data)
+
+class PdfFormatter(ReportFormatter):
+    def format(self, data) -> str: ...
+
+class CsvFormatter(ReportFormatter):
+    def format(self, data) -> str: ...
+```
+
+No Input Port, no Output Port -- just a simple strategy. Lighter weight than a full boundary.
+
+**3. Facade pattern (simplest):**
+
+```python
+class OrderFacade:
+    """Single entry point to order subsystem. Hides internal complexity."""
+    def place_order(self, items, customer_id):
+        # Delegates to internal classes
+        order = self._order_factory.create(items, customer_id)
+        self._order_repo.save(order)
+        self._notifier.notify(order)
+```
+
+The Facade provides a simpler interface but doesn't enforce dependency direction. It's the weakest form of boundary -- better than nothing, but easily violated.
+
+### Choosing Boundary Strength
+
+| Situation | Boundary Type | Cost | Protection |
+|-----------|--------------|------|------------|
+| Will definitely need to swap implementations | Full boundary (ports on both sides) | High | Complete |
+| Might need to swap; want the option | Partial (interfaces, same package) | Medium | Good |
+| Multiple strategies but stable architecture | Strategy pattern | Low-medium | Moderate |
+| Just want to simplify access to a subsystem | Facade | Low | Minimal |
+| Uncertain -- need might never arise | None (but document the decision) | Zero | None |
+
+## Services as Boundaries
+
+### Services Are Not Inherently Architectural
+
+A common misconception is that splitting a system into microservices automatically creates clean architectural boundaries. It does not. A microservice with a fat shared database or a shared data model is just a distributed monolith -- all the coupling of a monolith plus the complexity of network communication.
+
+### When Services Create Real Boundaries
+
+A service creates a genuine architectural boundary when:
+- It has its own data store that no other service accesses directly
+- It communicates through well-defined interfaces (API contracts)
+- Its internal structure follows the Dependency Rule independently
+- It can be developed, deployed, and scaled independently
+
+### When Services Fail as Boundaries
+
+| Anti-Pattern | Why It Fails |
+|-------------|-------------|
+| Shared database | Changes to the schema affect all services -- they're coupled |
+| Shared data model library | All services import the same DTOs -- they change together |
+| Synchronous orchestration | Service A calls B calls C calls D -- distributed monolith |
+| Chatty communication | Services exchange many small calls -- performance and coupling |
+
+### Services Should Contain Clean Architecture
+
+Each service should have its own concentric circles internally:
+
+```
+Service Boundary
+├── Entities (domain objects for this service's bounded context)
+├── Use Cases (application logic for this service)
+├── Adapters (controllers, gateways, presenters for this service)
+└── Frameworks (HTTP server, database driver for this service)
+```
+
+The service boundary is a deployment boundary. The Clean Architecture circles within each service are architectural boundaries. Both are needed.
+
+## Test Boundaries
+
+### Tests as the Most Isolated Component
+
+Tests are the most decoupled component in any system. They depend on the code being tested, but nothing in the production system depends on the tests. Tests always point inward -- they test entities, use cases, and adapters, but no production code imports test code.
+
+### The Testing Boundary Structure
+
+```
+[Production Code]                [Test Code]
+Entity ---------<depends-on------ EntityTest
+UseCase --------<depends-on------ UseCaseTest
+Adapter --------<depends-on------ AdapterTest
+
+(No arrow from Production to Test)
+```
+
+### Testing Each Circle
+
+| Circle | Test Strategy | Dependencies Needed |
+|--------|--------------|-------------------|
+| **Entities** | Unit tests with no mocks | None -- entities are self-contained |
+| **Use Cases** | Unit tests with mocked ports | Mock repositories, mock presenters |
+| **Adapters** | Integration tests | Real database (testcontainers), real HTTP |
+| **Frameworks** | End-to-end tests | Full system running |
+
+### The Fragile Test Problem
+
+When tests depend on implementation details (private methods, internal data structures, specific framework behavior), they break when the code is refactored even though behavior hasn't changed. The Dependency Rule helps: tests should depend on the same interfaces that the production code depends on.
+
+```python
+# FRAGILE: Test depends on internal implementation
+def test_order_internal_state():
+    order = Order(items)
+    assert order._internal_state == "pending"  # Private field -- fragile
+
+# ROBUST: Test depends on public behavior (same interface as production code)
+def test_order_is_pending_after_creation():
+    order = Order(items)
+    assert order.status == OrderStatus.PENDING  # Public behavior -- stable
+```
+
+## The Main Component as a Plugin
+
+### Main Is the Dirtiest Component
+
+The Main component (or composition root) is the one place where all concrete classes from all circles are known. It creates the concrete instances, wires them together, and starts the system. It is the most concrete, most dependent, and most volatile component.
+
+**But nothing depends on Main.** It sits at the outermost edge of the system. It is a plugin to the application -- a configuration detail that determines which concrete implementations are used for each abstract port.
+
+### Main's Responsibilities
+
+1. **Instantiate concrete infrastructure** (database connections, API clients, caches)
+2. **Instantiate concrete adapters** (repositories, presenters, gateways)
+3. **Instantiate use case interactors** with injected dependencies
+4. **Instantiate controllers** with injected use cases
+5. **Configure the framework** (routes, middleware, error handlers)
+6. **Start the application** (listen on port, begin event loop)
+
+### Different Mains for Different Configurations
+
+Because Main is a plugin, you can have multiple Main configurations:
+
+```python
+# main_production.py
+def create_app():
+    repo = PostgresOrderRepository(production_db_pool)
+    emailer = SendGridEmailer(production_api_key)
+    ...
+
+# main_test.py
+def create_app():
+    repo = InMemoryOrderRepository()
+    emailer = FakeEmailer()
+    ...
+
+# main_local.py
+def create_app():
+    repo = SqliteOrderRepository("local.db")
+    emailer = ConsoleEmailer()  # Prints to stdout
+    ...
+```
+
+The business logic (entities, use cases) is identical across all three. Only the wiring in Main changes. This is the ultimate demonstration that frameworks, databases, and external services are details -- plugins that can be swapped by changing the composition root.
+
+### Main and Dependency Injection Frameworks
+
+DI frameworks (Spring, Guice, tsyringe) can help wire dependencies in Main. But be careful:
+
+- **Use DI framework annotations ONLY in Main or configuration classes** -- never in entities or use cases
+- The DI framework is itself a framework detail -- it belongs in the outermost circle
+- You should be able to wire the entire system manually in a test without the DI framework
+- If removing the DI framework would require changes to business logic, you've coupled too tightly
+
+### The Plugin Architecture Realized
+
+When Main is the only place that knows about concrete implementations, the entire system becomes a plugin architecture:
+
+```
+                 Main (composition root)
+                /    |     |      \
+               /     |     |       \
+    PostgresRepo  SendGrid  Express  Stripe
+         |           |        |        |
+         v           v        v        v
+    [OrderRepo]  [Emailer]  [HTTP]  [Payment]
+    (interface)  (interface) (route) (interface)
+         \          |        |       /
+          \         |        |      /
+           Use Case Interactors
+                    |
+                 Entities
+```
+
+Entities and Use Cases sit at the center, defining what they need through interfaces. Main plugs in the concrete implementations. The business rules don't know or care which database, email provider, web framework, or payment processor is being used. They just work.

--- a/.claude/skills/clean-architecture/references/component-principles.md
+++ b/.claude/skills/clean-architecture/references/component-principles.md
@@ -1,0 +1,247 @@
+# Component Principles
+
+Components are the units of deployment -- the smallest entities that can be independently deployed. In Java they are jar files, in Ruby they are gems, in .NET they are DLLs, in JavaScript they are npm packages or bundled modules. Robert C. Martin defines six principles that govern how classes should be grouped into components (cohesion) and how components should relate to each other (coupling).
+
+This reference covers the three cohesion principles (REP, CCP, CRP), the three coupling principles (ADP, SDP, SAP), practical application of stability and abstractness metrics, and strategies for managing component dependencies.
+
+## Component Cohesion: What Goes Inside a Component
+
+### REP: The Reuse/Release Equivalence Principle
+
+**"The granule of reuse is the granule of release."**
+
+Classes and modules that are grouped into a component should be releasable together. If you version and release a component, every class in it should make sense as part of that release. A component should have a cohesive theme -- a reason for being grouped.
+
+**Why it matters:**
+- Users of a component expect that when they upgrade to a new version, all classes in the component have been updated coherently
+- If a component contains unrelated classes, users are forced to upgrade for changes they don't care about
+- A component without a coherent theme is difficult to document, understand, and maintain
+
+**Practical implications:**
+- A component named `order-domain` should contain `Order`, `OrderItem`, `OrderStatus`, `OrderPolicy` -- all cohesively related to order business rules
+- It should NOT also contain `UserPreferences` or `EmailTemplate` just because they happen to be used nearby
+- When you can't write a one-sentence description of what the component does, it probably violates REP
+
+### CCP: The Common Closure Principle
+
+**"Gather into components those classes that change for the same reasons and at the same times. Separate into different components those classes that change at different times and for different reasons."**
+
+This is the Single Responsibility Principle applied at the component level. A component should not have multiple reasons to change.
+
+**Why it matters:**
+- When a change in business requirements affects multiple classes, ideally all those classes are in the same component
+- This means only one component needs to be redeployed rather than many
+- Minimizes the ripple effect of changes across the deployment landscape
+
+**Practical application:**
+
+| Change Reason | Group Together | Separate From |
+|---------------|---------------|---------------|
+| Order pricing rules change | `OrderCalculator`, `DiscountPolicy`, `TaxCalculator` | `OrderController`, `OrderRepository` |
+| Database schema changes | `OrderMapper`, `OrderRepository`, `OrderMigration` | `Order`, `OrderCalculator` |
+| API response format changes | `OrderPresenter`, `OrderSerializer`, `OrderViewModel` | `Order`, `OrderService` |
+| Authentication rules change | `AuthPolicy`, `TokenValidator`, `SessionManager` | `OrderService`, `PaymentService` |
+
+**The key question:** "When this business rule changes, which classes will I need to modify?" Group those classes together.
+
+### CRP: The Common Reuse Principle
+
+**"Don't force users of a component to depend on things they don't need."**
+
+Classes in a component should be tightly related. If you depend on one class in a component, you should depend on most (ideally all) classes in that component. If you only use one class out of twenty, the component is too broad.
+
+**Why it matters:**
+- When a component changes, all components that depend on it must be revalidated and potentially redeployed
+- If Component A depends on Component B but only uses one class, changes to unrelated classes in B still force A to be revalidated
+- Fat components create unnecessary coupling
+
+**Practical test:** For each class in a component, ask: "If I remove this class, would users of this component notice?" If they wouldn't, the class may belong elsewhere.
+
+### The Tension Triangle
+
+REP, CCP, and CRP are in tension with each other:
+
+```
+         REP
+        /    \
+      /        \
+    CCP ------- CRP
+```
+
+- **REP + CCP** push toward larger components (group things that are released and changed together)
+- **CRP** pushes toward smaller components (don't include things that aren't used together)
+- **Early in development:** Favor CCP (minimize redeployment cost as code churns)
+- **As the system matures:** Shift toward CRP (minimize unnecessary coupling as the system stabilizes)
+
+A component's composition typically evolves over time, starting broad (CCP-oriented) and narrowing (CRP-oriented) as the system matures.
+
+## Component Coupling: Relationships Between Components
+
+### ADP: The Acyclic Dependencies Principle
+
+**"Allow no cycles in the component dependency graph."**
+
+The dependency graph of components must be a Directed Acyclic Graph (DAG). If Component A depends on B, and B depends on C, and C depends on A, you have a cycle -- and the three components are effectively one undivisible monolith.
+
+**Why cycles are destructive:**
+- Cycles make independent release impossible -- you can't release A without releasing B and C
+- Changes in any component in the cycle potentially affect all others
+- Build order becomes ambiguous or impossible
+- Testing requires all components in the cycle to be present
+
+**Detecting cycles:**
+
+```
+A --> B --> C --> A    (CYCLE: A, B, C are effectively one component)
+
+A --> B --> C          (NO CYCLE: DAG)
+      |         ^
+      v         |
+      D --------/
+```
+
+**Breaking cycles -- two strategies:**
+
+**Strategy 1: Apply the Dependency Inversion Principle**
+
+If B depends on A and A depends on B (cycle), extract an interface:
+
+```
+Before (cycle):
+  A <--> B
+
+After (no cycle):
+  A --> InterfaceX <-- B
+```
+
+A defines `InterfaceX`. B implements it. Now A depends on nothing new; B depends on `InterfaceX` (which lives with A). The cycle is broken.
+
+**Strategy 2: Extract a new component**
+
+Move the shared dependency into a new component that both A and B depend on:
+
+```
+Before (cycle):
+  A <--> B
+
+After (no cycle):
+  A --> C <-- B
+```
+
+C contains the shared classes. Both A and B depend on C. Neither depends on the other.
+
+### SDP: The Stable Dependencies Principle
+
+**"Depend in the direction of stability."**
+
+A component should only depend on components that are more stable than it is. Stability here means "difficulty of change" -- a component is stable if many other components depend on it (making it hard to change without breaking things).
+
+**Measuring stability:**
+
+- **Fan-in (Ca):** Number of classes outside the component that depend on classes inside the component (incoming dependencies)
+- **Fan-out (Ce):** Number of classes inside the component that depend on classes outside the component (outgoing dependencies)
+- **Instability (I):** I = Ce / (Ca + Ce), where I ranges from 0 (maximally stable) to 1 (maximally unstable)
+
+| Metric Value | Meaning | Implication |
+|-------------|---------|-------------|
+| I = 0 | Maximally stable (many dependents, no dependencies) | Hard to change; should be abstract |
+| I = 1 | Maximally unstable (no dependents, many dependencies) | Easy to change; should be concrete |
+| I = 0.5 | Balanced | Moderate change risk |
+
+**The SDP rule:** If Component A depends on Component B, then I(B) should be less than or equal to I(A). You should depend on things that are harder to change than you are.
+
+**Violation example:**
+If a highly stable component (I=0.1, many dependents) depends on a highly unstable component (I=0.9, few dependents), the unstable component's frequent changes will destabilize all the stable component's dependents.
+
+### SAP: The Stable Abstractions Principle
+
+**"A component should be as abstract as it is stable."**
+
+Stable components (hard to change) should be abstract (contain mostly interfaces and abstract classes). This way, their stability does not prevent them from being extended. Unstable components (easy to change) should be concrete, containing the implementations that change frequently.
+
+**Measuring abstractness:**
+
+- **Nc:** Number of classes in the component
+- **Na:** Number of abstract classes and interfaces in the component
+- **Abstractness (A):** A = Na / Nc, where A ranges from 0 (fully concrete) to 1 (fully abstract)
+
+### The Main Sequence
+
+Plot each component on a graph with Instability (I) on the x-axis and Abstractness (A) on the y-axis. The ideal line runs from (0,1) to (1,0) -- the "Main Sequence."
+
+```
+A (Abstractness)
+1 |  * Zone of Uselessness
+  |    \
+  |      \  <-- Main Sequence
+  |        \
+  |          \
+0 |____________* Zone of Pain
+  0          1
+    I (Instability)
+```
+
+**Zone of Pain (I=0, A=0):** Maximally stable AND maximally concrete. Very hard to change but contains no abstractions for extension. Examples: database schemas, concrete utility libraries that everyone depends on. Painful to modify.
+
+**Zone of Uselessness (I=1, A=1):** Maximally unstable AND maximally abstract. No one depends on these abstract interfaces. They serve no purpose. Dead code.
+
+**The Main Sequence:** Components should fall near the line from (0,1) to (1,0). Stable components should be abstract. Unstable components should be concrete.
+
+**Distance from the Main Sequence:**
+D = |A + I - 1|, where D ranges from 0 (on the line) to ~0.7 (in a zone).
+
+Components with high D values warrant investigation.
+
+## Practical Component Design
+
+### Component Mapping to Clean Architecture
+
+| Clean Architecture Circle | Stability | Abstractness | Character |
+|--------------------------|-----------|-------------|-----------|
+| **Entities** | Very stable (I near 0) | Abstract (interfaces, domain types) | Core business rules; many dependents |
+| **Use Cases** | Stable (I = 0.2-0.4) | Moderately abstract (ports, interactors) | Application rules; depend on entities |
+| **Adapters** | Unstable (I = 0.5-0.7) | Concrete (controllers, gateways) | Translation layer; depend on use cases |
+| **Frameworks** | Very unstable (I near 1) | Concrete (configuration, wiring) | Glue code; depend on everything |
+
+### Versioning Components Independently
+
+When components are properly decoupled:
+- Each can have its own version number
+- Each can be released on its own schedule
+- Teams can own components independently
+- Breaking changes in one component can be managed through interface versioning
+
+### Component Design Workflow
+
+1. **Start with CCP:** Group classes by reason for change. Don't worry about component size.
+2. **Apply CRP:** Remove classes that aren't used together. Split components that force unnecessary dependencies.
+3. **Check REP:** Ensure each component has a coherent theme and can be meaningfully versioned.
+4. **Graph dependencies:** Draw the component dependency graph. Look for cycles.
+5. **Break cycles (ADP):** Use DIP or extraction to eliminate every cycle.
+6. **Check stability direction (SDP):** Ensure dependencies flow toward stability.
+7. **Balance abstraction (SAP):** Make stable components abstract; make unstable components concrete.
+8. **Measure D:** Plot components on the I/A graph. Investigate those far from the Main Sequence.
+
+### Common Component Anti-Patterns
+
+| Anti-Pattern | Symptom | Fix |
+|-------------|---------|-----|
+| **God component** | One component contains everything | Split by CCP: group by reason for change |
+| **Circular dependencies** | Can't release or build independently | Apply ADP: DIP or extraction |
+| **Concrete stable component** | Many dependents, no abstractions, painful to change | Apply SAP: extract interfaces, move implementations to unstable components |
+| **Unstable abstractions** | Abstract component with no dependents | Remove dead abstractions or rethink dependency structure |
+| **Shotgun releases** | Changing one feature requires releasing five components | Apply CCP: group co-changing classes together |
+| **Dependency magnet** | One utility component everyone depends on | Split into focused components; apply CRP |
+
+### Dependency Analysis Tools
+
+| Language | Tool | Purpose |
+|----------|------|---------|
+| Java | JDepend, ArchUnit | Measure component metrics, enforce dependency rules |
+| JavaScript/TypeScript | Dependency Cruiser, Madge | Visualize and validate module dependencies |
+| Python | import-linter, pydeps | Enforce import rules, visualize package dependencies |
+| .NET | NDepend | Component metrics, dependency analysis |
+| Go | `go vet`, custom linters | Package dependency validation |
+| General | SonarQube | Cross-language dependency and quality analysis |
+
+These tools automate the detection of cycles, stability violations, and components in the Zone of Pain or Zone of Uselessness. Integrate them into CI/CD pipelines to prevent architectural drift.

--- a/.claude/skills/clean-architecture/references/dependency-rule.md
+++ b/.claude/skills/clean-architecture/references/dependency-rule.md
@@ -1,0 +1,245 @@
+# The Dependency Rule and Concentric Circles
+
+The Dependency Rule is the single most important concept in Clean Architecture. It states that source code dependencies can only point inward. Nothing in an inner circle can know anything at all about something in an outer circle. This includes names -- functions, classes, variables, data formats, or any other named software entity declared in an outer circle must not be mentioned by code in an inner circle.
+
+This reference covers the concentric circles model, how data crosses boundaries, why direction matters, how frameworks violate the rule, and how to keep the inner circle pure.
+
+## The Concentric Circles
+
+Clean Architecture organizes code into concentric circles, each representing a different level of abstraction and policy. The innermost circles contain the highest-level, most general policies. The outermost circles contain the lowest-level, most concrete details.
+
+### Circle 1: Entities (Innermost)
+
+Entities encapsulate enterprise-wide business rules. These are the most general, most stable rules in the system. They are the least likely to change when something external changes -- a page navigation change, a security policy change, or a database migration should not affect entities.
+
+**Characteristics of well-designed entities:**
+- They can be simple objects with methods, or they can be a set of data structures and functions
+- They encapsulate the most critical business rules
+- They have no dependency on anything in the outer circles
+- They would exist even if no software system existed (the rules are inherent to the business)
+- They are the most reusable elements across different applications in the enterprise
+
+**Example:**
+
+```python
+class LoanApplication:
+    def __init__(self, applicant_income: float, requested_amount: float, credit_score: int):
+        self.applicant_income = applicant_income
+        self.requested_amount = requested_amount
+        self.credit_score = credit_score
+
+    def debt_to_income_ratio(self) -> float:
+        return self.requested_amount / (self.applicant_income * 12)
+
+    def is_creditworthy(self) -> bool:
+        return self.credit_score >= 680 and self.debt_to_income_ratio() < 0.43
+```
+
+This entity knows nothing about databases, HTTP, or frameworks. It encapsulates the business rule that determines creditworthiness.
+
+### Circle 2: Use Cases
+
+Use Cases contain application-specific business rules. They orchestrate the flow of data to and from entities and direct those entities to use their enterprise-wide business rules to achieve the goals of the use case.
+
+**Characteristics:**
+- They define and implement input and output port interfaces
+- They manipulate entities to achieve application goals
+- Changes to use cases do not affect entities
+- Changes to external layers (database, UI) do not affect use cases
+
+### Circle 3: Interface Adapters
+
+This circle contains adapters that convert data between the format most convenient for the use cases and entities and the format most convenient for some external agency such as the database or the web.
+
+**Contains:**
+- Controllers (translate inbound requests to use case input)
+- Presenters (translate use case output to external format)
+- Gateways (implement repository interfaces using specific technologies)
+
+### Circle 4: Frameworks and Drivers (Outermost)
+
+The outermost layer is composed of frameworks and tools -- the database, the web framework, the messaging system. This is where all the details go. The web is a detail. The database is a detail. We keep these things on the outside where they can do little harm.
+
+**Contains:**
+- Web framework (Express, Spring, Django, Rails)
+- Database engine and ORM
+- External service clients
+- Device drivers and I/O
+
+## The Direction of Dependencies
+
+The arrow of dependency is not the same as the arrow of control flow. Control flow can go in any direction across a boundary. Source code dependencies, however, must always point inward.
+
+### How Control Flow Opposes Dependency Direction
+
+Consider this scenario: a controller needs to call a use case, and the use case needs to call a presenter. The control flows outward (from use case to presenter), but the dependency must point inward (presenter depends on use case, not the other way around).
+
+The mechanism is Dependency Inversion:
+
+```
+Controller --> [Use Case Input Port] <-- Use Case Interactor --> [Use Case Output Port] <-- Presenter
+```
+
+The Use Case defines both the Input Port (which the Controller calls) and the Output Port (which the Presenter implements). The Use Case never knows about the Controller or the Presenter directly. It only knows about the interfaces it defines.
+
+```python
+# Defined in the Use Case circle
+class PlaceOrderOutputPort(ABC):
+    @abstractmethod
+    def present_success(self, response: OrderResponse) -> None:
+        pass
+
+    @abstractmethod
+    def present_failure(self, error: str) -> None:
+        pass
+
+# Defined in the Use Case circle
+class PlaceOrderInteractor:
+    def __init__(self, order_repo: OrderRepository, presenter: PlaceOrderOutputPort):
+        self.order_repo = order_repo
+        self.presenter = presenter
+
+    def execute(self, request: PlaceOrderRequest) -> None:
+        order = Order.create(request.items, request.customer_id)
+        self.order_repo.save(order)
+        self.presenter.present_success(OrderResponse(order.id, order.total))
+
+# Defined in the Adapters circle -- implements the Use Case's interface
+class JsonOrderPresenter(PlaceOrderOutputPort):
+    def present_success(self, response: OrderResponse) -> None:
+        self.view_model = {"order_id": response.id, "total": str(response.total)}
+
+    def present_failure(self, error: str) -> None:
+        self.view_model = {"error": error}
+```
+
+The Interactor defines `PlaceOrderOutputPort`. The `JsonOrderPresenter` in the outer circle implements it. The dependency points inward even though control flows outward.
+
+## Data Crossing Boundaries
+
+When data crosses a boundary, it is always in the form that is most convenient for the inner circle. The outer circle must adapt its data into the form expected by the inner circle.
+
+### Principle: Inner Circle Dictates Data Format
+
+**Wrong -- outer circle format leaking inward:**
+
+```python
+# Use Case receives a Django request object (framework dependency)
+class CreateUserInteractor:
+    def execute(self, request: HttpRequest):  # VIOLATION: knows about Django
+        data = json.loads(request.body)
+        user = User(name=data['name'])
+```
+
+**Right -- inner circle defines its own data structure:**
+
+```python
+# Use Case defines its own request model
+@dataclass
+class CreateUserRequest:
+    name: str
+    email: str
+
+class CreateUserInteractor:
+    def execute(self, request: CreateUserRequest):  # Pure data structure
+        user = User(name=request.name, email=request.email)
+```
+
+The Controller in the outer circle is responsible for translating the HTTP request into the `CreateUserRequest`.
+
+### Crossing Data Patterns
+
+| Pattern | When to Use | Example |
+|---------|-------------|---------|
+| **Request/Response DTOs** | Standard use case boundaries | `CreateOrderRequest` and `CreateOrderResponse` as plain data classes |
+| **Primitives** | Simple boundaries with few parameters | `get_user(user_id: str) -> UserResponse` |
+| **Domain events** | Communicating between bounded contexts | `OrderPlaced(order_id, timestamp)` emitted by inner circle |
+| **Data maps (dicts)** | Crossing boundaries where type safety is less critical | Acceptable in dynamic languages; prefer typed DTOs in static ones |
+
+### What Must Not Cross Boundaries
+
+- **ORM entities or database rows**: These are outer circle artifacts. Never pass an ActiveRecord model into a Use Case.
+- **Framework request/response objects**: `HttpRequest`, `HttpResponse`, `Request`, `Response` -- all belong in the outer circle.
+- **Third-party library types**: If your Use Case accepts an `AwsS3Object`, you've coupled business logic to AWS.
+
+## How Frameworks Violate the Dependency Rule
+
+Frameworks want to be the center of your universe. They ask you to subclass their base classes, decorate your code with their annotations, and structure your project according to their conventions. Every such demand is a dependency pointing outward-to-inward -- a violation.
+
+### Common Framework Violations
+
+| Framework Pattern | Violation | Fix |
+|-------------------|-----------|-----|
+| **ORM annotations on entities** | Entity depends on database framework | Separate domain entity from ORM model; map between them |
+| **Controller base classes** | Business logic inherits framework code | Use composition: controller holds a reference to the interactor |
+| **Framework-specific return types** | Use Case returns `ResponseEntity` or `JsonResponse` | Return plain DTOs; let the adapter format the response |
+| **Dependency injection via framework** | Inner circle annotated with `@Inject`, `@Autowired` | Use constructor injection with plain interfaces; wire in Main |
+| **Validation annotations** | Business validation tied to framework | Validate in the use case using plain code or a domain validator |
+
+### Keeping Frameworks at Arm's Length
+
+The key insight is to treat the framework as a plugin, not as your architecture:
+
+1. **Don't derive from framework base classes** in your business logic. If the framework requires inheritance, create a thin adapter that inherits from the framework class and delegates to your clean inner code.
+
+2. **Don't scatter framework annotations** throughout your domain. If you must use annotations for ORM mapping, do so on a separate persistence model that maps to and from your domain entity.
+
+3. **Structure your project by business capability**, not by framework convention. Instead of `controllers/`, `models/`, `services/` (framework-driven), use `orders/`, `payments/`, `shipping/` (domain-driven), each with its own layers inside.
+
+## Keeping the Inner Circle Pure
+
+The inner circle is the most valuable part of the system because it contains the rules that make the business money. Protecting it from contamination requires vigilance.
+
+### Purity Checklist
+
+- **No imports from outer circles**: Grep your entity and use case code for imports of framework, database, or infrastructure packages. There should be none.
+- **No I/O**: Inner circle code never reads from a file, queries a database, or makes an HTTP call directly. It calls an interface, and the outer circle provides the implementation.
+- **No global state or singletons** that come from outer circles: If a use case accesses `Settings.DATABASE_URL`, it depends on infrastructure.
+- **No concurrency primitives** from the framework: Threads, async runtime, and event loops are outer circle concerns. Use cases should be synchronous-looking; the adapter handles async mechanics.
+- **Testable in isolation**: If you cannot instantiate a use case with mock implementations and run it without starting any server, database, or framework, the inner circle is not pure.
+
+### Enforcement Strategies
+
+| Strategy | How It Works | Tools |
+|----------|-------------|-------|
+| **Architecture tests** | Automated tests that verify import rules | ArchUnit (Java), Dependency Cruiser (JS/TS), import-linter (Python) |
+| **Module boundaries** | Language-level visibility (packages, modules) | Java modules, Go internal packages, Rust `pub(crate)` |
+| **Build system separation** | Inner and outer circles are separate build targets | Separate Gradle modules, npm packages, or Python packages |
+| **Code review rules** | Manual review for dependency direction violations | PR checklist: "Do any new imports in the domain cross outward?" |
+
+### The Four-Step Inversion Process
+
+When you discover an outward dependency in an inner circle:
+
+1. **Identify the dependency**: What concrete outer-circle class is being referenced?
+2. **Define an interface in the inner circle** that describes what the inner circle needs (not what the outer circle provides).
+3. **Move the concrete implementation to the outer circle**, implementing the inner circle's interface.
+4. **Wire the dependency in Main** (the composition root), injecting the concrete implementation into the inner circle at startup.
+
+This process always works. It may feel like ceremony, but it's the mechanism that keeps the most valuable code in your system independent of the most volatile.
+
+## The Dependency Rule in Practice: A Complete Example
+
+Consider an e-commerce system handling order placement:
+
+```
+[HTTP Layer]                     [Use Case Layer]              [Entity Layer]
+Express Route Handler  -->  PlaceOrderInteractor  -->  Order.create()
+                             |                          Order.calculateTotal()
+                             v
+                        OrderRepository (interface)
+                             ^
+                             |
+[Persistence Layer]
+PostgresOrderRepository (implements OrderRepository)
+```
+
+Dependencies:
+- Express Route Handler depends on PlaceOrderInteractor (inward) -- correct
+- PlaceOrderInteractor depends on Order (inward) -- correct
+- PlaceOrderInteractor depends on OrderRepository interface (same circle) -- correct
+- PostgresOrderRepository depends on OrderRepository interface (inward) -- correct
+- Express Route Handler does NOT appear in any inner circle -- correct
+- PostgreSQL does NOT appear in any inner circle -- correct
+
+The Dependency Rule is satisfied. The business rules (Order, PlaceOrderInteractor) know nothing about Express or PostgreSQL. You could swap both without changing a single line of business logic.

--- a/.claude/skills/clean-architecture/references/entities-use-cases.md
+++ b/.claude/skills/clean-architecture/references/entities-use-cases.md
@@ -1,0 +1,347 @@
+# Entities and Use Cases
+
+Entities and Use Cases form the two innermost circles of Clean Architecture. Entities contain Enterprise Business Rules -- the most general and highest-level rules. Use Cases contain Application Business Rules -- the automation rules specific to a particular application. Together, they represent the core value of the system, the code that is most worth protecting from external change.
+
+This reference covers entity design, use case structure, the interactor pattern, input/output boundaries, request/response models, and strategies for keeping use cases focused.
+
+
+## Table of Contents
+1. [Enterprise Business Rules (Entities)](#enterprise-business-rules-entities)
+2. [Application Business Rules (Use Cases)](#application-business-rules-use-cases)
+3. [Request and Response Models](#request-and-response-models)
+4. [Keeping Use Cases Focused](#keeping-use-cases-focused)
+
+---
+
+## Enterprise Business Rules (Entities)
+
+### What Is an Entity?
+
+An entity is an object within the system that embodies a small set of critical business rules operating on critical business data. The entity object either contains the critical business data or has easy access to it. The interface of the entity consists of the functions that implement the critical business rules.
+
+**Critical distinction:** An entity is not a database row. It is not an ORM model. It is not a struct that merely holds data. An entity encapsulates business rules -- logic that would exist even if there were no computer system at all.
+
+### Characteristics of Well-Designed Entities
+
+**1. Framework-independent:**
+Entities do not inherit from database base classes, do not carry ORM annotations, and do not import framework packages.
+
+```python
+# WRONG: Entity coupled to ORM
+class Order(db.Model):  # Inherits from SQLAlchemy
+    __tablename__ = 'orders'
+    id = db.Column(db.Integer, primary_key=True)
+    total = db.Column(db.Float)
+
+# RIGHT: Pure domain entity
+class Order:
+    def __init__(self, order_id: str, items: list[OrderItem], customer_id: str):
+        self._id = order_id
+        self._items = items
+        self._customer_id = customer_id
+        self._status = OrderStatus.PENDING
+
+    def calculate_total(self) -> Money:
+        subtotal = sum(item.price * item.quantity for item in self._items)
+        return subtotal + self._calculate_tax(subtotal)
+
+    def _calculate_tax(self, subtotal: Money) -> Money:
+        # Business rule: tax calculation
+        return subtotal * Decimal("0.08")
+```
+
+**2. Business-rule containers:**
+The methods on an entity enforce business invariants. They are not getters and setters -- they represent meaningful business operations.
+
+```python
+class BankAccount:
+    def withdraw(self, amount: Money) -> None:
+        if amount > self._balance:
+            raise InsufficientFundsError(self._balance, amount)
+        if self._is_frozen:
+            raise AccountFrozenError(self._account_id)
+        self._balance -= amount
+        self._record_transaction(TransactionType.WITHDRAWAL, amount)
+```
+
+The `withdraw` method encapsulates business rules: you cannot withdraw more than the balance, and you cannot withdraw from a frozen account. These rules exist regardless of whether the system is a web app, a mobile app, or a batch process.
+
+**3. Stable over time:**
+Entities change only when business rules change. A decision to migrate from PostgreSQL to DynamoDB should not require any entity modifications. A decision to change the web framework should not affect entities.
+
+**4. Testable in complete isolation:**
+You should be able to instantiate an entity and call its methods in a unit test with zero setup -- no database, no framework, no configuration files.
+
+```python
+def test_order_calculates_total_with_tax():
+    items = [OrderItem("widget", Money("10.00"), quantity=3)]
+    order = Order("order-1", items, "customer-1")
+    assert order.calculate_total() == Money("32.40")  # 30.00 + 2.40 tax
+```
+
+### Entity Design Patterns
+
+| Pattern | When to Use | Example |
+|---------|-------------|---------|
+| **Rich domain model** | Complex business rules with many invariants | `Order` with status transitions, validation, calculations |
+| **Value objects** | Immutable concepts defined by their attributes | `Money(amount, currency)`, `Address(street, city, zip)` |
+| **Aggregates** | Cluster of entities treated as a unit for data changes | `Order` aggregate contains `OrderItems`; external code accesses items only through `Order` |
+| **Domain events** | Communicate that something meaningful happened | `Order.place()` produces `OrderPlaced` event |
+| **Factory methods** | Complex construction that enforces invariants | `Order.create(items, customer)` validates and initializes |
+
+### Common Entity Mistakes
+
+| Mistake | Why It's Wrong | Fix |
+|---------|---------------|-----|
+| Anemic entities (data-only, no behavior) | Business rules scatter into services; entity is just a DTO | Move business logic into entity methods |
+| ORM annotations on domain entities | Entity depends on database framework | Separate domain entity from persistence model |
+| Entity knows about its repository | Entity depends on infrastructure | Pass dependencies into use cases, not entities |
+| Public setters on everything | No invariant protection; any code can put entity in invalid state | Use methods that enforce business rules; make fields private |
+
+## Application Business Rules (Use Cases)
+
+### What Is a Use Case?
+
+A Use Case describes a single, specific application operation. It orchestrates entities and defines the application-specific rules for how data flows to and from those entities. It accepts input through a defined port, manipulates entities, and produces output through another defined port.
+
+**Critical distinction:** Use Cases are not entities. An entity encapsulates a business rule that would exist without software. A Use Case automates a specific application workflow that only makes sense within the context of the software system.
+
+### The Interactor Pattern
+
+The Interactor is the concrete class that implements a Use Case. The pattern has three parts:
+
+1. **Input Port (Input Boundary):** An interface that defines what the Use Case accepts. The Controller calls this interface.
+2. **Interactor:** The concrete class that implements the Input Port and contains the application logic.
+3. **Output Port (Output Boundary):** An interface that defines what the Use Case produces. The Presenter implements this interface.
+
+```python
+# Input Port -- defined in the Use Case circle
+class PlaceOrderInput(ABC):
+    @abstractmethod
+    def execute(self, request: PlaceOrderRequest) -> None:
+        pass
+
+# Output Port -- defined in the Use Case circle
+class PlaceOrderOutput(ABC):
+    @abstractmethod
+    def present_success(self, response: OrderResponse) -> None:
+        pass
+
+    @abstractmethod
+    def present_validation_error(self, errors: list[str]) -> None:
+        pass
+
+    @abstractmethod
+    def present_failure(self, message: str) -> None:
+        pass
+
+# Interactor -- implements Input Port, uses Output Port
+class PlaceOrderInteractor(PlaceOrderInput):
+    def __init__(self, order_repo: OrderRepository, presenter: PlaceOrderOutput):
+        self._order_repo = order_repo
+        self._presenter = presenter
+
+    def execute(self, request: PlaceOrderRequest) -> None:
+        errors = self._validate(request)
+        if errors:
+            self._presenter.present_validation_error(errors)
+            return
+
+        order = Order.create(
+            items=[OrderItem(i.product_id, i.quantity, i.price) for i in request.items],
+            customer_id=request.customer_id,
+        )
+
+        self._order_repo.save(order)
+
+        response = OrderResponse(
+            order_id=order.id,
+            total=order.calculate_total(),
+            status=order.status.value,
+        )
+        self._presenter.present_success(response)
+```
+
+### Input/Output Boundaries
+
+The boundaries are the interfaces that separate the Use Case circle from the circles on either side. They are defined in the Use Case circle and implemented by the outer circles.
+
+**Why boundaries matter:**
+- The Controller depends on the Input Port (inward dependency -- correct)
+- The Presenter depends on the Output Port (inward dependency -- correct)
+- The Interactor depends on neither the Controller nor the Presenter (isolation preserved)
+
+### Alternative: Return-Based Use Cases
+
+Not every use case needs the full Output Port pattern. A simpler approach returns a result directly:
+
+```python
+class PlaceOrderInteractor:
+    def __init__(self, order_repo: OrderRepository):
+        self._order_repo = order_repo
+
+    def execute(self, request: PlaceOrderRequest) -> Result[OrderResponse, OrderError]:
+        errors = self._validate(request)
+        if errors:
+            return Failure(ValidationError(errors))
+
+        order = Order.create(...)
+        self._order_repo.save(order)
+        return Success(OrderResponse(order.id, order.calculate_total()))
+```
+
+This is simpler and often sufficient. Use the full Output Port pattern when the presentation logic is complex or when you need to support multiple presentation formats from the same use case.
+
+## Request and Response Models
+
+### Request Models
+
+Request models are simple data structures that carry input data across the boundary. They are defined in the Use Case circle.
+
+**Rules for request models:**
+- No framework types (no `HttpRequest`, no `Form`, no `JsonNode`)
+- No entity types (the controller maps external data to the request model; the interactor maps the request model to entity calls)
+- Contain only primitives, strings, and simple nested structures
+- May contain validation hints but not validation logic dependent on external state
+
+```python
+@dataclass(frozen=True)
+class PlaceOrderRequest:
+    customer_id: str
+    items: list[OrderItemRequest]
+    shipping_address: AddressRequest
+    coupon_code: str | None = None
+
+@dataclass(frozen=True)
+class OrderItemRequest:
+    product_id: str
+    quantity: int
+    unit_price: str  # String to avoid floating-point; Use Case converts to Money
+```
+
+### Response Models
+
+Response models carry output data across the boundary. They are defined in the Use Case circle.
+
+**Rules for response models:**
+- No entity types -- the Use Case extracts the relevant data from entities and populates the response
+- No framework types -- the Presenter (outer circle) converts the response into whatever format the delivery mechanism needs
+- Contain only the data the outer circle needs to fulfill its role
+
+```python
+@dataclass(frozen=True)
+class OrderResponse:
+    order_id: str
+    total: str  # Formatted money value
+    status: str
+    estimated_delivery: str | None
+    items: list[OrderItemResponse]
+
+@dataclass(frozen=True)
+class OrderItemResponse:
+    product_name: str
+    quantity: int
+    line_total: str
+```
+
+### The Mapping Chain
+
+Data transforms at each boundary:
+
+```
+HTTP Request (JSON)
+    --> Controller maps to --> PlaceOrderRequest (DTO)
+        --> Interactor maps to --> Entity method calls
+            --> Entity produces result
+        --> Interactor maps to --> OrderResponse (DTO)
+    --> Presenter maps to --> ViewModel or JSON
+--> HTTP Response
+```
+
+Each transformation is a boundary crossing. Each boundary is an opportunity to decouple.
+
+## Keeping Use Cases Focused
+
+### One Use Case, One Operation
+
+Each Use Case should represent a single application operation. If you find a Use Case doing multiple things, split it.
+
+**Signs of an unfocused Use Case:**
+- The class name contains "And" (e.g., `CreateAndNotifyOrder`)
+- The execute method has conditional branches for fundamentally different operations
+- The class has more than 3-4 dependencies
+- The test file has tests for unrelated scenarios
+
+### Use Case Granularity Guidelines
+
+| Granularity | Use Case Example | Notes |
+|-------------|-----------------|-------|
+| **Too coarse** | `ManageOrders` | Does everything -- create, update, cancel, refund |
+| **Right level** | `PlaceOrder`, `CancelOrder`, `RefundOrder` | Each is a single operation with clear input and output |
+| **Too fine** | `ValidateOrderItems`, `CalculateOrderTotal` | These are steps within a use case, not standalone operations |
+
+### Composing Use Cases
+
+Sometimes one application operation involves multiple steps that could be their own use cases. Two approaches:
+
+**1. Use Case calls Use Case (simple composition):**
+
+```python
+class PlaceOrderAndSendConfirmation:
+    def __init__(self, place_order: PlaceOrderInput, send_confirmation: SendConfirmationInput):
+        self._place_order = place_order
+        self._send_confirmation = send_confirmation
+
+    def execute(self, request: PlaceOrderRequest) -> None:
+        order_result = self._place_order.execute(request)
+        if order_result.is_success:
+            self._send_confirmation.execute(
+                SendConfirmationRequest(order_result.order_id)
+            )
+```
+
+**2. Domain events (loose coupling):**
+
+The Use Case emits a domain event; another Use Case subscribes to it. This is better when the steps are truly independent and could happen asynchronously.
+
+### Use Case Dependencies
+
+A Use Case should depend on:
+- **Entity types** (to call business rules)
+- **Repository interfaces** (to load and persist entities)
+- **Output port interfaces** (to present results)
+- **Domain service interfaces** (for cross-entity business operations)
+
+A Use Case should NOT depend on:
+- **Framework types** (HTTP, ORM, message queue)
+- **Concrete infrastructure classes** (database client, email service)
+- **Other use case concrete classes** (use input port interfaces instead)
+- **Configuration or environment variables** (inject configuration as constructor parameters)
+
+### Testing Use Cases
+
+Use Cases should be the most thoroughly tested part of the system because they contain the application's automation rules.
+
+```python
+def test_place_order_calculates_total_and_saves():
+    # Arrange
+    mock_repo = MockOrderRepository()
+    mock_presenter = MockPlaceOrderPresenter()
+    interactor = PlaceOrderInteractor(mock_repo, mock_presenter)
+
+    request = PlaceOrderRequest(
+        customer_id="cust-1",
+        items=[OrderItemRequest("prod-1", quantity=2, unit_price="25.00")],
+        shipping_address=AddressRequest("123 Main", "Springfield", "62704"),
+    )
+
+    # Act
+    interactor.execute(request)
+
+    # Assert
+    assert mock_repo.saved_order is not None
+    assert mock_repo.saved_order.calculate_total() == Money("54.00")  # 50 + 4 tax
+    assert mock_presenter.success_response.order_id == mock_repo.saved_order.id
+```
+
+No database. No web server. No framework. Just the use case logic running in a plain unit test. This is the payoff of the Dependency Rule.

--- a/.claude/skills/clean-architecture/references/solid-principles.md
+++ b/.claude/skills/clean-architecture/references/solid-principles.md
@@ -1,0 +1,412 @@
+# SOLID Principles
+
+The SOLID principles are five design principles for managing dependencies at the class and module level. They were assembled and named by Robert C. Martin in the early 2000s, drawing on decades of software engineering wisdom. In Clean Architecture, SOLID principles serve as the mid-level building blocks that make the Dependency Rule possible. Without SOLID, the concentric circles would leak and the boundaries would crumble.
+
+This reference covers each principle with definitions, code examples, common violations, and practical application guidance.
+
+
+## Table of Contents
+1. [SRP: The Single Responsibility Principle](#srp-the-single-responsibility-principle)
+2. [OCP: The Open-Closed Principle](#ocp-the-open-closed-principle)
+3. [LSP: The Liskov Substitution Principle](#lsp-the-liskov-substitution-principle)
+4. [ISP: The Interface Segregation Principle](#isp-the-interface-segregation-principle)
+5. [DIP: The Dependency Inversion Principle](#dip-the-dependency-inversion-principle)
+
+---
+
+## SRP: The Single Responsibility Principle
+
+**"A module should have one, and only one, reason to change."**
+
+More precisely: a module should be responsible to one, and only one, actor (a group of users or stakeholders who want the system to change in the same way).
+
+### Understanding SRP
+
+SRP is commonly misunderstood as "a function should do one thing." That's a good principle for functions, but SRP operates at a higher level. SRP says that the module (class) should serve one actor -- one group of people who would request changes.
+
+### Classic Violation
+
+```python
+class Employee:
+    def calculate_pay(self) -> Money:
+        # Serves the CFO / accounting department
+        regular_hours = self._get_regular_hours()
+        overtime = self._get_overtime_hours()
+        return regular_hours * self.hourly_rate + overtime * self.hourly_rate * 1.5
+
+    def report_hours(self) -> HoursReport:
+        # Serves the COO / operations department
+        return HoursReport(
+            regular=self._get_regular_hours(),
+            overtime=self._get_overtime_hours(),
+        )
+
+    def save(self) -> None:
+        # Serves the CTO / database administrators
+        db.execute("INSERT INTO employees ...", self._to_dict())
+
+    def _get_regular_hours(self) -> float:
+        # Shared by calculate_pay and report_hours -- dangerous coupling
+        return min(self.hours_worked, 40)
+
+    def _get_overtime_hours(self) -> float:
+        return max(self.hours_worked - 40, 0)
+```
+
+**The problem:** Three actors (CFO, COO, CTO) all have reasons to change this class. When the CFO wants to change how overtime is calculated, the shared `_get_regular_hours` method might be modified in a way that breaks the COO's reports.
+
+### SRP-Compliant Design
+
+```python
+class PayCalculator:
+    """Serves the CFO / accounting"""
+    def calculate_pay(self, employee_data: EmployeeData) -> Money:
+        regular = min(employee_data.hours_worked, 40)
+        overtime = max(employee_data.hours_worked - 40, 0)
+        return regular * employee_data.rate + overtime * employee_data.rate * 1.5
+
+class HoursReporter:
+    """Serves the COO / operations"""
+    def report_hours(self, employee_data: EmployeeData) -> HoursReport:
+        return HoursReport(
+            regular=min(employee_data.hours_worked, 40),
+            overtime=max(employee_data.hours_worked - 40, 0),
+        )
+
+class EmployeeRepository:
+    """Serves the CTO / database administration"""
+    def save(self, employee_data: EmployeeData) -> None:
+        self._db.execute("INSERT INTO employees ...", employee_data.to_dict())
+```
+
+Each class now serves one actor. Changes requested by the CFO only affect `PayCalculator`. The COO's changes only affect `HoursReporter`. They can evolve independently.
+
+### SRP Indicators
+
+| Indicator | Likely Violation |
+|-----------|-----------------|
+| Class has methods serving different departments/teams | Multiple actors |
+| "And" in the class name (`OrderValidatorAndNotifier`) | Multiple responsibilities |
+| Class changes frequently for unrelated reasons | Multiple change drivers |
+| Merge conflicts from unrelated feature branches | Multiple actors modifying same class |
+| Unit tests require many unrelated mocks | Class does too many things |
+
+## OCP: The Open-Closed Principle
+
+**"A software artifact should be open for extension but closed for modification."**
+
+You should be able to extend the behavior of a system without modifying existing code. New features are added by writing new code, not by changing old code.
+
+### The Strategy Pattern Approach
+
+```python
+# Closed for modification -- this code doesn't change when new shipping methods are added
+class OrderService:
+    def __init__(self, shipping_strategy: ShippingStrategy):
+        self._shipping = shipping_strategy
+
+    def calculate_total(self, order: Order) -> Money:
+        subtotal = order.subtotal()
+        shipping = self._shipping.calculate(order)
+        return subtotal + shipping
+
+# Open for extension -- add new shipping methods without touching OrderService
+class ShippingStrategy(ABC):
+    @abstractmethod
+    def calculate(self, order: Order) -> Money:
+        pass
+
+class StandardShipping(ShippingStrategy):
+    def calculate(self, order: Order) -> Money:
+        return Money("5.99")
+
+class ExpressShipping(ShippingStrategy):
+    def calculate(self, order: Order) -> Money:
+        return Money("14.99")
+
+# New shipping method -- no existing code modified
+class FreeShippingOver50(ShippingStrategy):
+    def calculate(self, order: Order) -> Money:
+        return Money("0.00") if order.subtotal() >= Money("50.00") else Money("5.99")
+```
+
+### Common OCP Violations
+
+```python
+# VIOLATION: Adding a new payment method requires modifying this function
+def process_payment(method: str, amount: Money) -> PaymentResult:
+    if method == "credit_card":
+        return charge_credit_card(amount)
+    elif method == "paypal":
+        return charge_paypal(amount)
+    elif method == "apple_pay":  # New method = new elif = modification
+        return charge_apple_pay(amount)
+```
+
+**Fix with OCP:**
+
+```python
+class PaymentProcessor(ABC):
+    @abstractmethod
+    def process(self, amount: Money) -> PaymentResult:
+        pass
+
+class CreditCardProcessor(PaymentProcessor):
+    def process(self, amount: Money) -> PaymentResult:
+        return self._gateway.charge(amount)
+
+# Adding Apple Pay = new class, no modification to existing code
+class ApplePayProcessor(PaymentProcessor):
+    def process(self, amount: Money) -> PaymentResult:
+        return self._apple_client.charge(amount)
+```
+
+### OCP in Clean Architecture
+
+OCP is foundational to the concentric circles model. The inner circles (entities, use cases) are closed for modification. The outer circles (adapters, frameworks) are open for extension. You extend the system by adding new adapters, new controllers, new gateways -- not by modifying business rules.
+
+## LSP: The Liskov Substitution Principle
+
+**"Subtypes must be substitutable for their base types."**
+
+If S is a subtype of T, then objects of type T may be replaced with objects of type S without altering the correctness of the program.
+
+### The Classic Violation: Square/Rectangle
+
+```python
+class Rectangle:
+    def __init__(self, width: float, height: float):
+        self._width = width
+        self._height = height
+
+    def set_width(self, w: float) -> None:
+        self._width = w
+
+    def set_height(self, h: float) -> None:
+        self._height = h
+
+    def area(self) -> float:
+        return self._width * self._height
+
+class Square(Rectangle):
+    def set_width(self, w: float) -> None:
+        self._width = w
+        self._height = w  # Must keep square invariant
+
+    def set_height(self, h: float) -> None:
+        self._width = h  # Must keep square invariant
+        self._height = h
+```
+
+**The problem:** Code that works correctly with `Rectangle` breaks with `Square`:
+
+```python
+def test_area(rect: Rectangle):
+    rect.set_width(5)
+    rect.set_height(4)
+    assert rect.area() == 20  # Fails for Square! Area is 16 because set_height changed width
+```
+
+`Square` is NOT substitutable for `Rectangle`. LSP is violated.
+
+### LSP in Practice
+
+| Violation Pattern | Why It Breaks | Fix |
+|-------------------|--------------|-----|
+| Subclass throws unexpected exceptions | Callers don't handle exceptions they didn't expect from the base type | Subclass should honor the base type's exception contract |
+| Subclass ignores methods (no-op override) | Callers rely on the method doing something | The class hierarchy is wrong; use composition or a different abstraction |
+| Subclass strengthens preconditions | Callers that work with base type fail with subtype | Subtypes may weaken preconditions, never strengthen them |
+| Subclass weakens postconditions | Callers expect guarantees the subtype doesn't provide | Subtypes may strengthen postconditions, never weaken them |
+
+### LSP and Interfaces in Clean Architecture
+
+LSP applies to interfaces as well as inheritance hierarchies. When a Use Case depends on `OrderRepository`, every implementation (`PostgresOrderRepository`, `MongoOrderRepository`, `InMemoryOrderRepository`) must behave consistently:
+
+- `save()` must persist the entity (or fail with a defined exception)
+- `find_by_id()` must return the entity if it exists or `None` if not
+- No implementation should silently drop data, return stale data, or throw exceptions not defined in the interface contract
+
+## ISP: The Interface Segregation Principle
+
+**"No client should be forced to depend on methods it does not use."**
+
+Fat interfaces create unnecessary coupling. When a client depends on an interface with methods it doesn't use, it becomes vulnerable to changes in those unused methods.
+
+### Classic Violation
+
+```python
+class MultiFunctionDevice(ABC):
+    @abstractmethod
+    def print_document(self, doc: Document) -> None: pass
+
+    @abstractmethod
+    def scan_document(self) -> Image: pass
+
+    @abstractmethod
+    def fax_document(self, doc: Document, number: str) -> None: pass
+
+    @abstractmethod
+    def staple_pages(self, pages: list[Page]) -> None: pass
+
+# A simple printer must implement fax and staple -- methods it can't fulfill
+class SimplePrinter(MultiFunctionDevice):
+    def print_document(self, doc: Document) -> None:
+        # Actually prints
+        ...
+
+    def scan_document(self) -> Image:
+        raise NotSupportedError()  # ISP violation!
+
+    def fax_document(self, doc: Document, number: str) -> None:
+        raise NotSupportedError()  # ISP violation!
+
+    def staple_pages(self, pages: list[Page]) -> None:
+        raise NotSupportedError()  # ISP violation!
+```
+
+### ISP-Compliant Design
+
+```python
+class Printer(ABC):
+    @abstractmethod
+    def print_document(self, doc: Document) -> None: pass
+
+class Scanner(ABC):
+    @abstractmethod
+    def scan_document(self) -> Image: pass
+
+class FaxMachine(ABC):
+    @abstractmethod
+    def fax_document(self, doc: Document, number: str) -> None: pass
+
+# Simple printer only implements what it can do
+class SimplePrinter(Printer):
+    def print_document(self, doc: Document) -> None:
+        ...
+
+# Multi-function device implements all relevant interfaces
+class OfficePrinter(Printer, Scanner, FaxMachine):
+    def print_document(self, doc: Document) -> None: ...
+    def scan_document(self) -> Image: ...
+    def fax_document(self, doc: Document, number: str) -> None: ...
+```
+
+### ISP in Clean Architecture
+
+ISP directly supports the Dependency Rule. Use Cases define narrow, focused input and output port interfaces. Each adapter implements only the interfaces it needs:
+
+```python
+# Focused interfaces (ISP-compliant)
+class OrderReader(ABC):
+    @abstractmethod
+    def find_by_id(self, order_id: str) -> Order | None: pass
+
+class OrderWriter(ABC):
+    @abstractmethod
+    def save(self, order: Order) -> None: pass
+
+class OrderSearcher(ABC):
+    @abstractmethod
+    def search(self, criteria: SearchCriteria) -> list[Order]: pass
+
+# Use Case that only reads doesn't depend on write methods
+class GetOrderDetailsInteractor:
+    def __init__(self, reader: OrderReader):  # Only depends on reading
+        self._reader = reader
+```
+
+## DIP: The Dependency Inversion Principle
+
+**"High-level modules should not depend on low-level modules. Both should depend on abstractions. Abstractions should not depend on details. Details should depend on abstractions."**
+
+DIP is the mechanism that makes the Dependency Rule work. It inverts the natural direction of source code dependencies so that the volatile, concrete, outer-circle code depends on the stable, abstract, inner-circle code.
+
+### Without DIP (Natural Dependencies)
+
+```
+OrderService --> PostgresDatabase
+  (high-level)     (low-level)
+```
+
+The high-level policy (OrderService) depends on the low-level detail (PostgresDatabase). Changing the database means changing the service.
+
+### With DIP (Inverted Dependencies)
+
+```
+OrderService --> OrderRepository (interface)
+                       ^
+                       |
+              PostgresOrderRepository
+```
+
+Both the high-level service and the low-level database adapter depend on the abstraction (OrderRepository). The abstraction is defined by the high-level module, not by the low-level module.
+
+### DIP Implementation Pattern
+
+```python
+# HIGH-LEVEL MODULE defines the abstraction
+class OrderRepository(ABC):
+    """Defined in the Use Case circle. The high-level policy dictates what it needs."""
+    @abstractmethod
+    def save(self, order: Order) -> None: pass
+
+    @abstractmethod
+    def find_by_id(self, order_id: str) -> Order | None: pass
+
+# HIGH-LEVEL MODULE uses the abstraction
+class PlaceOrderInteractor:
+    def __init__(self, repo: OrderRepository):  # Depends on abstraction
+        self._repo = repo
+
+    def execute(self, request: PlaceOrderRequest) -> None:
+        order = Order.create(request.items, request.customer_id)
+        self._repo.save(order)  # Calls abstraction
+
+# LOW-LEVEL MODULE implements the abstraction
+class PostgresOrderRepository(OrderRepository):  # Depends on abstraction
+    def __init__(self, pool):
+        self._pool = pool
+
+    def save(self, order: Order) -> None:
+        # SQL details here -- low-level
+        ...
+
+# COMPOSITION ROOT wires them together
+def main():
+    pool = create_pool(DATABASE_URL)
+    repo = PostgresOrderRepository(pool)
+    interactor = PlaceOrderInteractor(repo)  # Inject concrete into abstract slot
+```
+
+### DIP: Who Owns the Interface?
+
+This is the critical insight: **the interface belongs to the high-level module, not the low-level module.**
+
+| Ownership | Meaning | Result |
+|-----------|---------|--------|
+| Interface owned by high-level module | The Use Case defines what it needs | Low-level module adapts to high-level needs |
+| Interface owned by low-level module | The database defines its capabilities | High-level module must adapt to database -- dependency NOT inverted |
+
+When the Use Case defines `OrderRepository`, it specifies methods like `save(order)` and `find_by_id(id)` -- business-oriented operations. The database adapter must conform to this business-oriented interface.
+
+When the database adapter defines the interface, it specifies methods like `execute_query(sql)` and `fetch_rows(table)` -- technology-oriented operations. The Use Case must conform to the database's way of thinking. This is the natural dependency direction, NOT inverted.
+
+### Common DIP Violations
+
+| Violation | Example | Fix |
+|-----------|---------|-----|
+| Importing concrete classes in high-level modules | `from stripe import StripeClient` in Use Case | Define `PaymentGateway` interface in Use Case; implement with Stripe in adapter |
+| Using static/global factory methods | `Database.get_instance()` in Use Case | Inject repository through constructor |
+| Depending on framework types in domain | `@Autowired` on domain class | Use plain constructor injection; wire in Main |
+| Low-level module defines the interface | `IStripeGateway` lives in the Stripe adapter package | Move interface to Use Case package; rename to `PaymentGateway` |
+| New operator in high-level code | `repo = PostgresRepository()` inside Use Case | Inject through constructor; instantiate in Main |
+
+### DIP and Clean Architecture
+
+DIP is the engine of Clean Architecture. Every boundary in the concentric circles model is maintained through dependency inversion:
+
+- **Use Case to Database:** `OrderRepository` interface (defined by Use Case) inverts the dependency so the database adapter depends inward
+- **Use Case to Web:** `PlaceOrderOutput` interface (defined by Use Case) inverts the dependency so the presenter depends inward
+- **Use Case to External Service:** `EmailService` interface (defined by Use Case) inverts the dependency so the email adapter depends inward
+
+Without DIP, inner circles would depend on outer circles, the Dependency Rule would be violated, and the architecture would collapse into a ball of mud.

--- a/.claude/skills/discovery-engineering/SKILL.md
+++ b/.claude/skills/discovery-engineering/SKILL.md
@@ -29,6 +29,11 @@ entidad — así producto e ingeniería hablan de lo mismo aunque el schema habl
 | verificado          | `professionals.status = 'active'`          |
 ```
 
+Esta tabla es lenguaje ubicuo, aunque no se le llame así — usar el skill `domain-driven-design` para
+mantenerlo consistente y para decidir qué se construye a medida (el ranking de búsqueda, las reglas de
+verificación) versus qué se compra hecho (Supabase Auth, Resend): esa distinción entre dominio central y
+subdominio genérico evita sobre-diseñar lo que ya resuelve un proveedor.
+
 Invariante de diseño que viene de los guardrails de `CLAUDE.md`: el contacto sale directo hacia el
 profesional. Un diseño que introduce una bandeja intermedia, una cola de solicitudes o un paso de pago
 contradice una decisión vigente de producto y vuelve primero a `producto.md`.
@@ -161,6 +166,13 @@ inyecta. Su valor real no es elegancia: es que vuelve cortable la sustitución (
 No aplicar a CRUD simple ni a features de presentación — la abstracción tiene costo real y no hay
 beneficio si la lógica no cambia de forma.
 
+Este principio es un caso particular de la Dependency Rule del skill `clean-architecture`: la lógica de
+negocio nunca importa Drizzle, `event` ni la reactividad de Vue — son detalles que la envuelven, no al
+revés. Usarlo para revisar el diseño antes de que llegue a slicing: lógica de negocio metida en un
+handler, un modelo de Drizzle que se filtra como si fuera la entidad de dominio, o un "Use Case" de mil
+líneas son exactamente el tipo de hallazgo que hoy solo aparece en code review — el objetivo es que
+`ingenieria.md` los prevenga antes de que se escriba una línea de código.
+
 ## RLS no es un paso posterior, y tampoco es la autorización
 
 Toda tabla con datos de usuario nace con su política. `ingenieria.md` resuelve, para cada cambio de schema:
@@ -176,6 +188,11 @@ dueño y se salta RLS: la autorización real vive en el código de `server/api/`
 completo cuando nombra la policy — tiene que nombrar además **en qué endpoint se verifica la pertenencia**.
 Un `ingenieria.md` que solo dice "RLS: lectura pública, escritura del dueño" describe una defensa que no
 corre.
+
+Antes de escribir o cambiar cualquier tabla, policy, índice o migración, usar el skill
+`supabase-postgres-best-practices` — cubre desde ahí mismo cosas que hoy solo se atrapan en review: tipos
+de dato mal elegidos, falta de índice en una FK, RLS sin índice de soporte (la policy funciona pero cada
+query la paga en el plan), o una migración sin estrategia para las filas existentes.
 
 ## Preguntas para evaluar la factibilidad en discovery
 
@@ -216,4 +233,5 @@ alcance con su trade-off, y luego se actualiza `ingenieria.md`.
 
 Para patrones de Nuxt y Nitro, ver `.claude/skills/nuxt/`. Para schemas y queries, ver
 `.claude/skills/drizzle-orm/`. Para extraer composables y componentes al implementar, ver el skill
-`vue-composition`.
+`vue-composition`. Para el diseño de contratos y separación lógica/infraestructura, ver `clean-architecture`
+y `domain-driven-design`. Para schema, RLS, índices y migraciones, ver `supabase-postgres-best-practices`.

--- a/.claude/skills/domain-driven-design/SKILL.md
+++ b/.claude/skills/domain-driven-design/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: domain-driven-design
+description: 'Model software around the business domain using bounded contexts, aggregates, and ubiquitous language. Use when the user mentions "domain modeling", "bounded context", "aggregate root", "ubiquitous language", "anti-corruption layer", "context mapping", "domain events", "strategic design", "the code doesnt match the business", or "how do we split this big system". Also trigger when breaking a monolith into services, defining service boundaries, or aligning code structure with business processes. Covers entities vs value objects, domain events, and context mapping strategies. For architecture layers, see clean-architecture. For complexity, see software-design-philosophy.'
+license: MIT
+metadata:
+  author: wondelai
+  version: "1.4.0"
+---
+
+# Domain-Driven Design Framework
+
+Framework for tackling software complexity by modeling code around the business domain. The greatest risk in software is not technical failure -- it is building a model that does not reflect how the business actually works.
+
+## Core Principle
+
+**The model is the code; the code is the model.** Software should embody a deep, shared understanding of the business domain. When domain experts and developers speak the same language and that language is directly expressed in the codebase, complexity becomes manageable and the system evolves gracefully as the business changes.
+
+## Scoring
+
+**Goal: 10/10.** Score a domain model by awarding **1 point per satisfied row of the Quick Diagnostic** (7 rows) plus up to 3 points for depth: +1 if the Core Domain has a genuinely rich model (not just CRUD), +1 if invariants live inside aggregates rather than in services, +1 if the ubiquitous language is consistent across conversation, code, and tests. Bands: **9-10** = expert-readable names, explicit context boundaries with ACLs, small aggregates, behavior-rich entities, events for cross-aggregate flow, an identified Core Domain; **5-6** = some domain language but leaky boundaries or anemic objects; **<=3** = technical naming, one model for everything, logic scattered in services. Report the score and the specific diagnostic rows failing.
+
+## Framework
+
+### 1. Ubiquitous Language
+
+**Core concept:** A shared, rigorous language between developers and domain experts, used consistently in conversation, documentation, and code. When the language changes, the code changes -- and awkward naming in code feeds back into refining the language.
+
+**Why it works:** Ambiguity is the root cause of most modeling failures. When a developer says "order" and an expert means "purchase request," bugs are inevitable; a ubiquitous language forces every name in code to map to a concept the business recognizes and validates.
+
+**Key insights:**
+- The language emerges from deep collaboration, not a glossary bolted on after the fact
+- If a concept is hard to name, the model is likely wrong -- naming difficulty is a design signal
+- Technical jargon (`DataProcessor` vs. `ClaimAdjudicator`) hides domain logic from the experts who could correct it
+- Different bounded contexts may use the same word with different meanings -- and that is fine
+
+**Code applications:**
+
+| Context | Pattern | Example |
+|---------|---------|---------|
+| Class/method naming | Name after domain concepts and verbs | `LoanApplication`, `policy.underwrite()` -- not `RequestHandler`, `process()` |
+| Module structure | Organize by domain concept | `shipping/`, `billing/` -- not `controllers/`, `services/` |
+| Code review | Reject technical-only names | Flag `Manager`, `Helper`, `Processor`, `Utils` as naming smells |
+
+See: [references/ubiquitous-language.md](references/ubiquitous-language.md) when running modeling sessions or maintaining a glossary -- covers how the language evolves and feeds back into code.
+
+### 2. Bounded Contexts and Context Mapping
+
+**Core concept:** A bounded context is an explicit boundary within which a particular domain model applies. The same word ("Customer") can mean different things in different contexts; context maps define the relationships and translation strategies between them.
+
+**Why it works:** Large systems that try to maintain a single unified model inevitably collapse into inconsistency. Bounded contexts accept that different parts of the business need different models; context maps manage the integration between them.
+
+**Key insights:**
+- A bounded context is not a microservice -- it is a linguistic and model boundary that may contain multiple services
+- Context boundaries often align with team boundaries (Conway's Law)
+- The nine context mapping patterns describe political and technical relationships between teams
+- Anti-Corruption Layer is the most important defensive pattern -- never let a foreign model leak into your core domain
+- Shared Kernel couples two teams; keep it small and explicitly governed
+- Start by mapping what exists (Big Ball of Mud), then define target boundaries
+
+**Code applications:**
+
+| Context | Pattern | Example |
+|---------|---------|---------|
+| Service integration | Anti-Corruption Layer | Translate external API responses into your domain objects at the boundary |
+| Legacy migration | Conformist / ACL | Wrap the legacy system behind an adapter that speaks your domain language |
+| API design | Open Host Service + Published Language | Expose a well-documented REST API with a canonical schema |
+
+See: [references/bounded-contexts.md](references/bounded-contexts.md) for the nine mapping patterns and integration strategies.
+
+### 3. Entities, Value Objects, and Aggregates
+
+**Core concept:** Entities have identity that persists across state changes. Value Objects are defined entirely by their attributes and are immutable. Aggregates are clusters of entities and value objects with a single root that enforces consistency boundaries.
+
+**Why it works:** Without these distinctions, everything becomes a mutable, identity-bearing object -- tangled state, inconsistent updates, fragile concurrency. Aggregates draw the line: everything inside is guaranteed consistent; everything outside is eventually consistent.
+
+**Key insights:**
+- Entity test: "Am I the same thing even if all my attributes change?" (a person changes name and address -- still the same person)
+- Value Object test: "Am I defined only by my attributes?" (any $10 bill is interchangeable with another)
+- Most things should be Value Objects, not Entities -- prefer immutability
+- Keep aggregates small (one root plus a minimal cluster); reference other aggregates by ID, not object reference
+- Immediate consistency only within an aggregate; design for eventual consistency between aggregates
+
+**Code applications:**
+
+| Context | Pattern | Example |
+|---------|---------|---------|
+| Identity tracking | Entity with ID | `Order` identified by `orderId`, survives state changes |
+| Immutable attributes | Value Object | `Address(street, city, zip)` -- replace, never mutate |
+| Consistency boundary | Aggregate Root | `Order` is root; `OrderLine` items exist only through it |
+| Concurrency control | Optimistic locking on root | Version field on `Order`; conflict if two edits race |
+
+See: [references/building-blocks.md](references/building-blocks.md) for aggregate design rules and consistency boundaries.
+
+### 4. Domain Events
+
+**Core concept:** A domain event captures something that happened in the domain that experts care about, named in past tense (`OrderPlaced`, `PaymentReceived`) -- a fact that has already occurred.
+
+**Why it works:** Domain events decouple cause from effect. When `OrderPlaced` is published, shipping, billing, and notifications each react independently without the ordering context knowing about them -- less coupling, eventual consistency, a natural audit trail.
+
+**Key insights:**
+- Events are immutable facts -- once published, they cannot be changed or retracted
+- Domain events are internal to a bounded context; integration events cross boundaries
+- Events enable temporal decoupling: the producer does not wait for the consumer
+- Event sourcing stores the full event history as the source of truth, deriving current state by replay
+- Not every state change deserves an event -- only publish what the domain cares about
+
+**Code applications:**
+
+| Context | Pattern | Example |
+|---------|---------|---------|
+| State transitions | Raise event on domain action | `order.place()` raises `OrderPlaced` |
+| Cross-context integration | Publish integration event | `OrderPlaced` triggers `ShippingLabelRequested` in shipping context |
+| Eventual consistency | Async event handlers | Inventory handler updates stock asynchronously after `OrderPlaced` |
+
+See: [references/domain-events.md](references/domain-events.md) for event naming, event sourcing, and integration events.
+
+### 5. Repositories and Factories
+
+**Core concept:** Repositories provide the illusion of an in-memory collection of domain objects, hiding persistence. Factories encapsulate complex creation logic so aggregates are always born in a valid state.
+
+**Why it works:** When persistence and assembly details leak into domain code, every storage change ripples through business rules and aggregates can be constructed in half-valid states. Repositories confine SQL/ORM concerns to infrastructure so the domain stays testable in memory; factories make the only path to an aggregate one that enforces its invariants, so an invalid instance is unrepresentable.
+
+**Key insights:**
+- The Repository interface belongs in the domain layer; its implementation belongs in infrastructure
+- Repository methods speak the ubiquitous language: `findPendingOrders()`, not `getByStatusCode(3)`
+- Collection-oriented repositories mimic `add`/`remove`; persistence-oriented ones use `save`
+- Factories are warranted for complex rules or multi-part assembly; a two-field Value Object just needs a constructor
+- The Specification pattern encapsulates query criteria as domain objects: `OverdueInvoiceSpecification`
+
+**Code applications:**
+
+| Context | Pattern | Example |
+|---------|---------|---------|
+| Data access abstraction | Repository interface | `OrderRepository.findByCustomer(customerId)` in domain; `PostgresOrderRepository` in infrastructure |
+| Complex creation | Factory method | `Order.createFromQuote(quote)` validates and assembles from a `Quote` aggregate |
+| Query encapsulation | Specification | `spec = OverdueBy(days=30); repo.findMatching(spec)` |
+
+See: [references/repositories-factories.md](references/repositories-factories.md) for Repository, Factory, and Specification patterns.
+
+### 6. Strategic Design and Distillation
+
+**Core concept:** Not all parts of a system are equally important. Strategic design identifies the Core Domain -- where competitive advantage lives -- and distinguishes it from Supporting Subdomains (necessary, not differentiating) and Generic Subdomains (commodity).
+
+**Why it works:** Applying the same rigor everywhere spreads your best talent thin and over-engineers commodity functionality. Identifying the Core Domain concentrates the best developers and deepest modeling where they matter most.
+
+**Key insights:**
+- Core Domain: invest your best people and deepest modeling; Supporting: build, but don't over-engineer; Generic (auth, email, payments): buy or use open-source
+- Distillation extracts and highlights the Core Domain from surrounding complexity
+- A Domain Vision Statement is a one-page description of the Core Domain's value proposition
+- Revisit what is "core" as the business evolves -- today's differentiator may become tomorrow's commodity
+
+**Code applications:**
+
+| Context | Pattern | Example |
+|---------|---------|---------|
+| Build vs. buy | Classify subdomain type | Build custom pricing engine (core); use Stripe for payments (generic) |
+| Team allocation | Best developers on Core Domain | Seniors model underwriting rules; juniors integrate the email service |
+| Code organization | Separate core from generic | `domain/pricing/` (deep model) vs. `infrastructure/email/` (thin adapter) |
+
+See: [references/strategic-design.md](references/strategic-design.md) when deciding where to invest engineering effort -- subdomain classification and distillation techniques.
+
+## Common Mistakes
+
+| Mistake | Why It Fails | Fix |
+|---------|-------------|-----|
+| Technical names instead of domain language | Logic hidden behind `DataManager`; experts can't validate the model | Rename to domain terms (`ClaimAdjudicator`); if no domain term exists, the concept may be wrong |
+| One model to rule them all | A single `Customer` class for billing, shipping, and marketing becomes bloated and contradictory | Bounded contexts: each gets its own `Customer` with only the attributes it needs |
+| Giant aggregates | Concurrency conflicts, slow loads, transactional bottlenecks | Keep aggregates small; reference by ID; eventual consistency between them |
+| Anemic domain model | Objects are data bags; rules scatter across services and duplicate | Move behavior into entities and value objects; services orchestrate only |
+| No Anti-Corruption Layer | Foreign models leak in; code couples to external schemas | Wrap every external system behind a translation layer |
+| Bounded context = microservice | Premature extraction; distributed complexity without benefit | A context is a model boundary, not a deployment unit; start with modules in a monolith |
+| Skipping domain experts | Developers invent a model that doesn't match reality; expensive rework | Regular modeling sessions until experts say "yes, that is how it works" |
+
+## Quick Diagnostic
+
+| Question | If No | Action |
+|----------|-------|--------|
+| Can a domain expert read your class names and understand them? | Technical jargon hides the model | Rename classes, methods, events to ubiquitous language |
+| Are bounded context boundaries explicitly defined? | Models bleed; same term means different things | Draw a context map; define boundaries and translations |
+| Are aggregates small (one root + minimal cluster)? | Slow loads, concurrency issues | Split aggregates; reference by ID; accept eventual consistency |
+| Do domain objects contain behavior, not just data? | Anemic model; logic scattered in services | Move business rules into entities and value objects |
+| Are domain events used for cross-aggregate communication? | Tight coupling, synchronous chains | Introduce events; let aggregates react asynchronously |
+| Is there an Anti-Corruption Layer at every external integration? | Foreign models pollute your domain | Add a translation layer at each boundary |
+| Have you identified which subdomain is core? | Best talent spread thin | Classify subdomains; focus deep modeling on the Core Domain |
+
+## Further Reading
+
+For the complete methodology, patterns, and deeper insights:
+
+- [*"Domain-Driven Design: Tackling Complexity in the Heart of Software"*](https://www.amazon.com/Domain-Driven-Design-Tackling-Complexity-Software/dp/0321125215?tag=wondelai00-20) by Eric Evans
+
+## About the Author
+
+**Eric Evans** is a software design consultant and the originator of Domain-Driven Design, developed through work on large-scale systems in finance, insurance, and logistics. His 2003 book *Domain-Driven Design: Tackling Complexity in the Heart of Software* is one of the most influential software architecture books ever written, and he continues to evolve DDD through his consultancy, Domain Language.

--- a/.claude/skills/domain-driven-design/references/bounded-contexts.md
+++ b/.claude/skills/domain-driven-design/references/bounded-contexts.md
@@ -1,0 +1,203 @@
+# Bounded Contexts and Context Mapping
+
+A bounded context is the most important strategic pattern in Domain-Driven Design. It defines an explicit boundary within which a particular domain model is defined, consistent, and applicable. Context mapping describes the relationships between bounded contexts and the strategies for translating between them.
+
+## What Is a Bounded Context?
+
+A bounded context is not a module, a microservice, or a deployment unit -- though it may coincide with any of these. It is a linguistic boundary: within this boundary, every term has a single, precise meaning, and the model is internally consistent.
+
+### The Problem It Solves
+
+In any system of sufficient size, the same word means different things to different people:
+
+| Term | In Sales Context | In Shipping Context | In Billing Context |
+|------|-----------------|--------------------|--------------------|
+| Customer | A prospect or account with contact info and purchase history | A delivery address with receiving instructions | A billing entity with payment methods and credit terms |
+| Product | A catalog item with descriptions, images, and pricing tiers | A physical item with weight, dimensions, and handling requirements | A line item with a price, tax category, and discount rules |
+| Order | A quote or deal being negotiated | A shipment to be picked, packed, and dispatched | An invoice to be generated and collected |
+
+Trying to create a single `Customer` class that serves all three contexts produces a bloated, contradictory monstrosity with dozens of fields, most of which are irrelevant in any given use case. The bounded context pattern says: stop fighting this. Let each context have its own `Customer` model, optimized for its own needs.
+
+### Identifying Bounded Context Boundaries
+
+Boundaries emerge from several signals:
+
+**Linguistic signals:**
+- When the same term means different things to different groups, those groups are in different contexts
+- When conversations between groups require "translation" ("when you say X, do you mean Y?"), there is a boundary
+- When a concept exists in one group but has no analog in another, the boundary is clear
+
+**Organizational signals:**
+- Different teams owning different parts of the system
+- Different departments with different processes and vocabulary
+- Different regulatory requirements (e.g., PCI compliance for payments vs. HIPAA for patient data)
+
+**Technical signals:**
+- Different data storage needs (relational vs. document vs. event store)
+- Different consistency requirements (strong consistency for payments vs. eventual consistency for recommendations)
+- Different rate of change (billing rules change quarterly; product catalog changes daily)
+
+### Context Size
+
+There is no formula for the right size of a bounded context. However, guidelines help:
+
+- **Too large:** If a single context contains concepts that do not cohesively relate, it is too large. A context that contains both "insurance underwriting" and "marketing campaign management" is probably two contexts.
+- **Too small:** If you find yourself creating translation layers between closely related concepts that change together and are owned by the same team, you may have split too aggressively.
+- **Rule of thumb:** A bounded context should be ownable by a single team (5-9 people). If a context requires multiple teams to modify, it is either too large or the team boundaries are wrong.
+
+## Context Mapping Patterns
+
+Context mapping describes how bounded contexts relate to each other. Eric Evans and the DDD community have identified nine primary patterns. Each represents a different political and technical relationship.
+
+### 1. Shared Kernel
+
+**What it is:** Two bounded contexts share a small subset of the model, typically a library of common types. Both teams co-own this shared code and must coordinate changes.
+
+**When to use:** When two closely collaborating teams need the same domain concept (e.g., a `Money` value object or a `DateRange` type) and the overhead of translation is not justified.
+
+**Risks:** Coupling. Any change to the shared kernel requires coordination between both teams. If not carefully managed, the shared kernel grows uncontrollably.
+
+**Rules:**
+- Keep the shared kernel as small as possible -- value objects and basic types only
+- Require explicit agreement (both teams) for any change
+- Automated tests in both contexts must pass before any shared kernel change is merged
+- Never put entities or aggregates in the shared kernel
+
+**Example:** Two contexts (billing and shipping) share a `Money(amount, currency)` value object and an `Address(street, city, state, zip, country)` value object.
+
+### 2. Customer-Supplier
+
+**What it is:** An upstream context (supplier) provides data or services that a downstream context (customer) depends on. The upstream team plans with the downstream team's needs in mind but has its own priorities.
+
+**When to use:** When one team produces something another team consumes, and there is a reasonable working relationship. The downstream team can influence the upstream team's roadmap but does not control it.
+
+**Example:** The Product Catalog team (upstream) provides product data to the Pricing team (downstream). The Pricing team requests new attributes when needed, and the Catalog team accommodates these requests in their planning.
+
+### 3. Conformist
+
+**What it is:** The downstream context conforms to the upstream context's model without translation. The downstream team accepts the upstream model as-is, even if it is not ideal.
+
+**When to use:** When the upstream team has no incentive or ability to accommodate the downstream team (e.g., a large external service, a legacy system, or a dominant upstream team), and the cost of building a translation layer exceeds the cost of conforming.
+
+**Risks:** Your model is constrained by someone else's design decisions. If the upstream model changes, your context must change too.
+
+**Example:** A startup integrating with a major ERP system may conform to the ERP's data model rather than building translation layers, accepting the ERP's concept of "customer" and "order" even if they do not perfectly fit.
+
+### 4. Anti-Corruption Layer (ACL)
+
+**What it is:** A translation layer that sits between the downstream context and the upstream context, converting the upstream model into the downstream context's own domain language. The ACL protects the downstream model from being polluted by foreign concepts.
+
+**When to use:** When you need to integrate with a system whose model does not fit yours, and you cannot afford to let that foreign model leak into your domain. This is the most important defensive pattern in DDD.
+
+**Structure:**
+```
+Your Domain Layer  <-->  ACL (Adapters + Translators)  <-->  External System
+```
+
+The ACL contains:
+- **Adapters** that handle the technical protocol (HTTP, gRPC, message queue)
+- **Translators** that convert external model objects into your domain objects
+- **Facades** that present a clean interface to your domain layer
+
+**Example:** Integrating with a legacy mainframe that represents customers as `CUST_REC` with fields like `CUST_NM`, `CUST_ADDR1`. The ACL translates this into your domain's `Customer(name: PersonName, address: Address)` value objects.
+
+### 5. Open Host Service (OHS)
+
+**What it is:** An upstream context exposes a well-defined, documented protocol (API, message format) that downstream contexts can integrate with. The upstream team provides a stable, versioned interface designed for general consumption.
+
+**When to use:** When an upstream context serves multiple downstream consumers and cannot tailor its interface to each one. The OHS provides a standard integration point.
+
+**Characteristics:**
+- Versioned API with backward compatibility guarantees
+- Documentation and contracts (OpenAPI, protobuf schemas, JSON Schema)
+- The interface is deliberately designed for external consumption, not a direct exposure of the internal model
+
+**Example:** An Identity Provider exposes an OAuth 2.0 / OpenID Connect API. Any downstream context can integrate using the standard protocol without knowing the internal user model.
+
+### 6. Published Language
+
+**What it is:** A well-documented, shared language (schema, format, protocol) used for communication between contexts. Often paired with Open Host Service.
+
+**When to use:** When multiple contexts need to exchange data and a standard format prevents each integration from inventing its own.
+
+**Examples:**
+- Industry-standard formats: HL7 for healthcare, SWIFT for banking, EDI for supply chain
+- Internal schemas: a company-wide JSON schema for events published on a shared message bus
+- Protocol Buffers or Avro schemas for service-to-service communication
+
+### 7. Separate Ways
+
+**What it is:** Two contexts decide not to integrate at all. Each builds its own solution independently, even if there is some overlap.
+
+**When to use:** When the cost of integration (coordination, translation, coupling) exceeds the cost of duplication. Sometimes it is cheaper and simpler for two teams to build their own `Address` validation than to share one.
+
+**Signals that Separate Ways is appropriate:**
+- The integration would be trivial functionality on both sides
+- The teams are in different organizations with different release cycles
+- The shared functionality is not core to either context
+
+### 8. Big Ball of Mud
+
+**What it is:** A system with no clear boundaries, where models are entangled and concepts leak everywhere. This is not a recommended pattern -- it is a recognition of reality. Many existing systems are Big Balls of Mud.
+
+**When to use (as a label):** When mapping an existing landscape, some systems simply are Big Balls of Mud. Acknowledging this is the first step toward improvement. Drawing a boundary around the mud and treating it as a single (messy) context allows you to build clean contexts alongside it, protected by an ACL.
+
+**Migration strategy:**
+1. Draw a boundary around the entire mudball
+2. Build new functionality in a clean bounded context
+3. Protect the new context with an ACL against the mudball
+4. Gradually extract functionality from the mud into clean contexts
+
+### 9. Partnership
+
+**What it is:** Two contexts evolve together with mutual coordination. Both teams jointly plan features and synchronize releases. Neither dominates.
+
+**When to use:** When two contexts are tightly coupled in the domain and both teams are committed to evolving together. More intimate than Customer-Supplier; both teams have equal say.
+
+**Risks:** Requires strong coordination discipline. If one team slips, both are affected.
+
+**Example:** A checkout context and a payment processing context that must evolve in lockstep when payment methods change.
+
+## Team Relationships and Context Boundaries
+
+### Conway's Law in Practice
+
+Conway's Law states that systems mirror the communication structures of the organizations that build them. In DDD, this is not a warning -- it is a design tool:
+
+- **Align context boundaries with team boundaries.** If one team owns billing and another owns shipping, these should be separate bounded contexts.
+- **If two teams must share a context, expect friction.** Either split the context or merge the teams.
+- **Cross-team integration should happen at context boundaries,** using well-defined mapping patterns, not through shared code or databases.
+
+### Choosing the Right Pattern
+
+| Situation | Recommended Pattern |
+|-----------|-------------------|
+| Two teams with a good relationship and shared concepts | Shared Kernel (kept small) or Customer-Supplier |
+| Integrating with a system you do not control | Anti-Corruption Layer |
+| Exposing your context to many consumers | Open Host Service + Published Language |
+| Integrating with a hostile or unresponsive upstream | Conformist (if cost is low) or Separate Ways |
+| Legacy system with no clear model | Big Ball of Mud (label it) + ACL around it |
+| Two teams that must evolve in lockstep | Partnership |
+| Integration cost exceeds duplication cost | Separate Ways |
+
+### Drawing a Context Map
+
+A context map is a visual representation of all bounded contexts and their relationships. It should include:
+
+1. **Every bounded context** drawn as a labeled box
+2. **The relationships between them** using the patterns above (arrows show upstream/downstream)
+3. **The translation mechanism** (ACL, OHS, Shared Kernel)
+4. **Team ownership** for each context
+5. **The Big Balls of Mud** explicitly labeled
+
+The context map is a communication tool. It should be understandable by both developers and non-technical stakeholders. Keep it on a whiteboard or in a shared diagram that the team references and updates regularly.
+
+### When Boundaries Change
+
+Context boundaries are not permanent. They evolve as the business and team structure change:
+
+- **Splitting:** A context grows too large for one team; split it along natural seams and introduce a mapping pattern between the new contexts.
+- **Merging:** Two small contexts owned by the same team with heavy inter-communication; merge them and eliminate the translation overhead.
+- **Reclassifying:** A context that was Generic Subdomain becomes Core Domain as business strategy shifts; increase investment and modeling rigor.
+
+The key is to make boundaries explicit and intentional, so that when they need to change, the change is a deliberate design decision rather than an accidental drift.

--- a/.claude/skills/domain-driven-design/references/building-blocks.md
+++ b/.claude/skills/domain-driven-design/references/building-blocks.md
@@ -1,0 +1,234 @@
+# Building Blocks: Entities, Value Objects, and Aggregates
+
+The tactical building blocks of Domain-Driven Design provide a vocabulary for structuring domain models. Entities, Value Objects, and Aggregates are the three most critical patterns. Getting them right determines whether a domain model is expressive and maintainable or bloated and fragile.
+
+## Entities
+
+An Entity is a domain object defined by its identity rather than its attributes. An entity persists across time and state changes -- it is the "same thing" even when everything about it changes.
+
+### The Identity Test
+
+Ask: "If all the attributes change, is it still the same thing?"
+
+- A **person** changes name, address, phone number, job, and appearance -- still the same person. **Entity.**
+- A **bank account** changes its balance daily -- still the same account. **Entity.**
+- A **$10 bill** is interchangeable with any other $10 bill. **Not an entity -- Value Object.**
+
+### Identity Strategies
+
+| Strategy | How It Works | When to Use |
+|----------|-------------|-------------|
+| Natural key | Use a real-world identifier (SSN, ISBN, VIN) | When a stable, unique external identifier exists |
+| Surrogate key | Generate a synthetic ID (UUID, auto-increment) | When no natural key exists or the natural key can change |
+| Composite key | Combine multiple attributes | When identity is defined by a relationship (e.g., student + course = enrollment) |
+
+**Prefer UUIDs over auto-increment** for distributed systems. UUIDs can be generated anywhere without coordination; auto-increment requires a central authority.
+
+### Entity Design Rules
+
+1. **Identity is immutable.** Once assigned, an entity's identity never changes. If the "identity" can change, it is not really the identity.
+2. **Entities are mutable.** Unlike Value Objects, entities change state over time. An `Order` moves from `Pending` to `Confirmed` to `Shipped`.
+3. **Equality is based on identity.** Two `Order` objects with the same `orderId` are the same order, regardless of other attribute differences.
+4. **Entities have a lifecycle.** They are created, go through state transitions, and may eventually be archived or deleted.
+5. **Put behavior on entities.** An entity is not a data container. `order.addItem(product, quantity)` belongs on the `Order` entity, not in an `OrderService`.
+
+### Common Entity Pitfalls
+
+- **Over-identification.** Making everything an entity when most things should be Value Objects. Ask the identity test for every class.
+- **Anemic entities.** Entities with only getters and setters. If all behavior is in services, the entity is a data bag.
+- **Identity leakage.** Exposing database primary keys as domain identity. Use domain-meaningful identifiers (`orderNumber`) rather than technical ones (`id: 42`).
+
+## Value Objects
+
+A Value Object is a domain object defined entirely by its attributes. It has no identity -- two Value Objects with the same attributes are interchangeable. Value Objects are immutable: you do not change a Value Object; you replace it.
+
+### The Attribute Test
+
+Ask: "Is it defined by what it is, not which one it is?"
+
+- A **mailing address** (123 Main St, Springfield, IL 62704) -- defined by its attributes. Two objects with the same street, city, state, zip are the same address. **Value Object.**
+- A **money amount** ($49.99 USD) -- defined by amount and currency. **Value Object.**
+- A **date range** (Jan 1 - Dec 31) -- defined by start and end. **Value Object.**
+- A **color** (#FF5733) -- defined by its hex value. **Value Object.**
+
+### Why Value Objects Matter
+
+Value Objects are the unsung heroes of domain models. Most developers default to entities for everything, but **the majority of concepts in a well-designed domain model should be Value Objects.**
+
+**Benefits of Value Objects:**
+
+| Benefit | Explanation |
+|---------|-------------|
+| Immutability | No shared mutable state; safe to pass around, cache, and use in concurrent code |
+| Side-effect-free behavior | Methods return new Value Objects rather than mutating state; easy to reason about |
+| Self-validation | A Value Object validates itself on creation; an invalid Value Object can never exist |
+| Equality by value | `Money(100, "USD") == Money(100, "USD")` regardless of object reference |
+| Expressiveness | `Money` instead of `BigDecimal`; `EmailAddress` instead of `String`; domain meaning is encoded in the type |
+
+### Value Object Design Rules
+
+1. **Immutable.** All fields are set at construction and never change. No setters.
+2. **Self-validating.** A `Money` object with a negative amount or null currency should throw on construction. If it exists, it is valid.
+3. **Equality by attributes.** Override `equals()` and `hashCode()` to compare all attributes.
+4. **Side-effect-free methods.** `money.add(other)` returns a new `Money`; it does not mutate the original.
+5. **Replace, don't modify.** To change an address, create a new `Address` and assign it. `customer.changeAddress(newAddress)`.
+
+### Common Value Objects
+
+| Value Object | Replaces | Why It Is Better |
+|-------------|---------|------------------|
+| `Money(amount, currency)` | `BigDecimal` | Prevents currency mismatch errors; encapsulates rounding rules |
+| `EmailAddress(value)` | `String` | Validates format on construction; impossible to have invalid email in the system |
+| `DateRange(start, end)` | Two `Date` fields | Enforces `start <= end`; contains overlap/contains logic |
+| `Address(street, city, state, zip)` | Multiple String fields | Groups related data; validates as a unit |
+| `Quantity(value, unit)` | `int` or `double` | Prevents unit mismatch (adding kilograms to liters) |
+| `PhoneNumber(countryCode, number)` | `String` | Validates format; normalizes representation |
+
+### When to Use Value Objects vs. Entities
+
+| Signal | Entity | Value Object |
+|--------|--------|-------------|
+| Needs to be tracked over time | Yes | No |
+| Has a lifecycle (created, modified, archived) | Yes | No -- replaced, not modified |
+| Two instances with same attributes are different things | Yes | No -- they are the same thing |
+| Immutability is natural | No | Yes |
+| Appears in the model as a measurement, description, or attribute | No | Yes |
+
+**Rule of thumb:** If in doubt, make it a Value Object. You can always promote it to an Entity later if identity becomes important. Going the other direction (demoting an Entity to a Value Object) is much harder.
+
+## Aggregates
+
+An Aggregate is a cluster of domain objects (entities and value objects) treated as a single unit for data changes. Every aggregate has a single root entity -- the Aggregate Root -- through which all external access occurs.
+
+### Why Aggregates Exist
+
+Without aggregates, any object in the system can hold a reference to any other object and modify it directly. This creates an impossibly tangled web of dependencies where enforcing business invariants (rules that must always be true) becomes a nightmare.
+
+Aggregates solve this by drawing a boundary:
+- **Inside the boundary:** Strong consistency. All invariants are enforced within a single transaction.
+- **Outside the boundary:** Eventual consistency. Changes propagate via domain events or polling.
+
+### Aggregate Design Rules
+
+Eric Evans and Vaughn Vernon established these rules, refined by the DDD community:
+
+#### Rule 1: Protect Business Invariants Inside the Aggregate
+
+An invariant is a rule that must always be true. Example: "An order's total must equal the sum of its line items." This invariant involves `Order` and `OrderLineItem`. Both belong in the same aggregate because the invariant spans both.
+
+| If the invariant spans... | Then... |
+|--------------------------|---------|
+| A single entity | That entity is its own aggregate |
+| An entity and its closely related objects | They form one aggregate |
+| Two independently identifiable things | They are separate aggregates; enforce the rule via eventual consistency or a domain event |
+
+#### Rule 2: Small Aggregates
+
+Large aggregates cause:
+- **Concurrency conflicts.** Two users editing different parts of the same large aggregate will conflict.
+- **Performance problems.** Loading a large aggregate means loading everything it contains.
+- **Transaction scope bloat.** Larger transaction scope means longer locks and more contention.
+
+**Ideal aggregate size:** One root entity, a small set of value objects, and occasionally a small collection of child entities (e.g., `Order` with `OrderLineItems`).
+
+**Anti-pattern:** An `Organization` aggregate that contains `Departments` which contain `Employees` which contain `Assignments`. This is too large. `Employee` should be its own aggregate, referencing `Organization` and `Department` by ID.
+
+#### Rule 3: Reference Other Aggregates by ID Only
+
+Do not hold direct object references to other aggregates. Instead, store only the identifier:
+
+**Wrong:**
+```
+class Order {
+  Customer customer;  // Direct reference to another aggregate
+}
+```
+
+**Right:**
+```
+class Order {
+  CustomerId customerId;  // Reference by ID only
+}
+```
+
+**Why:** Direct references create tight coupling, prevent independent scaling, and make it impossible to enforce aggregate boundaries. With ID references, each aggregate can be loaded, stored, and cached independently.
+
+#### Rule 4: Use Eventual Consistency Across Aggregate Boundaries
+
+When one aggregate's action should trigger a change in another aggregate, do not try to update both in the same transaction. Instead:
+
+1. The first aggregate performs its action and publishes a domain event
+2. An event handler picks up the event and modifies the second aggregate in a separate transaction
+
+**Example:**
+- `Order.place()` publishes `OrderPlaced` event
+- `InventoryHandler` receives `OrderPlaced` and calls `inventory.reserve(items)`
+- These are two separate transactions
+
+### Choosing Aggregate Boundaries
+
+#### Start with the Invariant
+
+Identify every business invariant. Group objects that participate in the same invariant into the same aggregate.
+
+**Example invariants:**
+| Invariant | Objects Involved | Aggregate |
+|-----------|-----------------|-----------|
+| "An order total must equal the sum of its lines" | Order, OrderLineItem | Order aggregate |
+| "A product must have at least one category" | Product, Category | Product aggregate (Category is a value object or ID reference) |
+| "An account balance must never go below the overdraft limit" | Account | Account aggregate (single entity) |
+| "A reservation cannot overlap with another for the same room" | Reservation | Reservation aggregate (overlap check is a domain service or repository query, not a cross-aggregate invariant) |
+
+#### The Transaction Boundary Test
+
+Ask: "Must these two changes happen atomically, or can they happen with a small delay?"
+
+- If **atomically**: same aggregate
+- If **small delay is acceptable**: separate aggregates with eventual consistency
+
+Most of the time, a small delay is acceptable. Humans rarely need true atomicity outside of financial transactions.
+
+### Aggregate Root Pattern
+
+The Aggregate Root is the single entity through which all external interaction with the aggregate occurs:
+
+**Rules for the root:**
+1. External objects may only hold references to the root, never to internal entities
+2. All changes to the aggregate go through the root's methods
+3. The root enforces all aggregate invariants
+4. The root controls the lifecycle of all internal objects
+5. Delete the root and everything inside the aggregate is deleted
+
+**Example:**
+```
+// External code interacts only with Order (the root)
+order.addLineItem(product, quantity, price)
+order.removeLineItem(lineItemId)
+order.calculateTotal()
+
+// LineItems are never accessed directly from outside
+// WRONG: lineItem.changeQuantity(5)
+// RIGHT: order.changeLineItemQuantity(lineItemId, 5)
+```
+
+### Common Aggregate Mistakes
+
+| Mistake | Consequence | Fix |
+|---------|------------|-----|
+| Making the entire object graph one aggregate | Concurrency nightmares, slow loading | Split into multiple aggregates; reference by ID |
+| Holding direct references to other aggregates | Tight coupling; cannot enforce boundaries | Replace with ID references |
+| Updating multiple aggregates in one transaction | Distributed lock contention; scaling bottleneck | Use domain events for cross-aggregate consistency |
+| Putting all logic in services instead of the aggregate root | Anemic aggregate; invariants not enforced | Move invariant-enforcing logic into the aggregate root |
+| Creating aggregates based on database tables | Data model drives domain model (backward) | Design aggregates from domain invariants, then map to persistence |
+
+## Putting It All Together
+
+A well-designed domain model has this structure:
+
+1. **Value Objects** form the majority of types -- measurements, descriptions, identifiers, small composites
+2. **Entities** represent things with identity and lifecycle -- fewer than you think
+3. **Aggregates** cluster related entities and value objects behind a root -- enforcing consistency boundaries
+4. **References between aggregates** are by ID only -- enabling independent evolution
+5. **Cross-aggregate consistency** is achieved through domain events -- eventual consistency is the default
+
+The result is a model that is expressive (reads like the business), consistent (invariants are enforced), and scalable (aggregates are independent units of consistency, persistence, and caching).

--- a/.claude/skills/domain-driven-design/references/domain-events.md
+++ b/.claude/skills/domain-driven-design/references/domain-events.md
@@ -1,0 +1,264 @@
+# Domain Events
+
+A domain event represents something that happened in the domain that domain experts care about. Events are named in past tense, are immutable facts, and serve as the primary mechanism for decoupling bounded contexts and achieving eventual consistency across aggregate boundaries.
+
+## What Domain Events Are
+
+A domain event captures a meaningful occurrence in the business domain. "Meaningful" means that a domain expert would recognize it as significant -- not just a technical state change.
+
+### Domain Events vs. Technical Events
+
+| Domain Event | Technical Event | Why It Matters |
+|-------------|----------------|----------------|
+| `OrderPlaced` | `RowInserted` | The domain expert cares about orders being placed; they do not care about database rows |
+| `PaymentReceived` | `WebhookProcessed` | The business reacts to payments; the webhook is an implementation detail |
+| `ClaimDenied` | `StatusUpdated` | Denial triggers business processes (appeals, notifications); a status update triggers nothing meaningful |
+| `InventoryDepleted` | `CountReachedZero` | The business has specific procedures for depleted inventory; zero is just a number |
+
+### The Litmus Test
+
+Ask a domain expert: "Would you care if this happened?" If yes, it is a domain event. If they shrug, it is a technical event that belongs in infrastructure, not in the domain model.
+
+## Naming Domain Events
+
+### The Past-Tense Rule
+
+Domain events are always named in past tense because they represent facts that have already occurred. By the time anyone processes the event, the thing has already happened.
+
+**Correct naming:**
+- `OrderPlaced` -- an order was placed
+- `PaymentReceived` -- a payment was received
+- `ShipmentDispatched` -- a shipment was dispatched
+- `AccountSuspended` -- an account was suspended
+- `PolicyRenewed` -- a policy was renewed
+
+**Incorrect naming:**
+- `PlaceOrder` -- this is a command, not an event
+- `OrderPlacing` -- this implies the action is in progress
+- `OrderEvent` -- too generic; what happened?
+- `OrderUpdate` -- "update" is not a domain concept; what specifically changed?
+
+### Naming Specificity
+
+Be specific about what happened. Vague event names create the same problems as vague method names -- consumers cannot understand what occurred without reading the payload.
+
+| Vague | Specific | Why Specific Is Better |
+|-------|----------|----------------------|
+| `OrderChanged` | `OrderItemAdded`, `OrderItemRemoved`, `OrderAddressChanged` | Different changes trigger different business reactions |
+| `UserUpdated` | `UserEmailVerified`, `UserPasswordChanged`, `UserProfileCompleted` | A password change requires a security audit; a profile completion triggers onboarding flow |
+| `PaymentProcessed` | `PaymentAuthorized`, `PaymentCaptured`, `PaymentRefunded` | Authorization and capture are distinct business steps with different downstream effects |
+
+### Event Naming Conventions
+
+Adopt a consistent naming pattern across the codebase:
+
+```
+{AggregateType}{DomainAction}
+```
+
+Examples:
+- `OrderPlaced`, `OrderCancelled`, `OrderFulfilled`
+- `InvoiceSent`, `InvoicePaid`, `InvoiceOverdue`
+- `MemberRegistered`, `MemberSuspended`, `MemberReinstated`
+
+## Event Structure
+
+A well-designed domain event contains:
+
+| Field | Purpose | Example |
+|-------|---------|---------|
+| `eventId` | Unique identifier for this specific event occurrence | `uuid("a1b2c3d4...")` |
+| `eventType` | The name of the event | `"OrderPlaced"` |
+| `occurredAt` | When the event happened | `"2024-03-15T14:30:00Z"` |
+| `aggregateId` | The ID of the aggregate that produced the event | `orderId: "ORD-12345"` |
+| `aggregateType` | The type of aggregate | `"Order"` |
+| `payload` | The domain-relevant data | `{ customerId, items, total, shippingAddress }` |
+| `metadata` | Technical metadata (correlation ID, causation ID, user ID) | `{ correlationId, userId }` |
+
+### What Goes in the Payload
+
+Include enough data for consumers to react without calling back to the producer:
+
+**Too little:**
+```json
+{ "orderId": "ORD-12345" }
+```
+Every consumer must call back to the Order service to get details. This creates coupling and latency.
+
+**Too much:**
+```json
+{ "order": { /* entire order aggregate serialized */ } }
+```
+This bloats messages, exposes internal model details, and creates tight coupling to the aggregate structure.
+
+**Just right:**
+```json
+{
+  "orderId": "ORD-12345",
+  "customerId": "CUST-789",
+  "items": [
+    { "productId": "PROD-1", "quantity": 2, "unitPrice": 29.99 }
+  ],
+  "totalAmount": 59.98,
+  "currency": "USD",
+  "shippingAddress": { "city": "Springfield", "state": "IL" }
+}
+```
+Enough for most consumers to react; detailed enough to avoid callbacks for common cases.
+
+## Publishing Domain Events
+
+### Where Events Are Raised
+
+Domain events are raised within the aggregate, as part of the domain operation that caused them:
+
+```
+class Order:
+    def place(self):
+        self._validate_can_be_placed()
+        self.status = OrderStatus.PLACED
+        self._raise_event(OrderPlaced(
+            order_id=self.id,
+            customer_id=self.customer_id,
+            items=self.items,
+            total=self.total
+        ))
+```
+
+The aggregate records the event internally. An infrastructure mechanism (event dispatcher, outbox pattern) publishes it after the aggregate is persisted.
+
+### The Outbox Pattern
+
+The most reliable way to publish domain events is the transactional outbox:
+
+1. Within the same database transaction that persists the aggregate, insert the event into an `outbox` table
+2. A separate process (poller or CDC -- Change Data Capture) reads from the outbox and publishes to the message broker
+3. After successful publication, mark the outbox entry as published
+
+**Why this matters:** If you publish the event and then save the aggregate, the save might fail -- you published a lie. If you save the aggregate and then publish, the publish might fail -- the event is lost. The outbox pattern ties both operations to the same database transaction.
+
+### Delivery Guarantees
+
+| Guarantee | Meaning | Implementation |
+|-----------|---------|----------------|
+| At-most-once | Events may be lost but never duplicated | Fire-and-forget; no outbox; acceptable for non-critical events |
+| At-least-once | Events are never lost but may be duplicated | Outbox pattern with retry; consumers must be idempotent |
+| Exactly-once | Events are delivered exactly once | Practically impossible in distributed systems; achieve via at-least-once + idempotent consumers |
+
+**At-least-once with idempotent consumers** is the standard approach. Design every event handler to be safe to run multiple times with the same event.
+
+## Domain Events for Cross-Context Integration
+
+### Internal vs. Integration Events
+
+| Aspect | Domain Event (Internal) | Integration Event (External) |
+|--------|------------------------|------------------------------|
+| Scope | Within a bounded context | Across bounded contexts |
+| Audience | Event handlers in the same context | Other teams' services |
+| Schema | Can change freely with the model | Must be versioned and backward-compatible |
+| Naming | Uses internal ubiquitous language | Uses published language (shared schema) |
+| Transport | In-process event bus or same database | Message broker (Kafka, RabbitMQ, SNS) |
+
+### Translation at the Boundary
+
+When a domain event crosses a bounded context boundary, it should be translated into an integration event that uses the published language:
+
+1. **Order context** raises `OrderPlaced` (domain event, internal language)
+2. **Anti-corruption layer** translates to `PurchaseCompleted` (integration event, published language)
+3. **Shipping context** receives `PurchaseCompleted` and translates to `ShipmentRequested` (domain event, shipping language)
+
+This translation prevents internal model changes from breaking external consumers.
+
+### Event-Driven Architecture Patterns
+
+#### Event Notification
+
+The event carries minimal data ("something happened") and consumers call back for details. Simplest pattern but creates temporal coupling.
+
+#### Event-Carried State Transfer
+
+The event carries all the data consumers need. Consumers maintain their own local copy of relevant data, reducing coupling but increasing event size and requiring consumers to maintain projections.
+
+#### Event Sourcing
+
+Events are the source of truth. Current state is derived by replaying events. This is the most powerful and most complex pattern.
+
+## Event Sourcing
+
+Event sourcing stores the complete history of state changes as an ordered sequence of events. Instead of storing only the current state ("account balance is $1,000"), the system stores every event that led to that state ("deposited $500, deposited $800, withdrew $300").
+
+### When to Use Event Sourcing
+
+| Good Fit | Poor Fit |
+|----------|----------|
+| Audit requirements (financial, medical, legal) | Simple CRUD with no audit needs |
+| Complex domain with many state transitions | Domains with few state changes |
+| Need to answer "how did we get here?" | Only need current state |
+| Need to rebuild state at any point in time | No temporal query requirements |
+| High-value domain events that are worth preserving | High-volume, low-value data (telemetry) |
+
+### Event Sourcing Mechanics
+
+**Storing events:**
+```
+Stream: Order-12345
+  1: OrderCreated { customerId, items }
+  2: PaymentAuthorized { paymentId, amount }
+  3: OrderConfirmed { confirmedAt }
+  4: ItemShipped { trackingNumber, items }
+  5: OrderDelivered { deliveredAt, signedBy }
+```
+
+**Rebuilding state:**
+```
+currentState = OrderCreated.apply(emptyOrder)
+currentState = PaymentAuthorized.apply(currentState)
+currentState = OrderConfirmed.apply(currentState)
+currentState = ItemShipped.apply(currentState)
+currentState = OrderDelivered.apply(currentState)
+```
+
+**Snapshots** optimize performance: periodically save the current state so you do not need to replay from the beginning every time.
+
+### Event Sourcing Challenges
+
+| Challenge | Solution |
+|-----------|----------|
+| Event schema evolution | Use upcasters to transform old events into the current schema; never delete old events |
+| Performance with long event streams | Snapshots at regular intervals; read models for queries |
+| Complexity | Only use event sourcing for aggregates where it provides clear value; not everything needs to be event-sourced |
+| Debugging | Event logs provide excellent debugging and auditing; invest in tooling to browse and replay events |
+
+## Patterns for Event Handling
+
+### Idempotent Handlers
+
+Every event handler must be safe to execute multiple times with the same event. Strategies:
+
+- **Idempotency key:** Store processed event IDs; skip duplicates
+- **Idempotent operations:** Design the operation itself to be naturally idempotent (e.g., "set balance to X" instead of "add Y to balance")
+- **Conditional writes:** Use optimistic concurrency (version checks) to prevent double-application
+
+### Ordering Guarantees
+
+Events from the same aggregate should be processed in order. Events from different aggregates have no ordering guarantees. Design consumers accordingly:
+
+- Partition by aggregate ID in the message broker (Kafka partition key = aggregate ID)
+- Handle out-of-order events gracefully (check event version, buffer and reorder if needed)
+
+### Dead Letter Handling
+
+Events that repeatedly fail to process should be routed to a dead letter queue for investigation. Never silently drop failed events. Monitor dead letter queues actively.
+
+### Sagas and Process Managers
+
+Long-running business processes that span multiple aggregates or bounded contexts can be coordinated using sagas:
+
+1. `OrderPlaced` triggers the saga
+2. Saga sends `ReserveInventory` command
+3. `InventoryReserved` event continues the saga
+4. Saga sends `AuthorizePayment` command
+5. `PaymentAuthorized` event continues the saga
+6. If any step fails, the saga sends compensating commands (`ReleaseInventory`, `RefundPayment`)
+
+Sagas maintain their own state and react to events. They do not hold locks -- they coordinate through events and compensating actions.

--- a/.claude/skills/domain-driven-design/references/repositories-factories.md
+++ b/.claude/skills/domain-driven-design/references/repositories-factories.md
@@ -1,0 +1,353 @@
+# Repositories and Factories
+
+Repositories and Factories are infrastructure-facing patterns in Domain-Driven Design that separate domain logic from persistence and object creation concerns. The Repository provides the illusion of an in-memory collection of aggregates. The Factory encapsulates complex creation logic. Together, they keep the domain model clean and focused on business rules.
+
+
+## Table of Contents
+1. [The Repository Pattern](#the-repository-pattern)
+2. [The Factory Pattern](#the-factory-pattern)
+3. [The Specification Pattern](#the-specification-pattern)
+4. [Ports and Adapters Relationship](#ports-and-adapters-relationship)
+
+---
+
+## The Repository Pattern
+
+A Repository mediates between the domain and data mapping layers, acting like an in-memory collection of domain objects. Domain code uses the repository to obtain aggregates without knowing how they are stored, queried, or reconstructed.
+
+### Why Repositories Exist
+
+Without repositories, domain logic becomes tangled with data access:
+
+```
+// Without repository -- domain logic polluted with SQL
+def approve_claim(claim_id):
+    row = db.execute("SELECT * FROM claims WHERE id = ?", claim_id)
+    claim = Claim(row['id'], row['status'], row['amount'])
+    claim.approve()
+    db.execute("UPDATE claims SET status = ? WHERE id = ?", claim.status, claim.id)
+```
+
+```
+// With repository -- domain logic is clean
+def approve_claim(claim_id):
+    claim = claim_repository.find_by_id(claim_id)
+    claim.approve()
+    claim_repository.save(claim)
+```
+
+The second version is readable by a domain expert. The first is not.
+
+### Repository Interface Design
+
+The repository interface belongs in the domain layer. It speaks the ubiquitous language:
+
+**Good repository methods:**
+- `find_by_id(order_id)` -- straightforward identity lookup
+- `find_pending_orders()` -- uses domain language ("pending")
+- `find_by_customer(customer_id)` -- domain-meaningful query
+- `find_overdue_invoices(as_of_date)` -- business concept in the method name
+
+**Bad repository methods:**
+- `get_by_status_code(3)` -- magic number; what is status 3?
+- `query(sql_string)` -- leaks persistence technology into the domain
+- `find_all_with_joins()` -- technical concern, not domain language
+- `get_by_column("status", "PENDING")` -- generic data access, not domain query
+
+### Collection-Oriented vs. Persistence-Oriented Repositories
+
+Eric Evans described two flavors of repository, each modeling a different metaphor:
+
+#### Collection-Oriented Repository
+
+Models the repository as an in-memory collection. You add objects to it and remove objects from it. Changes to retrieved objects are automatically tracked and persisted (like JPA/Hibernate managed entities).
+
+```
+interface OrderRepository:
+    add(order)           # Like collection.add()
+    remove(order)        # Like collection.remove()
+    find_by_id(id)       # Like collection.find()
+    # No explicit save() -- changes to retrieved objects are auto-tracked
+```
+
+**Best with:** ORMs that support change tracking (JPA/Hibernate, Entity Framework).
+
+**Advantages:** Clean domain model; changes feel natural; no explicit save calls.
+
+**Disadvantages:** "Magic" change tracking can surprise developers; harder to reason about when persistence happens.
+
+#### Persistence-Oriented Repository
+
+Models the repository as a storage mechanism. You explicitly save objects and the repository does not track changes automatically.
+
+```
+interface OrderRepository:
+    save(order)          # Explicit persist/update
+    delete(order_id)     # Explicit remove
+    find_by_id(id)       # Retrieve
+    # Must call save() explicitly after making changes
+```
+
+**Best with:** Frameworks without change tracking (most non-ORM approaches, event sourcing, document stores).
+
+**Advantages:** Explicit control over when persistence happens; no surprises; easier to test.
+
+**Disadvantages:** Must remember to call save(); risk of losing changes if save is forgotten.
+
+**Which to choose:** If your persistence technology offers change tracking and your team is comfortable with it, use collection-oriented. Otherwise, use persistence-oriented. The persistence-oriented style is more common in modern applications because it is more explicit.
+
+### Repository Implementation
+
+The repository interface lives in the domain layer. The implementation lives in the infrastructure layer. This is the Dependency Inversion Principle in action:
+
+```
+domain/
+    model/
+        Order.py              # Aggregate root
+        OrderLineItem.py      # Entity within aggregate
+    repository/
+        OrderRepository.py    # Interface (abstract class / protocol)
+
+infrastructure/
+    persistence/
+        PostgresOrderRepository.py    # Implementation
+        InMemoryOrderRepository.py    # Implementation for tests
+```
+
+The domain layer defines what it needs (the interface). The infrastructure layer provides it (the implementation). The domain never imports from infrastructure.
+
+### What a Repository Returns
+
+A repository always returns fully constituted aggregates -- not partial objects, not DTOs, not database rows. The aggregate returned from a repository must be in a valid state with all its invariants satisfied.
+
+**Correct:** `order_repository.find_by_id(id)` returns an `Order` with all its `OrderLineItems` loaded, ready to have business operations performed on it.
+
+**Incorrect:** `order_repository.find_by_id(id)` returns an `OrderDTO` with some fields populated and others lazily loaded. The caller must check which fields are available.
+
+### Repository Anti-Patterns
+
+| Anti-Pattern | Problem | Fix |
+|-------------|---------|-----|
+| Generic repository (`Repository<T>`) | All aggregates look the same; domain-specific queries do not fit the generic interface | Create specific repository interfaces per aggregate type |
+| Repository returns DTOs | DTOs are not domain objects; behavior cannot be called on them | Return full aggregates; use separate read models (CQRS) for queries |
+| Repository per entity (not per aggregate) | Bypasses aggregate root; allows direct modification of internal entities | One repository per aggregate root only |
+| Repository with business logic | Repository starts containing validation or transformation logic | Keep repositories as pure storage; domain logic belongs in the aggregate |
+| Repository depends on domain services | Circular dependency between domain services and repositories | Repositories depend only on the domain model (aggregates, value objects) |
+
+## The Factory Pattern
+
+A Factory encapsulates the logic of creating a domain object, ensuring that the object is fully formed and valid from the moment it exists. In DDD, factories are used when object creation is complex enough to warrant its own abstraction.
+
+### When to Use a Factory
+
+| Situation | Factory Needed? | Why |
+|-----------|----------------|-----|
+| Creating a Value Object with 2-3 fields | No | A constructor suffices: `Money(100, "USD")` |
+| Creating an aggregate with multiple parts and validation rules | Yes | The assembly logic is complex; a constructor would be enormous |
+| Creating an object from an external representation (API response, file) | Yes | Translation from external format to domain object is a separate concern |
+| Creating an object with conditional logic (different subtypes) | Yes | The decision of which subtype to create should not be in client code |
+| Reconstituting an object from persistence | Maybe | If the repository handles it, a separate factory may not be needed |
+
+### Factory Patterns in DDD
+
+#### Factory Method on the Aggregate
+
+The most common pattern: a static or class method on the aggregate itself:
+
+```
+class Order:
+    @staticmethod
+    def create_from_cart(cart, customer_id):
+        # Validates cart is not empty
+        # Converts cart items to OrderLineItems
+        # Calculates initial total
+        # Returns a fully valid Order
+        order = Order(
+            id=OrderId.generate(),
+            customer_id=customer_id,
+            status=OrderStatus.PENDING,
+            items=[OrderLineItem.from_cart_item(item) for item in cart.items],
+            total=cart.calculate_total()
+        )
+        order._raise_event(OrderCreated(...))
+        return order
+```
+
+**Advantages:** Creation logic lives close to the aggregate. The aggregate controls its own birth.
+
+#### Factory Method on Another Aggregate
+
+When one aggregate creates another:
+
+```
+class Quote:
+    def convert_to_order(self):
+        # Quote knows how to create an Order from itself
+        order = Order(
+            id=OrderId.generate(),
+            customer_id=self.customer_id,
+            items=[OrderLineItem(item.product_id, item.quantity, item.quoted_price)
+                   for item in self.line_items],
+            source_quote_id=self.id
+        )
+        return order
+```
+
+#### Standalone Factory
+
+When creation logic does not naturally belong to any existing aggregate:
+
+```
+class LoanApplicationFactory:
+    def create_from_submission(self, submission, credit_report):
+        # Complex assembly involving multiple inputs
+        # Conditional logic based on loan type
+        # Validation against business rules
+        applicant = Applicant(submission.name, submission.ssn)
+        risk_score = RiskScore.calculate(credit_report)
+
+        if submission.loan_type == "mortgage":
+            return MortgageApplication(applicant, risk_score, submission.property)
+        elif submission.loan_type == "auto":
+            return AutoLoanApplication(applicant, risk_score, submission.vehicle)
+```
+
+### Factory Invariants
+
+The most critical rule of factories: **a factory must never produce an invalid object.** If the inputs are insufficient or violate business rules, the factory must fail (throw an exception), not produce a partially valid object.
+
+```
+# Good -- factory enforces invariants
+class Order:
+    @staticmethod
+    def create(customer_id, items):
+        if not items:
+            raise EmptyOrderError("Cannot create an order with no items")
+        if not customer_id:
+            raise InvalidCustomerError("Order requires a customer")
+        return Order(OrderId.generate(), customer_id, items)
+
+# Bad -- factory produces potentially invalid objects
+class Order:
+    @staticmethod
+    def create(customer_id=None, items=None):
+        return Order(OrderId.generate(), customer_id, items or [])
+        # caller can now have an order with no customer and no items
+```
+
+### Reconstitution vs. Creation
+
+There is an important distinction between creating a new aggregate and reconstituting one from persistence:
+
+| Aspect | Creation | Reconstitution |
+|--------|---------|----------------|
+| When | A new domain object comes into existence | An existing object is loaded from storage |
+| Validation | Full business rule validation | No validation needed; data was validated on creation |
+| Domain events | May raise creation events (`OrderCreated`) | Should NOT raise events; nothing new happened |
+| Identity | Generate a new ID | Use the stored ID |
+| Invariants | Enforce all invariants | Assume invariants hold (data was valid when stored) |
+
+Reconstitution typically happens inside the repository implementation:
+
+```
+class PostgresOrderRepository:
+    def find_by_id(self, order_id):
+        row = self.db.query("SELECT * FROM orders WHERE id = ?", order_id)
+        items = self.db.query("SELECT * FROM order_items WHERE order_id = ?", order_id)
+        # Reconstitute -- no validation, no events
+        return Order._reconstitute(
+            id=row['id'],
+            customer_id=row['customer_id'],
+            status=row['status'],
+            items=[OrderLineItem._reconstitute(i) for i in items]
+        )
+```
+
+## The Specification Pattern
+
+The Specification pattern encapsulates query criteria as first-class domain objects. Instead of building queries in service code, you express criteria as composable specification objects.
+
+### Why Specifications
+
+Without specifications, query logic scatters across the codebase:
+
+```
+# Query logic in a service -- not reusable, not composable
+def find_risky_orders(self):
+    return db.query("SELECT * FROM orders WHERE total > 10000 AND customer_risk > 7")
+
+# Same logic duplicated elsewhere with slight variations
+def find_very_risky_orders(self):
+    return db.query("SELECT * FROM orders WHERE total > 50000 AND customer_risk > 9")
+```
+
+With specifications:
+
+```
+high_value = OrderValueExceeds(10000)
+high_risk = CustomerRiskAbove(7)
+risky_orders = order_repository.find_matching(high_value.and_(high_risk))
+
+very_risky = OrderValueExceeds(50000).and_(CustomerRiskAbove(9))
+very_risky_orders = order_repository.find_matching(very_risky)
+```
+
+### Specification Composition
+
+Specifications compose using logical operators:
+
+| Operator | Meaning | Example |
+|----------|---------|---------|
+| `and_` | Both must be true | `HighValue.and_(HighRisk)` |
+| `or_` | Either must be true | `HighValue.or_(HighRisk)` |
+| `not_` | Must not be true | `not_(Cancelled)` |
+
+### Specifications in the Domain Layer
+
+The specification interface lives in the domain layer. Implementations can be in the domain (for in-memory filtering) or infrastructure (for database queries):
+
+```
+# Domain layer -- specification interface
+class Specification:
+    def is_satisfied_by(self, candidate) -> bool:
+        pass
+
+class OverdueInvoice(Specification):
+    def __init__(self, as_of_date):
+        self.as_of_date = as_of_date
+
+    def is_satisfied_by(self, invoice):
+        return invoice.due_date < self.as_of_date and not invoice.is_paid
+```
+
+## Ports and Adapters Relationship
+
+Repositories and Factories fit naturally into the Ports and Adapters (Hexagonal) architecture:
+
+```
+                    Domain Layer
+                   ┌─────────────────────────┐
+                   │  Aggregates             │
+                   │  Value Objects           │
+                   │  Domain Events           │
+                   │  Repository Interfaces ──┼── Port (interface)
+                   │  Factory Interfaces   ──┼── Port (interface)
+                   └─────────────────────────┘
+                              │
+                              │ implements
+                              ▼
+                   Infrastructure Layer
+                   ┌─────────────────────────┐
+                   │  PostgresOrderRepo    ──┼── Adapter (implementation)
+                   │  InMemoryOrderRepo    ──┼── Adapter (for tests)
+                   │  S3DocumentFactory    ──┼── Adapter (implementation)
+                   └─────────────────────────┘
+```
+
+**The key principle:** The domain defines what it needs (ports). Infrastructure provides it (adapters). Dependencies point inward -- infrastructure depends on domain, never the reverse.
+
+This means:
+- The domain layer has zero imports from infrastructure packages
+- Repository interfaces use domain types (`Order`, `OrderId`), not infrastructure types (`Row`, `Document`)
+- The application can swap persistence technologies by providing a new adapter without touching domain code
+- Tests use in-memory adapters to test domain logic without databases

--- a/.claude/skills/domain-driven-design/references/strategic-design.md
+++ b/.claude/skills/domain-driven-design/references/strategic-design.md
@@ -1,0 +1,251 @@
+# Strategic Design and Distillation
+
+Strategic design is the practice of identifying which parts of a system matter most and allocating design effort accordingly. Not all code is created equal. Some code is the reason the business exists; other code is necessary plumbing. Domain distillation is the process of separating the essential from the incidental, so that the core of the domain model receives the deepest thought and the best talent.
+
+## The Three Types of Subdomains
+
+Eric Evans classifies every part of a system into one of three subdomain types. This classification drives every major design and investment decision.
+
+### Core Domain
+
+The Core Domain is the part of the system that provides competitive advantage. It is the reason the business exists and what differentiates it from competitors. Without it, the business has no unique value proposition.
+
+**Characteristics:**
+- Contains the most complex and nuanced business rules
+- Is the source of competitive advantage
+- Changes frequently as the business evolves its strategy
+- Cannot be outsourced without losing differentiation
+- Requires the deepest domain expertise
+
+**Examples:**
+
+| Business | Core Domain | Why It Is Core |
+|----------|-------------|----------------|
+| Amazon | Recommendation engine, marketplace matching, logistics optimization | These are the algorithms that make Amazon uniquely effective |
+| Stripe | Payment processing, fraud detection, developer experience | These are what make Stripe better than alternatives |
+| Netflix | Content recommendation, streaming optimization | These keep subscribers engaged and differentiators from competitors |
+| Insurance company | Risk assessment, claims adjudication, actuarial modeling | These determine profitability and pricing accuracy |
+| Trading firm | Signal generation, execution algorithms, risk management | These are the source of alpha |
+
+**Investment rule:** Put your best developers here. Apply the deepest modeling techniques. This is where DDD patterns earn their complexity cost.
+
+### Supporting Subdomain
+
+A Supporting Subdomain is necessary for the business to function but does not provide competitive advantage. It supports the Core Domain. You build it because off-the-shelf solutions do not fit your specific needs, but you do not need to over-engineer it.
+
+**Characteristics:**
+- Custom-built because available solutions do not quite fit
+- Important but not differentiating
+- Moderately complex; business-specific but not competitively critical
+- Can be built by competent developers without deep domain modeling
+
+**Examples:**
+
+| Business | Supporting Subdomain | Why It Is Supporting |
+|----------|---------------------|---------------------|
+| E-commerce platform | Order management, inventory tracking | Necessary for operations but not what makes this e-commerce site unique |
+| Insurance company | Policy administration, document generation | Must work correctly but is not a competitive differentiator |
+| Trading firm | Position reporting, compliance reporting | Regulatory requirement, not a source of trading advantage |
+| SaaS product | Tenant management, billing integration | Needed but not what customers buy the product for |
+
+**Investment rule:** Build it, but keep it simple. Use straightforward designs. Do not apply deep DDD modeling patterns unless the complexity warrants it.
+
+### Generic Subdomain
+
+A Generic Subdomain is functionality that is common across many businesses and has no business specificity. It is commodity software that you should buy, use open-source, or outsource.
+
+**Characteristics:**
+- Not specific to your business; every company needs it
+- Well-solved problems with mature solutions available
+- Building it yourself is a waste of your best developers' time
+- Off-the-shelf solutions are often better than what you would build
+
+**Examples:**
+
+| Generic Subdomain | Buy/Use Instead |
+|-------------------|----------------|
+| Authentication and authorization | Auth0, Okta, Keycloak, Clerk |
+| Email sending | SendGrid, Amazon SES, Postmark |
+| Payment processing (if not your core) | Stripe, Braintree, Adyen |
+| File storage | Amazon S3, Google Cloud Storage |
+| Search indexing | Elasticsearch, Algolia, Typesense |
+| Monitoring and alerting | Datadog, Grafana, PagerDuty |
+| CMS / Content management | WordPress, Contentful, Sanity |
+
+**Investment rule:** Do not build this. Buy it, use open-source, or outsource it. Every hour your best developer spends building a custom email sender is an hour stolen from the Core Domain.
+
+## Identifying Your Core Domain
+
+### The Differentiation Test
+
+For each part of the system, ask: "If a competitor had exactly the same implementation of this, would we lose our competitive advantage?"
+
+- **Yes, we would lose advantage:** Core Domain
+- **No, but we would be inconvenienced:** Supporting Subdomain
+- **No, and we could swap it easily:** Generic Subdomain
+
+### The Outsourcing Test
+
+Ask: "Could we outsource this to a competent contractor or replace it with a SaaS product without damaging our competitive position?"
+
+- **No, absolutely not -- this is our secret sauce:** Core Domain
+- **Maybe, but it would need customization:** Supporting Subdomain
+- **Yes, easily:** Generic Subdomain
+
+### The Talent Test
+
+Ask: "Does working on this require deep expertise in our specific business domain?"
+
+- **Yes -- only people who deeply understand our industry can get this right:** Core Domain
+- **Somewhat -- general software skills with some domain knowledge:** Supporting Subdomain
+- **No -- any competent developer could implement this:** Generic Subdomain
+
+### Common Misclassification Errors
+
+| Error | Reality | Consequence |
+|-------|---------|-------------|
+| "Everything is core" | Most things are supporting or generic | Best talent spread thin; nothing gets deep modeling |
+| "Our custom CRM is core" | CRM is generic; your customer relationships are core | Team spent years building what Salesforce does better |
+| "Authentication is core" | Authentication is generic (unless you are Auth0) | Security expertise wasted on commodity functionality |
+| "Infrastructure is core" | Infrastructure is generic (unless you are AWS) | Platform team grows while product team starves |
+| "Our billing system is core" | Billing is usually supporting or generic | Over-engineered billing while the actual product suffered |
+
+## Domain Distillation
+
+Distillation is the process of extracting and clarifying the Core Domain from the rest of the system. It makes the most important parts of the model explicit, visible, and well-understood.
+
+### The Domain Vision Statement
+
+A Domain Vision Statement is a short document (one page or less) that describes the Core Domain's value proposition and its most important aspects. It serves as a north star for the team.
+
+**What it contains:**
+- What makes this domain unique and valuable
+- What distinguishes the Core Domain from everything else in the system
+- What the domain model must capture to deliver competitive advantage
+- What the team should focus on and what they should explicitly not focus on
+
+**Example for an insurance company:**
+
+> Our competitive advantage is our ability to accurately assess risk in real-time for commercial property insurance. Our core domain model must capture the nuanced relationships between property characteristics, geographic risk factors, historical claims data, and market conditions. The model must support rapid repricing as conditions change. Everything else -- policy administration, document generation, payment processing -- is supporting infrastructure that must work correctly but does not differentiate us.
+
+### The Highlighted Core
+
+The Highlighted Core is a technique for making the Core Domain visually obvious in the codebase and in documentation.
+
+**In documentation:**
+- Create a document that marks which modules, classes, and interactions constitute the Core Domain
+- Use diagrams that distinguish core from supporting from generic
+- Keep this document updated as the model evolves
+
+**In code:**
+- Organize the codebase so that Core Domain modules are clearly separated: `domain/core/`, `domain/supporting/`, `infrastructure/`
+- Use naming conventions that signal importance: a module called `pricing-engine` conveys more importance than `util-helpers`
+- Code review standards can be higher for core domain code (require domain expert sign-off)
+
+### Distillation Techniques
+
+#### Segregated Core
+
+Physically separate the Core Domain from the rest of the codebase. The core should have no dependencies on supporting or generic subdomains -- only the other way around.
+
+```
+src/
+    core/                           # Core Domain -- deepest modeling
+        risk-assessment/
+            RiskModel.py
+            RiskFactor.py
+            UnderwritingRules.py
+        pricing/
+            PricingEngine.py
+            RateTable.py
+    supporting/                     # Supporting -- necessary, simpler design
+        policy-admin/
+            PolicyRepository.py
+            PolicyDocument.py
+        notifications/
+            NotificationService.py
+    generic/                        # Generic -- thin wrappers around external services
+        email/
+            EmailGateway.py
+        storage/
+            FileStorage.py
+        auth/
+            AuthenticationAdapter.py
+```
+
+#### Abstract Core
+
+Create a distilled model that captures the essential abstractions of the Core Domain without the implementation details. This abstract model serves as a communication tool and a guide for detailed implementation.
+
+The Abstract Core is like an executive summary of the domain model: it captures the key concepts, their relationships, and the most important business rules, without the full detail of every attribute and method.
+
+## Build vs. Buy vs. Outsource
+
+### Decision Framework
+
+| Question | Core Domain | Supporting Subdomain | Generic Subdomain |
+|----------|-------------|---------------------|-------------------|
+| Should we build it in-house? | **Yes, always** | Yes, if no good fit exists | **No** |
+| Should we buy/use SaaS? | **No** -- too important to delegate | Only if it fits well | **Yes, always** |
+| Should we outsource development? | **No** -- requires deep domain expertise | Possible with good specs | **Yes** -- or better yet, buy |
+| Should we use open-source? | Only as a foundation to build on | Yes, if it fits | **Yes** |
+| What quality standard? | Highest -- deep modeling, extensive testing, expert review | Good -- solid engineering, adequate testing | Adequate -- it just needs to work |
+
+### The Opportunity Cost Lens
+
+Every hour spent on non-core work is an hour not spent on the Core Domain. Frame build-vs-buy decisions as opportunity costs:
+
+- "We could build our own email service in 3 months." That is 3 months your best developers are not improving the Core Domain. Use SendGrid.
+- "We could build a custom monitoring dashboard in 6 weeks." That is 6 weeks not spent on the pricing engine. Use Grafana.
+- "We could build our own authentication system in 2 months." That is 2 months of security engineering not applied to fraud detection. Use Auth0.
+
+### When "Buy" Becomes "Core"
+
+Sometimes a generic subdomain becomes core as the business evolves:
+
+- Stripe started as a payment processor (generic for most businesses) but made payments their Core Domain
+- Amazon started as a bookstore; logistics (supporting for most retailers) became a Core Domain that turned into AWS
+- Netflix treated content recommendation as core from the beginning, while most video platforms treated it as supporting
+
+**Revisit classifications regularly.** What is generic today may become core tomorrow if the business strategy shifts. Annual or quarterly reviews of subdomain classifications prevent stale assumptions.
+
+## Applying Strategic Design to Team Structure
+
+### Team Allocation by Subdomain Type
+
+| Subdomain Type | Team Characteristics | Practices |
+|---------------|---------------------|-----------|
+| Core Domain | Senior engineers, domain experts embedded in team, smallest and most skilled team | Deep modeling, event storming, pair programming with domain experts, extensive testing |
+| Supporting Subdomain | Mid-level engineers, domain knowledge acquired through documentation | Standard engineering practices, adequate testing, clear interfaces |
+| Generic Subdomain | Junior engineers or no team at all (use external service) | Integration work, adapter implementation, vendor management |
+
+### Conway's Law Application
+
+Design team boundaries to match desired bounded context boundaries:
+
+- One team per bounded context (or small number of contexts)
+- Core Domain teams should be co-located or closely collaborating
+- Supporting Subdomain teams can be more independent
+- Generic Subdomain work can be distributed or handled by a platform team
+
+### Investment Over Time
+
+As the system matures, investment should shift:
+
+| Phase | Core Domain Investment | Supporting Investment | Generic Investment |
+|-------|----------------------|----------------------|-------------------|
+| Early (MVP) | 70% | 20% | 10% (buy everything) |
+| Growth | 60% | 25% | 15% (integrate more) |
+| Mature | 50% | 30% | 20% (optimize and replace) |
+
+The Core Domain always receives the plurality of investment. If it drops below 50%, the team is likely over-engineering supporting functionality or building generic functionality that should be bought.
+
+## Strategic Design Anti-Patterns
+
+| Anti-Pattern | Signal | Fix |
+|-------------|--------|-----|
+| "Golden hammer" -- applying Core Domain rigor to everything | Every module has aggregates, repositories, domain events, factories | Classify subdomains; simplify supporting and generic code |
+| "Platform first" -- building infrastructure before product | Months spent on logging, monitoring, and deployment before a single domain feature | Use off-the-shelf infrastructure; build Core Domain features first |
+| "Resume-driven development" -- choosing technology for novelty | Core Domain uses experimental framework because it is interesting | Choose boring technology for production; innovate in modeling, not infrastructure |
+| "Outsourced core" -- contracting out the competitive advantage | Core Domain built by offshore team with no domain expertise | Bring core development in-house; invest in domain expert access |
+| "Everyone is equal" -- same standards and investment everywhere | No distinction between a pricing algorithm and a CRUD admin panel | Apply deep modeling only where it pays off; keep the rest simple |

--- a/.claude/skills/domain-driven-design/references/ubiquitous-language.md
+++ b/.claude/skills/domain-driven-design/references/ubiquitous-language.md
@@ -1,0 +1,202 @@
+# Ubiquitous Language
+
+The single most important practice in Domain-Driven Design. A ubiquitous language is the shared vocabulary between developers and domain experts that is used everywhere -- in conversation, documentation, code, tests, and diagrams. It is not a glossary appended to a wiki. It is the living, evolving language that shapes how the system is built and how the team thinks about the domain.
+
+## Why Language Matters More Than Code
+
+Software development is fundamentally a communication problem. The hardest bugs are not off-by-one errors or null pointer exceptions -- they are misunderstandings between people. When a developer hears "account" and thinks "user login record" while the domain expert means "financial ledger position," the resulting code will be structurally wrong in ways that no amount of testing can catch.
+
+A ubiquitous language eliminates this class of failure by establishing a single, precise vocabulary that both sides use without translation. When the language is embedded in code, every class name, method name, and variable name becomes a checkpoint: if a domain expert cannot read the code and recognize the concepts, the model is wrong.
+
+### The Cost of Translation
+
+Without a ubiquitous language, every conversation requires mental translation:
+
+| Developer Says | Domain Expert Hears | Actual Meaning | Risk |
+|---------------|--------------------|-|------|
+| `UserEntity` | "User? We don't have users, we have policyholders" | The system models a concept the business does not recognize | Code does not reflect reality; edge cases are missed |
+| `processData()` | "Process what data? Which business operation?" | A generic method hiding domain-specific logic | Business rules buried in implementation; impossible to validate |
+| `status = 3` | "What does 3 mean?" | An opaque encoding of a domain concept | Magic numbers replace meaningful domain states |
+| `ServiceManager` | "Manager of what?" | A catch-all class with no domain analog | God class accumulates unrelated responsibilities |
+
+### The Payoff of Alignment
+
+When the language is shared:
+
+- **Domain experts can read tests.** A test that says `policy.underwrite(application)` is immediately meaningful. A test that says `service.process(dto)` is opaque.
+- **Developers catch domain errors.** When a developer writes `order.cancel()` and the domain expert says "we don't cancel orders, we void them," the naming mismatch reveals a modeling error.
+- **New team members onboard faster.** The codebase teaches the domain because the names are the domain.
+- **Refactoring is safer.** Renaming `process()` to `adjudicateClaim()` is not just cosmetic -- it encodes domain knowledge that prevents future misuse.
+
+## Building the Language
+
+### Start with Domain Expert Conversations
+
+The language does not come from developers reading documentation. It comes from intensive, iterative conversations between developers and domain experts. These conversations follow a pattern:
+
+1. **Listen for the nouns and verbs the expert uses naturally.** "When a claim comes in, the adjuster reviews it, and then we either approve or deny the claim." The nouns are `Claim`, `Adjuster`. The verbs are `review`, `approve`, `deny`.
+
+2. **Challenge ambiguity.** "You said 'review' -- what exactly happens during a review? Is it the same as 'assess'?" Often the expert will distinguish between terms that outsiders conflate.
+
+3. **Propose the model.** "So a `Claim` goes through an `Adjudication` process where an `Adjuster` either `approves` or `denies` it?" The expert corrects: "Not exactly -- the adjuster makes a recommendation, but only a senior adjuster can approve claims over $10,000."
+
+4. **Refine until the model is precise.** The conversation reveals business rules that no requirements document captured: approval authority limits, recommendation vs. decision, escalation paths.
+
+### Model Exploration Whirlpool
+
+Eric Evans describes a "whirlpool" process for modeling:
+
+1. **Scenario walkthrough.** Walk through concrete business scenarios with domain experts. "A customer calls to report damage to their vehicle. What happens next?"
+
+2. **Concept extraction.** Identify the key domain concepts that emerge: `Claim`, `Incident`, `CoverageVerification`, `DamageAssessment`.
+
+3. **Name negotiation.** Debate and agree on names. "Should we call it a 'damage report' or a 'claim'? When does a report become a claim?"
+
+4. **Code spike.** Quickly implement the emerging model in code to test whether it holds up under real logic.
+
+5. **Feedback loop.** Show the code (or at least the class and method names) back to the domain expert. "Does this look right to you?"
+
+This cycle repeats continuously throughout the project, not just at the beginning.
+
+## Language in Code
+
+### Naming Classes After Domain Concepts
+
+Every class in the domain layer should be named after a concept the business recognizes:
+
+**Good names (domain language):**
+- `LoanApplication` -- the business knows what this is
+- `CreditDecision` -- an explicit outcome of an underwriting process
+- `PaymentSchedule` -- a concrete domain concept
+- `PolicyRenewalNotice` -- named exactly as the business document is named
+
+**Bad names (technical language):**
+- `ApplicationDTO` -- DTO is a technical pattern, not a domain concept
+- `PaymentService` -- "service" is a technical role, not a domain concept; what does this service do?
+- `DataProcessor` -- meaningless in domain terms
+- `BaseEntityAbstractFactory` -- pure technical jargon
+
+### Naming Methods After Domain Operations
+
+Methods should read like sentences a domain expert would say:
+
+**Good:**
+```
+policy.renew(effectiveDate)
+claim.submitForAdjudication()
+account.applyInterest(rate, period)
+order.fulfillWith(shipment)
+```
+
+**Bad:**
+```
+policy.update(data)
+claim.process()
+account.calculate()
+order.setStatus(STATUS_SHIPPED)
+```
+
+The difference is not cosmetic. `claim.submitForAdjudication()` tells you what the business operation is. `claim.process()` tells you nothing -- you must read the implementation to understand what it does, which means the domain knowledge is hidden.
+
+### Naming Events After Domain Facts
+
+Domain events should be named as past-tense facts that a domain expert would recognize as significant business occurrences:
+
+**Good:** `PolicyIssued`, `ClaimDenied`, `PaymentOverdue`, `MembershipExpired`
+
+**Bad:** `PolicyUpdated`, `ClaimProcessed`, `DataChanged`, `RecordModified`
+
+"Updated," "processed," and "changed" are technical descriptions of what happened to data. "Issued," "denied," "overdue," and "expired" are domain descriptions of what happened in the business.
+
+## Glossary Maintenance
+
+### The Living Glossary
+
+Maintain a glossary document that evolves with the model. This is not a static artifact created at the start of the project and forgotten. It is a living document updated every time the language changes.
+
+**What goes in the glossary:**
+
+| Term | Definition | Context | Example |
+|------|-----------|---------|---------|
+| Claim | A formal request for payment under an insurance policy following a covered event | Claims processing | "The policyholder filed a claim for water damage" |
+| Adjudication | The process of evaluating a claim to determine whether it is covered and how much to pay | Claims processing | "The claim is in adjudication pending the damage assessment" |
+| Coverage | The set of perils and limits defined in a policy | Underwriting | "This policy provides coverage for fire but not flood" |
+| Premium | The amount the policyholder pays for coverage | Billing | "The annual premium is $1,200, payable monthly" |
+
+**What does NOT go in the glossary:**
+- Technical terms (`Repository`, `Service`, `Controller`)
+- Implementation details (`PostgreSQL table name`, `API endpoint`)
+- Generic programming concepts (`interface`, `abstract class`)
+
+### When Terms Conflict
+
+The same word often means different things in different parts of the business. This is expected and healthy:
+
+- **"Account"** in billing means a financial ledger position. In authentication, it means a user login. In sales, it means a company relationship.
+- **"Product"** in the catalog means something you can browse. In inventory, it means a physical item with a location. In marketing, it means a brand offering.
+
+The solution is not to force one definition. The solution is bounded contexts: each context has its own definition, and translations happen at the boundary.
+
+## Language Evolution
+
+### When to Change the Language
+
+The ubiquitous language is not fixed. It evolves as the team's understanding of the domain deepens. Signals that the language needs to change:
+
+- **Awkward conversations.** "Well, it's kind of like a customer but not exactly -- it's more of an applicant who might become a customer." This means `Customer` is the wrong term; `Applicant` is a distinct concept.
+- **Workarounds in code.** A `type` field that switches behavior (e.g., `if customer.type == 'prospect'`) often means a single class is trying to represent two different domain concepts.
+- **Expert correction.** "We don't really call it a 'request' -- we call it a 'submission.'" Change the code immediately.
+- **New domain insight.** "Actually, a cancellation and a voiding are different things. Cancellation is prospective; voiding is retroactive." Split the concept.
+
+### The Refactoring Trigger
+
+When the language changes, the code must change. This is not optional. If the team agrees that "submission" is the correct term instead of "request," then:
+
+1. Rename the class: `Request` becomes `Submission`
+2. Rename the repository: `RequestRepository` becomes `SubmissionRepository`
+3. Rename the events: `RequestCreated` becomes `SubmissionFiled`
+4. Update the database: table `requests` becomes `submissions` (with a migration)
+5. Update the API: `/api/requests` becomes `/api/submissions` (with versioning)
+
+This may seem expensive, but the cost of maintaining a divergence between language and code is far higher. Every time a developer reads `Request` and has to mentally translate to "submission," they lose context and risk introducing errors.
+
+## How Naming Shapes Design
+
+Names are not labels applied after the fact. They are design decisions that constrain and guide the system's evolution.
+
+### Names Reveal Missing Concepts
+
+When you struggle to name something, the model is telling you something is wrong:
+
+- **"OrderProcessorHelper"** -- If you need a helper, the class it is helping probably has the wrong boundaries. The behavior likely belongs inside `Order` or in a separate, well-named domain concept.
+- **"MiscService"** -- If you cannot name it, you do not understand it. Break it apart until each piece has a clear domain name.
+- **"DataValidator"** -- Validation of what? By what rules? `CreditApplicationValidator` or `AddressVerifier` tells you exactly what domain rules are being enforced.
+
+### Names Prevent Misuse
+
+A method named `account.debit(amount)` tells future developers exactly what this does and constrains its usage. A method named `account.update(amount)` invites misuse because "update" could mean anything.
+
+### Names Create Boundaries
+
+When two concepts share a name but have different behaviors, splitting the name splits the model:
+
+- `Customer` in sales vs. `Customer` in billing? These are different bounded contexts. The split in naming reveals the split in models.
+- `Order` before payment vs. `Order` after payment? Perhaps these are `PendingOrder` and `ConfirmedOrder` -- two distinct states that deserve distinct types, not a `status` flag.
+
+## Anti-Patterns to Avoid
+
+### The Jargon Trap
+
+Developers invent internal jargon that has no domain analog: "We call it a 'widget' internally." If domain experts do not use the word "widget," it does not belong in the domain model.
+
+### The Abbreviation Trap
+
+`CustAcctMgr` is not a ubiquitous language term. Write `CustomerAccountManager` -- or better yet, ask what the business actually calls this role. Maybe it is a `RelationshipOfficer` or an `AccountExecutive`.
+
+### The Thesaurus Trap
+
+Using synonyms interchangeably (`customer` / `client` / `user` / `patron`) destroys precision. Pick one term per concept and enforce it everywhere. If the business uses "client" in legal contexts and "customer" in sales contexts, those are different bounded contexts with different terms -- and both are correct within their context.
+
+### The Persistence Trap
+
+Naming domain concepts after their storage mechanism: `CustomerRecord`, `OrderRow`, `PaymentTable`. Domain objects are not records or rows. They are domain concepts that happen to be persisted. Name them for what they are in the domain: `Customer`, `Order`, `Payment`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,16 +229,18 @@ Skills propios del repo, escritos para las convenciones de Datealo:
 
 Skills de terceros, pre-instalados y trackeados en `skills-lock.json` (con su fuente exacta): `nuxt`,
 `vue`, `drizzle-orm`, `frontend-design`, `ui-ux-pro-max`, `web-design-guidelines`, `marketing-psychology`,
-`ai-seo`, `content-strategy`, `page-cro`, `vue-best-practices`, `supabase-postgres-best-practices`,
+`ai-seo`, `content-strategy`, `page-cro`, `vue-best-practices`,
 `prompt-engineering-patterns`, `copywriting`, `ux-writing` (microcopy/content design — usarlo al redactar
 o revisar texto de interfaz en `discovery-ux`: labels, errores, empty states, CTAs), `mom-test` (entrevistas
 sin sesgo), `jobs-to-be-done` (profundiza el formato JTBD de `producto.md`), `cold-start-problem`
 (bootstrapping de marketplaces de dos lados — el arranque en frío de `discovery-product`), `lean-analytics`
 (métricas y benchmarks por modelo/etapa, evita vanity metrics en las señales `M-xxx`), `obviously-awesome`
-(positioning competitivo). Los últimos cinco se usan en `discovery-product`. Están todos localmente — nunca
-sugerir instalarlos. `drizzle-orm`, `prompt-engineering-patterns` y `copywriting` tienen origen sin
-verificar (ver nota en `skills-lock.json`) — evaluar re-sourcing antes de confiar ciegamente en su
-contenido.
+(positioning competitivo) — estos cinco se usan en `discovery-product`. `supabase-postgres-best-practices`
+(schema, RLS, índices, migraciones), `clean-architecture` (Dependency Rule — lógica de negocio separada de
+Drizzle/handler/Vue) y `domain-driven-design` (lenguaje ubicuo, dominio central vs. subdominio genérico) se
+usan en `discovery-engineering`. Están todos localmente — nunca sugerir instalarlos. `drizzle-orm`,
+`prompt-engineering-patterns` y `copywriting` tienen origen sin verificar (ver nota en `skills-lock.json`)
+— evaluar re-sourcing antes de confiar ciegamente en su contenido.
 
 ## Guardrails de trabajo
 

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -101,6 +101,16 @@
       "source": "wondelai/skills",
       "sourceType": "github",
       "computedHash": "abfb03a452f964cfdd06a8ee11d51a541894778c2d4013c15b16dd1718002af6"
+    },
+    "clean-architecture": {
+      "source": "wondelai/skills",
+      "sourceType": "github",
+      "computedHash": "fc9fe201ae040df80164bc7a407507882783e2c8cdbc0379a1fbdcf3719e4446"
+    },
+    "domain-driven-design": {
+      "source": "wondelai/skills",
+      "sourceType": "github",
+      "computedHash": "14f80bc0c209e8500f52813158afb8b6b819b47a54b92576f0c0586acac38668"
     }
   }
 }


### PR DESCRIPTION
## Resumen

- `supabase-postgres-best-practices` estaba instalado desde antes pero huérfano — ningún skill lo referenciaba. Se wirea a la sección "RLS no es un paso posterior" y al gate de salida de `discovery-engineering` (schema, RLS, índices, migraciones).
- Se instalan `clean-architecture` (Robert C. Martin) y `domain-driven-design` (Eric Evans), de `wondelai/skills` (mismo repo ya verificado para los skills de producto en #70).
  - `clean-architecture` profundiza el principio que `discovery-engineering` ya insinuaba a medias ("la lógica pura vive fuera de la infraestructura") con la Dependency Rule completa — objetivo: que problemas como lógica de negocio metida en un handler se atrapen en el diseño, no en code review.
  - `domain-driven-design` le da rigor a la tabla de vocabulario producto↔código (lenguaje ubicuo) y a las decisiones build-vs-buy (dominio central vs. subdominio genérico — ej. Supabase Auth/Resend comprados, ranking de búsqueda construido).
- Evalué también `ddia-systems` (Kleppmann) pero lo descarté por ahora — pensado para sistemas distribuidos a escala, no calza con un Postgres único pre-lanzamiento y podría empujar contra el YAGNI de `CLAUDE.md`.

## Test plan

- [ ] `python3 -c "import json; json.load(open('skills-lock.json'))"` — JSON válido (ya verificado)
- [ ] Confirmar que `clean-architecture`, `domain-driven-design` y `supabase-postgres-best-practices` aparecen en el listado de skills disponibles en una sesión nueva

🤖 Generated with [Claude Code](https://claude.com/claude-code)