### PR TITLE
feat(app): el CTA de la landing para profesionales navega a iniciar sesión

### DIFF
--- a/app/components/landing/LandingForProfessionals.vue
+++ b/app/components/landing/LandingForProfessionals.vue
@@ -1,8 +1,6 @@
 <script setup lang="ts">
-import { Star, Loader2, CheckCircle, Check } from '@lucide/vue'
+import { Star, Check } from '@lucide/vue'
 import { LANDING_FOR_PROFESSIONALS } from '~/constants/landing'
-
-const { email, loading, submitted, error, submit } = useWaitlist('profesional')
 </script>
 
 <template>
@@ -45,47 +43,19 @@ const { email, loading, submitted, error, submit } = useWaitlist('profesional')
             </ul>
           </div>
 
-          <!-- Inline form -->
+          <!-- CTA: navega directo a iniciar sesión, sin capturar nada acá -->
           <div class="rounded-2xl bg-white p-3 shadow-2xl shadow-black/20">
             <p class="text-datealo-text/60 text-sm mb-3 px-2 font-medium">{{ LANDING_FOR_PROFESSIONALS.ctaContext }}</p>
 
-            <Transition name="fade" mode="out-in">
-              <div
-                v-if="submitted"
-                class="flex items-center gap-3 rounded-xl bg-success/10 border border-success/20 p-5"
-              >
-                <CheckCircle class="h-6 w-6 text-success shrink-0" />
-                <p class="text-success font-bold">¡Registrado! Te contactaremos pronto.</p>
-              </div>
-
-              <form v-else class="flex flex-col sm:flex-row gap-2" @submit.prevent="submit">
-                <div class="flex-1 min-w-0 relative">
-                  <label for="pro-email" class="sr-only">Email profesional</label>
-                  <UInput
-                    id="pro-email"
-                    v-model="email"
-                    type="email"
-                    autocomplete="email"
-                    placeholder="Tu email"
-                    :disabled="loading"
-                    variant="none"
-                    class="w-full"
-                    :ui="{ base: 'h-14 rounded-xl bg-datealo-surface/50 px-4 text-base text-datealo-text placeholder:text-datealo-text/40 focus:ring-2 focus:ring-primary/20 focus:bg-datealo-surface transition-all' }"
-                  />
-                  <p v-if="error" class="absolute -bottom-6 left-2 text-xs text-error font-medium">{{ error }}</p>
-                </div>
-                <UButton
-                  type="submit"
-                  variant="link"
-                  color="neutral"
-                  class="h-14 rounded-xl px-6 text-sm font-bold bg-secondary text-white hover:bg-secondary/90 hover:text-white active:text-white shadow-lg shadow-secondary/20 transition-all shrink-0"
-                  :disabled="loading"
-                >
-                  <Loader2 v-if="loading" class="h-5 w-5 animate-spin" />
-                  <template v-else>{{ LANDING_FOR_PROFESSIONALS.cta }}</template>
-                </UButton>
-              </form>
-            </Transition>
+            <UButton
+              to="/profesional/ingresar"
+              block
+              variant="link"
+              color="neutral"
+              class="h-14 rounded-xl text-sm font-bold bg-secondary text-white hover:bg-secondary/90 hover:text-white active:text-white shadow-lg shadow-secondary/20 transition-all"
+            >
+              {{ LANDING_FOR_PROFESSIONALS.cta }}
+            </UButton>
           </div>
         </div>
 


### PR DESCRIPTION
## Qué hace

Cierra #78 — S-006, la última pieza del plan de construcción de la misión 04.

`LandingForProfessionals.vue` deja de capturar el email en la lista de espera de profesionales (`useWaitlist('profesional')`) al tocar "Quiero unirme" — ese botón hoy no lleva a ningún lado, es la única puerta de entrada al registro y no navegaba. Ahora es un `UButton` con `to="/profesional/ingresar"` (link real, no un handler de JS). El texto del botón y su contexto ("Gratis · Menos de 1 minuto") no cambian.

`useWaitlist` sigue existiendo tal cual — lo sigue usando `LandingHero.vue` para la lista de espera de buscadores, que esta misión no toca.

## Verificado

- `npx nuxi typecheck` sin errores
- `npm run build` compila
- `npm run test` sin regresión (21 tests existentes)
- Verificación visual: la sección se ve igual salvo el campo de email que desapareció; toqué "Quiero unirme" y navegó a `/profesional/ingresar` — con sesión activa, el middleware lo mandó directo a `/profesional/perfil` (encadena bien con la revisión de T-005 del PR de S-002/S-003)

Con este PR se cierra el plan de construcción completo de la misión 04.

## Test plan

- [x] `npx nuxi typecheck` sin errores
- [x] `npm run build` compila
- [x] `npm run test` sin regresión
- [x] Verificación visual + navegación real desde la landing