### PR TITLE
feat(server): subir y borrar fotos del perfil

### DIFF
--- a/app/components/professional/ProfessionalPhotos.vue
+++ b/app/components/professional/ProfessionalPhotos.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import { Loader2, Plus, X } from '@lucide/vue'
+
+const MAX_PHOTOS = 12
+
+const { professional } = useProfessionalProfile()
+const { uploading, uploadError, deletingPath, deleteError, upload, remove } = useProfessionalPhotos()
+
+const { public: pub } = useRuntimeConfig()
+const photos = computed(() =>
+  (professional.value?.photoUrls ?? []).map(url => ({ url, path: photoPathFromUrl(url, pub.supabaseUrl) })),
+)
+
+const fileInput = ref<HTMLInputElement | null>(null)
+
+function openPicker() {
+  fileInput.value?.click()
+}
+
+function onFileSelected(event: Event) {
+  const file = (event.target as HTMLInputElement).files?.[0]
+  if (file) upload(file)
+  if (fileInput.value) fileInput.value.value = ''
+}
+</script>
+
+<template>
+  <div class="rounded-2xl border border-datealo-surface p-4">
+    <p class="text-sm font-semibold text-datealo-text">Fotos de tus trabajos</p>
+
+    <div class="mt-3 grid grid-cols-3 gap-2">
+      <div v-for="photo in photos" :key="photo.path" class="relative aspect-square overflow-hidden rounded-lg bg-datealo-surface">
+        <img :src="photo.url" alt="" class="h-full w-full object-cover">
+        <button
+          type="button"
+          class="absolute right-1 top-1 flex h-6 w-6 items-center justify-center rounded-full bg-black/60 text-white disabled:opacity-50"
+          :disabled="deletingPath === photo.path"
+          @click="remove(photo.path)"
+        >
+          <Loader2 v-if="deletingPath === photo.path" class="h-3.5 w-3.5 animate-spin" />
+          <X v-else class="h-3.5 w-3.5" />
+        </button>
+      </div>
+
+      <button
+        v-if="photos.length < MAX_PHOTOS"
+        type="button"
+        class="flex aspect-square items-center justify-center rounded-lg border-2 border-dashed border-datealo-surface text-datealo-muted disabled:opacity-50"
+        :disabled="uploading"
+        @click="openPicker"
+      >
+        <Loader2 v-if="uploading" class="h-5 w-5 animate-spin" />
+        <Plus v-else class="h-6 w-6" />
+      </button>
+    </div>
+
+    <input ref="fileInput" type="file" accept="image/*" class="hidden" @change="onFileSelected">
+
+    <p v-if="uploadError" class="mt-2 text-xs font-semibold text-error" aria-live="polite">{{ uploadError }}</p>
+    <p v-if="deleteError" class="mt-2 text-xs font-semibold text-error" aria-live="polite">{{ deleteError }}</p>
+  </div>
+</template>

--- a/app/composables/useProfessionalPhotos.ts
+++ b/app/composables/useProfessionalPhotos.ts
@@ -1,0 +1,48 @@
+export function useProfessionalPhotos() {
+  const { professional } = useProfessionalProfile()
+
+  const uploading = useState('professional-photos-uploading', () => false)
+  const uploadError = useState<string | null>('professional-photos-upload-error', () => null)
+  const deletingPath = useState<string | null>('professional-photos-deleting', () => null)
+  const deleteError = useState<string | null>('professional-photos-delete-error', () => null)
+
+  async function upload(file: File) {
+    uploadError.value = null
+    uploading.value = true
+
+    try {
+      const compressed = await compressPhoto(file)
+      const body = new FormData()
+      body.append('file', compressed, 'photo.jpg')
+
+      const { photoUrls } = await $fetch<{ path: string, photoUrls: string[] }>('/api/professionals/me/photos', {
+        method: 'POST',
+        body,
+      })
+      if (professional.value) professional.value = { ...professional.value, photoUrls }
+    } catch {
+      uploadError.value = 'No pudimos subir la foto. Intenta de nuevo.'
+    } finally {
+      uploading.value = false
+    }
+  }
+
+  async function remove(path: string) {
+    deleteError.value = null
+    deletingPath.value = path
+
+    try {
+      const { photoUrls } = await $fetch<{ photoUrls: string[] }>('/api/professionals/me/photos', {
+        method: 'DELETE',
+        body: { path },
+      })
+      if (professional.value) professional.value = { ...professional.value, photoUrls }
+    } catch {
+      deleteError.value = 'No pudimos borrar la foto. Intenta de nuevo.'
+    } finally {
+      deletingPath.value = null
+    }
+  }
+
+  return { uploading, uploadError, deletingPath, deleteError, upload, remove }
+}

--- a/app/pages/profesional/perfil.vue
+++ b/app/pages/profesional/perfil.vue
@@ -72,7 +72,9 @@ function commitPrice() {
       <h1 class="text-xl font-extrabold text-datealo-text">{{ professional.displayName }}</h1>
       <p class="mt-0.5 text-sm text-datealo-muted">{{ categoriaNombre }} · {{ comunaNombre }}</p>
 
-      <div class="mt-5 rounded-2xl border border-datealo-surface p-4">
+      <ProfessionalPhotos class="mt-5" />
+
+      <div class="mt-3 rounded-2xl border border-datealo-surface p-4">
         <div class="flex items-center justify-between">
           <p class="text-sm font-semibold text-datealo-text">Descripción</p>
           <Loader2 v-if="isSavingDescription" class="h-3.5 w-3.5 animate-spin text-primary" />

--- a/app/utils/professional-photos.ts
+++ b/app/utils/professional-photos.ts
@@ -1,0 +1,35 @@
+const MAX_DIMENSION = 1600
+const JPEG_QUALITY = 0.8
+
+// Canvas, sin librería nueva — el archivo siempre sale como JPEG sin importar el formato de entrada,
+// así el servidor y el bucket solo ven un tipo real en el camino normal de la app (png/webp en
+// allowed_mime_types quedan como defensa del bucket contra alguien que suba directo, saltándose esto).
+export async function compressPhoto(file: File): Promise<Blob> {
+  const bitmap = await createImageBitmap(file)
+  const scale = Math.min(1, MAX_DIMENSION / Math.max(bitmap.width, bitmap.height))
+  const width = Math.round(bitmap.width * scale)
+  const height = Math.round(bitmap.height * scale)
+
+  const canvas = document.createElement('canvas')
+  canvas.width = width
+  canvas.height = height
+  const ctx = canvas.getContext('2d')
+  if (!ctx) throw new Error('No se pudo comprimir la imagen')
+  ctx.drawImage(bitmap, 0, 0, width, height)
+
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      blob => (blob ? resolve(blob) : reject(new Error('No se pudo comprimir la imagen'))),
+      'image/jpeg',
+      JPEG_QUALITY,
+    )
+  })
+}
+
+// El perfil solo trae la URL pública de cada foto, nunca su path dentro del bucket — para borrar una
+// foto hace falta ese path, así que se reconstruye a partir del prefijo fijo con el que el servidor
+// arma la URL.
+export function photoPathFromUrl(url: string, supabaseUrl: string): string {
+  const prefix = `${supabaseUrl}/storage/v1/object/public/professional-photos/`
+  return url.startsWith(prefix) ? url.slice(prefix.length) : url
+}

--- a/server/api/professionals/me/photos.delete.ts
+++ b/server/api/professionals/me/photos.delete.ts
@@ -1,0 +1,34 @@
+export default defineEventHandler(async (event) => {
+  const user = await requireUser(event)
+  const body = await readBody<{ path?: unknown }>(event)
+
+  const path = body.path
+  if (typeof path !== 'string' || !path) {
+    setResponseStatus(event, 400)
+    return { error: 'missing_field', field: 'path' }
+  }
+
+  if (!path.startsWith(`${user.id}/`)) {
+    setResponseStatus(event, 403)
+    return { error: 'forbidden' }
+  }
+
+  const owns = await professionalHasPhotoPath(user.id, path)
+  if (!owns) {
+    setResponseStatus(event, 404)
+    return { error: 'not_found' }
+  }
+
+  const { error: removeError } = await serverSupabase(event).storage.from('professional-photos').remove([path])
+  if (removeError) {
+    throw createError({ statusCode: 502, statusMessage: 'remove_failed' })
+  }
+
+  const updated = await removeProfessionalPhoto(user.id, path)
+  if (!updated) {
+    setResponseStatus(event, 404)
+    return { error: 'not_found' }
+  }
+
+  return { photoUrls: updated.photoUrls }
+})

--- a/server/api/professionals/me/photos.post.ts
+++ b/server/api/professionals/me/photos.post.ts
@@ -1,0 +1,53 @@
+import { randomUUID } from 'node:crypto'
+
+const MAX_FILE_SIZE = 4 * 1024 * 1024
+const MAX_PHOTOS = 12
+const EXTENSION_BY_MIME_TYPE: Record<string, string> = {
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/webp': 'webp',
+}
+
+export default defineEventHandler(async (event) => {
+  const user = await requireUser(event)
+
+  const professional = await findProfessionalByUserId(user.id)
+  if (!professional) {
+    setResponseStatus(event, 404)
+    return { error: 'not_found' }
+  }
+  if (professional.photoUrls.length >= MAX_PHOTOS) {
+    setResponseStatus(event, 400)
+    return { error: 'too_many_photos' }
+  }
+
+  const formData = await readMultipartFormData(event)
+  const file = formData?.find(part => part.name === 'file')
+  const extension = file?.type ? EXTENSION_BY_MIME_TYPE[file.type] : undefined
+  if (!file || !extension) {
+    setResponseStatus(event, 400)
+    return { error: 'invalid_file_type' }
+  }
+  if (file.data.length > MAX_FILE_SIZE) {
+    setResponseStatus(event, 400)
+    return { error: 'file_too_large' }
+  }
+
+  const path = `${user.id}/${randomUUID()}.${extension}`
+  const { error: uploadError } = await serverSupabase(event)
+    .storage.from('professional-photos')
+    .upload(path, file.data, { contentType: file.type })
+
+  if (uploadError) {
+    throw createError({ statusCode: 502, statusMessage: 'upload_failed' })
+  }
+
+  const updated = await addProfessionalPhoto(user.id, path)
+  if (!updated) {
+    setResponseStatus(event, 404)
+    return { error: 'not_found' }
+  }
+
+  setResponseStatus(event, 201)
+  return { path, photoUrls: updated.photoUrls }
+})

--- a/server/db/sql/rls.sql
+++ b/server/db/sql/rls.sql
@@ -62,3 +62,41 @@ create policy professionals_update_own on professionals
 -- `force row level security` queda deliberadamente sin usar: forzarlo aplicaría RLS también al
 -- rol dueño de Drizzle, donde auth.uid() es NULL, y rompería todo insert/update del servidor.
 revoke all on public.professionals from anon, authenticated;
+
+-- professional-photos: acá la policy es la barrera real, no un respaldo — las fotos se suben con el
+-- cliente de sesión del propio usuario (mismo publishable key + JWT que arma requireUser()), que sí
+-- evalúa storage.objects. file_size_limit y allowed_mime_types quedan fijados en el propio bucket:
+-- son la única capa que sobrevive si alguien sube directo desde la consola del navegador, saltándose
+-- la validación de server/api/.
+insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+values ('professional-photos', 'professional-photos', true, 4194304, array['image/jpeg', 'image/png', 'image/webp'])
+on conflict (id) do update set
+  public = excluded.public,
+  file_size_limit = excluded.file_size_limit,
+  allowed_mime_types = excluded.allowed_mime_types;
+
+-- Las tres llevan bucket_id explícito: sin esa condición, `using (true)` aplicaría a toda la tabla
+-- storage.objects, no solo a este bucket, y expondría cualquier otro bucket que se agregue después.
+drop policy if exists professional_photos_select_own on storage.objects;
+create policy professional_photos_select_own on storage.objects
+  for select to authenticated using (
+    bucket_id = 'professional-photos'
+    and (storage.foldername(name))[1] = (select auth.uid())::text
+  );
+
+drop policy if exists professional_photos_insert_own on storage.objects;
+create policy professional_photos_insert_own on storage.objects
+  for insert to authenticated with check (
+    bucket_id = 'professional-photos'
+    and (storage.foldername(name))[1] = (select auth.uid())::text
+  );
+
+drop policy if exists professional_photos_delete_own on storage.objects;
+create policy professional_photos_delete_own on storage.objects
+  for delete to authenticated using (
+    bucket_id = 'professional-photos'
+    and (storage.foldername(name))[1] = (select auth.uid())::text
+  );
+
+-- Sin policy de update: cada foto sube con un uuid nuevo, el código nunca llama upload() con
+-- upsert: true.

--- a/server/utils/professionals.ts
+++ b/server/utils/professionals.ts
@@ -1,4 +1,4 @@
-import { eq } from 'drizzle-orm'
+import { eq, sql } from 'drizzle-orm'
 import { existsActiveCategoria } from './categorias'
 import { existsActiveComuna } from './comunas'
 import { professionals } from '../db/schema/professionals'
@@ -131,6 +131,34 @@ export async function updateProfessional(
     .where(eq(professionals.userId, userId))
     .returning(publicColumns)
   return updated ? toPublicProfessional(updated) : null
+}
+
+export async function addProfessionalPhoto(userId: string, path: string): Promise<Professional | null> {
+  const [updated] = await useDb()
+    .update(professionals)
+    .set({ photoPaths: sql`array_append(${professionals.photoPaths}, ${path})`, updatedAt: new Date() })
+    .where(eq(professionals.userId, userId))
+    .returning(publicColumns)
+  return updated ? toPublicProfessional(updated) : null
+}
+
+export async function removeProfessionalPhoto(userId: string, path: string): Promise<Professional | null> {
+  const [updated] = await useDb()
+    .update(professionals)
+    .set({ photoPaths: sql`array_remove(${professionals.photoPaths}, ${path})`, updatedAt: new Date() })
+    .where(eq(professionals.userId, userId))
+    .returning(publicColumns)
+  return updated ? toPublicProfessional(updated) : null
+}
+
+// Chequea existencia del perfil y pertenencia de la foto en una sola query — evita reconstruir "no
+// existe" a partir de dos casos distintos (perfil ausente vs. path que no está en photoPaths).
+export async function professionalHasPhotoPath(userId: string, path: string): Promise<boolean> {
+  const [row] = await useDb()
+    .select({ id: professionals.id })
+    .from(professionals)
+    .where(sql`${professionals.userId} = ${userId} and ${path} = any(${professionals.photoPaths})`)
+  return Boolean(row)
 }
 
 function escapeHtml(value: string): string {


### PR DESCRIPTION
## Qué hace

Cierra #77 — S-005 del plan de construcción de la misión 04, la última pieza de perfil de profesional antes de búsqueda.

- Bucket `professional-photos` (`server/db/sql/rls.sql`): público, `file_size_limit` 4MB y `allowed_mime_types` (jpeg/png/webp) fijados en la creación del bucket — la única capa que sobrevive si alguien sube directo desde la consola del navegador, saltándose el endpoint. Sus tres policies (`select`/`insert`/`delete`, todas `own`, todas con `bucket_id` explícito). Sin policy de `update`: el código nunca sube con `upsert: true`.
- Acá la policy **es** la barrera real, no un respaldo — las fotos se suben con el cliente de sesión del propio usuario (mismo publishable key + JWT que ya arma `requireUser()`), que sí evalúa `storage.objects`. Distinto del resto de `professionals`, donde Drizzle (rol dueño) salta RLS por completo.
- `POST`/`DELETE /api/professionals/me/photos`: sube a `{userId}/{uuid}.ext` (verificado en código antes de llamar a Storage), actualiza `photoPaths` con `array_append`/`array_remove` en la misma operación que `updatedAt`. Tope de 12 fotos antes de llegar a Storage. Errores `invalid_file_type`/`file_too_large`/`too_many_photos`/`404`/`403`.
- Compresión client-side en canvas (max 1600px, calidad JPEG 0.8, sin librería nueva) — el archivo siempre sale JPEG sin importar el formato de entrada.
- `ProfessionalPhotos.vue`: completa la sección de fotos en `/profesional/perfil` que había quedado pendiente en #76 — grid de miniaturas, borrar por foto, "+" para agregar que desaparece al llegar a 12.

**Detalle de contrato:** como el perfil solo expone `photoUrls` (nunca `photoPaths`, A-005), borrar una foto ya subida necesita reconstruir su path a partir del prefijo fijo con el que se arma esa URL (`app/utils/professional-photos.ts#photoPathFromUrl`) — el servidor igual revalida `path` de forma independiente (pertenencia + membership en `photoPaths`), así que esto no reabre nada de lo que `T-003` evitaba al no guardar URLs completas.

## Verificado

- `npx nuxi typecheck` sin errores
- `npm run build` compila
- `npm run test` — sin regresión (21 tests existentes)
- `npm run db:rls` aplicado contra el proyecto de desarrollo real — bucket y las 3 policies confirmados con una query directa a `storage.buckets`/`pg_policies`
- Flujo real de punta a punta contra el proyecto de desarrollo: subí una foto de prueba → quedó en `storage.objects` con el path esperado y `mimetype: image/jpeg` (confirma la compresión), y en `professionals.photoPaths` con el mismo path; la borré → desapareció de las dos tablas

## Lo que no entra en este PR

Una prueba de bypass real (llamar `.storage` directo desde la consola del navegador con la sesión de un usuario A contra la carpeta de un usuario B) queda para que la corras vos — necesita dos cuentas reales, no algo que pueda armar solo. El criterio de aceptación completo la pide explícitamente.

## Test plan

- [x] `npx nuxi typecheck` sin errores
- [x] `npm run build` compila
- [x] `npm run test` sin regresión
- [x] `npm run db:rls` aplicado y verificado contra la base real
- [x] Subir y borrar una foto de punta a punta, verificado en `storage.objects` y `professionals.photoPaths`
- [ ] Patricio: con el cliente de sesión de un usuario A (consola del navegador, `$supabase.storage...`), confirmar que subir/borrar/listar la carpeta de otro usuario B falla por policy
- [ ] Patricio: confirmar que un archivo de 5MB o un `application/pdf` fallan por el bucket (no por el endpoint) al subirlos directo con el cliente de sesión, sin pasar por `server/api/`