### PR TITLE
docs(docs): cerrar la misión 04

### DIFF
--- a/docs/missions/04-registro-perfil-profesional/README.md
+++ b/docs/missions/04-registro-perfil-profesional/README.md
@@ -2,9 +2,9 @@
 
 **Tipo:** producto. **Abierta el** 2026-08-13. **Nace de:** ninguna.
 
-**Estado de la misión:** lista para construir
+**Estado de la misión:** cerrada 2026-08-28
 
-**Última actualización:** 2026-08-24
+**Última actualización:** 2026-08-28
 
 Tercera de seis misiones hacia el MVP (registrarse, mostrarse, buscar, reseñar). Depende de
 [misión 02](../02-base-de-datos-y-auth/) (login del profesional, y el `sendEmail()` que esta misión usa
@@ -14,7 +14,11 @@ qué categorías y comunas se registra).
 **Documentos:** [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-**Próximo hito:** cortar el Plan de construcción de `ingenieria.md` en issues de GitHub y empezar S-001.
+Plan de construcción completo: S-001 a S-006 (issues [#73](https://github.com/PatricioTabilo/datealo/issues/73),
+[#74](https://github.com/PatricioTabilo/datealo/issues/74), [#75](https://github.com/PatricioTabilo/datealo/issues/75),
+[#76](https://github.com/PatricioTabilo/datealo/issues/76), [#77](https://github.com/PatricioTabilo/datealo/issues/77),
+[#78](https://github.com/PatricioTabilo/datealo/issues/78)) mergeados. El profesional puede registrarse con
+enlace mágico, quedar publicado de inmediato, y editar cualquier campo de su perfil incluidas las fotos.
 
 ## Brief
 

--- a/docs/missions/README.md
+++ b/docs/missions/README.md
@@ -12,7 +12,7 @@ abrieron y de dónde salió cada una.
 | 01  | [migración a Nuxt UI](./01-migracion-nuxt-ui/) | técnica | 2026-08-11 | cerrada 2026-08-13 | — | A-004 |
 | 02  | [base de datos, Auth y correo (config)](./02-base-de-datos-y-auth/) | técnica | 2026-08-13 | cerrada 2026-08-17 | — | A-001, A-002, A-003 |
 | 03  | [taxonomía: categorías y comunas](./03-taxonomia-categorias-y-comunas/) | producto | 2026-08-13 | cerrada 2026-08-20 | — | — |
-| 04  | [registro y perfil de profesional](./04-registro-perfil-profesional/) | producto | 2026-08-13 | lista para construir | — | — |
+| 04  | [registro y perfil de profesional](./04-registro-perfil-profesional/) | producto | 2026-08-13 | cerrada 2026-08-28 | — | — |
 | 05  | [perfil público de profesional](./05-perfil-publico-profesional/) | producto | 2026-08-13 | exploración | — | — |
 | 06  | [búsqueda y resultados](./06-busqueda-resultados/) | producto | 2026-08-13 | exploración | — | — |
 | 07  | [reseñas verificadas por contacto](./07-resenas-verificadas-por-contacto/) | producto | 2026-08-13 | exploración | — | — |


### PR DESCRIPTION
## Qué hace

Marca la misión 04 (registro y perfil de profesional) como cerrada — los 6 issues de su plan de construcción (S-001 a S-006, #73 a #78) ya están mergeados en `main`.

Actualiza el estado en el README de la misión y en el registro de `docs/missions/README.md`. Sin cambios de código.