### PR TITLE
feat(server): ver y editar los campos de texto del perfil

### DIFF
--- a/app/components/professional/ProfessionalCatalogRow.vue
+++ b/app/components/professional/ProfessionalCatalogRow.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import { Loader2 } from '@lucide/vue'
+import type { ProfessionalField } from '~/types/professional'
+
+const props = defineProps<{
+  label: string
+  field: ProfessionalField
+  value: string
+  displayValue: string
+}>()
+
+const { editingField, savingField, saveErrorField, startEdit, save } = useProfessionalProfile()
+
+const isEditing = computed(() => editingField.value === props.field)
+const isSaving = computed(() => savingField.value === props.field)
+const hasSaveError = computed(() => saveErrorField.value === props.field)
+
+const draft = ref<string | null>(props.value)
+
+function edit() {
+  draft.value = props.value
+  startEdit(props.field)
+}
+
+// CategoriaSelect/ComunaSelect confirman el valor al elegir una opción de la lista — no hay blur que
+// esperar, a diferencia de un input de texto.
+function onSelect(newValue: string | null | undefined) {
+  if (!newValue || newValue === props.value) return
+  save(props.field, newValue)
+}
+</script>
+
+<template>
+  <div class="border-b border-datealo-surface py-3 text-sm last:border-b-0">
+    <div class="flex items-center justify-between gap-3">
+      <span class="shrink-0 text-datealo-muted">{{ label }}</span>
+      <button v-if="!isEditing" type="button" class="text-right text-datealo-text" @click="edit">
+        {{ displayValue }}
+        <Loader2 v-if="isSaving" class="ml-1 inline h-3 w-3 animate-spin" />
+      </button>
+      <div v-else class="w-40">
+        <slot name="select" :model-value="draft" :update="onSelect" />
+      </div>
+    </div>
+    <p v-if="hasSaveError" class="mt-1 text-right text-xs font-semibold text-error" aria-live="polite">
+      No se pudo guardar, toca para reintentar
+    </p>
+  </div>
+</template>

--- a/app/components/professional/ProfessionalDataRow.vue
+++ b/app/components/professional/ProfessionalDataRow.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import { Loader2 } from '@lucide/vue'
+import type { ProfessionalField } from '~/types/professional'
+
+const props = defineProps<{
+  label: string
+  field: ProfessionalField
+  value: string
+  type?: 'text' | 'tel'
+}>()
+
+const { editingField, savingField, fieldError, saveErrorField, startEdit, cancelEdit, save } = useProfessionalProfile()
+
+const isEditing = computed(() => editingField.value === props.field)
+const isSaving = computed(() => savingField.value === props.field)
+const hasSaveError = computed(() => saveErrorField.value === props.field)
+
+const draft = ref(props.value)
+
+function edit() {
+  if (!hasSaveError.value) draft.value = props.value
+  startEdit(props.field)
+}
+
+function commit() {
+  if (draft.value.trim() === props.value) {
+    cancelEdit()
+    return
+  }
+  save(props.field, draft.value.trim())
+}
+</script>
+
+<template>
+  <div class="border-b border-datealo-surface py-3 text-sm last:border-b-0">
+    <div class="flex items-center justify-between gap-3">
+      <span class="shrink-0 text-datealo-muted">{{ label }}</span>
+      <button v-if="!isEditing" type="button" class="text-right text-datealo-text" @click="edit">
+        {{ value }}
+        <Loader2 v-if="isSaving" class="ml-1 inline h-3 w-3 animate-spin" />
+      </button>
+      <UInput
+        v-else
+        v-model="draft"
+        :type="type === 'tel' ? 'tel' : 'text'"
+        size="sm"
+        class="w-40"
+        autofocus
+        :color="fieldError ? 'error' : 'primary'"
+        :highlight="Boolean(fieldError)"
+        @blur="commit"
+        @keyup.enter="commit"
+      />
+    </div>
+    <p v-if="isEditing && fieldError" class="mt-1 text-right text-xs font-semibold text-error" aria-live="polite">
+      {{ fieldError }}
+    </p>
+    <p v-if="hasSaveError" class="mt-1 text-right text-xs font-semibold text-error" aria-live="polite">
+      No se pudo guardar, toca para reintentar
+    </p>
+  </div>
+</template>

--- a/app/composables/useProfessionalProfile.ts
+++ b/app/composables/useProfessionalProfile.ts
@@ -1,0 +1,84 @@
+import type { Professional, ProfessionalField } from '~/types/professional'
+
+export function useProfessionalProfile() {
+  const professional = useState<Professional | null>('professional-profile', () => null)
+  const pending = useState('professional-profile-pending', () => true)
+  const loadError = useState<string | null>('professional-profile-load-error', () => null)
+
+  const editingField = useState<ProfessionalField | null>('professional-profile-editing', () => null)
+  const savingField = useState<ProfessionalField | null>('professional-profile-saving', () => null)
+  // fieldError es del valor mientras se escribe (contacto con formato inválido, no deja ni intentar
+  // guardar); saveErrorField es de un guardado que sí se intentó y falló en el servidor — son casos
+  // distintos con recuperación distinta (corregir el valor vs. reintentar el mismo valor).
+  const fieldError = useState<string | null>('professional-profile-field-error', () => null)
+  const saveErrorField = useState<ProfessionalField | null>('professional-profile-save-error', () => null)
+
+  async function load() {
+    pending.value = true
+    loadError.value = null
+    try {
+      // useRequestFetch(), no $fetch a secas: durante SSR reenvía las cookies de la request original
+      // (mismo motivo que app/middleware/profesional.ts), y en el cliente se comporta igual que $fetch.
+      const { professional: data } = await useRequestFetch()<{ professional: Professional }>('/api/professionals/me')
+      professional.value = data
+    } catch {
+      loadError.value = 'No pudimos cargar tu perfil.'
+    } finally {
+      pending.value = false
+    }
+  }
+
+  function startEdit(field: ProfessionalField) {
+    saveErrorField.value = null
+    fieldError.value = null
+    editingField.value = field
+  }
+
+  function cancelEdit() {
+    editingField.value = null
+    fieldError.value = null
+  }
+
+  async function save(field: ProfessionalField, value: string | number | null) {
+    if (!professional.value) return
+
+    if (field === 'contact' && typeof value === 'string') {
+      if (!isValidChileanContact(value)) {
+        fieldError.value = 'Ese número no parece válido. Debe ser un WhatsApp o teléfono chileno, ej: +56 9 1234 5678.'
+        return
+      }
+      value = normalizeChileanContact(value)
+    }
+
+    fieldError.value = null
+    editingField.value = null
+    savingField.value = field
+    saveErrorField.value = null
+
+    try {
+      const { professional: updated } = await $fetch<{ professional: Professional }>('/api/professionals/me', {
+        method: 'PATCH',
+        body: { [field]: value },
+      })
+      professional.value = updated
+    } catch {
+      saveErrorField.value = field
+    } finally {
+      savingField.value = null
+    }
+  }
+
+  return {
+    professional,
+    pending,
+    loadError,
+    editingField,
+    savingField,
+    fieldError,
+    saveErrorField,
+    load,
+    startEdit,
+    cancelEdit,
+    save,
+  }
+}

--- a/app/middleware/profesional.ts
+++ b/app/middleware/profesional.ts
@@ -1,13 +1,30 @@
-// Único lugar que decide a dónde manda una página de este dominio según la sesión — así las tres
-// páginas comparten la misma regla en vez de repetir la llamada a /api/auth/me cada una por su lado.
+// Único lugar que decide a dónde manda una página de este dominio según sesión + existencia de perfil
+// — así las tres páginas comparten la misma regla en vez de repetir la lógica cada una por su lado.
 export default defineNuxtRouteMiddleware(async (to) => {
-  if (to.path === '/profesional/ingresar') return
+  // useRequestFetch(), no $fetch a secas: durante SSR reenvía las cookies de la request original — sin
+  // esto, seguir el enlace del correo (una navegación completa) siempre ve "sin sesión".
+  const fetcher = useRequestFetch()
 
   try {
-    // $fetch a secas no reenvía las cookies de la request original durante SSR — justo el caso de
-    // seguir el enlace del correo, una navegación completa. useRequestFetch() sí las reenvía.
-    await useRequestFetch()('/api/auth/me')
+    await fetcher('/api/auth/me')
   } catch {
+    if (to.path === '/profesional/ingresar') return
     return navigateTo('/profesional/ingresar')
+  }
+
+  // Con sesión, dónde corresponde pararse depende de si ya existe un perfil — la misma pregunta que
+  // GET /auth/confirm ya resuelve al terminar el enlace mágico. Se repite acá porque también se puede
+  // llegar a estas páginas con sesión ya armada sin pasar por ese endpoint (un bookmark, la URL escrita
+  // a mano).
+  let hasProfile = true
+  try {
+    await fetcher('/api/professionals/me')
+  } catch {
+    hasProfile = false
+  }
+
+  const destination = hasProfile ? '/profesional/perfil' : '/profesional/registro'
+  if (to.path !== destination) {
+    return navigateTo(destination)
   }
 })

--- a/app/pages/profesional/perfil.vue
+++ b/app/pages/profesional/perfil.vue
@@ -1,17 +1,173 @@
 <script setup lang="ts">
+import { Loader2 } from '@lucide/vue'
+
 definePageMeta({ middleware: 'profesional' })
 
 useSeoMeta({ title: 'Tu perfil', robots: 'noindex' })
 
-const { data: user } = await useFetch('/api/auth/me')
+const { professional, pending, loadError, editingField, savingField, saveErrorField, startEdit, cancelEdit, save, load } = useProfessionalProfile()
+
+if (!professional.value) await load()
+
+const { items: categoriaItems } = useCategoriasCatalog()
+const { items: comunaItems } = useComunasCatalog()
+
+const categoriaNombre = computed(
+  () => categoriaItems.value.find(item => item.value === professional.value?.categoriaSlug)?.label
+    ?? professional.value?.categoriaSlug ?? '',
+)
+const comunaNombre = computed(
+  () => comunaItems.value.find(item => item.value === professional.value?.comunaCodigo)?.label
+    ?? professional.value?.comunaCodigo ?? '',
+)
+
+const isEditingDescription = computed(() => editingField.value === 'description')
+const isSavingDescription = computed(() => savingField.value === 'description')
+const hasDescriptionError = computed(() => saveErrorField.value === 'description')
+const descriptionDraft = ref('')
+
+function editDescription() {
+  descriptionDraft.value = professional.value?.description ?? ''
+  startEdit('description')
+}
+
+function commitDescription() {
+  const trimmed = descriptionDraft.value.trim()
+  if (trimmed === (professional.value?.description ?? '')) {
+    cancelEdit()
+    return
+  }
+  save('description', trimmed || null)
+}
+
+const isEditingPrice = computed(() => editingField.value === 'priceFrom')
+const isSavingPrice = computed(() => savingField.value === 'priceFrom')
+const hasPriceError = computed(() => saveErrorField.value === 'priceFrom')
+const priceDraft = ref('')
+
+function editPrice() {
+  priceDraft.value = professional.value?.priceFrom ? String(professional.value.priceFrom) : ''
+  startEdit('priceFrom')
+}
+
+function commitPrice() {
+  const trimmed = priceDraft.value.trim()
+  const parsed = trimmed === '' ? null : Number(trimmed)
+  const normalized = parsed !== null && !Number.isNaN(parsed) ? parsed : null
+  if (normalized === (professional.value?.priceFrom ?? null)) {
+    cancelEdit()
+    return
+  }
+  save('priceFrom', normalized)
+}
 </script>
 
 <template>
-  <div class="mx-auto flex min-h-screen max-w-md flex-col justify-center px-6 py-10 text-center">
-    <h1 class="text-2xl font-extrabold text-datealo-text">Tu perfil</h1>
-    <p class="mt-2 text-sm text-datealo-muted">
-      Sesión iniciada como <strong class="text-datealo-text">{{ user?.email }}</strong>. La edición del
-      perfil llega en el próximo paso.
-    </p>
+  <div class="mx-auto min-h-screen max-w-md px-5 py-8 pb-16">
+    <p v-if="pending" class="text-sm text-datealo-muted">Cargando tu perfil…</p>
+
+    <p v-else-if="loadError" class="text-sm text-error">{{ loadError }}</p>
+
+    <template v-else-if="professional">
+      <h1 class="text-xl font-extrabold text-datealo-text">{{ professional.displayName }}</h1>
+      <p class="mt-0.5 text-sm text-datealo-muted">{{ categoriaNombre }} · {{ comunaNombre }}</p>
+
+      <div class="mt-5 rounded-2xl border border-datealo-surface p-4">
+        <div class="flex items-center justify-between">
+          <p class="text-sm font-semibold text-datealo-text">Descripción</p>
+          <Loader2 v-if="isSavingDescription" class="h-3.5 w-3.5 animate-spin text-primary" />
+        </div>
+
+        <p v-if="!isEditingDescription && professional.description" class="mt-1 text-sm text-datealo-text">
+          {{ professional.description }}
+        </p>
+        <button
+          v-else-if="!isEditingDescription"
+          type="button"
+          class="mt-1 text-left text-sm italic text-datealo-muted"
+          @click="editDescription"
+        >
+          Ej: "Electricista con 10 años de experiencia en Ñuñoa"
+        </button>
+        <UTextarea
+          v-else
+          v-model="descriptionDraft"
+          autofocus
+          class="mt-2 w-full"
+          :rows="2"
+          @blur="commitDescription"
+        />
+        <button
+          v-if="!isEditingDescription && professional.description"
+          type="button"
+          class="mt-1 text-xs font-semibold text-primary underline"
+          @click="editDescription"
+        >
+          Editar
+        </button>
+        <p v-if="hasDescriptionError" class="mt-2 text-xs font-semibold text-error" aria-live="polite">
+          No se pudo guardar, toca para reintentar
+        </p>
+      </div>
+
+      <div class="mt-3 rounded-2xl border border-datealo-surface p-4">
+        <div class="flex items-center justify-between">
+          <p class="text-sm font-semibold text-datealo-text">Precio</p>
+          <Loader2 v-if="isSavingPrice" class="h-3.5 w-3.5 animate-spin text-primary" />
+        </div>
+
+        <button v-if="!isEditingPrice" type="button" class="mt-1 block text-left text-sm" @click="editPrice">
+          <template v-if="professional.priceFrom">
+            <span class="text-datealo-text">Desde ${{ formatPriceFrom(professional.priceFrom) }}</span>
+          </template>
+          <template v-else>
+            <span class="text-datealo-muted">Desde $</span>
+            <span class="italic text-datealo-muted">Ej: 10.000</span>
+          </template>
+        </button>
+        <div v-else class="mt-2 flex items-center gap-2">
+          <span class="text-sm text-datealo-muted">Desde $</span>
+          <UInput
+            v-model="priceDraft"
+            inputmode="numeric"
+            autofocus
+            size="sm"
+            class="w-32"
+            @blur="commitPrice"
+            @keyup.enter="commitPrice"
+          />
+        </div>
+        <p v-if="hasPriceError" class="mt-2 text-xs font-semibold text-error" aria-live="polite">
+          No se pudo guardar, toca para reintentar
+        </p>
+      </div>
+
+      <div class="mt-3 rounded-2xl border border-datealo-surface p-4">
+        <p class="mb-1 text-sm font-semibold text-datealo-text">Tus datos</p>
+
+        <ProfessionalDataRow label="Nombre" field="displayName" :value="professional.displayName" />
+        <ProfessionalCatalogRow
+          label="Categoría"
+          field="categoriaSlug"
+          :value="professional.categoriaSlug"
+          :display-value="categoriaNombre"
+        >
+          <template #select="{ modelValue, update }">
+            <CategoriaSelect :model-value="modelValue" @update:model-value="update" />
+          </template>
+        </ProfessionalCatalogRow>
+        <ProfessionalCatalogRow
+          label="Comuna"
+          field="comunaCodigo"
+          :value="professional.comunaCodigo"
+          :display-value="comunaNombre"
+        >
+          <template #select="{ modelValue, update }">
+            <ComunaSelect :model-value="modelValue" @update:model-value="update" />
+          </template>
+        </ProfessionalCatalogRow>
+        <ProfessionalDataRow label="Contacto" field="contact" type="tel" :value="professional.contact" />
+      </div>
+    </template>
   </div>
 </template>

--- a/app/types/professional.ts
+++ b/app/types/professional.ts
@@ -1,0 +1,19 @@
+export type Professional = {
+  id: string
+  displayName: string
+  categoriaSlug: string
+  comunaCodigo: string
+  contact: string
+  description: string | null
+  priceFrom: number | null
+  photoUrls: string[]
+  active: boolean
+}
+
+export type ProfessionalField =
+  | 'displayName'
+  | 'categoriaSlug'
+  | 'comunaCodigo'
+  | 'contact'
+  | 'description'
+  | 'priceFrom'

--- a/app/utils/professional-price.ts
+++ b/app/utils/professional-price.ts
@@ -1,0 +1,3 @@
+export function formatPriceFrom(value: number): string {
+  return new Intl.NumberFormat('es-CL').format(value)
+}

--- a/server/api/professionals/me/index.get.ts
+++ b/server/api/professionals/me/index.get.ts
@@ -1,0 +1,11 @@
+export default defineEventHandler(async (event) => {
+  const user = await requireUser(event)
+
+  const professional = await findProfessionalByUserId(user.id)
+  if (!professional) {
+    setResponseStatus(event, 404)
+    return { error: 'not_found' }
+  }
+
+  return { professional }
+})

--- a/server/api/professionals/me/index.patch.ts
+++ b/server/api/professionals/me/index.patch.ts
@@ -1,0 +1,50 @@
+const TEXT_FIELDS = ['displayName', 'categoriaSlug', 'comunaCodigo', 'contact'] as const
+
+export default defineEventHandler(async (event) => {
+  const user = await requireUser(event)
+  const body = await readBody<Record<string, unknown>>(event)
+
+  const patch: ProfessionalFieldsInput = {}
+
+  for (const field of TEXT_FIELDS) {
+    if (!(field in body)) continue
+    const value = body[field]
+    if (typeof value !== 'string' || !value.trim()) {
+      setResponseStatus(event, 400)
+      return { error: 'missing_field', field }
+    }
+    patch[field] = field === 'contact' ? normalizeContact(value.trim()) : value.trim()
+  }
+
+  if ('description' in body) {
+    const value = body.description
+    if (value !== null && typeof value !== 'string') {
+      setResponseStatus(event, 400)
+      return { error: 'invalid_description' }
+    }
+    patch.description = typeof value === 'string' ? value.trim() || null : null
+  }
+
+  if ('priceFrom' in body) {
+    const value = body.priceFrom
+    if (value !== null && typeof value !== 'number') {
+      setResponseStatus(event, 400)
+      return { error: 'invalid_price' }
+    }
+    patch.priceFrom = value
+  }
+
+  const fieldError = await validateProfessionalFields(patch)
+  if (fieldError) {
+    setResponseStatus(event, 400)
+    return fieldError
+  }
+
+  const professional = await updateProfessional(user.id, patch)
+  if (!professional) {
+    setResponseStatus(event, 404)
+    return { error: 'not_found' }
+  }
+
+  return { professional }
+})

--- a/server/utils/professionals.ts
+++ b/server/utils/professionals.ts
@@ -5,11 +5,16 @@ import { professionals } from '../db/schema/professionals'
 
 const CONTACT_REGEX = /^\+56\d{9}$/
 
-export type ProfessionalFieldsInput = {
-  displayName?: string
-  categoriaSlug?: string
-  comunaCodigo?: string
-  contact?: string
+export type ProfessionalCoreFields = {
+  displayName: string
+  categoriaSlug: string
+  comunaCodigo: string
+  contact: string
+}
+
+export type ProfessionalFieldsInput = Partial<ProfessionalCoreFields> & {
+  description?: string | null
+  priceFrom?: number | null
 }
 
 export type ProfessionalFieldError = { error: string }
@@ -68,6 +73,9 @@ export async function validateProfessionalFields(
   if (fields.contact !== undefined && !CONTACT_REGEX.test(fields.contact)) {
     return { error: 'invalid_contact' }
   }
+  if (fields.priceFrom != null && (!Number.isInteger(fields.priceFrom) || fields.priceFrom <= 0)) {
+    return { error: 'invalid_price' }
+  }
   return null
 }
 
@@ -95,7 +103,7 @@ export async function findProfessionalByUserId(userId: string): Promise<Professi
 
 export async function createProfessional(
   userId: string,
-  fields: Required<ProfessionalFieldsInput>,
+  fields: ProfessionalCoreFields,
 ): Promise<{ professional: Professional, created: boolean }> {
   const [inserted] = await useDb()
     .insert(professionals)
@@ -111,6 +119,18 @@ export async function createProfessional(
   // falló en silencio.
   const existing = await findProfessionalByUserId(userId)
   return { professional: existing!, created: false }
+}
+
+export async function updateProfessional(
+  userId: string,
+  patch: ProfessionalFieldsInput,
+): Promise<Professional | null> {
+  const [updated] = await useDb()
+    .update(professionals)
+    .set({ ...patch, updatedAt: new Date() })
+    .where(eq(professionals.userId, userId))
+    .returning(publicColumns)
+  return updated ? toPublicProfessional(updated) : null
 }
 
 function escapeHtml(value: string): string {


### PR DESCRIPTION
## Qué hace

Cierra #76 — S-004 del plan de construcción de la misión 04.

- `GET /api/professionals/me` / `PATCH /api/professionals/me`: siempre sobre el propio perfil (`where user_id = sesión.id`, sin `id` en la URL — la pertenencia es estructural, no un chequeo que se pueda olvidar).
- `PATCH` acepta cualquier subconjunto de `{ displayName, categoriaSlug, comunaCodigo, contact, description, priceFrom }`, reusando `validateProfessionalFields()` para categoría/comuna/contacto (la misma función que ya usa #75) y sumándole la validación de precio (entero positivo, `invalid_price`).
- `app/pages/profesional/perfil.vue` reemplaza el placeholder por la UI real de V-003: descripción y precio en tarjetas con guardado automático al salir del campo, y "Tus datos" (nombre, categoría, comuna, contacto) editable in-place — categoría/comuna abren `CategoriaSelect`/`ComunaSelect` y guardan al elegir una opción, sin esperar blur.
- `app/composables/useProfessionalProfile.ts` centraliza el estado de edición (qué campo se está editando, guardando, o falló) para que cada fila/tarjeta lo consuma sin duplicar la lógica.
- `app/middleware/profesional.ts` ahora llama a `GET /api/professionals/me` para decidir el destino real (`registro` o `perfil`) en las tres páginas — cierra la revisión de T-005 del PR anterior: `/profesional/ingresar` también redirige cuando ya hay sesión.

**Lo que no entra en este PR:** la sección de fotos (subida, borrado) es el issue siguiente (#77) — sin bucket de Storage todavía, no hay nada real que construir ahí.

## Verificado

- `npx nuxi typecheck` sin errores
- `npm run build` compila
- `npm run test` — sin regresión (21 tests existentes)
- Probado a mano contra el proyecto de desarrollo real, con el perfil ya creado en #75: edité precio, descripción, categoría y contacto uno por uno — cada guardado quedó confirmado en la base (verificado con una query directa), el header se actualiza solo al cambiar categoría/comuna, el contacto con formato inválido muestra el error exacto de `experiencia.md` sin guardar nada, y navegar a `/profesional/ingresar` con sesión activa redirige directo a `/profesional/perfil`
- Encontré y arreglé un bug real durante la prueba manual: `UInput type="number"` de Nuxt UI coerciona el valor a `number` automáticamente (menos cuando el campo queda vacío, que se comporta distinto) — mi código asumía string y explotaba en `.trim()`. Cambiado a `type="text"` + `inputmode="numeric"`, parseo manual en `commitPrice()`.

## Test plan

- [x] `npx nuxi typecheck` sin errores
- [x] `npm run build` compila
- [x] `npm run test` sin regresión
- [x] Editar cada campo de "Tus datos", descripción y precio a mano contra la base real — confirmado con query directa
- [x] Contacto con formato inválido no guarda y muestra el error correcto
- [x] `/profesional/ingresar` con sesión activa redirige a `/profesional/perfil`
- [ ] Patricio: probar `GET`/`PATCH /api/professionals/me` sin sesión (401) y con un campo realmente inválido (`invalid_price` con un número negativo, por ejemplo)