### PR TITLE
fix(app): reenviar cookie de sesión en SSR y mostrar errores del login que fallaban en silencio

### DIFF
--- a/app/composables/useMagicLink.ts
+++ b/app/composables/useMagicLink.ts
@@ -15,7 +15,11 @@ export function useMagicLink() {
     route.query.error === 'enlace_invalido' ? 'enlace-invalido' : 'email',
   )
   const email = useState('magic-link-email', () => '')
+  // emailError es del formato de lo que se escribió (pinta el input en rojo); sendError es de la
+  // acción de enviar el enlace (falla de red o del servidor) — un typo y una falla de Supabase no son
+  // lo mismo, y el input no debería marcarse inválido por algo que no tiene que ver con su contenido.
   const emailError = useState<string | null>('magic-link-email-error', () => null)
+  const sendError = useState<string | null>('magic-link-send-error', () => null)
   const loading = useState('magic-link-loading', () => false)
   const resendHintVisible = useState('magic-link-resend-hint', () => false)
 
@@ -34,6 +38,7 @@ export function useMagicLink() {
     }
 
     emailError.value = null
+    sendError.value = null
     loading.value = true
 
     try {
@@ -43,7 +48,7 @@ export function useMagicLink() {
       })
 
       if (error) {
-        emailError.value = 'No pudimos enviar el enlace. Intenta de nuevo.'
+        sendError.value = 'No pudimos enviar el enlace. Intenta de nuevo.'
         return
       }
 
@@ -63,10 +68,11 @@ export function useMagicLink() {
     step.value = 'email'
     email.value = ''
     emailError.value = null
+    sendError.value = null
     resendHintVisible.value = false
   }
 
   onUnmounted(clearResendHintTimer)
 
-  return { step, email, emailError, loading, resendHintVisible, sendLink, startOver }
+  return { step, email, emailError, sendError, loading, resendHintVisible, sendLink, startOver }
 }

--- a/app/middleware/profesional.ts
+++ b/app/middleware/profesional.ts
@@ -4,7 +4,9 @@ export default defineNuxtRouteMiddleware(async (to) => {
   if (to.path === '/profesional/ingresar') return
 
   try {
-    await $fetch('/api/auth/me')
+    // $fetch a secas no reenvía las cookies de la request original durante SSR — justo el caso de
+    // seguir el enlace del correo, una navegación completa. useRequestFetch() sí las reenvía.
+    await useRequestFetch()('/api/auth/me')
   } catch {
     return navigateTo('/profesional/ingresar')
   }

--- a/app/pages/profesional/ingresar.vue
+++ b/app/pages/profesional/ingresar.vue
@@ -5,7 +5,7 @@ definePageMeta({ middleware: 'profesional' })
 
 useSeoMeta({ title: 'Entra a Datealo', robots: 'noindex' })
 
-const { step, email, emailError, loading, resendHintVisible, sendLink, startOver } = useMagicLink()
+const { step, email, emailError, sendError, loading, resendHintVisible, sendLink, startOver } = useMagicLink()
 </script>
 
 <template>
@@ -16,7 +16,7 @@ const { step, email, emailError, loading, resendHintVisible, sendLink, startOver
         Te mandamos un enlace a tu correo, sin contraseña que recordar.
       </p>
 
-      <form class="mt-8" @submit.prevent="sendLink">
+      <form class="mt-8" novalidate @submit.prevent="sendLink">
         <label for="magic-link-email" class="mb-2 block text-sm font-semibold text-datealo-text">
           Tu email
         </label>
@@ -45,6 +45,9 @@ const { step, email, emailError, loading, resendHintVisible, sendLink, startOver
         <UButton type="submit" block size="lg" class="mt-6 font-bold" :loading="loading" :disabled="loading">
           <template v-if="!loading">Enviar enlace</template>
         </UButton>
+        <p v-if="sendError" class="mt-2 text-xs font-semibold text-error" aria-live="polite">
+          {{ sendError }}
+        </p>
       </form>
     </template>
 
@@ -60,9 +63,17 @@ const { step, email, emailError, loading, resendHintVisible, sendLink, startOver
         </p>
         <p v-if="resendHintVisible" class="mt-10 text-xs text-datealo-muted" aria-live="polite">
           ¿No te llegó? Revisa spam o
-          <button type="button" class="font-semibold text-primary underline" @click="sendLink">
-            pide otro enlace
+          <button
+            type="button"
+            class="font-semibold text-primary underline disabled:opacity-50"
+            :disabled="loading"
+            @click="sendLink"
+          >
+            {{ loading ? 'enviando…' : 'pide otro enlace' }}
           </button>
+        </p>
+        <p v-if="sendError" class="mt-2 text-xs font-semibold text-error" aria-live="polite">
+          {{ sendError }}
         </p>
       </div>
     </template>

--- a/app/pages/profesional/registro.vue
+++ b/app/pages/profesional/registro.vue
@@ -49,7 +49,7 @@ const completedCount = computed(() =>
       {{ submitError }}
     </p>
 
-    <form class="mt-6 flex-1" @submit.prevent="submit">
+    <form class="mt-6 flex-1" novalidate @submit.prevent="submit">
       <label for="registro-nombre" class="mb-2 block text-sm font-semibold text-datealo-text">Tu nombre</label>
       <UInput
         id="registro-nombre"

--- a/docs/missions/04-registro-perfil-profesional/ingenieria.md
+++ b/docs/missions/04-registro-perfil-profesional/ingenieria.md
@@ -2,7 +2,7 @@
 
 **Estado:** vigente — aprobado por Patricio el 2026-08-24
 
-**Última actualización:** 2026-08-24
+**Última actualización:** 2026-08-28
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
@@ -391,22 +391,31 @@ puesta?) y los siguientes lo engrosan sin volver a tocar ese contrato.
 
 ### T-005 — Un middleware de página, no cada página por separado, decide a dónde redirige según sesión + existencia de perfil
 
-- **Estado:** aceptada. **Fecha:** 2026-08-24.
+- **Estado:** aceptada. **Fecha:** 2026-08-24, revisada 2026-08-28.
 - **Contratos:** UXF-001, UXF-002, UXF-003.
 - **Alternativas descartadas:** cada página (`ingresar.vue`, `registro.vue`, `perfil.vue`) resuelve su
   propia redirección en el `<script setup>` — funciona, pero repite la misma llamada a
   `GET /api/auth/me` (misión 02) y a `GET /api/professionals/me` tres veces, una por archivo, con el riesgo
-  real de que la regla de una diverja de las otras dos con el tiempo.
+  real de que la regla de una diverja de las otras dos con el tiempo. Dejar `/profesional/ingresar` sin
+  redirigir nunca, aunque ya haya sesión — la versión original de esta decisión, descartada en la revisión
+  del 2026-08-28: el único motivo que daba (dejar espacio a un futuro botón de "cambiar de cuenta") no
+  corresponde a nada que esta misión construya, y el resultado observable es que alguien ya autenticado
+  vuelve a ver el formulario pidiéndole el email — la referencia de productos comparables con login sin
+  contraseña (Notion, Slack, Linear, GitHub) es unánime: si ya hay sesión, saltar la pantalla de login por
+  completo es el default, no la excepción.
 - **Decisión y consecuencia:** `app/middleware/profesional.ts`, aplicado con `definePageMeta({ middleware:
-  'profesional' })` en las tres páginas. Sin sesión → `/profesional/ingresar`. Con sesión y sin perfil,
-  parado en `/profesional/perfil` → `/profesional/registro`. Con sesión y con perfil, parado en
-  `/profesional/registro` → `/profesional/perfil`. `/profesional/ingresar` nunca redirige desde acá — si ya
-  hay sesión y llega ahí, se deja entrar (puede querer cerrar sesión y entrar con otra cuenta más adelante,
-  aunque esta misión no construye ese botón). Costo aceptado: un fetch extra a `/api/professionals/me` en
-  cada navegación entre estas tres páginas — sin caché de cliente todavía, aceptable al volumen de esta
-  entrega.
+  'profesional' })` en las tres páginas, con la misma regla para las tres — ninguna es un caso especial.
+  Sin sesión → `/profesional/ingresar`. Con sesión y sin perfil, parado en `/profesional/perfil` o en
+  `/profesional/ingresar` → `/profesional/registro`. Con sesión y con perfil, parado en
+  `/profesional/registro` o en `/profesional/ingresar` → `/profesional/perfil`. Es la misma pregunta que ya
+  resuelve `GET /auth/confirm` (TC-006) al terminar el enlace mágico — acá se repite porque alguien puede
+  llegar a `/profesional/ingresar` con sesión ya armada sin pasar por ese endpoint (un bookmark, la URL
+  escrita a mano). Costo aceptado: un fetch extra a `/api/professionals/me` en cada navegación entre estas
+  tres páginas — sin caché de cliente todavía, aceptable al volumen de esta entrega.
 - **Reapertura:** si el fetch repetido se vuelve un costo real medible, ahí conviene cachear el resultado en
-  estado de cliente en vez de repetirlo por navegación.
+  estado de cliente en vez de repetirlo por navegación. Si alguna vez se construye un flujo real de "cambiar
+  de cuenta", `/profesional/ingresar` necesita una forma explícita de pedirlo (ej. `?cambiar_cuenta=1`) en
+  vez de volver a ser el default.
 
 ## Preguntas
 


### PR DESCRIPTION
## Qué hace

Cuatro bugs encontrados probando de punta a punta el flujo de S-002/S-003 (misión 04), más la revisión de T-005 que abre paso a #76.

**Fixes de código:**

1. **`app/middleware/profesional.ts` no reenviaba la cookie de sesión en SSR** — usaba `$fetch()` a secas, que durante un render de servidor no lleva las cookies de la request original. Cualquier navegación completa (seguir el enlace del correo desde el cliente de mail) veía "sin sesión" siempre y rebotaba a `/profesional/ingresar`, aunque `GET /auth/confirm` hubiera guardado la cookie bien. `useRequestFetch()` sí las reenvía — es la razón por la que existe ese composable en Nuxt.
2. **El botón "pide otro enlace" fallaba en silencio** — su error se guardaba en una variable que solo se renderizaba en el modo "ingresar email" de la pantalla, no en "revisa tu correo".
3. **Esa misma variable mezclaba dos errores distintos**: formato del email inválido (cliente) vs. falla al enviar el enlace (servidor, ej. rate limit de Supabase). Un fallo de envío pintaba el input en rojo como si el problema fuera lo que el usuario escribió. Separados en `emailError` (formato, afecta el color del input) y `sendError` (falla de la acción, mensaje propio).
4. **Validación nativa del navegador tapaba la copy del producto** — los `UInput type="email"` disparaban el tooltip propio de Chrome/Firefox antes de que el `@submit.prevent` corriera, así que el mensaje "Ese correo no parece válido..." de `experiencia.md` nunca llegaba a mostrarse. `novalidate` en los `<form>` lo evita sin perder el teclado de email en mobile.

**Revisión de doc (T-005, `ingenieria.md`):** `/profesional/ingresar` dejaba de redirigir aunque ya hubiera sesión — la razón que daba (dejar espacio a un futuro botón de "cambiar de cuenta") no corresponde a nada que la misión construya. Benchmark contra Notion/Slack/Linear/GitHub: todos saltan la pantalla de login si ya hay sesión, es el default, no la excepción. Queda documentado el cambio; la implementación real depende de `GET /api/professionals/me` (para saber si mandar a registro o a perfil) y se hace junto con #76.

## Verificado

- `npx nuxi typecheck` sin errores
- `npm run build` compila
- Probado a mano contra el proyecto de desarrollo real: registro completo, perfil creado en la base con los datos correctos, correo de confirmación recibido
- Los 4 bugs reproducidos y corregidos uno por uno durante la sesión de pruebas

## Test plan

- [x] `npx nuxi typecheck` sin errores
- [x] `npm run build` compila
- [x] Flujo completo probado a mano (enlace mágico, registro, perfil creado, correo recibido)
- [ ] Confirmar que "pide otro enlace" ahora muestra el error si Supabase rechaza por rate limit