### PR TITLE
feat(app): flujo de iniciar sesión con enlace mágico y GET /auth/confirm

### DIFF
--- a/app/composables/useMagicLink.ts
+++ b/app/composables/useMagicLink.ts
@@ -1,0 +1,71 @@
+// UXF-001: las tres pantallas de V-001 son estados de un solo flujo, no rutas separadas — así el email
+// ya escrito sobrevive a un error de formato o a un reenvío sin que el usuario lo vuelva a tipear.
+export type MagicLinkStep = 'email' | 'revisa-correo' | 'enlace-invalido'
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+// "Después de un minuto sin nada" — experiencia.md, UXF-001, Variantes y recuperación.
+const RESEND_HINT_DELAY_MS = 60_000
+
+export function useMagicLink() {
+  const { $supabase } = useNuxtApp()
+  const route = useRoute()
+
+  const step = useState<MagicLinkStep>('magic-link-step', () =>
+    route.query.error === 'enlace_invalido' ? 'enlace-invalido' : 'email',
+  )
+  const email = useState('magic-link-email', () => '')
+  const emailError = useState<string | null>('magic-link-email-error', () => null)
+  const loading = useState('magic-link-loading', () => false)
+  const resendHintVisible = useState('magic-link-resend-hint', () => false)
+
+  let resendHintTimer: ReturnType<typeof setTimeout> | undefined
+
+  function clearResendHintTimer() {
+    clearTimeout(resendHintTimer)
+    resendHintTimer = undefined
+  }
+
+  async function sendLink() {
+    const trimmed = email.value.trim()
+    if (!EMAIL_REGEX.test(trimmed)) {
+      emailError.value = 'Ese correo no parece válido. Falta arroba o dominio, ej: hector@gmail.com.'
+      return
+    }
+
+    emailError.value = null
+    loading.value = true
+
+    try {
+      const { error } = await $supabase.auth.signInWithOtp({
+        email: trimmed,
+        options: { emailRedirectTo: `${useRequestURL().origin}/auth/confirm` },
+      })
+
+      if (error) {
+        emailError.value = 'No pudimos enviar el enlace. Intenta de nuevo.'
+        return
+      }
+
+      step.value = 'revisa-correo'
+      resendHintVisible.value = false
+      clearResendHintTimer()
+      resendHintTimer = setTimeout(() => {
+        resendHintVisible.value = true
+      }, RESEND_HINT_DELAY_MS)
+    } finally {
+      loading.value = false
+    }
+  }
+
+  function startOver() {
+    clearResendHintTimer()
+    step.value = 'email'
+    email.value = ''
+    emailError.value = null
+    resendHintVisible.value = false
+  }
+
+  onUnmounted(clearResendHintTimer)
+
+  return { step, email, emailError, loading, resendHintVisible, sendLink, startOver }
+}

--- a/app/composables/useMagicLink.ts
+++ b/app/composables/useMagicLink.ts
@@ -1,9 +1,10 @@
-// UXF-001: las tres pantallas de V-001 son estados de un solo flujo, no rutas separadas — así el email
-// ya escrito sobrevive a un error de formato o a un reenvío sin que el usuario lo vuelva a tipear.
+// Las tres pantallas del login son estados de un mismo flujo, no rutas separadas — así el email ya
+// escrito sobrevive a un error de formato o a un reenvío sin que el usuario lo vuelva a tipear.
 export type MagicLinkStep = 'email' | 'revisa-correo' | 'enlace-invalido'
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
-// "Después de un minuto sin nada" — experiencia.md, UXF-001, Variantes y recuperación.
+// No hay forma de saber si el correo llegó o no, así que el hint de reenvío aparece recién después de
+// esperar un minuto, no de inmediato.
 const RESEND_HINT_DELAY_MS = 60_000
 
 export function useMagicLink() {

--- a/app/middleware/profesional.ts
+++ b/app/middleware/profesional.ts
@@ -1,0 +1,11 @@
+// Único lugar que decide a dónde manda una página de este dominio según la sesión — así las tres
+// páginas comparten la misma regla en vez de repetir la llamada a /api/auth/me cada una por su lado.
+export default defineNuxtRouteMiddleware(async (to) => {
+  if (to.path === '/profesional/ingresar') return
+
+  try {
+    await $fetch('/api/auth/me')
+  } catch {
+    return navigateTo('/profesional/ingresar')
+  }
+})

--- a/app/pages/profesional/ingresar.vue
+++ b/app/pages/profesional/ingresar.vue
@@ -1,0 +1,81 @@
+<script setup lang="ts">
+definePageMeta({ middleware: 'profesional' })
+
+useSeoMeta({ title: 'Entra a Datealo', robots: 'noindex' })
+
+const { step, email, emailError, loading, resendHintVisible, sendLink, startOver } = useMagicLink()
+</script>
+
+<template>
+  <div class="mx-auto flex min-h-screen max-w-md flex-col justify-center px-6 py-10">
+    <template v-if="step === 'email'">
+      <h1 class="text-2xl font-extrabold text-datealo-text">Entra a Datealo</h1>
+      <p class="mt-2 text-sm text-datealo-muted">
+        Te mandamos un enlace a tu correo, sin contraseña que recordar.
+      </p>
+
+      <form class="mt-8" @submit.prevent="sendLink">
+        <label for="magic-link-email" class="mb-2 block text-sm font-semibold text-datealo-text">
+          Tu email
+        </label>
+        <UInput
+          id="magic-link-email"
+          v-model="email"
+          type="email"
+          autocomplete="email"
+          placeholder="hector@gmail.com"
+          size="lg"
+          class="w-full"
+          :disabled="loading"
+          :color="emailError ? 'error' : 'primary'"
+          :highlight="Boolean(emailError)"
+          :aria-describedby="emailError ? 'magic-link-email-error' : undefined"
+        />
+        <p
+          v-if="emailError"
+          id="magic-link-email-error"
+          class="mt-2 text-xs font-semibold text-error"
+          aria-live="polite"
+        >
+          {{ emailError }}
+        </p>
+
+        <UButton type="submit" block size="lg" class="mt-6 font-bold" :loading="loading" :disabled="loading">
+          <template v-if="!loading">Enviar enlace</template>
+        </UButton>
+      </form>
+    </template>
+
+    <template v-else-if="step === 'revisa-correo'">
+      <div class="flex flex-col items-center text-center">
+        <div class="flex h-16 w-16 items-center justify-center rounded-full bg-datealo-surface text-2xl">
+          ✉️
+        </div>
+        <h1 class="mt-6 text-xl font-extrabold text-datealo-text">Revisa tu correo</h1>
+        <p class="mt-3 text-sm text-datealo-muted">
+          Te mandamos un enlace a<br />
+          <strong class="text-datealo-text">{{ email }}</strong>. Tócalo para entrar.
+        </p>
+        <p v-if="resendHintVisible" class="mt-10 text-xs text-datealo-muted" aria-live="polite">
+          ¿No te llegó? Revisa spam o
+          <button type="button" class="font-semibold text-primary underline" @click="sendLink">
+            pide otro enlace
+          </button>
+        </p>
+      </div>
+    </template>
+
+    <template v-else>
+      <div class="flex flex-col items-center text-center">
+        <div class="flex h-16 w-16 items-center justify-center rounded-full bg-datealo-surface text-2xl">
+          ⚠️
+        </div>
+        <h1 class="mt-6 text-xl font-extrabold text-datealo-text">Este enlace ya no funciona</h1>
+        <p class="mt-3 text-sm text-datealo-muted">
+          Puede que ya lo hayas usado, o que hayan pasado más de 60 minutos desde que lo pediste.
+        </p>
+        <UButton size="lg" block class="mt-8 font-bold" @click="startOver">Enviar uno nuevo</UButton>
+      </div>
+    </template>
+  </div>
+</template>

--- a/app/pages/profesional/ingresar.vue
+++ b/app/pages/profesional/ingresar.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { Mail, TriangleAlert } from '@lucide/vue'
+
 definePageMeta({ middleware: 'profesional' })
 
 useSeoMeta({ title: 'Entra a Datealo', robots: 'noindex' })
@@ -48,8 +50,8 @@ const { step, email, emailError, loading, resendHintVisible, sendLink, startOver
 
     <template v-else-if="step === 'revisa-correo'">
       <div class="flex flex-col items-center text-center">
-        <div class="flex h-16 w-16 items-center justify-center rounded-full bg-datealo-surface text-2xl">
-          ✉️
+        <div class="flex h-16 w-16 items-center justify-center rounded-full bg-datealo-surface">
+          <Mail class="h-7 w-7 text-primary" />
         </div>
         <h1 class="mt-6 text-xl font-extrabold text-datealo-text">Revisa tu correo</h1>
         <p class="mt-3 text-sm text-datealo-muted">
@@ -67,8 +69,8 @@ const { step, email, emailError, loading, resendHintVisible, sendLink, startOver
 
     <template v-else>
       <div class="flex flex-col items-center text-center">
-        <div class="flex h-16 w-16 items-center justify-center rounded-full bg-datealo-surface text-2xl">
-          ⚠️
+        <div class="flex h-16 w-16 items-center justify-center rounded-full bg-datealo-surface">
+          <TriangleAlert class="h-7 w-7 text-error" />
         </div>
         <h1 class="mt-6 text-xl font-extrabold text-datealo-text">Este enlace ya no funciona</h1>
         <p class="mt-3 text-sm text-datealo-muted">

--- a/app/pages/profesional/perfil.vue
+++ b/app/pages/profesional/perfil.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+definePageMeta({ middleware: 'profesional' })
+
+useSeoMeta({ title: 'Tu perfil', robots: 'noindex' })
+
+const { data: user } = await useFetch('/api/auth/me')
+</script>
+
+<template>
+  <div class="mx-auto flex min-h-screen max-w-md flex-col justify-center px-6 py-10 text-center">
+    <h1 class="text-2xl font-extrabold text-datealo-text">Tu perfil</h1>
+    <p class="mt-2 text-sm text-datealo-muted">
+      Sesión iniciada como <strong class="text-datealo-text">{{ user?.email }}</strong>. La edición del
+      perfil llega en el próximo paso.
+    </p>
+  </div>
+</template>

--- a/app/pages/profesional/registro.vue
+++ b/app/pages/profesional/registro.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+definePageMeta({ middleware: 'profesional' })
+
+useSeoMeta({ title: 'Crea tu perfil', robots: 'noindex' })
+
+const { data: user } = await useFetch('/api/auth/me')
+</script>
+
+<template>
+  <div class="mx-auto flex min-h-screen max-w-md flex-col justify-center px-6 py-10 text-center">
+    <h1 class="text-2xl font-extrabold text-datealo-text">Crea tu perfil</h1>
+    <p class="mt-2 text-sm text-datealo-muted">
+      Sesión iniciada como <strong class="text-datealo-text">{{ user?.email }}</strong>. El formulario de
+      registro llega en el próximo paso.
+    </p>
+  </div>
+</template>

--- a/app/plugins/supabase.client.ts
+++ b/app/plugins/supabase.client.ts
@@ -1,0 +1,10 @@
+import { createBrowserClient } from '@supabase/ssr'
+
+// Excepción de A-001: Auth es lo único que el browser habla directo con Supabase. createBrowserClient
+// (no createClient de @supabase/supabase-js) para que la sesión quede en la cookie que el servidor
+// sabe leer, no en localStorage.
+export default defineNuxtPlugin(() => {
+  const { public: pub } = useRuntimeConfig()
+  const supabase = createBrowserClient(pub.supabaseUrl, pub.supabaseKey)
+  return { provide: { supabase } }
+})

--- a/app/plugins/supabase.client.ts
+++ b/app/plugins/supabase.client.ts
@@ -1,8 +1,8 @@
 import { createBrowserClient } from '@supabase/ssr'
 
-// Excepción de A-001: Auth es lo único que el browser habla directo con Supabase. createBrowserClient
-// (no createClient de @supabase/supabase-js) para que la sesión quede en la cookie que el servidor
-// sabe leer, no en localStorage.
+// Auth es lo único que el browser habla directo con Supabase, sin pasar por /api/. createBrowserClient
+// (no createClient de @supabase/supabase-js) deja la sesión en una cookie que el servidor sabe leer,
+// no en localStorage.
 export default defineNuxtPlugin(() => {
   const { public: pub } = useRuntimeConfig()
   const supabase = createBrowserClient(pub.supabaseUrl, pub.supabaseKey)

--- a/server/routes/auth/confirm.get.ts
+++ b/server/routes/auth/confirm.get.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-// Nombres exactos que arma el template "Magic Link" de Supabase Auth (TR-001) — no un contrato propio.
+// Nombres exactos que arma el template "Magic Link" configurado en Supabase Auth — no un contrato propio.
 const querySchema = z.object({
   token_hash: z.string().min(1),
   type: z.literal('email'),
@@ -12,8 +12,9 @@ export default defineEventHandler(async (event) => {
     return sendRedirect(event, '/profesional/ingresar?error=enlace_invalido', 302)
   }
 
-  // T-001: verifyOtp con token_hash, no el flujo PKCE — así el enlace funciona abierto desde otro
-  // navegador o dispositivo del que lo pidió.
+  // verifyOtp con token_hash, no el flujo PKCE (exchangeCodeForSession): PKCE exige que el mismo
+  // navegador que pidió el enlace sea el que lo completa, y acá el enlace se toca a menudo desde la
+  // app de correo, en otro navegador o dispositivo.
   const { data, error } = await serverSupabase(event).auth.verifyOtp(query.data)
   if (error || !data.user) {
     return sendRedirect(event, '/profesional/ingresar?error=enlace_invalido', 302)

--- a/server/routes/auth/confirm.get.ts
+++ b/server/routes/auth/confirm.get.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod'
+
+// Nombres exactos que arma el template "Magic Link" de Supabase Auth (TR-001) — no un contrato propio.
+const querySchema = z.object({
+  token_hash: z.string().min(1),
+  type: z.literal('email'),
+})
+
+export default defineEventHandler(async (event) => {
+  const query = querySchema.safeParse(getQuery(event))
+  if (!query.success) {
+    return sendRedirect(event, '/profesional/ingresar?error=enlace_invalido', 302)
+  }
+
+  // T-001: verifyOtp con token_hash, no el flujo PKCE — así el enlace funciona abierto desde otro
+  // navegador o dispositivo del que lo pidió.
+  const { data, error } = await serverSupabase(event).auth.verifyOtp(query.data)
+  if (error || !data.user) {
+    return sendRedirect(event, '/profesional/ingresar?error=enlace_invalido', 302)
+  }
+
+  const professional = await findProfessionalByUserId(data.user.id)
+  return sendRedirect(event, professional ? '/profesional/perfil' : '/profesional/registro', 302)
+})

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -9,8 +9,8 @@ export type AuthUser = {
   email: string | null
 }
 
-// Exportado: server/routes/auth/confirm.get.ts (TC-006) necesita el mismo cliente para que
-// verifyOtp() deje la sesión en la misma cookie que requireUser() sabe leer.
+// Exportado: server/routes/auth/confirm.get.ts necesita el mismo cliente para que verifyOtp() deje la
+// sesión en la misma cookie que requireUser() sabe leer.
 export function serverSupabase(event: H3Event) {
   const { public: pub } = useRuntimeConfig()
   // La publishable key, no la secret key: este cliente representa al usuario de la sesión, no un

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -9,7 +9,9 @@ export type AuthUser = {
   email: string | null
 }
 
-function serverSupabase(event: H3Event) {
+// Exportado: server/routes/auth/confirm.get.ts (TC-006) necesita el mismo cliente para que
+// verifyOtp() deje la sesión en la misma cookie que requireUser() sabe leer.
+export function serverSupabase(event: H3Event) {
   const { public: pub } = useRuntimeConfig()
   // La publishable key, no la secret key: este cliente representa al usuario de la sesión, no un
   // acceso admin. Con la secret key cualquier query por este cliente saltaría RLS por completo.

--- a/server/utils/professionals.ts
+++ b/server/utils/professionals.ts
@@ -1,0 +1,10 @@
+import { eq } from 'drizzle-orm'
+import { professionals } from '../db/schema/professionals'
+
+export async function findProfessionalByUserId(userId: string) {
+  const [row] = await useDb()
+    .select({ id: professionals.id })
+    .from(professionals)
+    .where(eq(professionals.userId, userId))
+  return row ?? null
+}


### PR DESCRIPTION
## Qué hace

Cierra #74 — S-002 del plan de construcción de la misión 04.

- `app/plugins/supabase.client.ts`: cliente de Supabase en el browser (`createBrowserClient`), la excepción de auth que A-001 ya contempla.
- `app/pages/profesional/ingresar.vue` + `app/composables/useMagicLink.ts`: las cuatro pantallas de V-001 (ingresar email, formato inválido, revisa tu correo con el hint de reenvío a los 60s, enlace inválido), sin pasar por `/api/*` para pedir el enlace (`signInWithOtp` directo, como documenta TC-006).
- `server/routes/auth/confirm.get.ts`: `GET /auth/confirm`, fuera de `/api/`, completa `verifyOtp` con `token_hash`/`type` y redirige a `/profesional/perfil` o `/profesional/registro` según si ya existe fila en `professionals` (`server/utils/professionals.ts`, nuevo), o a `/profesional/ingresar?error=enlace_invalido` si falla.
- `server/utils/auth.ts`: `serverSupabase` ahora exportado — lo reusa el callback para que la sesión quede en la misma cookie que ya sabe leer `requireUser()`.
- `app/middleware/profesional.ts` + `app/pages/profesional/{registro,perfil}.vue`: placeholders mínimos (walking skeleton) detrás de un middleware que exige sesión — sin ella, redirige a `/profesional/ingresar`.

Lo que no entra en este PR: la redirección entre `registro`/`perfil` según si ya existe perfil (necesita `GET /api/professionals/me`, que es S-004) y el formulario real de ambas páginas (S-003/S-004).

## Configuración operativa pendiente (no es código — la tienes que hacer tú en el dashboard de Supabase antes de probar el flujo real)

- Template "Magic Link" en Authentication → Email Templates: cambiar a `{{ .RedirectTo }}?token_hash={{ .TokenHash }}&type=email` (no `{{ .SiteURL }}`).
- Redirect URLs permitidas: dominio de producción + el patrón exacto de previews de Vercel — nunca un wildcard amplio.

Sin esto, `GET /auth/confirm` nunca recibe `token_hash`/`type` y el flujo no se puede probar en un ambiente real.

## Test plan

- [x] `npx nuxi typecheck` sin errores
- [x] `npm run build` compila
- [x] `npm run test` — sin regresión en los 21 tests existentes
- [ ] Patricio: aplicar la config del template de correo y las Redirect URLs en el dashboard de Supabase
- [ ] Pedir el enlace, tocarlo desde otro navegador del mismo celular, llegar autenticado a `/profesional/registro` (primera vez) o `/profesional/perfil` (ya tenía cuenta)
- [ ] Enlace vencido o reusado dos veces → `/profesional/ingresar?error=enlace_invalido`, nunca una sesión a medio crear (TR-003)
- [ ] Sin sesión, `/profesional/registro` y `/profesional/perfil` redirigen a `/profesional/ingresar`
- [ ] Un magic link pedido desde un preview de Vercel llega apuntando a ese preview