### PR TITLE
feat(server): crear el perfil de profesional y publicar de inmediato

### DIFF
--- a/app/components/CatalogSelect.vue
+++ b/app/components/CatalogSelect.vue
@@ -12,6 +12,7 @@ import { computed, ref, watch } from 'vue'
 export type CatalogOption = { value: string, label: string }
 
 const props = defineProps<{
+  id?: string
   items: CatalogOption[]
   pending: boolean
   error: boolean
@@ -125,6 +126,7 @@ function retry() {
 <template>
   <div ref="containerRef" class="relative" @focusin="handleFocusIn" @focusout="handleFocusOut">
     <UInput
+      :id="id"
       ref="uInputRef"
       :model-value="searchTerm"
       :placeholder="placeholder"

--- a/app/composables/useProfessionalRegistration.ts
+++ b/app/composables/useProfessionalRegistration.ts
@@ -1,0 +1,62 @@
+export function useProfessionalRegistration() {
+  const displayName = useState('professional-registration-display-name', () => '')
+  const categoriaSlug = useState<string | null>('professional-registration-categoria', () => null)
+  const comunaCodigo = useState<string | null>('professional-registration-comuna', () => null)
+  const contact = useState('professional-registration-contact', () => '')
+  const contactError = useState<string | null>('professional-registration-contact-error', () => null)
+  const loading = useState('professional-registration-loading', () => false)
+  const submitError = useState<string | null>('professional-registration-submit-error', () => null)
+
+  const isComplete = computed(() =>
+    Boolean(
+      displayName.value.trim()
+      && categoriaSlug.value
+      && comunaCodigo.value
+      && contact.value.trim()
+      && !contactError.value,
+    ),
+  )
+
+  function validateContact() {
+    contactError.value = !contact.value.trim() || isValidChileanContact(contact.value)
+      ? null
+      : 'Ese número no parece válido. Debe ser un WhatsApp o teléfono chileno, ej: +56 9 1234 5678.'
+  }
+
+  async function submit() {
+    if (!isComplete.value || loading.value) return
+
+    submitError.value = null
+    loading.value = true
+
+    try {
+      await $fetch('/api/professionals', {
+        method: 'POST',
+        body: {
+          displayName: displayName.value.trim(),
+          categoriaSlug: categoriaSlug.value,
+          comunaCodigo: comunaCodigo.value,
+          contact: normalizeChileanContact(contact.value),
+        },
+      })
+      await navigateTo('/profesional/perfil')
+    } catch {
+      submitError.value = 'No pudimos publicar tu perfil, pero tus datos siguen acá.'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return {
+    displayName,
+    categoriaSlug,
+    comunaCodigo,
+    contact,
+    contactError,
+    loading,
+    submitError,
+    isComplete,
+    validateContact,
+    submit,
+  }
+}

--- a/app/pages/profesional/registro.vue
+++ b/app/pages/profesional/registro.vue
@@ -1,17 +1,113 @@
 <script setup lang="ts">
+import { TriangleAlert } from '@lucide/vue'
+
 definePageMeta({ middleware: 'profesional' })
 
 useSeoMeta({ title: 'Crea tu perfil', robots: 'noindex' })
 
-const { data: user } = await useFetch('/api/auth/me')
+const {
+  displayName,
+  categoriaSlug,
+  comunaCodigo,
+  contact,
+  contactError,
+  loading,
+  submitError,
+  isComplete,
+  validateContact,
+  submit,
+} = useProfessionalRegistration()
+
+const completedCount = computed(() =>
+  [
+    Boolean(displayName.value.trim()),
+    Boolean(categoriaSlug.value),
+    Boolean(comunaCodigo.value),
+    Boolean(contact.value.trim() && !contactError.value),
+  ].filter(Boolean).length,
+)
 </script>
 
 <template>
-  <div class="mx-auto flex min-h-screen max-w-md flex-col justify-center px-6 py-10 text-center">
+  <div class="mx-auto flex min-h-screen max-w-md flex-col px-6 py-8">
     <h1 class="text-2xl font-extrabold text-datealo-text">Crea tu perfil</h1>
-    <p class="mt-2 text-sm text-datealo-muted">
-      Sesión iniciada como <strong class="text-datealo-text">{{ user?.email }}</strong>. El formulario de
-      registro llega en el próximo paso.
+    <div class="mt-4 flex gap-1.5">
+      <div
+        v-for="n in 4"
+        :key="n"
+        class="h-1.5 flex-1 rounded-full"
+        :class="n <= completedCount ? 'bg-primary' : 'bg-datealo-surface'"
+      />
+    </div>
+
+    <p
+      v-if="submitError"
+      class="mt-4 flex items-start gap-2 rounded-lg bg-error/10 p-3 text-sm text-error"
+      aria-live="polite"
+    >
+      <TriangleAlert class="mt-0.5 h-4 w-4 shrink-0" />
+      {{ submitError }}
     </p>
+
+    <form class="mt-6 flex-1" @submit.prevent="submit">
+      <label for="registro-nombre" class="mb-2 block text-sm font-semibold text-datealo-text">Tu nombre</label>
+      <UInput
+        id="registro-nombre"
+        v-model="displayName"
+        placeholder="Ej: Héctor Silva"
+        size="lg"
+        class="w-full"
+        :disabled="loading"
+      />
+
+      <label for="registro-categoria" class="mb-2 mt-5 block text-sm font-semibold text-datealo-text">
+        Tu categoría
+      </label>
+      <CategoriaSelect id="registro-categoria" v-model="categoriaSlug" />
+
+      <label for="registro-comuna" class="mb-2 mt-5 block text-sm font-semibold text-datealo-text">Tu comuna</label>
+      <ComunaSelect id="registro-comuna" v-model="comunaCodigo" />
+
+      <label for="registro-contacto" class="mb-2 mt-5 block text-sm font-semibold text-datealo-text">
+        Tu contacto (WhatsApp o teléfono)
+      </label>
+      <UInput
+        id="registro-contacto"
+        v-model="contact"
+        placeholder="+56 9 …"
+        size="lg"
+        class="w-full"
+        :disabled="loading"
+        :color="contactError ? 'error' : 'primary'"
+        :highlight="Boolean(contactError)"
+        :aria-describedby="contactError ? 'registro-contacto-error' : undefined"
+        @blur="validateContact"
+      />
+      <p
+        v-if="contactError"
+        id="registro-contacto-error"
+        class="mt-2 text-xs font-semibold text-error"
+        aria-live="polite"
+      >
+        {{ contactError }}
+      </p>
+    </form>
+
+    <div class="mt-6">
+      <UButton
+        type="submit"
+        block
+        size="lg"
+        class="font-bold"
+        :disabled="!isComplete || loading"
+        :loading="loading"
+        @click="submit"
+      >
+        <template v-if="!loading">Publicar mi perfil</template>
+      </UButton>
+      <p v-if="!isComplete" class="mt-2 text-center text-xs text-datealo-muted">
+        Completa los 4 campos para continuar
+      </p>
+    </div>
   </div>
 </template>

--- a/app/utils/professional-contact.ts
+++ b/app/utils/professional-contact.ts
@@ -1,0 +1,9 @@
+const CHILEAN_CONTACT_REGEX = /^\+56\d{9}$/
+
+export function normalizeChileanContact(value: string): string {
+  return value.replace(/\s+/g, '')
+}
+
+export function isValidChileanContact(value: string): boolean {
+  return CHILEAN_CONTACT_REGEX.test(normalizeChileanContact(value))
+}

--- a/server/api/professionals/index.post.ts
+++ b/server/api/professionals/index.post.ts
@@ -1,0 +1,45 @@
+const REQUIRED_FIELDS = ['displayName', 'categoriaSlug', 'comunaCodigo', 'contact'] as const
+
+export default defineEventHandler(async (event) => {
+  const user = await requireUser(event)
+  const body = await readBody<Record<string, unknown>>(event)
+
+  const fields = { displayName: '', categoriaSlug: '', comunaCodigo: '', contact: '' }
+  for (const field of REQUIRED_FIELDS) {
+    const value = body[field]
+    if (typeof value !== 'string' || !value.trim()) {
+      setResponseStatus(event, 400)
+      return { error: 'missing_field', field }
+    }
+    fields[field] = value.trim()
+  }
+  fields.contact = normalizeContact(fields.contact)
+
+  const fieldError = await validateProfessionalFields(fields)
+  if (fieldError) {
+    setResponseStatus(event, 400)
+    return fieldError
+  }
+
+  const { professional, created } = await createProfessional(user.id, fields)
+
+  // El correo solo se dispara al crear de verdad — si el usuario ya tenía perfil, no se reenvía.
+  if (created && user.email) {
+    const [categoriaNombre, comunaNombre] = await Promise.all([
+      findCategoriaNombre(fields.categoriaSlug),
+      findComunaNombre(fields.comunaCodigo),
+    ])
+    const { subject, html } = buildProfessionalWelcomeEmail({
+      displayName: fields.displayName,
+      categoriaNombre: categoriaNombre ?? fields.categoriaSlug,
+      comunaNombre: comunaNombre ?? fields.comunaCodigo,
+      profileUrl: `${getRequestURL(event).origin}/profesional/perfil`,
+    })
+    // waitUntil mantiene la función viva para el correo sin bloquear la respuesta al cliente; el
+    // catch descarta el error a propósito — una falla de Resend nunca debe deshacer un perfil ya creado.
+    event.waitUntil(sendEmail({ to: user.email, subject, html }).catch(() => {}))
+  }
+
+  setResponseStatus(event, created ? 201 : 200)
+  return { professional }
+})

--- a/server/utils/categorias.ts
+++ b/server/utils/categorias.ts
@@ -1,4 +1,4 @@
-import { asc, eq } from 'drizzle-orm'
+import { and, asc, eq } from 'drizzle-orm'
 import { categorias } from '../db/schema/categorias'
 
 export async function findActiveCategorias() {
@@ -7,4 +7,17 @@ export async function findActiveCategorias() {
     .from(categorias)
     .where(eq(categorias.activa, true))
     .orderBy(asc(categorias.nombre))
+}
+
+export async function existsActiveCategoria(slug: string): Promise<boolean> {
+  const [row] = await useDb()
+    .select({ slug: categorias.slug })
+    .from(categorias)
+    .where(and(eq(categorias.slug, slug), eq(categorias.activa, true)))
+  return Boolean(row)
+}
+
+export async function findCategoriaNombre(slug: string): Promise<string | null> {
+  const [row] = await useDb().select({ nombre: categorias.nombre }).from(categorias).where(eq(categorias.slug, slug))
+  return row?.nombre ?? null
 }

--- a/server/utils/comunas.ts
+++ b/server/utils/comunas.ts
@@ -1,4 +1,4 @@
-import { asc, eq } from 'drizzle-orm'
+import { and, asc, eq } from 'drizzle-orm'
 import { comunas } from '../db/schema/comunas'
 
 export async function findActiveComunas() {
@@ -7,4 +7,17 @@ export async function findActiveComunas() {
     .from(comunas)
     .where(eq(comunas.activa, true))
     .orderBy(asc(comunas.nombre))
+}
+
+export async function existsActiveComuna(codigo: string): Promise<boolean> {
+  const [row] = await useDb()
+    .select({ codigo: comunas.codigo })
+    .from(comunas)
+    .where(and(eq(comunas.codigo, codigo), eq(comunas.activa, true)))
+  return Boolean(row)
+}
+
+export async function findComunaNombre(codigo: string): Promise<string | null> {
+  const [row] = await useDb().select({ nombre: comunas.nombre }).from(comunas).where(eq(comunas.codigo, codigo))
+  return row?.nombre ?? null
 }

--- a/server/utils/professionals.ts
+++ b/server/utils/professionals.ts
@@ -1,10 +1,144 @@
 import { eq } from 'drizzle-orm'
+import { existsActiveCategoria } from './categorias'
+import { existsActiveComuna } from './comunas'
 import { professionals } from '../db/schema/professionals'
 
-export async function findProfessionalByUserId(userId: string) {
-  const [row] = await useDb()
-    .select({ id: professionals.id })
-    .from(professionals)
-    .where(eq(professionals.userId, userId))
-  return row ?? null
+const CONTACT_REGEX = /^\+56\d{9}$/
+
+export type ProfessionalFieldsInput = {
+  displayName?: string
+  categoriaSlug?: string
+  comunaCodigo?: string
+  contact?: string
+}
+
+export type ProfessionalFieldError = { error: string }
+
+export type Professional = {
+  id: string
+  displayName: string
+  categoriaSlug: string
+  comunaCodigo: string
+  contact: string
+  description: string | null
+  priceFrom: number | null
+  photoUrls: string[]
+  active: boolean
+}
+
+type ProfessionalRow = {
+  id: string
+  displayName: string
+  categoriaSlug: string
+  comunaCodigo: string
+  contact: string
+  description: string | null
+  priceFrom: number | null
+  photoPaths: string[]
+  active: boolean
+}
+
+// select explícito de las columnas públicas — nunca la fila cruda de Drizzle, así una columna nueva en
+// la tabla (una nota de moderación, un score interno) queda afuera de la respuesta por default.
+const publicColumns = {
+  id: professionals.id,
+  displayName: professionals.displayName,
+  categoriaSlug: professionals.categoriaSlug,
+  comunaCodigo: professionals.comunaCodigo,
+  contact: professionals.contact,
+  description: professionals.description,
+  priceFrom: professionals.priceFrom,
+  photoPaths: professionals.photoPaths,
+  active: professionals.active,
+}
+
+export function normalizeContact(value: string): string {
+  return value.replace(/\s+/g, '')
+}
+
+export async function validateProfessionalFields(
+  fields: ProfessionalFieldsInput,
+): Promise<ProfessionalFieldError | null> {
+  if (fields.categoriaSlug !== undefined && !(await existsActiveCategoria(fields.categoriaSlug))) {
+    return { error: 'invalid_categoria' }
+  }
+  if (fields.comunaCodigo !== undefined && !(await existsActiveComuna(fields.comunaCodigo))) {
+    return { error: 'invalid_comuna' }
+  }
+  if (fields.contact !== undefined && !CONTACT_REGEX.test(fields.contact)) {
+    return { error: 'invalid_contact' }
+  }
+  return null
+}
+
+function toPublicProfessional(row: ProfessionalRow): Professional {
+  const { public: pub } = useRuntimeConfig()
+  return {
+    id: row.id,
+    displayName: row.displayName,
+    categoriaSlug: row.categoriaSlug,
+    comunaCodigo: row.comunaCodigo,
+    contact: row.contact,
+    description: row.description,
+    priceFrom: row.priceFrom,
+    photoUrls: row.photoPaths.map(
+      path => `${pub.supabaseUrl}/storage/v1/object/public/professional-photos/${path}`,
+    ),
+    active: row.active,
+  }
+}
+
+export async function findProfessionalByUserId(userId: string): Promise<Professional | null> {
+  const [row] = await useDb().select(publicColumns).from(professionals).where(eq(professionals.userId, userId))
+  return row ? toPublicProfessional(row) : null
+}
+
+export async function createProfessional(
+  userId: string,
+  fields: Required<ProfessionalFieldsInput>,
+): Promise<{ professional: Professional, created: boolean }> {
+  const [inserted] = await useDb()
+    .insert(professionals)
+    .values({ userId, ...fields })
+    .onConflictDoNothing({ target: professionals.userId })
+    .returning(publicColumns)
+
+  if (inserted) {
+    return { professional: toPublicProfessional(inserted), created: true }
+  }
+
+  // userId es unique — si el insert no devolvió fila es porque ya existía una, nunca porque el insert
+  // falló en silencio.
+  const existing = await findProfessionalByUserId(userId)
+  return { professional: existing!, created: false }
+}
+
+function escapeHtml(value: string): string {
+  const entities: Record<string, string> = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }
+  return value.replace(/[&<>"']/g, char => entities[char]!)
+}
+
+export function buildProfessionalWelcomeEmail({
+  displayName,
+  categoriaNombre,
+  comunaNombre,
+  profileUrl,
+}: {
+  displayName: string
+  categoriaNombre: string
+  comunaNombre: string
+  profileUrl: string
+}): { subject: string, html: string } {
+  const firstName = escapeHtml(displayName.trim().split(/\s+/)[0] ?? displayName)
+
+  return {
+    subject: 'Tu perfil ya está publicado en Datealo',
+    html: `
+      <p>Hola ${firstName}, tu perfil de ${escapeHtml(categoriaNombre)} en ${escapeHtml(comunaNombre)} ya es
+      visible en Datealo. Cualquiera que te busque ya puede encontrarte y contactarte.</p>
+      <p>Todavía te faltan fotos de tus trabajos y tu precio: agrégalos para que la gente confíe más en
+      ti.</p>
+      <p><a href="${profileUrl}">Completar mi perfil</a></p>
+    `.trim(),
+  }
 }


### PR DESCRIPTION
## Qué hace

Cierra #75 — S-003 del plan de construcción de la misión 04.

- `POST /api/professionals`: crea el perfil con `active = true` de inmediato (sin revisión), con insert atómico (`onConflictDoNothing` + select de respaldo) para que un doble envío nunca duplique el perfil.
- Validación de los 4 campos: presencia (los 4 obligatorios), categoría/comuna contra el catálogo activo, contacto contra `/^\+56\d{9}$/` tras sacar espacios — vive en `validateProfessionalFields()` (`server/utils/professionals.ts`), pensada para que el próximo endpoint (editar perfil) la reuse sin duplicar la regla.
- Correo de confirmación disparado con `event.waitUntil()` (API nativa de Nitro, no hace falta `@vercel/functions`), envuelto en `catch` que descarta el error — nunca bloquea la respuesta ni deshace el perfil si Resend falla. Solo se dispara si el perfil se creó de verdad, nunca en el camino idempotente.
- Respuesta siempre por un `select` explícito (`toPublicProfessional`) — nunca la fila cruda de Drizzle, así `userId`/`createdAt`/`updatedAt` no salen nunca.
- `app/pages/profesional/registro.vue` reemplaza el placeholder por el formulario real de 4 campos (nombre, `CategoriaSelect`, `ComunaSelect`, contacto), con la barra de progreso, validación de contacto en el momento, y el estado de error con "Reintentar" que ya definía el mockup.
- `CategoriaSelect`/`ComunaSelect` (de la misión 03) reusados tal cual — sin repetir su lógica de búsqueda/selección.

**Cambio de un componente compartido:** `CatalogSelect.vue` ahora acepta un `id` opcional y lo reenvía al `UInput` real. Sin esto, un `<label for="...">` sobre `CategoriaSelect`/`ComunaSelect` apunta a nada — Vue hace fallthrough del atributo al div contenedor, no al input. Es el primer uso real de estos componentes con un label asociado, así que el hueco no se había notado antes.

## Verificado

- `npx nuxi typecheck` sin errores
- `npm run build` compila
- `npm run test` — sin regresión (21 tests existentes)
- Servidor real (`npm run dev` contra el proyecto de desarrollo): `/api/categorias` y `/api/comunas` responden 200, `/api/auth/me` sin sesión responde 401, `/profesional/registro` sin sesión redirige a `/profesional/ingresar` (server-side, no solo cliente)
- Verificación visual en browser: el formulario renderiza los 4 campos como el mockup; tocar el label "Tu categoría" abre `CategoriaSelect` con el catálogo real (Cerrajería, Electricidad, Gasfitería, …) — confirma que el fix de `id` en `CatalogSelect` funciona

## Lo que no entra en este PR

El correo de confirmación no se probó de punta a punta contra un envío real de Resend (queda para prueba manual — ver checklist abajo). La edición de perfil (`PATCH /api/professionals/me`, fotos) es el siguiente issue (#76).

## Test plan

- [x] `npx nuxi typecheck` sin errores
- [x] `npm run build` compila
- [x] `npm run test` sin regresión
- [x] Verificación visual del formulario y del fix de accesibilidad de `CatalogSelect`
- [ ] Patricio: completar el registro real (con sesión) y confirmar que el correo llega en menos de un minuto con el contenido de `experiencia.md`
- [ ] Reenviar el mismo formulario dos veces (dos pestañas) y confirmar que no duplica el perfil ni reenvía el correo