### PR TITLE
feat(server): perfil público de profesional — GET /api/professionals/[id]

### DIFF
--- a/docs/missions/05-perfil-publico-profesional/README.md
+++ b/docs/missions/05-perfil-publico-profesional/README.md
@@ -2,9 +2,9 @@
 
 **Tipo:** producto. **Abierta el** 2026-08-13. **Nace de:** ninguna.
 
-**Estado de la misión:** exploración
+**Estado de la misión:** lista para construir
 
-**Última actualización:** 2026-08-13
+**Última actualización:** 2026-08-28
 
 Cuarta de seis misiones hacia el MVP (registrarse, mostrarse, buscar, reseñar). Depende de
 [misión 04](../04-registro-perfil-profesional/): sin perfiles de profesional reales, no hay qué mostrar.
@@ -12,13 +12,18 @@ Cuarta de seis misiones hacia el MVP (registrarse, mostrarse, buscar, reseñar).
 **Documentos:** [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-**Próximo hito:** ninguno todavía — esta misión no se ha empezado a trabajar.
+**Próximo hito:** crear los issues de S-001 a S-003 (`ingenieria.md#plan-de-construcción`) y empezar a
+construir.
 
 ## Brief
 
-Lo que ve el buscador al entrar al perfil de un profesional: fotos, precios orientativos, reseñas, badge de
-verificado, y el botón de contacto directo (WhatsApp o teléfono, sin intermediarios — la landing ya lo
-prometió). Es el lado "mostrarse" desde quien busca.
+Lo que ve el buscador al entrar al perfil de un profesional: fotos, precios orientativos, y el botón de
+contacto directo (WhatsApp o teléfono, sin intermediarios — la landing ya lo prometió). Es el lado
+"mostrarse" desde quien busca.
+
+Reseñas y badge de verificado quedan fuera de esta entrega (ver "Fuera de alcance" en `producto.md`):
+reseñas porque dependen de la misión 07, que todavía no existe; verificado porque hoy no hay ningún
+mecanismo real detrás de esa palabra — mostrarlo sin respaldo sería peor que no tenerlo.
 
 Acá vive el evento de contacto: cuando el buscador aprieta el botón, eso queda registrado — es lo que
 después habilita dejar una reseña en la [misión 07](../07-resenas-verificadas-por-contacto/), sin esta

--- a/docs/missions/05-perfil-publico-profesional/design-mockups/perfil-publico.html
+++ b/docs/missions/05-perfil-publico-profesional/design-mockups/perfil-publico.html
@@ -1,0 +1,275 @@
+<!doctype html>
+<html lang="es-CL">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>V-001 Perfil público de profesional — misión 05</title>
+
+    <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+    <link
+      href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&family=Plus+Jakarta+Sans:wght@600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../../design/datealo-mockup-kit.css" />
+    <style type="text/tailwindcss">
+      @theme {
+        --color-primary: var(--ui-primary);
+        --color-secondary: var(--ui-secondary);
+        --color-success: var(--ui-success);
+        --color-error: var(--ui-error);
+      }
+    </style>
+    <style>
+      .hero-photo {
+        aspect-ratio: 4 / 3;
+        background: var(--ui-bg-accented);
+        position: relative;
+      }
+      .hero-photo.skeleton {
+        background: linear-gradient(
+          100deg,
+          var(--ui-bg-accented) 40%,
+          var(--ui-bg-muted) 50%,
+          var(--ui-bg-accented) 60%
+        );
+        background-size: 200% 100%;
+        animation: shimmer 1.4s infinite;
+      }
+      @keyframes shimmer {
+        from {
+          background-position: 200% 0;
+        }
+        to {
+          background-position: -200% 0;
+        }
+      }
+      .skeleton-block {
+        background: var(--ui-bg-accented);
+        border-radius: 0.375rem;
+      }
+      .dot {
+        width: 6px;
+        height: 6px;
+        border-radius: 999px;
+        background: rgba(255, 255, 255, 0.5);
+      }
+      .dot.active {
+        background: #fff;
+      }
+      .avatar-initials {
+        width: 5.5rem;
+        height: 5.5rem;
+        border-radius: 999px;
+        background: var(--ui-primary);
+        color: #fff;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-weight: 800;
+        font-size: 1.5rem;
+      }
+      .btn-whatsapp {
+        background: var(--ui-primary);
+        color: #fff;
+        font-weight: 700;
+        border-radius: var(--ui-radius, 0.5rem);
+      }
+      .btn-call {
+        border: 1.5px solid var(--ui-border-accented);
+        color: var(--ui-text-highlighted);
+        border-radius: var(--ui-radius, 0.5rem);
+      }
+      .since-pill {
+        display: inline-block;
+        color: var(--ui-text-muted);
+      }
+      .hero-scrim {
+        background: linear-gradient(to top, rgba(0, 0, 0, 0.45), transparent);
+      }
+    </style>
+  </head>
+
+  <body>
+    <div class="frames">
+      <!-- 1. cargando -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-001 · modo cargando
+          <small>pidiendo los datos del perfil — todavía no se sabe si existe</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="flex h-full flex-col">
+            <div class="flex-1 overflow-y-auto pb-4">
+              <div class="hero-photo skeleton"></div>
+              <div class="p-5">
+                <div class="skeleton-block h-6 w-48"></div>
+                <div class="skeleton-block mt-2 h-4 w-32"></div>
+                <div class="skeleton-block mt-5 h-4 w-full"></div>
+                <div class="skeleton-block mt-2 h-4 w-2/3"></div>
+              </div>
+            </div>
+            <div class="safe-bottom px-5">
+              <div class="skeleton-block h-[50px] w-full"></div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- 2. encontrado, perfil completo -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-001 · modo encontrado — perfil con fotos, descripción, precio y reseñas futuras
+          <small>botón de contacto fijo abajo durante todo el scroll (UX-001)</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="flex h-full flex-col">
+            <div class="flex-1 overflow-y-auto pb-4">
+              <div class="hero-photo">
+                <div class="hero-scrim absolute inset-x-0 bottom-0 h-16"></div>
+                <div class="absolute bottom-3 left-1/2 flex -translate-x-1/2 gap-1.5">
+                  <div class="dot active"></div>
+                  <div class="dot"></div>
+                  <div class="dot"></div>
+                </div>
+              </div>
+              <div class="p-5">
+                <h1 class="text-xl font-extrabold" style="color: var(--ui-text-highlighted)">Marcelo Rojas</h1>
+                <p class="mt-0.5 text-sm" style="color: var(--ui-text-muted)">Electricidad · Ñuñoa</p>
+
+                <p class="mt-4 text-sm leading-relaxed" style="color: var(--ui-text-highlighted)">
+                  Electricista hace 8 años, atiendo Ñuñoa y Providencia.
+                </p>
+
+                <p class="mt-3 text-base font-bold" style="color: var(--ui-text-highlighted)">Desde $15.000</p>
+
+                <p class="since-pill mt-3 text-xs">En Datealo desde julio de 2026</p>
+              </div>
+            </div>
+            <div class="safe-bottom px-5">
+              <div class="flex gap-2">
+                <button class="btn-whatsapp flex-1 py-3.5 text-[0.9375rem]">Escribir por WhatsApp</button>
+                <button class="btn-call w-14 py-3.5" aria-label="Llamar">
+                  <svg class="mx-auto" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72c.127.96.361 1.903.7 2.81a2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45c.907.339 1.85.573 2.81.7A2 2 0 0 1 22 16.92z"/></svg>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- 3. encontrado, perfil recién publicado (caso de lanzamiento) -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-001 · modo encontrado — perfil recién publicado (CL-001, CL-002, CL-003)
+          <small>sin foto, sin descripción, sin precio, sin reseñas — es el 100% de los perfiles al lanzamiento, no un caso raro (C-004)</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="flex h-full flex-col">
+            <div class="flex-1 overflow-y-auto pb-4">
+              <div class="hero-photo flex items-center justify-center">
+                <div class="avatar-initials">HS</div>
+              </div>
+              <div class="p-5">
+                <h1 class="text-xl font-extrabold" style="color: var(--ui-text-highlighted)">Héctor Silva</h1>
+                <p class="mt-0.5 text-sm" style="color: var(--ui-text-muted)">Electricidad · Ñuñoa</p>
+
+                <p class="since-pill mt-4 text-xs">En Datealo desde agosto de 2026</p>
+              </div>
+            </div>
+            <div class="safe-bottom px-5">
+              <div class="flex gap-2">
+                <button class="btn-whatsapp flex-1 py-3.5 text-[0.9375rem]">Escribir por WhatsApp</button>
+                <button class="btn-call w-14 py-3.5" aria-label="Llamar">
+                  <svg class="mx-auto" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72c.127.96.361 1.903.7 2.81a2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45c.907.339 1.85.573 2.81.7A2 2 0 0 1 22 16.92z"/></svg>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- 4. no encontrado -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-001 · modo no encontrado
+          <small>el link no corresponde a ningún perfil activo — typo, o el perfil ya no existe</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="flex h-full flex-col items-center justify-center p-8 text-center">
+            <p class="text-4xl">🔍</p>
+            <h1 class="mt-4 text-lg font-extrabold" style="color: var(--ui-text-highlighted)">
+              No encontramos este perfil
+            </h1>
+            <p class="mt-2 text-sm" style="color: var(--ui-text-muted)">
+              Puede que ya no esté disponible o que el link esté mal escrito.
+            </p>
+            <button class="btn-whatsapp mt-6 px-6 py-3 text-[0.9375rem]">Buscar profesionales</button>
+          </div>
+        </div>
+      </section>
+
+      <!-- 5. tardando -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-001 · modo tardando (&gt;10s)
+          <small>la carga inicial superó los 10s — deja de mostrarse como skeleton y pasa a un mensaje explícito</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="flex h-full flex-col items-center justify-center p-8 text-center">
+            <p class="text-4xl">⏳</p>
+            <h1 class="mt-4 text-lg font-extrabold" style="color: var(--ui-text-highlighted)">
+              Esto está tardando más de lo normal
+            </h1>
+            <button class="btn-whatsapp mt-6 px-6 py-3 text-[0.9375rem]">Reintentar</button>
+          </div>
+        </div>
+      </section>
+
+      <!-- 6. encontrado, perfil completo — desktop -->
+      <section class="frame frame-desktop">
+        <div class="frame-label">
+          V-001 · modo encontrado — perfil completo, desktop
+          <small>dos columnas: fotos a la izquierda; a la derecha, datos y el bloque de contacto en
+            `position: sticky` dentro de la columna (no fijo a toda la pantalla) — la columna de fotos
+            suele ser más alta que el texto</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="flex h-full">
+            <div class="hero-photo" style="width: 55%; aspect-ratio: auto;">
+              <div class="hero-scrim absolute inset-x-0 bottom-0 h-20"></div>
+              <div class="absolute bottom-4 left-1/2 flex -translate-x-1/2 gap-1.5">
+                <div class="dot active"></div>
+                <div class="dot"></div>
+                <div class="dot"></div>
+              </div>
+            </div>
+            <div class="flex-1 p-10" style="position: sticky; top: 0; align-self: flex-start;">
+              <h1 class="text-2xl font-extrabold" style="color: var(--ui-text-highlighted)">Marcelo Rojas</h1>
+              <p class="mt-1 text-sm" style="color: var(--ui-text-muted)">Electricidad · Ñuñoa</p>
+
+              <p class="mt-5 text-sm leading-relaxed" style="color: var(--ui-text-highlighted)">
+                Electricista hace 8 años, atiendo Ñuñoa y Providencia.
+              </p>
+
+              <p class="mt-4 text-lg font-bold" style="color: var(--ui-text-highlighted)">Desde $15.000</p>
+
+              <p class="since-pill mt-3 text-xs">En Datealo desde julio de 2026</p>
+
+              <div class="mt-8 flex gap-2">
+                <button class="btn-whatsapp flex-1 py-3.5 text-[0.9375rem]">Escribir por WhatsApp</button>
+                <button class="btn-call w-14 py-3.5" aria-label="Llamar">
+                  <svg class="mx-auto" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72c.127.96.361 1.903.7 2.81a2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45c.907.339 1.85.573 2.81.7A2 2 0 0 1 22 16.92z"/></svg>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  </body>
+</html>

--- a/docs/missions/05-perfil-publico-profesional/experiencia.md
+++ b/docs/missions/05-perfil-publico-profesional/experiencia.md
@@ -1,183 +1,274 @@
-# Misión: <nombre> — Experiencia
+# Misión: perfil público de profesional — Experiencia
 
-**Estado:** borrador
+**Estado:** vigente — aprobado por Patricio el 2026-08-28
 
-**Última actualización:** AAAA-MM-DD
+**Última actualización:** 2026-08-28
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-<!--
-Fuente de verdad para flujos, estados, contenido e interacción. No redefine reglas de producto: si el
-diseño descubre una regla nueva o invalida una, abre o actualiza una decisión en producto.md.
+## Decisión de experiencia: una sola pantalla de lectura, con el botón de contacto siempre alcanzable
 
-Núcleo obligatorio: vistas, mapa de estados, flujos críticos y estados por superficie. Las secciones bajo
-demanda (modelo mental, jerarquía de información, validación) se agregan solo cuando una decisión las
-necesita.
+El perfil es una sola vista (V-001), sin pasos ni pantallas intermedias: foto(s) arriba, datos abajo, y un
+botón de contacto fijo que nunca se mueve del fondo de la pantalla mientras se hace scroll. No hay una
+versión distinta del layout para un perfil recién publicado sin nada cargado — es la misma pantalla, con
+menos contenido, porque ese es el estado de todos los perfiles al lanzamiento (C-004 de investigación) y
+tratarlo como un caso especial lo haría sentir peor, no mejor.
 
-Gate de salida — experiencia.md está lista para ingenieria.md cuando:
-- cada flujo crítico tiene secuencia, variantes, recuperación y criterio de término
-- cada estado tiene contenido concreto (texto real, información visible, acción disponible)
-- cada vista lista sus modos, y el mapa de estados cubre todas las transiciones entre ellos
-- cada modo tiene su indicador permanente de estado, y cada flujo tiene todas sus salidas documentadas
-- los casos límite de producto.md tienen flujo o estado mapeado
-- cada flujo crítico está mockeado en móvil (390px), y en desktop si también vive ahí
-- ninguna pantalla queda descrita como "similar a X" sin especificar qué cambia
--->
+Contactar (F-002) no es una pantalla propia: es lo que pasa al tocar cualquiera de los dos botones del
+perfil — "Escribir por WhatsApp" o "Llamar" —, ambos construidos desde el mismo número que guarda misión
+04, porque Datealo no distingue "WhatsApp" de "teléfono" como dos contactos separados (ver corrección a
+[F-002 de producto.md](./producto.md#f-002) hecha durante este trabajo).
 
-## Decisión de experiencia: <qué cambia para quien usa el producto>
-
-<Modelo de interacción elegido, flujo más importante y la incertidumbre que sigue abierta.>
-
-- **Funcionalidades cubiertas:** F-001, <otras>.
-- **Pendiente bloqueante:** <pregunta o "ninguna">.
+- **Funcionalidades cubiertas:** F-001, F-002.
+- **Pendiente bloqueante:** ninguna.
 
 ## Vistas
 
-<!--
-El listado de pantallas que define la experiencia — el mapa que se entrega antes de los flujos. Una línea
-por vista, sin tabla, con sus modos anidados debajo. Una vista es un destino: se llega a ella. Un modo es
-un estado de esa vista que cambia qué se puede hacer y qué se ve — se anida, nunca se lista como vista
-hermana.
-
-El porqué de cada vista, su trade-off o su justificación no van aquí: viven en su flujo (UXF) o en una
-decisión (UX-xxx). Regla de formato para todo el documento: las tablas se reservan para índices de celdas
-cortas; lo que lleva justificación extensa va en secciones con header + bullets, nunca en una celda.
--->
-
-- **V-001 — <vista>** · móvil / desktop · resuelve F-001 · flujos UXF-001 · pendiente
-  - modo **<nombre>** — <qué lo distingue y qué se puede hacer en él>
-  - modo **<nombre>** — <ídem>
+- **V-001 — Perfil público de profesional** · móvil / desktop · resuelve [F-001](./producto.md#f-001),
+  [F-002](./producto.md#f-002) · flujos UXF-001, UXF-002
+  - modo **cargando** — pidiendo los datos del perfil, todavía no se sabe si existe
+  - modo **encontrado** — el perfil normal; el contenido varía según qué cargó el profesional (fotos,
+    descripción, precio) y hace cuánto existe, pero es la misma pantalla — nunca un modo distinto por eso
+  - modo **no encontrado** — el link no corresponde a ningún perfil activo (typo, o el perfil ya no existe)
 
 ## Mapa de estados
 
-<!--
-Vistas y flujos son listas, y una lista no muestra un camino. Esta tabla conecta los modos: qué acción
-lleva de uno a otro y qué pasa con el trabajo del usuario en cada salto. Cada fila que falte es una
-pregunta que ingeniería resuelve inventando.
--->
+| Desde     | Acción                                              | Queda en                         | Qué pasa con el trabajo |
+| --------- | ------------------------------------------------------ | ----------------------------------- | ---------------------------- |
+| cargando  | el servidor responde con un perfil activo               | encontrado                          | ninguno — es la primera carga |
+| cargando  | el servidor responde sin ningún perfil (no existe o inactivo) | no encontrado                | ninguno |
+| encontrado | toca "Escribir por WhatsApp"                            | encontrado (WhatsApp se abre aparte) | Datealo registra el contacto en paralelo; al volver de WhatsApp, el perfil sigue en el mismo scroll |
+| encontrado | toca "Llamar"                                            | encontrado (se abre el marcador aparte) | mismo registro de contacto; al volver, mismo perfil, mismo scroll |
+| no encontrado | toca "Buscar profesionales"                          | fuera de V-001 (a resultados cuando exista misión 06, o a la home mientras tanto) | ninguno |
 
-| Desde  | Acción             | Queda en | Qué pasa con el trabajo              |
-| ------ | ------------------ | -------- | ------------------------------------ |
-| <modo> | <acción concreta>  | <modo>   | <qué se aplicó, qué quedó pendiente> |
-| <modo> | <salir sin cerrar> | <modo>   | <qué se pierde o se conserva>        |
+## UXF-001 — Ver el perfil de un profesional
 
-## UXF-001 — <flujo principal en verbo>
+**Objetivo:** que el buscador tenga lo que necesita para decidir si confía en el profesional, sin tener que
+preguntarle nada primero. **Contrato:** [F-001](./producto.md#f-001).
 
-<!--
-Duplica por flujo crítico. Cada paso describe acción → respuesta al nivel de "el usuario toca X → Datealo
-muestra Y". Un mockup no reemplaza la secuencia porque no explica estados ni recuperación.
--->
+**Punto de entrada:** hoy, el único origen real es un link compartido directo (o uno probado a mano en
+desarrollo) — cuando exista misión 06, también desde una card de resultados. La pantalla no distingue el
+origen: el perfil se ve igual venga de donde venga.
 
-**Objetivo:** <qué se completa o comprende>. **Contrato:** [F-001](./producto.md#f-001).
+**Criterio de término:** no es una acción que "se completa" — es una pantalla de lectura. Su criterio de
+término es que el buscador llegó al botón de contacto con todo lo que el profesional cargó a la vista, sin
+tener que buscar información en otro lado.
 
-**Punto de entrada:** <estado y superficie inicial, y qué acción trae al usuario hasta acá>.
+**Cómo sabe el usuario dónde está:** el nombre, la categoría y la comuna quedan siempre visibles apenas
+termina de cargar, arriba de todo lo demás — es lo primero que confirma que está en el perfil correcto.
 
-**Criterio de término:** <estado observable que confirma que el flujo terminó bien>.
+### Divergencia antes de converger
 
-**Cómo sabe el usuario dónde está:** <el elemento concreto y permanente en pantalla que se lo dice, por
-cada modo que toca este flujo>.
+Para resolver el mismo JTBD (decidir sin poder leer ninguna reseña) se generaron tres enfoques
+genuinamente distintos, no variantes de layout del mismo enfoque:
+
+- **Enfoque A — hero de foto + botón de contacto fijo abajo:** foto(s) grandes arriba, datos debajo en
+  orden de relevancia, barra de contacto que nunca se mueve del fondo de la pantalla. Patrón directo de
+  Airbnb y TaskRabbit ([E-003](./investigacion.md#e-003), [E-005](./investigacion.md#e-005)).
+- **Enfoque B — ficha compacta tipo agenda de contactos:** todo en una pantalla sin scroll grande, foto
+  chica a un costado, datos a la derecha en filas cortas — prioriza velocidad de lectura sobre impacto
+  visual.
+- **Enfoque C — vista conversacional embebida:** la pantalla se abre directo con un preview tipo chat de
+  WhatsApp, con la info del profesional como si fuera su "perfil de contacto", enfatizando el mensaje de
+  bienvenida antes que ningún dato.
+
+**Elegido: A.** C-004 de investigación exige que un perfil sin fotos ni descripción "transmita seriedad sin
+sentirse abandonado ni falso" — el Enfoque B, comprimido y con foto chica, es exactamente lo que se ve
+pobre cuando faltan datos: menos espacio dedicado a lo poco que sí existe lo hace lucir más vacío, no menos.
+El Enfoque C simula un chat que no es un WhatsApp real, contradice el guardrail de `CLAUDE.md` de "contacto
+directo, sin intermediarios" al insertar una capa de Datealo entre el perfil y la conversación real, y no
+tiene behavior estándar que resolver con un componente existente — sería construir algo nuevo sin que
+ninguna conclusión de investigación lo pida. El Enfoque A además deja el botón de contacto alcanzable en
+todo momento del scroll, sirviendo directo a [C-002](./investigacion.md#c-002) (el contacto es la
+herramienta de "tanteo", no solo el cierre de una decisión ya tomada).
+
+### Jerarquía de información
+
+Con foto, nombre, categoría, comuna, descripción, precio y antigüedad compitiendo por la misma pantalla, el
+orden es:
+
+1. **Foto(s)** — lo primero que se ve, porque es la señal de confianza más fuerte que Datealo puede
+   mostrar sin reseñas ([C-001](./investigacion.md#c-001)).
+2. **Nombre + categoría + comuna** — confirma que es el perfil correcto y para qué sirve.
+3. **Descripción** (si existe) — el profesional hablando de sí mismo, en su propio lenguaje.
+4. **Precio** (si existe) — filtro rápido de presupuesto, sin tener que preguntar.
+5. **"En Datealo desde..."** — el único dato de actividad que Datealo puede mostrar sin inventar nada.
+6. **Botón de contacto** — no compite por posición en el scroll: vive fijo abajo, fuera del orden anterior.
 
 ### Salidas
 
-<!--
-Todas las formas de irse, no solo terminar bien. El criterio de término cubre la salida buena; las otras
-son las que el usuario encuentra primero. Un modo del que no se sabe salir es un modo donde el usuario se
-pierde.
--->
-
-| Salida                | Cómo se ejecuta       | Qué queda del trabajo           |
-| --------------------- | --------------------- | ------------------------------- |
-| <termina bien>        | <acción>              | <qué se aplicó y dónde>         |
-| <descarta>            | <acción, Esc, cerrar> | <nada, ni a medias>             |
-| <abandona sin cerrar> | <navega a otra parte> | <se conserva, se pierde, avisa> |
+| Salida                                  | Cómo se ejecuta                 | Qué queda del trabajo |
+| ---------------------------------------- | ------------------------------- | -------------------------- |
+| Decide contactar                         | toca "Escribir por WhatsApp" o "Llamar" | continúa en UXF-002; el perfil sigue atrás sin cambios |
+| Vuelve a resultados o cierra la pestaña  | botón atrás del navegador, o cierra    | nada que perder — es una pantalla de solo lectura |
+| El link no corresponde a nadie           | el servidor no encuentra el perfil      | ve el modo "no encontrado" con una salida hacia buscar profesionales |
 
 ### Secuencia principal
 
-| Paso | Acción            | Respuesta del sistema         | Información visible |
-| ---- | ----------------- | ----------------------------- | ------------------- |
-| 1    | <acción concreta> | <feedback o cambio de estado> | <dato y jerarquía>  |
+| Paso | Acción                                                    | Respuesta del sistema                                                                                     | Información visible |
+| ---- | ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| 1    | Abre el link de un perfil                                   | Datealo pide los datos; si tarda más de 300ms, muestra un skeleton con la forma de la pantalla (bloque de foto, dos líneas de texto) | Solo la forma, ningún dato real todavía |
+| 2    | El perfil carga                                              | Se muestra completo: foto(s) en carrusel (si tiene), nombre + categoría + comuna, descripción y precio (si existen), "En Datealo desde <mes y año>", y el botón de contacto fijo abajo | Todo lo que el profesional cargó — nunca un campo que diga "no especificado" cuando algo falta |
+| 3    | Se desplaza por las fotos (si hay más de una)                | El carrusel responde al swipe (comportamiento estándar de `UCarousel`, no se especifica interacción propia), con puntos que indican cuántas fotos hay | Posición actual dentro del carrusel |
+| 4    | Decide contactar                                              | Continúa en UXF-002                                                                                              | — |
 
 ### Variantes y recuperación
 
-| Condición          | Qué cambia              | Cómo se entiende    | Cómo se recupera             |
-| ------------------ | ----------------------- | ------------------- | ---------------------------- |
-| <sin resultados>   | <estado>                | <mensaje concreto>  | <acción disponible>          |
-| <sin permiso de ubicación> | <comportamiento> | <indicador visible> | <alternativa manual>         |
-| <conexión lenta>   | <skeleton, no spinner>  | <qué se ve mientras>| <qué pasa si falla>          |
+| Condición                                              | Qué cambia                                                                          | Cómo se entiende                                                        | Cómo se recupera |
+| ----------------------------------------------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ | --------------------- |
+| Sin ninguna foto ([CL-001](./producto.md#cl-001))            | El espacio de foto muestra un círculo con las iniciales del profesional, no un rectángulo vacío ni una foto de stock | Visualmente distinto a una foto real, para nunca insinuar que es suya           | No aplica — es el estado esperado de todos los perfiles al lanzamiento |
+| Sin descripción ni precio ([CL-002](./producto.md#cl-002))   | Esos bloques simplemente no aparecen — el perfil pasa directo de la foto a "En Datealo desde..." | El espacio no queda con un hueco ni un "sin información"                        | No aplica |
+| Sin ninguna reseña ([CL-003](./producto.md#cl-003)) — el caso de todos al lanzamiento | No hay sección de reseñas ni contador "0 reseñas"                | "En Datealo desde <mes>" ocupa el lugar donde iría ese dato                     | No aplica |
+| El link no corresponde a ningún perfil activo                | Modo no encontrado — ícono, título y explicación, sin foto ni datos                       | "No encontramos este perfil. Puede que ya no esté disponible o que el link esté mal escrito." | Botón "Buscar profesionales" |
+| Conexión lenta (>300ms)                                       | Skeleton con la forma de la pantalla real (bloque de foto, líneas de texto)                | El botón de contacto ya aparece en su posición fija aunque el resto siga cargando, para que el buscador sepa que va a estar ahí | Si pasa de 10s, mismo modo "no encontrado" pero con "Esto está tardando más de lo normal" + "Reintentar" |
 
 ### Decisiones que no deben quedar implícitas
 
-- <qué ocurre al cancelar, volver atrás, reintentar o confirmar>.
-- <qué cambio se guarda inmediato y cuál necesita confirmación>.
+- El botón "Escribir por WhatsApp" queda fijo abajo (`safe-bottom`) durante todo el scroll, nunca solo al
+  final de la página — ver [UX-001](#ux-001).
+- "En Datealo desde..." usa mes y año, nunca el día exacto — un dato tan preciso no aporta nada extra y
+  puede sentirse como vigilancia sobre el profesional.
+- No hay botón de "compartir perfil" ni de "guardar como favorito" — no está en el alcance de F-001, y
+  agregarlo solo porque es común en otros perfiles públicos sería expandir el alcance sin sustento.
+- El modo sin fotos usa el mismo contenedor de foto (mismo ancho completo, mismo `aspect-ratio`) con el
+  círculo de iniciales centrado adentro, nunca un layout distinto y compacto — es la misma pantalla con
+  menos contenido, no una composición aparte para el caso vacío (ver [UX-001](#ux-001)).
+- Cada foto del carrusel lleva un `alt` descriptivo con el nombre del profesional y su posición (ej. "Foto
+  de trabajo de Marcelo Rojas, 1 de 3"), nunca vacío. El contenedor en modo cargando lleva `aria-busy="true"`
+  mientras no hay contenido real.
+- Los puntos del carrusel llevan un degradado oscuro detrás (`hero-scrim`, ya en el mockup) para garantizar
+  contraste sobre cualquier foto real, sin depender de qué tan clara u oscura sea la foto que suba cada
+  profesional.
+- El ícono de "Llamar" es el ícono `Phone` de `@lucide/vue` (`CLAUDE.md`), nunca un emoji — el mockup ya lo
+  representa como SVG en vez de 📞 para no confundir a ingeniería.
+- En desktop, el bloque de datos y contacto queda en `position: sticky` dentro de su columna, no fijo a
+  toda la pantalla — la columna de fotos suele ser más alta que el bloque de texto, así que "fijo abajo" de
+  móvil se traduce a "pegado arriba de su columna mientras se hace scroll" en desktop, no al mismo mecanismo
+  literal.
+
+## UXF-002 — Contactar al profesional desde el perfil
+
+**Objetivo:** escribir o llamar al profesional sin salir de una decisión que ya tomó, sin ningún paso de
+Datealo en el medio. **Contrato:** [F-002](./producto.md#f-002). Sin divergencia propia: el mecanismo (dos
+botones desde el mismo número, sin pantalla intermedia) ya lo fija [D-001](./producto.md#d-001) y
+[D-002](./producto.md#d-002) de producto — acá se especifica solo la interacción concreta.
+
+**Punto de entrada:** el buscador está en V-001 modo encontrado, decidido a escribir o llamar (o solo a
+tantear cómo responde el profesional, ver [C-002](./investigacion.md#c-002)).
+
+**Criterio de término:** se abrió la app externa (WhatsApp o el marcador del celular) con el número
+correcto, y Datealo registró que el contacto ocurrió.
+
+**Cómo sabe el usuario dónde está:** no hay una vista nueva — sigue viendo el mismo perfil detrás. Al
+volver de WhatsApp o de la llamada, la pantalla está exactamente donde la dejó, mismo scroll.
+
+### Salidas
+
+| Salida                                              | Cómo se ejecuta                        | Qué queda del trabajo |
+| --------------------------------------------------------- | ------------------------------------------ | -------------------------- |
+| Termina bien                                              | toca "Escribir por WhatsApp" o "Llamar"     | se abre la app externa; el perfil queda atrás sin cambios, listo para cuando vuelva |
+| Se arrepiente antes de mandar el mensaje en WhatsApp       | cierra WhatsApp sin enviar nada             | Datealo ya registró el contacto — contó el toque del botón, no si el mensaje se envió; vuelve al perfil intacto |
+| El registro del contacto falla en el servidor              | seguía queriendo contactar de todas formas  | WhatsApp o la llamada se abren igual, sin que el buscador note nada ([M-002](./producto.md#m-002)) |
+
+### Secuencia principal
+
+| Paso | Acción                                    | Respuesta del sistema                                                                                       | Información visible |
+| ---- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| 1    | Toca "Escribir por WhatsApp"                 | Datealo dispara en paralelo el registro del contacto (sin esperar la respuesta) y abre `wa.me/<número>` con un mensaje pre-armado | "Hola Marcelo, vi tu perfil de Electricidad en Datealo y quería consultarte algo" — para que el profesional sepa de dónde vino sin que el buscador tenga que explicarlo |
+| 2    | (alternativa) Toca "Llamar"                  | Mismo registro de contacto en paralelo, y se abre el marcador del celular con el número ya cargado             | El número visible en el marcador antes de llamar |
+| 3    | Vuelve a Datealo (cierra WhatsApp o cuelga)  | El perfil sigue exactamente donde lo dejó                                                                       | Nada cambia visualmente — no hay un mensaje de "gracias por contactar" |
+
+### Variantes y recuperación
+
+| Condición                                                     | Qué cambia                                                                              | Cómo se entiende                                                | Cómo se recupera |
+| -------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ | --------------------- |
+| El registro del contacto falla (servidor caído)                       | Nada visible cambia para el buscador — WhatsApp o la llamada se abren igual ([M-002](./producto.md#m-002)) | No hay ningún indicador de error — el buscador nunca debe notar que algo falló acá | No aplica — es responsabilidad interna de Datealo |
+| El celular no tiene WhatsApp instalado ([CL-004](./producto.md#cl-004)) | `wa.me` abre la tienda de aplicaciones o WhatsApp Web, según el dispositivo — comportamiento estándar del enlace, Datealo no lo controla | El botón "Llamar" ya estaba visible al lado desde antes, como alternativa siempre disponible | Toca "Llamar" en cambio |
+| Toca "Escribir por WhatsApp" dos veces seguidas                       | Se abre WhatsApp una o dos veces, según el sistema operativo — no es un error que Datealo prevenga | No aplica un mensaje especial                                             | No aplica — no hay ningún estado roto que recuperar |
+
+### Decisiones que no deben quedar implícitas
+
+- El mensaje pre-armado de WhatsApp es el único "formulario" que existe en todo el flujo — texto libre que
+  el buscador puede borrar y reescribir antes de enviar, nunca un campo que Datealo controla o revisa.
+- El registro del contacto se dispara sin esperar a que `wa.me` o `tel:` terminen de abrir — en paralelo,
+  no en secuencia — porque cualquier demora ahí sería una demora real para abrir WhatsApp, y
+  [D-002](./producto.md#d-002) ya establece que el registro nunca puede retrasar el contacto real.
+- No hay ninguna confirmación visual de "contacto registrado" en pantalla — el buscador nunca necesita
+  saber que Datealo guardó algo; su experiencia completa es "toqué el botón y se abrió WhatsApp".
 
 ## Estados por superficie
 
-<!--
-El contenido es concreto: texto real, no "mensaje apropiado". El estado vacío de un marketplace
-pre-lanzamiento no es un detalle: para muchas búsquedas será el estado principal durante meses.
--->
-
-| Estado  | Qué se muestra (texto e información real) | Acción disponible                   |
-| ------- | ----------------------------------------- | ----------------------------------- |
-| inicial | <contenido>                               | <acción>                            |
-| vacío   | <por qué está vacío, con texto concreto>  | <cómo avanzar, o ninguna y por qué> |
-| carga   | <skeleton de qué forma>                   | <ninguna>                           |
-| error   | <causa útil y alcance>                    | <recuperación>                      |
+| Estado                                                    | Qué se muestra (texto e información real)                                                                                          | Acción disponible |
+| ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
+| V-001 cargando                                                    | Skeleton con la forma de la pantalla: bloque de foto y dos líneas de texto                                                                     | Ninguna |
+| V-001 encontrado, perfil completo                                 | "Marcelo Rojas · Electricidad · Ñuñoa", carrusel con 3 fotos, "Electricista hace 8 años, atiendo Ñuñoa y Providencia", "Desde $15.000", "En Datealo desde julio de 2026" | "Escribir por WhatsApp" (fijo abajo) + "Llamar" al lado |
+| V-001 encontrado, perfil recién publicado (CL-001, CL-002, CL-003 — el caso de lanzamiento) | "Héctor Silva · Electricidad · Ñuñoa", círculo con iniciales "HS" en vez de foto, sin descripción ni precio, "En Datealo desde agosto de 2026" | "Escribir por WhatsApp" (fijo abajo) + "Llamar" — igual de alcanzable que en el perfil completo |
+| V-001 no encontrado                                                | "No encontramos este perfil. Puede que ya no esté disponible o que el link esté mal escrito."                                                  | "Buscar profesionales" |
+| V-001 tardando (>10s)                                              | "Esto está tardando más de lo normal."                                                                                                          | "Reintentar" |
 
 ## Mockups
 
-<!--
-Los mockups viven en design-mockups/ como HTML (ver el skill discovery-ux y docs/design/README.md).
-Exploran o materializan una decisión; no son fuente de verdad de reglas de producto.
--->
-
-| Mockup   | Cubre   | Estado                 | Ruta                              |
-| -------- | ------- | ---------------------- | --------------------------------- |
-| <nombre> | UXF-001 | exploración o validado | `./design-mockups/<archivo>.html` |
+| Mockup          | Cubre              | Estado       | Ruta |
+| ---------------- | -------------------- | -------------- | ------ |
+| perfil-publico   | UXF-001, UXF-002 (V-001) | validado | `./design-mockups/perfil-publico.html` |
 
 ## Cobertura
 
-<!-- Detecta huecos antes de construir. Una funcionalidad sin pantalla nueva igual tiene estados. -->
-
-| Funcionalidad | Flujo   | Estados cubiertos       | Estado    |
-| ------------- | ------- | ----------------------- | --------- |
-| F-001         | UXF-001 | principal, vacío, error | pendiente |
-
-## Secciones bajo demanda
-
-<!--
-Agregar solo cuando una decisión las necesite, con estos títulos:
-
-- "Modelo mental y lenguaje": cuando un concepto de producto pueda confundirse en la interfaz.
-- "Jerarquía de información": cuando una superficie densa exija decidir qué se ve primero (una card de
-  resultado con foto, rating, distancia, precio y disponibilidad es exactamente ese caso).
-- "Validación (UXV-xxx)": cuando una incertidumbre de diseño necesite prueba con usuarios.
-- "Accesibilidad y adaptación": cuando el contexto de uso cambie el flujo o la representación.
--->
+| Funcionalidad | Flujo   | Estados cubiertos                                                                    | Estado    |
+| ------------- | ------- | ----------------------------------------------------------------------------------------- | --------- |
+| F-001         | UXF-001 | cargando, completo, recién publicado (CL-001, CL-002, CL-003), no encontrado, tardando       | borrador |
+| F-002         | UXF-002 | escribir por WhatsApp, llamar, registro en paralelo, sin WhatsApp instalado (CL-004)         | borrador |
 
 ## Decisiones de experiencia
 
 <a id="ux-001"></a>
 
-### UX-001 — <decisión en una frase>
+### UX-001 — El perfil usa un hero de foto con el botón de contacto fijo abajo, no una ficha compacta ni un chat embebido
 
-- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
-- **Sustento:** F-001 o <hallazgo>.
-- **Alternativas descartadas:** <opciones relevantes y trade-off, con el porqué del rechazo>.
-- **Decisión y consecuencia:** <qué flujo o superficie cambia>.
-- **Impacto en producto:** <ninguno o enlace a D-xxx/F-xxx actualizado>.
+- **Estado:** aceptada. **Fecha:** 2026-08-28.
+- **Sustento:** [C-001](./investigacion.md#c-001), [C-004](./investigacion.md#c-004) de investigación;
+  [E-003](./investigacion.md#e-003), [E-005](./investigacion.md#e-005) (Airbnb, TaskRabbit).
+- **Alternativas descartadas:** ver "Divergencia antes de converger" de UXF-001 — ficha compacta tipo
+  agenda de contactos (se ve pobre cuando faltan datos, exactamente lo que C-004 pide evitar) y vista
+  conversacional embebida tipo chat (simula un WhatsApp que no es real, contradice el guardrail de
+  "contacto directo, sin intermediarios" de `CLAUDE.md`).
+- **Decisión y consecuencia:** layout definido en la Secuencia principal de UXF-001 — foto(s) arriba, datos
+  en orden de relevancia debajo, botón de contacto en una barra fija inferior durante todo el scroll. La
+  evaluación heurística de esta misión intentó tumbar esta decisión señalando que, en el caso sin fotos
+  (el 100% de los perfiles al lanzamiento), el mockup inicial colapsaba a una composición distinta —sin la
+  banda de foto, centrada— que es justo lo que descartó al Enfoque B ("se ve pobre cuando faltan datos").
+  El argumento no tumbó la elección de A sobre B o C, pero sí exigió un ajuste: el modo sin fotos conserva
+  el mismo contenedor de foto (mismo ancho, mismo `aspect-ratio`) con el círculo de iniciales centrado
+  adentro, en vez de una composición aparte — ya corregido en el mockup y en "Decisiones que no deben
+  quedar implícitas" de UXF-001.
+- **Impacto en producto:** ninguno.
+
+<a id="ux-002"></a>
+
+### UX-002 — El botón de contacto ofrece WhatsApp y Llamar simultáneos, nunca uno solo ni una elección previa
+
+- **Estado:** aceptada. **Fecha:** 2026-08-28.
+- **Sustento:** hallazgo de esta misma sesión de diseño — `professionals.contact` (misión 04) guarda un
+  solo número de teléfono, no un WhatsApp y un teléfono separados.
+- **Alternativas descartadas:** mostrar solo "Escribir por WhatsApp" como único botón (más simple
+  visualmente) — se descarta porque deja sin alternativa a quien no tiene WhatsApp instalado, ocultando un
+  dato (el mismo número sirve para llamar) que Datealo ya tiene gratis. Preguntar "¿cómo prefieres
+  contactarlo?" con un selector antes de mostrar el botón — se descarta porque agrega un paso al flujo core
+  que `CLAUDE.md` protege, por una decisión que de todas formas termina abriendo el mismo número.
+- **Decisión y consecuencia:** dos botones siempre visibles y simultáneos — "Escribir por WhatsApp" como
+  principal (más grande, primero) y "Llamar" como secundario (ícono, al lado) — ambos construidos desde el
+  mismo `contact`.
+- **Impacto en producto:** sí — [F-002 de producto.md](./producto.md#f-002) se corrigió en esta misma
+  sesión: ya no dice "si eligió WhatsApp... o teléfono" (esa elección no existe en el dato), dice que ambos
+  botones salen del mismo número.
 
 ## Preguntas
 
-<!--
-Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
-Estado: abierta | resuelta AAAA-MM-DD | disuelta AAAA-MM-DD. Solo las abiertas llevan bloque de detalle.
--->
+Ninguna bloquea F-001 ni F-002 tal como quedan definidas acá. La única pregunta pendiente de esta misión
+([Q-001](./producto.md#q-001), cómo misión 07 va a atar una reseña a un contacto real) es de `producto.md`,
+no una duda de esta vista — el perfil y el botón de contacto funcionan igual sin que esté resuelta.
 
-<Una frase que responde "¿qué falta?": la pregunta que bloquea construcción y qué bloquea.>
-
-| ID      | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
-| ------- | ---------------------- | ------------------- | --------------------------------------------------------------- |
-| UXQ-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
-| UXQ-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |
+| ID | La duda | Estado | Respuesta, o quién la resuelve |
+| -- | ------- | ------ | ------------------------------- |
+| —  | —       | —      | sin preguntas abiertas propias de experiencia |

--- a/docs/missions/05-perfil-publico-profesional/ingenieria.md
+++ b/docs/missions/05-perfil-publico-profesional/ingenieria.md
@@ -1,162 +1,298 @@
-# Misión: <nombre> — Ingeniería
+# Misión: perfil público de profesional — Ingeniería
 
-**Estado:** borrador
+**Estado:** vigente — aprobado por Patricio el 2026-08-28
 
-**Última actualización:** AAAA-MM-DD
+**Última actualización:** 2026-08-28
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-<!--
-Fuente de verdad para arquitectura, datos, contratos, factibilidad y pruebas. Consume el comportamiento
-definido en producto. Una limitación técnica cambia el alcance solo mediante una decisión explícita en
-producto.md.
+## Decisión técnica: dos endpoints públicos sobre lo que ya existe, más una tabla nueva y aislada para el evento de contacto
 
-Núcleo obligatorio: contratos, modelo de datos, RLS y riesgos de factibilidad. Las secciones bajo demanda
-(migración, rendimiento, entrega por etapas) se agregan solo cuando el riesgo lo justifica.
+`professionals` (misión 04) ya tiene todo el dato que el perfil público necesita — nombre, categoría,
+comuna, contacto, descripción, precio, fotos y `createdAt`. Esta misión no le agrega ninguna columna: solo
+expone un subconjunto nuevo de esos datos, ya públicos por diseño (D-001 de producto.md), a través de un
+endpoint sin sesión. Lo único que agrega es una tabla chica y aislada, `professional_contact_events`, para
+el evento de contacto — sin ninguna columna que identifique a quien contacta (D-002 de producto.md).
 
-Gate de salida — ingenieria.md está lista para construir cuando:
-- los contratos definen qué entra, qué sale y qué invariantes se mantienen, sin ambigüedad
-- el modelo de datos soporta los casos límite de producto.md sin workarounds
-- el impacto en RLS está resuelto: qué policy se crea o cambia, o por qué ninguna
-- la migración de datos existentes tiene estrategia o está explícitamente fuera del alcance
-- los escenarios verificables de producto están mapeados a pruebas
-- el plan de construcción corta el diseño en slices atómicos ordenados (un slice = un Issue = un PR)
--->
+Todo se lee y escribe vía `server/api/` con Drizzle, el mismo camino que ya usa misión 04 — esta misión no
+reabre PostgREST para `professionals` ni para nada nuevo, aunque sea literalmente "el perfil público": la
+policy `professionals_select_public` que misión 04 dejó escrita "por si algún día se revierte el revoke"
+sigue inerte, a propósito, porque ese día no es hoy (ver Impacto en RLS).
 
-## Decisión técnica: <arquitectura y riesgo principal>
+- **Contratos de producto cubiertos:** F-001, F-002, D-001, D-002, M-002.
+- **Riesgo bloqueante:** ninguno.
 
-<Dirección técnica, trade-off principal y el riesgo que todavía podría invalidarla.>
+## Vocabulario: producto ↔ código
 
-- **Contratos de producto cubiertos:** F-001, <otros>.
-- **Riesgo bloqueante:** <incertidumbre o "ninguna">.
+| Término de producto              | Entidad/campo en código                                                        |
+| ------------------------------------ | ------------------------------------------------------------------------------------ |
+| perfil público                       | `GET /api/professionals/[id]` — lee `professionals` (misión 04), sin cambio de schema |
+| "En Datealo desde..."                | `professionals.createdAt`, expuesto por primera vez en una forma pública            |
+| evento de contacto                   | `professional_contact_events` (tabla nueva) — el nombre lleva "events" porque es un log de hechos ya ocurridos, no una libreta de contactos |
+| botón "Escribir por WhatsApp" / "Llamar" | construidos en el cliente a partir de `professional.contact` (T-002) — no hay dos contactos separados en el dato |
 
-## Arquitectura: <cómo se divide la responsabilidad>
+## Arquitectura: dos dominios nuevos y chicos, cada uno en su propio archivo de utils
 
-<!--
-La lógica de negocio se separa de la infraestructura: funciones puras en utils/ y server/utils/,
-reactividad en composables, acceso a datos en server/api/ con Drizzle. Incluye diagrama solo cuando tres o
-más partes interactúan.
--->
+```
+Browser (sin sesión) ──GET──> server/api/professionals/[id].get.ts ──> server/utils/professionals.ts ──Drizzle──> professionals, categorias, comunas
 
-<Descripción del enfoque y por qué satisface los contratos con menor riesgo.>
+                       ──POST (sendBeacon, sin esperar)──> server/api/professionals/[id]/contacts.post.ts ──> server/utils/professional-contact-events.ts ──Drizzle──> professional_contact_events
 
-| Componente | Responsabilidad       | No debe decidir | Contratos |
-| ---------- | --------------------- | --------------- | --------- |
-| <nombre>   | <una responsabilidad> | <frontera>      | F-001     |
+                       └─(en paralelo, sin pasar por Datealo)─> wa.me/<contact> o tel:<contact>
+```
+
+`server/utils/professionals.ts` (misión 04) se extiende con una función nueva de lectura pública. El
+registro del evento de contacto va en un archivo propio, `server/utils/professional-contact-events.ts`, no
+mezclado en `professionals.ts` — son dos razones de cambio distintas (leer/editar un perfil vs. registrar un
+evento) y dos dominios distintos con su propio ciclo de vida, consistente con A-006 del skill `arquitectura`
+("cada archivo de `server/utils/` es de un dominio... nunca sirve a dos dominios a la vez"). La única regla
+que sí se comparte de verdad entre las dos formas públicas de `professionals` (`Professional` de misión 04 y
+la nueva de esta misión) es armar `photoUrls` desde `photoPaths` — se extrae a un helper interno de
+`professionals.ts`, porque ahí sí es la misma regla, no dos parecidas.
+
+| Componente                                                | Responsabilidad                                                              | No debe decidir                              | Contratos      |
+| -------------------------------------------------------------- | ----------------------------------------------------------------------------------- | -------------------------------------------------- | ---------------- |
+| `server/db/schema/professional-contact-events.ts`               | Forma de la tabla nueva                                                             | Qué filas existen                                   | TC-002           |
+| `server/utils/professionals.ts` (extendido)                     | Query pública por `id`, con categoría/comuna resueltas en la misma consulta         | Presentación, HTTP, el dominio de contactos         | TC-001           |
+| `server/utils/professional-contact-events.ts` (nuevo)           | Verificar que el profesional existe y registrar el evento                            | Presentación, HTTP, el dominio de perfiles          | TC-002           |
+| `server/api/professionals/[id].get.ts`                          | I/O: valida forma de `id`, llama a utils, arma la respuesta pública                  | Reglas de negocio (eso ya lo hizo utils)            | TC-001           |
+| `server/api/professionals/[id]/contacts.post.ts`                 | I/O: valida forma de `id`, llama a utils                                            | Identificar a quien contacta (D-002 lo prohíbe)     | TC-002           |
+| `app/pages/profesionales/[id].vue`                               | Renderiza los modos de V-001 (`experiencia.md`), arma `wa.me`/`tel:` en el cliente, dispara TC-002 sin esperar | Verificación de sesión — no aplica, no hay ninguna | UXF-001, UXF-002 |
 
 ## Contratos
 
-<!--
-Cada contrato especifica entrada, salida e invariantes al nivel en que se puede implementar sin reuniones
-de aclaración. Incluye los errores observables y el código HTTP cuando es un endpoint.
--->
+### TC-001 — `GET /api/professionals/[id]` — ver el perfil público de un profesional
 
-### TC-001 — <contrato en una frase>
+- **Entrada:** path param `id`. Sin sesión — cualquiera puede llamarlo (D-001 de producto.md).
+- **Salida:** `200 { professional: PublicProfessionalProfile }`.
+  `PublicProfessionalProfile = { id, displayName, categoriaNombre: string, comunaNombre: string, contact,
+  description: string | null, priceFrom: number | null, photoUrls: string[], createdAt: string }` —
+  `createdAt` en ISO 8601, es lo único que esta forma expone y que `Professional` (misión 04, `GET /me`) no
+  expone. `categoriaNombre`/`comunaNombre` son el nombre legible, no el slug/código — el perfil público no
+  necesita el identificador técnico, solo lo que se muestra (V-001 de `experiencia.md` nunca lee
+  `categoriaSlug`).
+- **Invariantes:** solo devuelve una fila con `active = true` — un perfil inactivo responde exactamente
+  igual (`404`) que un `id` que no existe, para no filtrar por el código de respuesta si alguien se dio de
+  baja. Un `id` sin forma de UUID se descarta antes de tocar la base (mismo `404`; sin este chequeo, un
+  valor mal formado contra una columna tipada `uuid` produce un error de Postgres —`22P02`— en vez de un
+  resultado vacío controlado). Nunca incluye `userId` (A-005) — es un `select` explícito nuevo, no reutiliza
+  `publicColumns` de misión 04 tal cual (que sí incluye `active`, que esta forma tampoco expone: no hace
+  falta, si la respuesta existe ya es porque está activo); ambos `select` excluyen `userId`
+  independientemente, así que una columna privada futura en `professionals` (una nota de moderación, un
+  score interno) hay que recordar excluirla en los dos lugares, no en uno — queda anotado con un comentario
+  cruzado en ambos archivos para no depender de la memoria. `categoriaNombre`/`comunaNombre` se resuelven en
+  la misma consulta (`leftJoin` contra `categorias` y `comunas`), no con dos queries adicionales por
+  separado — este es, según T-001, el endpoint con más tráfico esperado de todo el diseño (el destino de las
+  cards de misión 06), así que el costo de un round-trip evitable importa acá de una forma en que no importa
+  en el flujo de correo de bienvenida de misión 04 (que sí usa dos queries separadas, porque corre una vez
+  por registro, no una vez por visita).
+- **Errores:** `404 { error: 'not_found' }` — único caso de error de este contrato.
+- **Contrato de producto:** [F-001](./producto.md#f-001), [D-001](./producto.md#d-001),
+  [D-002](./producto.md#d-002).
 
-- **Entrada:** <datos y precondiciones, con tipos y forma concreta>.
-- **Salida:** <resultado y su forma concreta>.
-- **Invariantes:** <qué se cumple siempre: atomicidad, consistencia, idempotencia>.
-- **Errores:** <condición → código HTTP y cuerpo `{ error, code? }`, y qué puede hacer el llamador>.
-- **Contrato de producto:** [F-001](./producto.md#f-001).
+### TC-002 — `POST /api/professionals/[id]/contacts` — registrar que ocurrió un contacto
+
+- **Entrada:** path param `id`. Sin sesión, sin body — [D-002 de producto.md](./producto.md#d-002) es
+  explícito: nada que identifique a quien contacta.
+- **Salida:** `204` sin cuerpo — el cliente nunca lee esta respuesta (la dispara con `sendBeacon`, ver
+  T-003).
+- **Invariantes:** un `id` sin forma de UUID se descarta antes de tocar la base, mismo criterio y mismo
+  motivo que TC-001 (evita el `22P02` de Postgres contra la columna `uuid`, en vez de dejarlo escapar como
+  un `500`). Inserta una fila en `professional_contact_events` con `professionalId = id` y
+  `createdAt = now()`. No exige que el perfil siga `active` — solo que exista (verificado con un `select`
+  antes del insert, no parseando el código de violación de FK de Postgres); un perfil que se desactivó entre
+  que el buscador abrió la pantalla y tocó el botón igual registra el contacto, porque el contacto ya
+  ocurrió de verdad.
+- **Errores:** `404 { error: 'not_found' }` si `id` no tiene forma de UUID, o no corresponde a ningún
+  profesional.
+- **Contrato de producto:** [F-002](./producto.md#f-002), [D-002](./producto.md#d-002),
+  [M-002](./producto.md#m-002).
 
 ## Modelo de datos
 
-<!-- Entidades con significado, escritura y ciclo de vida. El schema completo vive en server/db/. -->
-
-| Entidad o campo | Significado             | Escritura          | Retención o historial |
-| --------------- | ----------------------- | ------------------ | --------------------- |
-| <dato>          | <semántica de producto> | <endpoint o acción>| <política>            |
+| Entidad o campo                              | Significado                                                        | Escritura           | Retención o historial |
+| -------------------------------------------------- | ------------------------------------------------------------------------ | ---------------------- | ------------------------ |
+| `professionals.*`                                  | Sin cambio de schema — misión 04 ya tiene todo lo que esta misión lee    | (misión 04)             | (misión 04)              |
+| `professional_contact_events.id`                   | Identificador propio de la fila, sin uso fuera de la base                | TC-002                  | Permanente               |
+| `professional_contact_events.professionalId`       | FK a `professionals.id` — el profesional que recibió el contacto. `onDelete: 'restrict'` explícito: hoy ningún flujo borra un `professionals` row (misión 04), así que nunca se ejerce, pero queda decidido en vez de depender del default silencioso de Postgres — si algún día se agrega un borrado de perfiles, ese diseño tiene que decidir qué hacer con su historial de contactos, no heredar un comportamiento que nadie eligió | TC-002, una vez, nunca cambia | Permanente          |
+| `professional_contact_events.createdAt`            | Cuándo ocurrió el contacto                                               | TC-002                  | Permanente               |
 
 ### Invariantes de datos
 
-- <unicidad, pertenencia, orden o consistencia temporal>.
-- <qué operación es atómica o qué dato tiene una única fuente de verdad>.
+- `professional_contact_events` no tiene ninguna columna que identifique al buscador — a propósito, por
+  [D-002 de producto.md](./producto.md#d-002). Cómo misión 07 va a atar una reseña a un contacto real sin
+  esa identidad es [Q-001 de producto.md](./producto.md#q-001), no algo que esta misión resuelva.
+- `professional_contact_events` no tiene ninguna defensa contra un `POST` fabricado (sin sesión, sin límite
+  de tasa) — cualquiera puede inflar el conteo de un profesional real sin que el contacto haya ocurrido. Hoy
+  no importa: ningún dato de esta tabla es público ni se consume todavía (fuera de alcance de esta misión,
+  ver Fuera de alcance de `producto.md`). Es exactamente la superficie que Q-001 deja pendiente para misión
+  07 — cualquier uso futuro de esta tabla como "prueba de que un contacto ocurrió" tiene que resolver esto
+  primero, no asumir que la fila ya es confiable.
+- `professional_contact_events.professionalId` lleva índice — es la única columna por la que se va a
+  consultar (un conteo por profesional, el día que exista esa necesidad).
+- TC-001 nunca lee `professional_contact_events` — no hay ningún contador visible en esta misión
+  ([C-001](./investigacion.md#c-001), [C-004](./investigacion.md#c-004) de investigación; "Fuera de
+  alcance" de `producto.md`).
+
+**Migración:** no aplica — `professional_contact_events` es una tabla nueva, sin dato previo que adaptar. El
+cambio a `professionals` es de exposición (un endpoint nuevo la lee distinto), no de schema — no hay
+migración de datos existentes.
 
 ### Impacto en RLS
 
-<!--
-Obligatorio. Fuente de verdad: server/db/sql/rls.sql. Si el cambio no toca ownership ni relaciones usadas
-en policies, decirlo explícitamente con esa razón — no dejar la sección vacía.
--->
+**`professionals` no cambia de policy ni de camino de acceso a nivel de RLS/PostgREST.** TC-001 lee vía
+Drizzle (rol dueño, A-002), el mismo camino que TC-002/TC-003 de misión 04 — no PostgREST directo. Esto es,
+literalmente, el escenario que el comentario de `professionals_select_public` en `rls.sql` ya anticipaba
+("si algún día se revierte el revoke... para un perfil público futuro") — pero este diseño no lo activa: el
+perfil público de Datealo se sirve vía `server/api/`, como todo lo demás (A-001), no vía PostgREST. La
+policy sigue existiendo, sigue inerte por el `revoke` de misión 04, y sigue sin ser la barrera de nada.
 
-| Tabla    | Cambio                 | Policy afectada | Acción                    |
-| -------- | ---------------------- | --------------- | ------------------------- |
-| <tabla>  | <nueva, ownership, FK> | <nombre>        | <crear, actualizar, nada> |
+Esto es distinto de decir que **la exposición a nivel de aplicación** no cambia: sí cambia, a propósito.
+Misión 04 solo dejaba leer `professionals` vía Drizzle para el dueño autenticado (`GET /me`,
+`requireUser()`); TC-001 lee vía Drizzle para cualquiera, sin sesión. Ese es exactamente el efecto que
+[D-001 de producto.md](./producto.md#d-001) decide a propósito ("el número de WhatsApp o teléfono del
+profesional es visible... sin iniciar sesión") — se nombra acá para que quede claro que el cambio real de
+superficie vive en la autorización de `server/api/` (A-002: "cada endpoint verifica pertenencia en el
+código" — acá la verificación es "no hace falta ninguna", explícita, no ausente), no en RLS.
+
+| Tabla                          | Cambio | Policy o grant                                                                | Acción                                                                                          |
+| ----------------------------------- | ------ | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------- |
+| `professionals`                     | ninguno | (sin cambio — `professionals_select_public`, `_insert_own`, `_update_own`, el `revoke`, todo de misión 04) | nada — TC-001 usa el mismo camino (Drizzle, rol dueño) que ya bypassea RLS por completo |
+| `professional_contact_events`       | nueva  | `alter table professional_contact_events enable row level security`                  | crear — sin esto, cualquier policy futura sobre esta tabla no se evaluaría nunca, sin aviso        |
+| `professional_contact_events`       | nueva  | `revoke all on public.professional_contact_events from anon, authenticated`          | crear — cierra PostgREST por completo (A-007). Nada en el diseño necesita leer ni escribir esta tabla por ahí: TC-002 usa Drizzle (rol dueño), que no le afecta |
+| `professional_contact_events`       | nueva  | sin ninguna policy (`select`/`insert`/`update`/`delete`)                             | ninguna — nada de este diseño necesita que un rol `anon`/`authenticated` toque esta tabla vía PostgREST; sin policy, Postgres deniega por default para esos roles, que es el comportamiento que se quiere. **`force row level security` no se usa** — rompería el `insert` de TC-002, que corre con el rol dueño de Drizzle, donde `auth.uid()` es `NULL` |
+
+No hay bucket de Storage nuevo, ni cliente de Supabase nuevo en el browser — el browser de esta misión solo
+habla con `/api/*` (dos rutas nuevas) y con `wa.me`/`tel:` fuera de Datealo, ningún cliente de Supabase
+entra en juego del lado del buscador.
 
 ## Riesgos y experimentos de factibilidad
 
-<!--
-Un riesgo que podría cambiar el producto se enlaza como pregunta o decisión en producto.md. Un experimento
-tiene pregunta, límite de tiempo y resultado capaz de cerrar la incertidumbre.
--->
-
-| ID     | Riesgo o pregunta | Qué invalida        | Experimento o mitigación  | Criterio de salida      | Estado  |
-| ------ | ----------------- | ------------------- | ------------------------- | ----------------------- | ------- |
-| TR-001 | <incertidumbre>   | <alcance en riesgo> | <spike, prueba o recorte> | <resultado concluyente> | abierto |
+Ninguno bloqueante — el diseño es una extensión chica de un camino ya construido y probado en misión 04.
 
 ## Estrategia de pruebas
 
-<!-- Mapea los ejemplos verificables de producto.md a niveles de prueba. Qué demuestra cada una. -->
+Mismo criterio que misión 04: sin infraestructura de test de integración contra Postgres, se verifica a
+mano contra la base de desarrollo.
 
-| Contrato o riesgo | Nivel                          | Caso principal | Límite o falla |
-| ----------------- | ------------------------------ | -------------- | -------------- |
-| F-001, CL-001     | <unidad, contrato, integración>| <caso>         | <caso>         |
+| Contrato o riesgo                                            | Nivel  | Caso principal                                                                                     | Límite o falla |
+| ------------------------------------------------------------------ | ------ | ---------------------------------------------------------------------------------------------------- | ----------------- |
+| TC-001 (F-001)                                                      | manual | Abrir `/profesionales/<id>` de un perfil activo con fotos, precio y descripción muestra todo, incluida "En Datealo desde..." | Un `id` inexistente, mal formado, o de un perfil `active = false` devuelve `404` — los tres casos, indistinguibles entre sí |
+| TC-001 (perfil recién publicado — CL-001, CL-002, CL-003)            | manual | Un perfil sin fotos, descripción ni precio devuelve la misma forma, con esos campos en `null`/`[]`  | El cliente los trata como "no mostrar la sección", nunca como un error |
+| TC-002 (F-002, M-002)                                                | manual | Tocar "Escribir por WhatsApp" o "Llamar" agrega una fila en `professional_contact_events` con el `professionalId` correcto | Un `id` inexistente o mal formado devuelve `404` sin insertar ninguna fila |
+| TC-002 (D-002, M-002 — el registro nunca bloquea el contacto real)    | manual | Desconectar la red antes de tocar el botón: `wa.me`/`tel:` se abren igual, sin ningún error visible | — |
+| Impacto en RLS — PostgREST directo, `professional_contact_events`    | manual, **desde la consola del navegador**, con o sin sesión | `$supabase.from('professional_contact_events').select('*')` devuelve `permission denied` | `.insert({ professionalId: '...' })` también falla — el `revoke` bloquea antes de evaluar cualquier policy |
+| Impacto en RLS — `professionals` sigue cerrado (sin cambio respecto a misión 04) | manual, sin sesión | `$supabase.from('professionals').select('*')` sigue devolviendo `permission denied` — esta misión no reabre ese camino | — |
 
 ### Propiedades que deben probarse
 
-- <invariante bajo reintentos, concurrencia o distintas entradas>.
-- <ausencia de efectos parciales en falla>.
+- Un perfil `active = false` nunca es alcanzable por su `id` vía TC-001 — mismo `404` que un `id`
+  inexistente, sin que la respuesta permita distinguir los dos casos.
+- Ningún endpoint de esta misión expone `professional_contact_events` de vuelta al cliente — ni un conteo,
+  ni una lista, ni ningún dato derivado (verificable por ausencia: no hay ningún endpoint de lectura para
+  esta tabla en todo el diseño).
+- Una falla de red o de servidor en TC-002 nunca impide que `wa.me`/`tel:` se abran — el `sendBeacon` de
+  T-003 no tiene forma de bloquear la navegación siguiente, así que esta propiedad la garantiza la elección
+  de API, no un `try/catch` que alguien podría olvidar escribir.
 
 ## Plan de construcción
 
-<!--
-Se completa al final, cuando el gate de salida se cumple y ninguna pregunta bloqueante sigue abierta —
-cortar sobre decisiones abiertas produce issues que mueren. Cada slice es un cambio funcional atómico: un
-Issue, un PR, ejecutable sin haber leído la misión (el issue lleva su contrato inline) y con criterios
-pass/fail enumerables como tests. Guía completa en el skill discovery-engineering.
--->
+| ID    | Slice (una frase, sin "y")                                          | Sustento                       | Criterio de aceptación principal                                                                                                                                                                 | Depende de| Issue |
+| ----- | ------------------------------------------------------------------------ | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------| ----- |
+| S-001 | Endpoint público `GET /api/professionals/[id]` con nombres de categoría/comuna resueltos y "En Datealo desde" | F-001, D-001, D-002, TC-001, CL-001, CL-002, CL-003 | Un `id` de un perfil activo devuelve sus datos completos, incluido `createdAt`, con `categoriaNombre`/`comunaNombre` resueltos en una sola consulta; un perfil sin fotos/descripción/precio devuelve esos campos vacíos, no un error; un `id` inexistente, mal formado o de un perfil `active = false` devuelve `404` idéntico en los tres casos; la respuesta nunca incluye `userId` | —          | [#87](https://github.com/PatricioTabilo/datealo/issues/87) |
+| S-002 | Tabla `professional_contact_events` (con su índice, RLS habilitada y el `revoke`) y el endpoint `POST /api/professionals/[id]/contacts` | F-002, D-002, TC-002, M-002 | Tocar el endpoint con un `id` real inserta una fila con `professionalId` y `createdAt`, sin ningún otro dato; un `id` inexistente o mal formado devuelve `404` sin insertar; vía PostgREST (consola del navegador, con o sin sesión), `select`/`insert` sobre `professional_contact_events` devuelven `permission denied` | —          | [#88](https://github.com/PatricioTabilo/datealo/issues/88) |
+| S-003 | Vista pública `/profesionales/[id].vue` — todos los modos de V-001 (cargando, encontrado completo, encontrado vacío, no encontrado, tardando) con los botones de contacto | F-001, F-002, UXF-001, UXF-002, CL-001 a CL-005 | Abrir la URL de un perfil real muestra el mockup validado (`design-mockups/perfil-publico.html`) con datos reales; un `id` inválido muestra el modo "no encontrado"; tocar "Escribir por WhatsApp"/"Llamar" abre la app externa correcta y dispara TC-002 sin esperar su respuesta (verificable con la red desconectada, ver Estrategia de pruebas) | S-001, S-002 | [#89](https://github.com/PatricioTabilo/datealo/issues/89) |
 
-| ID    | Slice (una frase, sin "y") | Sustento      | Criterio de aceptación principal          | Depende de |
-| ----- | -------------------------- | ------------- | ----------------------------------------- | ---------- |
-| S-001 | <cambio atómico>           | TC-001, D-001 | <entrada concreta → resultado observable> | —          |
-
-## Secciones bajo demanda
-
-<!--
-Agregar solo cuando el riesgo lo justifique, con estos títulos:
-
-- "Migración y compatibilidad": cuando existan datos o consumidores que deben llegar al nuevo contrato.
-  Incluye rollback lógico si la migración física no puede revertirse.
-- "Rendimiento y observabilidad": cuando haya presupuesto de latencia o volumen que defender (búsqueda
-  geográfica y listados paginados son los candidatos naturales).
-- "SEO e indexación": cuando la superficie deba ser indexable (páginas por categoría + comuna, datos
-  estructurados).
-- "Entrega por etapas": cuando el cambio necesite despliegue incremental o feature flags.
--->
+Tres slices, sin dependencia entre S-001 y S-002 — podrían ir en paralelo, cada uno en su propio archivo de
+utils (`professionals.ts` vs. `professional-contact-events.ts`) sin tocar el mismo archivo salvo el barril
+`server/db/schema/index.ts` (un `export *` más, sin conflicto real). S-003 es el walking skeleton completo:
+la vista real, consumiendo los dos endpoints ya probados por separado.
 
 ## Decisiones técnicas
 
 <a id="t-001"></a>
 
-### T-001 — <decisión en una frase>
+### T-001 — La URL pública usa `/profesionales/[id]`, un namespace nuevo y separado de `/profesional/*`
 
-- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
-- **Contratos:** F-001 y <regla relevante>.
-- **Alternativas descartadas:** <opciones y trade-offs, con el porqué del rechazo>.
-- **Decisión y consecuencias:** <enfoque elegido, beneficio, costo y trabajo futuro aceptado>.
-- **Reapertura:** <medición o cambio que justificaría revisar>.
+- **Estado:** aceptada. **Fecha:** 2026-08-28.
+- **Contratos:** TC-001, UXF-001.
+- **Alternativas descartadas:** reusar `/profesional/[id]` (mismo prefijo singular que las páginas de
+  autogestión del profesional — `ingresar`, `registro`, `perfil`, misión 04) — funciona técnicamente,
+  porque Nitro/Nuxt priorizan rutas estáticas sobre dinámicas en el mismo prefijo, pero mezcla dos
+  audiencias completamente distintas (el profesional gestionando su propia cuenta vs. cualquiera viendo el
+  perfil de un tercero) bajo el mismo namespace — confunde a la próxima misión que toque esa carpeta. Un
+  slug legible en vez de `id` (ej. `/profesionales/marcelo-rojas-electricidad-nunoa`) — más amigable para
+  compartir o para SEO, pero ni `producto.md` ni `experiencia.md` piden nada de eso para esta entrega, y ya
+  hay una decisión tomada en [T-004 de misión 04](../04-registro-perfil-profesional/ingenieria.md#t-004) de
+  usar `professionals.id` en la URL pública — agregar un slug es una migración real (unicidad, colisiones,
+  qué pasa si el profesional cambia de nombre) sin ningún requisito que la sustente hoy.
+- **Decisión y consecuencia:** la vista pública vive en `/profesionales/[id]`, plural, sin relación de ruta
+  con `/profesional/*`. Anticipa el prefijo que misión 06 (búsqueda y resultados) probablemente va a
+  necesitar para listar profesionales.
+- **Reapertura:** si producto pide URLs legibles (SEO, compartir en redes) — ahí se evalúa agregar un slug
+  sin romper `id` como identificador estable.
+
+<a id="t-002"></a>
+
+### T-002 — Los links de contacto se arman en el cliente, no en el servidor
+
+- **Estado:** aceptada. **Fecha:** 2026-08-28.
+- **Contratos:** TC-001, UXF-002, [D-001](./producto.md#d-001)/[D-002](./producto.md#d-002) de producto.
+- **Alternativas descartadas:** devolver `whatsappUrl`/`telUrl` ya construidos en TC-001 — no hay ninguna
+  regla de negocio en armar estas URLs, es formateo puro; hacerlo en el servidor le agrega una
+  responsabilidad a un contrato de lectura sin necesidad, cuando el cliente ya tiene todo lo que hace falta.
+- **Decisión y consecuencia:** el cliente arma `https://wa.me/<dígitos sin +>?text=<mensaje codificado>`
+  (`wa.me` exige el número sin el símbolo `+`, según su propia documentación) y `tel:<contact>` (con el
+  `+`, el mismo formato E.164 en que ya se guarda `professionals.contact`, misión 04). El mensaje
+  pre-armado usa `displayName` y `categoriaNombre`, ya presentes en la respuesta de TC-001 — sin ningún
+  dato adicional del servidor.
+- **Reapertura:** ninguna prevista.
+
+<a id="t-003"></a>
+
+### T-003 — El registro del contacto usa `navigator.sendBeacon`, no `fetch`, y nunca se espera antes de navegar
+
+- **Estado:** aceptada. **Fecha:** 2026-08-28.
+- **Contratos:** TC-002, [D-002](./producto.md#d-002)/[M-002](./producto.md#m-002) de producto, UXF-002.
+- **Alternativas descartadas:** `fetch()` sin `await` ("fire-and-forget") antes de navegar a `wa.me`/`tel:`
+  — es la opción más obvia, pero un `fetch` en vuelo puede cancelarse si el navegador descarga la pestaña
+  al navegar afuera (más probable en `tel:`, que en algunos navegadores móviles sí produce una navegación
+  real). Esperar la respuesta del `POST` antes de abrir WhatsApp/la llamada — garantiza el registro, pero
+  contradice directo D-002/M-002 ("el registro nunca puede retrasar el contacto real"): cualquier latencia
+  de red ahí sería una demora real y visible para alguien que solo quiere escribir un mensaje.
+- **Decisión y consecuencia:** el cliente llama `navigator.sendBeacon('/api/professionals/<id>/contacts')`
+  — la API que los navegadores exponen exactamente para este caso: enviar datos justo antes de que la
+  página se descargue o pierda foco, sin bloquear ni devolver una promesa que haya que esperar. Costo
+  aceptado: `sendBeacon` siempre usa `POST` y no permite leer la respuesta — coherente con que TC-002 ya
+  devuelve `204` sin cuerpo. Si `sendBeacon` no está disponible (navegador muy antiguo), el botón de
+  contacto igual funciona — solo no queda registro de ese contacto puntual, mismo costo aceptado que una
+  falla de red.
+- **Reapertura:** si M-002 (el evento de contacto queda registrado de forma confiable) muestra en producción
+  una tasa de pérdida real y medible que preocupe a producto — ahí se evalúa un mecanismo con reintento,
+  que `sendBeacon` no ofrece.
+
+<a id="t-004"></a>
+
+### T-004 — El registro del evento de contacto vive en su propio archivo de dominio, no en `professionals.ts`
+
+- **Estado:** aceptada. **Fecha:** 2026-08-28.
+- **Contratos:** TC-002.
+- **Alternativas descartadas:** extender `server/utils/professionals.ts` con la función de registrar el
+  contacto (el borrador inicial de este documento lo planteaba así) — más corto de escribir, pero mezcla dos
+  razones de cambio distintas (editar un perfil vs. registrar un evento de otro dominio) en el mismo
+  archivo, contradiciendo A-006 del skill `arquitectura` sin nombrarlo — una auditoría de este documento lo
+  encontró antes de construir.
+- **Decisión y consecuencia:** `server/utils/professional-contact-events.ts` es un archivo nuevo, propio del
+  dominio "evento de contacto" — mismo patrón que ya separa `professionals.ts` de `categorias.ts`/
+  `comunas.ts`. Solo la función que arma `photoUrls` sigue compartida dentro de `professionals.ts`, porque
+  ahí sí es la misma regla para las dos formas públicas del mismo agregado (`professionals`).
+- **Reapertura:** ninguna prevista.
 
 ## Preguntas
 
-<!--
-Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
-Estado: abierta | resuelta AAAA-MM-DD | disuelta AAAA-MM-DD. Solo las abiertas llevan bloque de detalle.
--->
+Ninguna bloquea construcción.
 
-<Una frase que responde "¿qué falta?": la pregunta que bloquea construcción y qué bloquea.>
-
-| ID     | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
-| ------ | ---------------------- | ------------------- | --------------------------------------------------------------- |
-| TQ-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
-| TQ-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |
+| ID     | La duda | Estado | Respuesta, o quién la resuelve |
+| ------ | ------- | ------ | ------------------------------- |
+| —      | —       | —      | sin preguntas abiertas todavía |

--- a/docs/missions/05-perfil-publico-profesional/investigacion.md
+++ b/docs/missions/05-perfil-publico-profesional/investigacion.md
@@ -1,118 +1,186 @@
-# Misión: <nombre> — Investigación
+# Misión: perfil público de profesional — Investigación
 
 **Estado:** activo
 
-**Última actualización:** AAAA-MM-DD
+**Última actualización:** 2026-08-28
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-<!--
-Este documento se acumula: la evidencia y las conclusiones no se borran cuando el alcance cambia, porque
-explican por qué el producto es como es. Lo que sí se actualiza es el ideal, que resume la dirección que
-la investigación sostiene hoy.
+## El problema aparece cuando la señora Carmen tiene que elegir entre tres desconocidos
 
-Gate de salida — la investigación sostiene un producto.md cuando:
-- el problema tiene situación y consecuencia concretas, no una categoría abstracta
-- al menos una conclusión con confianza alta o media respalda la dirección
-- el ideal describe capacidades observables, no intenciones
--->
+**Situación:** a la señora Carmen se le quema el tablero eléctrico un sábado en la noche. Busca
+"electricista" en Ñuñoa en Datealo y le aparecen tres perfiles — Héctor, Marcelo y Jorge — mismo oficio,
+misma comuna, y ninguno con una sola reseña todavía, porque Datealo recién lanzó y misión 07 (reseñas) ni
+siquiera existe todavía.
 
-## El problema aparece cuando <historia concreta>
+**Acción o necesidad:** decidir a cuál de los tres llamar, sabiendo que va a dejarlo entrar a su casa esa
+misma noche, sin que nadie de su círculo lo conozca.
 
-<!--
-Una situación real o reconstruida con precisión. No abras con una categoría como "falta de confianza" —
-abre con quién estaba haciendo qué y qué salió mal. Nombra a la persona y el servicio concreto.
--->
+**Respuesta actual:** hoy pregunta en el grupo de WhatsApp del edificio o mira Facebook Marketplace — ahí
+al menos alguien responde con un nombre y un "a mí me fue bien con él", aunque sea de un vecino que no
+conoce en persona ([E-008](#e-008)).
 
-**Situación:** <qué está ocurriendo antes del problema>.
-
-**Acción o necesidad:** <qué se intenta resolver o decidir>.
-
-**Respuesta actual:** <qué hace hoy la persona: grupo de WhatsApp, Google, recomendación de un vecino,
-Datealo si ya existe la superficie>.
-
-**Consecuencia:** <error, demora, riesgo o decisión que no puede tomarse>.
+**Consecuencia:** si elige mal, no es una reseña de tres estrellas — es un desconocido dentro de su casa de
+noche, o alguien malo tocando cableado eléctrico. Si no logra decidirse a tiempo, cierra la pestaña y
+vuelve al grupo de WhatsApp, y Datealo pierde el contacto antes de que exista.
 
 ## Preguntas que la investigación debe resolver
 
-<!--
-Solo preguntas capaces de cambiar el ideal o una decisión. Al resolver una, moverla a evidencia o
-conclusión. No es un backlog.
--->
-
-- ¿<pregunta y decisión que depende de ella>?
+- ¿Qué información del perfil mueve de verdad a elegir a un profesional sobre otro cuando ninguno tiene
+  reseñas todavía? Afecta qué se muestra y en qué orden en el perfil.
+- ¿Cómo se ve un perfil sin ninguna foto, descripción ni reseña sin que parezca abandonado o falso? No es
+  un caso raro — es el estado de todos los perfiles el día del lanzamiento ([C-004](#c-004)).
+- ¿Qué evento exacto cuenta como "contacto" para que misión 07 pueda atarle una reseña más adelante — el
+  click en el botón de WhatsApp/teléfono, o algo más? Sin esta respuesta misión 07 no tiene de qué agarrarse
+  (ver [README](./README.md)).
 
 ## Evidencia
 
-<!--
-Un hecho verificable con fuente y límite. Prioriza observación directa, entrevistas y comportamiento
-comprobado. Los benchmarks de otros productos también son evidencia: qué hacen, qué trade-off eligieron y
-qué no aplica a Datealo.
+| ID    | Tipo                  | Fuente                                                                                          | Hecho verificable | Límite de la evidencia |
+| ----- | --------------------- | ------------------------------------------------------------------------------------------------- | ------------------ | ----------------------- |
+| E-001 | código                | `app/constants/landing.ts` (`hero.subheadline`, `solution.benefits`, `forProfessionals.benefits`) | La landing promete al buscador "profesionales verificados", "reseñas de vecinos reales" y "contacto directo... sin intermediarios"; y al profesional, "perfil público con fotos de tus trabajos" y "reseñas que construyen tu reputación" | Es copy de marketing pre-lanzamiento, no una spec cerrada — la parte de "verificación" ya choca con una decisión de producto ya tomada (ver [E-009](#e-009)) |
+| E-002 | código                | `server/db/schema/professionals.ts`                                                              | El perfil ya guarda `displayName`, `categoriaSlug`, `comunaCodigo`, `contact`, `description`, `priceFrom`, `photoPaths` y `active` — no existe ninguna columna de reseña, verificación ni registro de contacto | Dice qué datos existen hoy, no cómo deberían presentarse — el perfil público (esta misión) es la primera vez que alguien lee estos datos, todavía no se diseñó su presentación |
+| E-003 | benchmark              | [Cómo funciona el perfil de un anfitrión en Airbnb (Guesty)](https://www.guesty.com/blog/setting-up-profile-airbnb-how-does-it-work/), [Airbnb Host Rating System (Selah Collective)](https://selahcollective.studio/resources/airbnb-host-rating-system) | Las señales de confianza del perfil de un host son verificación de identidad, reseñas, tasa y tiempo de respuesta a mensajes, y el badge "Superhost" (exige 90%+ de tasa de respuesta) | Airbnb tiene millones de reseñas acumuladas y verificación de identidad formal (documento de identidad) — no aplica directo a un lanzamiento con cero reseñas y sin ningún mecanismo de identidad |
+| E-004 | benchmark              | [¿Cómo se verifica la autenticidad de un especialista? (Doctoralia)](https://pro.doctoralia.cl/preguntas-frecuentes/verificacion-perfiles) | Doctoralia verifica cada perfil cruzando la información contra el colegio profesional oficial correspondiente (ej. colegio médico), combinando sistema automatizado y revisión humana | Existe porque hay un registro oficial único y centralizado que cubre el 100% de la categoría (medicina) — no hay un equivalente así para peluquería, mudanzas o limpieza en Chile; sí existe uno parcial para electricidad/gas (ver [E-006](#e-006)) |
+| E-005 | benchmark              | [Elite Status Overview (TaskRabbit Support)](https://support.taskrabbit.com/hc/en-us/articles/46260436549915-Elite-Status-Overview), [How Do I Know Which Tasker Is Best (TaskRabbit Support)](https://support.taskrabbit.com/hc/en-us/articles/46260459709723-How-Do-I-Know-Which-Tasker-Is-Best-for-My-Task) | El badge "Elite" y el conteo de tareas completadas por categoría solo existen para taskers con volumen (top 35% de su rubro, o 4.9★ sostenido); en el perfil también se ven fotos que el tasker eligió compartir de trabajos previos | Describe el perfil de un tasker con historial — no dice qué le muestra TaskRabbit a un tasker nuevo el primer día, que es exactamente el estado de todo profesional en Datealo al lanzamiento |
+| E-006 | benchmark              | [Cómo Mercado Libre calcula tu reputación (WooSync)](https://www.woosync.io/blog/infografia-como-mercado-libre-calcula-tu-reputacion/) | El "termómetro" de reputación (rojo a verde) recién empieza a calcularse después de que el vendedor completa al menos 10 ventas | No dice qué ve un comprador de un vendedor con 0 a 9 ventas — pero confirma que ni un marketplace maduro y con volumen finge una reputación antes de tener datos reales, el mismo principio que Datealo necesita el día uno |
+| E-007 | benchmark (foro de usuarios) | [Booking something with no reviews and new host (comunidad Airbnb)](https://community.withairbnb.com/t5/Ask-about-your-listing/Booking-something-with-no-reviews-and-new-host/td-p/2050845) | Ante un anfitrión sin reseñas, la respuesta que la comunidad ofrece es mandarle un mensaje directo antes de reservar, para evaluar qué tan rápido y bien responde | Son opiniones de usuarios en un foro, no datos agregados de comportamiento — pero confirma que "escribir para tantear" es un sustituto real de la reseña cuando esta no existe |
+| E-008 | benchmark local        | [Buscador de instaladores eléctricos y de gas SEC (ChileAtiende)](https://www.chileatiende.gob.cl/fichas/67276-buscador-de-instaladores-electricos-y-de-gas-autorizados-por-la-sec) | La Superintendencia de Electricidad y Combustibles (SEC) mantiene un buscador público y oficial de instaladores eléctricos y de gas certificados en Chile | Es un registro real, pero cubre solo dos de las categorías del catálogo de Datealo (electricidad, gas) — no existe un equivalente para el resto de los oficios; hoy Datealo no lo consulta ni lo cruza contra ningún perfil |
+| E-009 | decisión interna       | [D-002 de misión 04](../04-registro-perfil-profesional/producto.md#d-002)                        | El perfil de un profesional en Datealo nace `active = true` sin que nadie lo revise — no hay verificación automatizada ni manual al lanzamiento | Es una decisión de producto ya tomada, no evidencia externa — fija una restricción real para esta misión: el perfil público tiene que funcionar bien incluso cuando nadie lo revisó nunca |
 
-Datealo no tiene datos de uso propios todavía. Cuando la única evidencia disponible sea un benchmark o
-una entrevista, la columna "límite" es lo que impide que se lea como dato duro.
--->
+<a id="e-008"></a>
 
-| ID    | Tipo                                              | Fuente                | Hecho verificable | Límite de la evidencia |
-| ----- | ------------------------------------------------- | --------------------- | ----------------- | ---------------------- |
-| E-001 | <entrevista, benchmark, uso, código, observación> | <enlace o referencia> | <hecho>           | <qué no demuestra>     |
+### E-008 — El único registro oficial que Chile ya tiene es parcial
 
-<a id="e-001"></a>
+La SEC certifica instaladores eléctricos y de gas por ley — es un dato verificable, público y gratuito, no
+un proceso que Datealo tendría que inventar ni operar. Pero solo cubre 2 de las categorías del catálogo de
+Datealo (misión 03 tiene más: peluquería, limpieza, mudanzas, etc.), así que no sirve como mecanismo de
+verificación general para todo el catálogo.
 
-### E-001 — <fuente o hecho en una frase>
-
-<!--
-Desarrollar solo cuando la tabla no alcanza para evaluar la calidad de la evidencia. Cierra con la
-consecuencia para la investigación.
--->
-
-<Observación precisa y contexto necesario.>
-
-Esto permite afirmar <alcance>, pero no demuestra <límite>.
+Esto permite afirmar que existe un camino concreto y de bajo costo para una verificación real futura,
+acotada a electricidad y gas, pero no demuestra que valga la pena construirla antes de tener volumen, ni
+resuelve nada para el resto de las categorías.
 
 ## Conclusiones
 
-<!--
-Una conclusión interpreta evidencia; no es una preferencia ni una funcionalidad. El título expresa el
-hallazgo, no el tema.
--->
-
 <a id="c-001"></a>
 
-### C-001 — <conclusión en una frase>
+### C-001 — Sin reseñas ni verificación, la confianza tiene que salir de lo único que sí es real hoy: lo que el propio profesional sube
 
-- **Sustento:** [E-001](#e-001).
-- **Razonamiento:** <por qué la evidencia conduce a esta lectura y no a otra>.
-- **Implicación:** <qué deberá ser cierto en el producto o qué alternativa queda debilitada>.
-- **Confianza:** <alta, media o baja> porque <razón o validación pendiente>.
+- **Sustento:** [E-003](#e-003), [E-005](#e-005), [E-006](#e-006), [E-009](#e-009).
+- **Razonamiento:** cada benchmark maduro (Airbnb, TaskRabbit, Mercado Libre) pone las reseñas primero
+  cuando existen, pero ninguno inventa reputación cuando no hay datos — Mercado Libre literalmente no
+  calcula el termómetro antes de 10 ventas. Datealo día uno está en esa misma zona con cada profesional del
+  catálogo, porque misión 07 (reseñas) todavía no existe. Tampoco puede prometerse una tasa de respuesta
+  como Airbnb, porque las conversaciones pasan por WhatsApp, fuera del control de Datealo. Lo único
+  verificable sin depender de reseñas es lo que el profesional mismo cargó (fotos, descripción, precio) y
+  cuánto tiempo lleva su perfil activo.
+- **Implicación:** el perfil público de esta misión no debe simular reseñas, "vistas" ni ningún número que
+  no ocurrió de verdad — la confianza que ofrece hoy es completitud del perfil (fotos reales, descripción,
+  precio) y nada que finja actividad inexistente.
+- **Confianza:** media, porque no hay comportamiento propio medido todavía (Datealo no tiene usuarios) —
+  se apoya en el patrón consistente de tres benchmarks distintos, no en un solo caso.
 
-## El ideal: <resultado completo, sin recortar>
+<a id="c-002"></a>
 
-<!--
-El ideal es el producto de la investigación: la dirección que la evidencia sostiene, sin restricciones de
-implementación. El recorte a la primera entrega no vive aquí — vive en producto.md como decisión de
-alcance. Esta sección sí se reescribe cuando nueva evidencia cambia la dirección.
--->
+### C-002 — El mensaje de contacto directo es el sustituto real de la reseña mientras esta no existe
+
+- **Sustento:** [E-007](#e-007), brief de esta misión (ver [README](./README.md): "acá vive el evento de
+  contacto").
+- **Razonamiento:** si ni Mercado Libre ni Airbnb logran ofrecer reputación completa a un vendedor u host
+  nuevo, y la gente igual transacciona con ellos, es porque existe una vía de evaluación de bajo costo: el
+  mensaje directo. Datealo ya construye esto por diseño — contacto directo sin intermediarios (D-004 de
+  misión 04) —, así que el "tanteo" que en Airbnb es un paso extra opcional, en Datealo ya es el flujo
+  principal.
+- **Implicación:** el botón de contacto no es solo el cierre del perfil, es también la herramienta que
+  reemplaza a la reseña mientras esta no existe — tiene que ser fácil de encontrar y usar como "primer
+  contacto para tantear", no solo como "ya decidí, ahora contacto". Y como ese click es el evento del que
+  depende misión 07, tiene que quedar registrado de forma confiable, no ser solo un `<a href="https://wa.me/...">`.
+- **Confianza:** media — es una inferencia razonada sobre comportamiento reportado en un foro, no un dato
+  medido de Datealo.
+
+<a id="c-003"></a>
+
+### C-003 — El "verificado" que la landing promete hoy no tiene ningún mecanismo real detrás
+
+- **Sustento:** [E-001](#e-001), [E-004](#e-004), [E-008](#e-008), [E-009](#e-009).
+- **Razonamiento:** Doctoralia puede verificar porque existe un registro central único que cubre el 100% de
+  su categoría (colegio médico). Chile tiene un equivalente parcial (SEC) solo para electricidad y gas — el
+  resto del catálogo de Datealo (peluquería, limpieza, mudanzas) no tiene ningún registro oficial que
+  cruzar. Mostrar un badge de "verificado" sin un mecanismo real detrás (manual o cruzado contra un
+  registro como la SEC) transfiere a Datealo la responsabilidad de un mal servicio que en realidad nunca
+  verificó — exactamente el riesgo que ya motivó D-002 de misión 04 (nace sin revisión de nadie).
+- **Implicación:** un badge de "verificado" queda fuera de esta misión — la palabra se reserva para cuando
+  exista un mecanismo real detrás, aunque sea parcial (electricidad y gas primero, vía SEC, sería el camino
+  más barato si se retoma). El copy actual de la landing (E-001) queda como una inconsistencia a resolver
+  fuera de esta misión, no algo que esta misión deba construir para dejar de ser falso.
+- **Confianza:** alta — no depende de comportamiento de usuario, es una restricción lógica (no existe el
+  registro que la verificación general necesitaría) confirmada por E-008 y por la decisión ya tomada en
+  misión 04.
+
+<a id="c-004"></a>
+
+### C-004 — El perfil tiene que verse completo y con intención incluso sin ninguna foto ni reseña, porque el día del lanzamiento eso es todos los perfiles, no un caso raro
+
+- **Sustento:** [E-006](#e-006), [E-009](#e-009).
+- **Razonamiento:** en un marketplace maduro, "sin reseñas" es la minoría marginal — un vendedor nuevo entre
+  millones. En Datealo el día del lanzamiento es el 100% de los perfiles, porque misión 07 (reseñas) ni
+  siquiera existe todavía y el perfil nace sin fotos ni descripción salvo que el profesional las suba
+  (misión 04, F-002). Diseñar el perfil público asumiendo que "para cuando alguien lo vea ya va a tener
+  fotos y reseñas" es diseñar para un estado que no va a existir por meses.
+- **Implicación:** el estado vacío (sin fotos, sin descripción, sin precio, sin reseñas) no es un caso
+  límite de esta misión — es el caso principal a resolver primero, y tiene que transmitir seriedad (nombre,
+  categoría, comuna, contacto) sin sentirse abandonado ni falso.
+- **Confianza:** alta — es una inferencia directa del estado real y conocido del producto (cero
+  profesionales, cero reseñas hoy), no depende de un benchmark externo.
+
+## El ideal: cualquier persona que necesita un profesional puede elegir con confianza entre desconocidos, sin depender de una reseña que todavía no existe
 
 ### El resultado ideal se ve así
 
-<Narra de principio a fin una situación futura con datos concretos: nombres, comunas, oficios, horarios.
-Qué acción ocurre, qué responde Datealo, qué decisión puede tomar la persona. Evita "una experiencia
-simple" sin comportamiento observable.>
+La señora Carmen entra al perfil de Marcelo, electricista de Ñuñoa. Ve su nombre, su categoría, tres fotos
+de tableros que ha instalado, una frase corta ("Electricista hace 8 años, atiendo Ñuñoa y Providencia"),
+"Desde $15.000" y un botón grande de WhatsApp. Marcelo no tiene ninguna reseña todavía, pero el perfil no
+se siente vacío ni sospechoso — se ve como el perfil de alguien real que trabaja en esto. Carmen le escribe
+directo desde el perfil, sin llenar ningún formulario ni pasar por Datealo. Ese click queda registrado como
+el primer contacto real de Marcelo, y semanas después, cuando exista misión 07, es lo que le va a permitir
+a Carmen dejarle una reseña de verdad. Si en cambio Carmen abre el perfil de Jorge, que ya lleva meses
+activo y acumuló reseñas de otros vecinos de Ñuñoa, Datealo se las muestra con la misma honestidad: ninguna
+inventada, ninguna oculta, y ningún número de "vistas" o "contactos" que Marcelo no tiene todavía y que solo
+serviría para hacerlo lucir peor sin decir nada real sobre su trabajo.
 
 ### Capacidades del ideal
 
-| Capacidad | Acción habilitada    | Respuesta esperada              | Conclusión que la justifica |
-| --------- | -------------------- | ------------------------------- | --------------------------- |
-| <nombre>  | <qué se puede hacer> | <qué produce o explica Datealo> | [C-001](#c-001)             |
+| Capacidad                             | Acción habilitada                                                        | Respuesta esperada                                                                                  | Conclusión que la justifica |
+| -------------------------------------- | ---------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ---------------------------- |
+| Ver el perfil completo                 | El buscador abre el perfil de un profesional desde el buscador (misión 06)   | Ve fotos, descripción, precio, categoría, comuna y contacto, incluso si algunos campos están vacíos  | [C-004](#c-004)              |
+| Contactar directo desde el perfil      | El buscador toca el botón de WhatsApp o teléfono                            | Se abre la conversación directa con el profesional, sin pasar por ningún formulario de Datealo       | [C-002](#c-002)              |
+| Registrar que el contacto ocurrió      | Cuando el buscador toca el botón de contacto                                | Datealo guarda que ese contacto ocurrió, en qué perfil y cuándo — es la base de la reseña de misión 07 | [C-002](#c-002)              |
+| Ver reseñas acumuladas cuando existen  | El buscador abre un perfil con reseñas ya dejadas (misión 07)               | Ve las reseñas reales, sin ninguna inventada ni oculta                                                | [C-001](#c-001)              |
 
-### El ideal no significa <confusión probable>
+### El ideal no significa que Datealo verifique o mida algo que todavía no puede medir de verdad
 
-- <límite conceptual que evita una interpretación incorrecta>.
+- No significa que todo perfil tenga fotos o reseñas — la mayoría, sobre todo al lanzamiento, no las va a
+  tener, y el ideal ya lo asume (C-004).
+- No significa que Datealo verifique al profesional — el "verificado" no existe en este ideal; ver a qué
+  costo se deja fuera y bajo qué condición se reconsidera (C-003).
+- No significa que Datealo sepa si el contacto se convirtió en un trabajo real — solo que el buscador tocó
+  el botón; lo que pasó después (se hizo el trabajo, quedó bien) lo resuelve misión 07, no esta.
 
 ## Referencias
 
-<!-- Fuentes primarias citadas por las evidencias. El enlace no sustituye el hecho y el límite en E-xxx. -->
-
-- [<título descriptivo>](URL): usado en E-001 para <afirmación concreta>.
+- [Cómo funciona el perfil de un anfitrión en Airbnb (Guesty)](https://www.guesty.com/blog/setting-up-profile-airbnb-how-does-it-work/)
+  y [Airbnb Host Rating System (Selah Collective)](https://selahcollective.studio/resources/airbnb-host-rating-system):
+  usados en E-003 para las señales de confianza del perfil de un host con historial.
+- [¿Cómo se verifica la autenticidad de un especialista? (Doctoralia)](https://pro.doctoralia.cl/preguntas-frecuentes/verificacion-perfiles):
+  usado en E-004 para el mecanismo real de verificación contra un registro oficial único.
+- [Elite Status Overview (TaskRabbit Support)](https://support.taskrabbit.com/hc/en-us/articles/46260436549915-Elite-Status-Overview)
+  y [How Do I Know Which Tasker Is Best (TaskRabbit Support)](https://support.taskrabbit.com/hc/en-us/articles/46260459709723-How-Do-I-Know-Which-Tasker-Is-Best-for-My-Task):
+  usados en E-005 para qué señales de confianza dependen de volumen acumulado.
+- [Cómo Mercado Libre calcula tu reputación (WooSync)](https://www.woosync.io/blog/infografia-como-mercado-libre-calcula-tu-reputacion/):
+  usado en E-006 para confirmar que ni un marketplace maduro finge reputación antes de tener datos.
+- [Booking something with no reviews and new host (comunidad Airbnb)](https://community.withairbnb.com/t5/Ask-about-your-listing/Booking-something-with-no-reviews-and-new-host/td-p/2050845):
+  usado en E-007 para el mensaje directo como sustituto real de la reseña.
+- [Buscador de instaladores eléctricos y de gas SEC (ChileAtiende)](https://www.chileatiende.gob.cl/fichas/67276-buscador-de-instaladores-electricos-y-de-gas-autorizados-por-la-sec):
+  usado en E-008 para el único registro oficial chileno equivalente, y su cobertura parcial.

--- a/docs/missions/05-perfil-publico-profesional/producto.md
+++ b/docs/missions/05-perfil-publico-profesional/producto.md
@@ -1,149 +1,234 @@
-# Misión: <nombre> — Producto
+# Misión: perfil público de profesional — Producto
 
-**Estado:** borrador
+**Estado:** vigente — aprobado por Patricio el 2026-08-28
 
-**Última actualización:** AAAA-MM-DD
+**Última actualización:** 2026-08-28
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-<!--
-Este documento es la spec viva del resultado: qué construimos ahora y bajo qué reglas. El porqué vive en
-investigacion.md — aquí solo se enlaza. Se reescribe cuando el alcance cambia; no acumula historia.
+## Qué construimos: cualquiera puede ver el perfil de un profesional y escribirle directo, sin reseñas ni verificación todavía
 
-Gate de salida — producto.md está listo para experiencia.md cuando:
-- cada funcionalidad tiene formato JTBD, reglas y al menos un caso límite con comportamiento definido
-- cada funcionalidad enlaza una conclusión de investigacion.md y una señal de éxito
-- cada funcionalidad declara a qué lado del marketplace sirve, y qué necesita del otro lado para funcionar
-- no hay decisiones de producto delegadas a diseño o ingeniería
-- las decisiones propuestas tienen fecha límite en el README
--->
+**Resultado:** cualquier persona que abre el link de un profesional —desde el buscador de misión 06, o
+compartido directo— ve su perfil completo (fotos, descripción, precio, categoría, comuna, contacto) y puede
+escribirle por WhatsApp o llamarlo sin pasar por ningún formulario de Datealo. Ese contacto queda
+registrado, sea el perfil nuevo y vacío o ya tenga meses de actividad.
 
-## Qué construimos: <resultado en una frase>
+**Recorte respecto del ideal:** el ideal ([investigacion.md](./investigacion.md)) incluye reseñas visibles
+y variar la confianza según cuánta actividad acumuló el perfil. Acá se recorta a lo que existe hoy: sin
+reseñas, porque misión 07 todavía no se construye, y sin ningún indicador de actividad inventado
+([C-001](./investigacion.md#c-001), [C-004](./investigacion.md#c-004)). El perfil se apoya solo en lo que
+el profesional cargó de verdad.
 
-<!--
-El recorte vigente del ideal y por qué sigue entregando el resultado central. Máximo cuatro párrafos
-cortos. El ideal completo vive en investigacion.md.
--->
-
-**Resultado:** <qué podrá lograr una persona al finalizar esta entrega>.
-
-**Recorte respecto del ideal:** <qué dimensión se reduce y por qué sigue siendo suficiente>
-(ver [el ideal](./investigacion.md)).
-
-**Restricciones aceptadas:** <plataforma, cobertura geográfica, categorías, volumen inicial de
-profesionales>.
+**Restricciones aceptadas:** sin badge de "verificado" de ningún tipo — no hay mecanismo real detrás
+([C-003](./investigacion.md#c-003), ver Fuera de alcance); sin identificar a la persona que contacta, más
+allá de que el contacto ocurrió ([D-002](#d-002), deja abierta [Q-001](#q-001) para misión 07); sin
+analítica de conversión instrumentada — M-001 y M-002 quedan cualitativas hasta que exista.
 
 ## Funcionalidades
 
-| ID    | Funcionalidad                  | Lado         | Sustento     | Éxito |
-| ----- | ------------------------------ | ------------ | ------------ | ----- |
-| F-001 | <verbo + resultado observable> | buscador     | C-001, D-001 | M-001 |
+| ID    | Funcionalidad                                                        | Lado     | Sustento               | Éxito |
+| ----- | ---------------------------------------------------------------------- | -------- | ----------------------- | ----- |
+| F-001 | Ver el perfil completo de un profesional, con o sin actividad acumulada | buscador | C-001, C-004, D-001 | M-001 |
+| F-002 | Contactar al profesional directo desde el perfil, y que quede registrado | ambos    | C-002, D-001, D-002     | M-002 |
 
 <a id="f-001"></a>
 
-### F-001 — <verbo + resultado observable>
+### F-001 — Ver el perfil completo de un profesional, con o sin actividad acumulada
 
-<!--
-Duplica este bloque por funcionalidad. Se escribe desde el resultado del usuario (working backwards):
-primero el JTBD, después las reglas. Si la respuesta de Datealo no se puede describir sin hablar de tablas
-o componentes, falta cerrar la decisión de producto.
--->
+Cuando la señora Carmen encuentra a Marcelo en los resultados de búsqueda y necesita decidir si confía en
+él antes de escribirle,
+quiero ver todo lo que Marcelo cargó de su trabajo — fotos, descripción, precio —,
+para decidir sin tener que preguntarle nada primero.
 
-Cuando <usuario en contexto concreto>,
-quiero <acción>,
-para <resultado observable>.
+**Lado del marketplace:** buscador. **Qué necesita del otro lado:** que exista al menos un perfil activo
+(misión 04) — funciona exactamente igual con 0 o con 20 fotos, con o sin reseñas cuando misión 07 exista.
 
-**Lado del marketplace:** buscador, profesional o ambos. **Qué necesita del otro lado:** <volumen mínimo
-de perfiles, reseñas o cobertura sin el cual esta funcionalidad no entrega su resultado>.
-
-**Sustento:** [C-001](./investigacion.md#c-001) y [D-001](#d-001). **Éxito:** [M-001](#m-001).
+**Sustento:** [C-001](./investigacion.md#c-001), [C-004](./investigacion.md#c-004), [D-001](#d-001).
+**Éxito:** [M-001](#m-001).
 
 **Reglas:**
 
-- Si <condición>, Datealo <comportamiento esperado>.
-- Si <caso límite>, Datealo <comportamiento seguro y qué información muestra>.
-- Datealo nunca <comportamiento que rompería el significado o la confianza>.
+- Cualquiera puede abrir el perfil sin iniciar sesión ni tener cuenta de buscador ([D-001](#d-001)).
+- Si el profesional no subió ninguna foto, el perfil se muestra igual, sin ninguna foto de stock que
+  sugiera que es suya ([CL-001](#cl-001)).
+- Si no definió descripción o precio, esos campos simplemente no aparecen — el perfil no muestra un espacio
+  vacío ni un "sin información" ([CL-002](#cl-002)).
+- Si el profesional no tiene ninguna reseña todavía — el caso de todos al lanzamiento —, el perfil no
+  muestra un contador de "0 reseñas" ni ningún indicador que sugiera abandono. En su lugar muestra desde
+  cuándo existe el perfil (ej. "En Datealo desde agosto de 2026") — es la única señal de actividad que
+  Datealo puede mostrar sin inventar nada mientras no hay reseñas ([CL-003](#cl-003),
+  [C-001](./investigacion.md#c-001)).
+- Datealo nunca muestra en el perfil un badge, texto o ícono de "verificado" — no existe ese mecanismo hoy
+  ([C-003 de investigación](./investigacion.md#c-003), ver Fuera de alcance).
+- Datealo nunca muestra contadores de "vistas" o "veces contactado" — sin volumen real, ese número casi
+  siempre sería 0 o 1 y perjudicaría más de lo que informaría ([C-001](./investigacion.md#c-001)).
 
-**Ejemplo verificable:** dado <estado con datos concretos>, cuando <acción>, entonces <resultado
-observable>.
+**Ejemplo verificable:** dado el perfil de Marcelo (categoría Electricidad, comuna Ñuñoa, 3 fotos, "Desde
+$15.000", activo desde julio de 2026, sin reseñas), cuando la señora Carmen abre su link, entonces ve su
+nombre, categoría, comuna, las 3 fotos, la descripción, el precio, "En Datealo desde julio de 2026" y el
+botón de contacto — sin ningún badge de verificado, sin contador de reseñas ni de vistas.
 
-**No incluye:** <variante del ideal excluida de esta funcionalidad>.
+**No incluye:** reseñas (misión 07), badge de verificado (ver Fuera de alcance), cualquier indicador de
+actividad que Datealo no pueda respaldar con un dato real.
 
-**Experiencia:** <enlace a UXF-xxx cuando exista>. **Ingeniería:** <enlace a T-xxx cuando exista>.
+**Experiencia:** pendiente. **Ingeniería:** pendiente.
+
+<a id="f-002"></a>
+
+### F-002 — Contactar al profesional directo desde el perfil, y que quede registrado
+
+Cuando la señora Carmen ya decidió a quién llamar, o solo quiere tantear cómo responde Marcelo antes de
+decidirse del todo,
+quiero tocar un botón y escribirle por WhatsApp o llamarlo sin llenar ningún formulario,
+para resolver su problema esa misma noche.
+
+**Lado del marketplace:** ambos — el buscador inicia el contacto, el profesional lo recibe; es la razón de
+ser del perfil para los dos. **Qué necesita del otro lado:** nada adicional — funciona con cualquier
+profesional que tenga contacto cargado (obligatorio desde el registro, misión 04 F-001).
+
+**Sustento:** [C-002](./investigacion.md#c-002), [D-001](#d-001), [D-002](#d-002). **Éxito:**
+[M-002](#m-002).
+
+**Reglas:**
+
+- Datealo guarda un solo número de contacto por profesional (misión 04, `professionals.contact`), no un
+  WhatsApp y un teléfono separados — así que el perfil ofrece los dos botones a partir de ese mismo número:
+  "Escribir por WhatsApp" (principal) y "Llamar" (secundario). Nunca un formulario ni una pantalla
+  intermedia de Datealo ([D-001](#d-001)).
+- Cada vez que se toca el botón, Datealo registra que ocurrió un contacto en ese perfil, con la fecha —
+  sin pedirle nada al buscador ni exigirle una cuenta ([D-002](#d-002)).
+- Si el registro del contacto falla por cualquier razón, Datealo igual abre WhatsApp o la llamada — el
+  registro nunca bloquea ni demora el contacto real.
+- Si el profesional cambió su número de contacto después de que alguien guardó el enlace del perfil, el
+  botón siempre usa el contacto vigente, nunca uno desactualizado ([CL-005](#cl-005)).
+
+**Ejemplo verificable:** dado el perfil de Marcelo con contacto +56 9 1234 5678, cuando la señora Carmen
+toca "Escribir por WhatsApp", entonces se abre una conversación de WhatsApp con ese número, y Datealo
+guarda un registro de que hubo un contacto en el perfil de Marcelo a esa hora. Si en cambio toca "Llamar",
+el mismo registro ocurre y se inicia una llamada al mismo número.
+
+**No incluye:** identificar quién generó el contacto ([Q-001](#q-001), lo resuelve misión 07), ningún chat
+interno de Datealo, ninguna confirmación de que el trabajo se concretó.
+
+**Experiencia:** pendiente. **Ingeniería:** pendiente.
 
 ## Casos límite que cruzan funcionalidades
 
-<!--
-Solo condiciones que afectan varias funcionalidades. Las propias de una viven en su bloque. Un caso
-retirado no se borra ni se reutiliza: conserva su fila, o se nombra con su motivo en una línea debajo.
+<a id="cl-001"></a>
 
-Los casos límite propios de un marketplace pre-lanzamiento aparecen acá: cero resultados en una comuna,
-un profesional sin reseñas, una categoría con un solo perfil, un perfil sin verificar.
--->
-
-| ID     | Condición concreta     | Comportamiento esperado | Funcionalidades |
-| ------ | ---------------------- | ----------------------- | --------------- |
-| CL-001 | <estado o combinación> | <qué hace Datealo>      | F-001           |
+| ID     | Condición concreta                                                         | Comportamiento esperado                                                                                     | Funcionalidades |
+| ------ | ----------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ---------------- |
+| CL-001 | Un perfil activo no tiene ninguna foto subida                                | Se muestra igual, con un espacio vacío o genérico — nunca una foto de stock que insinúe que es del profesional | F-001            |
+| CL-002 | Un perfil activo no tiene descripción ni precio definido                     | Se muestra igual, sin esos campos — nunca un "sin información" ni un hueco visual roto                        | F-001            |
+| CL-003 | Un perfil activo no tiene ninguna reseña (todos los perfiles al lanzamiento) | Se muestra igual, sin un contador de "0 reseñas" ni ningún texto que sugiera abandono                          | F-001            |
+| CL-004 | El buscador toca "Escribir por WhatsApp" pero no tiene la app instalada     | El botón "Llamar" con el mismo número ya estaba visible desde antes, como alternativa siempre disponible — no aparece recién en ese momento | F-002            |
+| CL-005 | El profesional cambió su número de contacto después de que alguien guardó el enlace del perfil | El botón de contacto siempre usa el número vigente en la base, nunca uno cacheado en la página          | F-002            |
 
 ## Fuera de alcance
 
-<!-- Distingue postergado de descartado y qué condición justificaría reabrirlo. -->
-
-| Capacidad o caso      | Estado                  | Razón del recorte | Condición para reconsiderar |
-| --------------------- | ----------------------- | ----------------- | --------------------------- |
-| <capacidad del ideal> | postergada o descartada | <trade-off>       | <evidencia o hito>          |
+| Capacidad o caso                                                        | Estado     | Razón del recorte                                                                                   | Condición para reconsiderar |
+| --------------------------------------------------------------------------- | ---------- | -------------------------------------------------------------------------------------------------------- | -------------------------------- |
+| Badge de "verificado"                                                    | postergada | Sin mecanismo real de verificación al lanzamiento; mostrarlo sin respaldo es peor que no tenerlo ([C-003](./investigacion.md#c-003)). La landing hoy promete "profesionales verificados" sin que exista ese mecanismo — esta misión no corrige ese copy ni construye un badge vacío para calzar con él; queda como inconsistencia identificada, a resolver aparte | Cuando exista un mecanismo real, aunque sea parcial (ej. cruzar contra el registro SEC para electricidad/gas, [E-008](./investigacion.md#e-008)) |
+| Reseñas visibles en el perfil                                            | postergada | Depende de misión 07, que todavía no se construye                                                          | Cuando misión 07 esté lista para construir |
+| Contador público de "vistas" o "veces contactado"                       | descartada | Sin volumen real, el número sería casi siempre 0 o 1 y perjudicaría a los perfiles nuevos en vez de ayudarlos ([C-001](./investigacion.md#c-001), [C-004](./investigacion.md#c-004)) | Cuando exista volumen suficiente para que el número informe en vez de estigmatizar |
+| Identificar a la persona exacta que generó un contacto                  | postergada | Contactar no exige ninguna cuenta ([D-001](#d-001), [D-002](#d-002)); resolverlo es problema de misión 07 | Cuando misión 07 defina su mecanismo de verificación de reseña ([Q-001](#q-001)) |
+| Analítica instrumentada de conversión a contacto (M-001, M-002)         | postergada | No existe todavía infraestructura de analítica en el proyecto                                              | Cuando esa infraestructura exista, fuera del alcance técnico de esta misión |
 
 ## Señales de éxito
 
 <a id="m-001"></a>
 
-### M-001 — <señal que demuestra el resultado>
+### M-001 — El perfil transmite confianza suficiente para generar un contacto, incluso sin reseñas
 
-- **Pregunta:** ¿<qué queremos comprobar>?
-- **Señal:** <comportamiento o resultado observable>.
-- **Método y umbral:** <instrumentación o revisión, qué resultado, en qué población y ventana>.
-- **Guardrail:** <daño que no debe aumentar para conseguir la señal>.
+- **Pregunta:** ¿de los buscadores que abren un perfil sin ninguna reseña, una parte igual toca el botón de
+  contacto, o todos rebotan?
+- **Señal (qué observaríamos si funciona):** de cada 10 buscadores que abren un perfil, al menos 3 tocan el
+  botón de WhatsApp o teléfono.
+- **Método y umbral:** sin instrumentación de analítica todavía — se resuelve cuando exista (fuera del
+  alcance técnico de esta misión). Mientras tanto, revisión cualitativa de Patricio sobre los primeros
+  perfiles reales.
+- **Guardrail:** ningún perfil sin fotos, descripción o reseñas queda oculto o penalizado en su posición
+  por eso — CL-001 a CL-003 son la garantía de esto, no solo la intención.
+
+<a id="m-002"></a>
+
+### M-002 — El evento de contacto queda registrado de forma confiable para sostener misión 07
+
+- **Pregunta:** ¿el click en WhatsApp o teléfono se registra siempre, o hay casos donde se pierde — por
+  ejemplo, si el buscador cierra la app antes de que el registro termine?
+- **Señal:** cada click en el botón de contacto genera exactamente un registro en la base, ninguno
+  duplicado ni perdido.
+- **Método y umbral:** prueba directa en desarrollo antes de cerrar el issue de ingeniería correspondiente
+  — no es una revisión cualitativa, es verificable con datos.
+- **Guardrail:** el registro del contacto nunca bloquea ni demora la apertura de WhatsApp o la llamada — si
+  el registro falla, el contacto real igual ocurre.
 
 ## Decisiones de producto
 
-<!--
-Solo decisiones con alternativas reales. No borres decisiones reemplazadas: explican por qué el producto
-es como es. Toda decisión propuesta se refleja en el README con fecha límite.
--->
-
 <a id="d-001"></a>
 
-### D-001 — <decisión en una frase que se entiende sola>
+### D-001 — El perfil público, incluido el contacto, es visible para cualquiera sin necesitar cuenta ni sesión
 
-- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
-- **Sustento:** [C-001](./investigacion.md#c-001).
-- **Tensión:** <criterios que no podían maximizarse al mismo tiempo>.
-- **Alternativas descartadas:** <opciones y razón concreta del rechazo, en la misma línea>.
-- **Decisión y consecuencia:** <qué se hará y qué habilita, limita o exige revisar en UX e ingeniería>.
-- **Reapertura:** <evidencia o cambio que justificaría revisarla>.
+- **Estado:** aceptada. **Fecha:** 2026-08-28.
+- **Sustento:** guardrail de `CLAUDE.md` ("el contacto es directo y sin intermediación") y [D-004 de misión
+  04](../04-registro-perfil-profesional/producto.md#d-004) (Datealo nunca se pone en medio del contacto).
+- **Tensión:** mostrar el contacto libre es fiel al flujo core (buscar → perfil → contactar, sin pasos
+  extra) y evita que Datealo intermedie; pero exponer un número de WhatsApp o teléfono sin ningún filtro
+  invita a spam hacia el profesional, y el competidor más grande del rubro (Thumbtack) exige justamente
+  "pedir cotización" antes de revelar el contacto para filtrar eso.
+- **Alternativas descartadas:** exigir que el buscador cree una cuenta ligera antes de ver el contacto — se
+  descarta porque agrega un paso al flujo que `CLAUDE.md` declara sagrado, y ninguna misión ha definido
+  todavía un mecanismo de cuenta para el buscador. Exigir "solicitar cotización" antes de revelar el
+  contacto (patrón Thumbtack) — se descarta porque reintroduce a Datealo como intermediario del contacto,
+  contradice directamente D-004 de misión 04.
+- **Decisión y consecuencia:** el número de WhatsApp o teléfono del profesional es visible en su perfil
+  público para cualquiera, sin iniciar sesión ni completar ningún paso previo — igual que el resto del
+  perfil. El riesgo de spam hacia el profesional se acepta como costo de este guardrail, no se mitiga en
+  esta misión.
+- **Reapertura:** si el spam hacia profesionales resulta ser un problema real (no solo teórico) una vez
+  haya tráfico, reconsiderar un filtro liviano que no agregue una cuenta (ej. un captcha antes del click).
+
+<a id="d-002"></a>
+
+### D-002 — El evento de contacto que registra Datealo es "se tocó el botón de contacto en este perfil", sin capturar quién lo tocó
+
+- **Estado:** aceptada. **Fecha:** 2026-08-28.
+- **Sustento:** [C-002](./investigacion.md#c-002), [D-001](#d-001) (contactar no exige cuenta).
+- **Tensión:** misión 07 necesita saber qué contacto corresponde a qué reseña para que una reseña sea
+  "verificada por contacto" y no un formulario abierto; pero capturar la identidad de quien contacta
+  exigiría pedirle algo al buscador antes de escribir por WhatsApp, un paso extra que D-001 ya descartó por
+  el mismo motivo.
+- **Alternativas descartadas:** pedir el teléfono del buscador antes de abrir WhatsApp, para poder cruzarlo
+  después con la reseña — se descarta acá porque agrega fricción al paso que este proyecto más protege
+  (contactar), y el brief de misión 07 ya apunta a resolver la identidad del lado de la reseña (OTP por
+  teléfono al momento de reseñar), no del lado del contacto.
+- **Decisión y consecuencia:** Datealo guarda que un contacto ocurrió en el perfil de un profesional
+  determinado, con su fecha — nada que identifique a la persona que lo generó. Cómo esa reseña futura se
+  ata a un contacto real sin esa identidad es un problema que resuelve misión 07 con su propio mecanismo,
+  no esta misión.
+- **Reapertura:** si misión 07, al diseñar su verificación, concluye que necesita datos adicionales del
+  momento del contacto (más allá de perfil + fecha), esta decisión se revisa junto con esa misión.
 
 ## Preguntas
 
-<!--
-Solo preguntas que pueden cambiar una decisión o funcionalidad. Lo demás va a un issue.
-Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
-Estado: abierta | resuelta AAAA-MM-DD (alguien la respondió) | disuelta AAAA-MM-DD (el producto cambió y la
-pregunta dejó de tener sentido). Solo las abiertas llevan bloque de detalle debajo de la tabla.
--->
+Ninguna bloquea F-001 o F-002 tal como están definidas acá — Q-001 es sobre cómo misión 07 va a atar una
+reseña a un contacto real, no sobre si el perfil o el botón de contacto funcionan.
 
-<Una frase que responde "¿qué falta?": la pregunta que bloquea y qué bloquea.>
-
-| ID    | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
-| ----- | ---------------------- | ------------------- | --------------------------------------------------------------- |
-| Q-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
-| Q-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |
+| ID    | La duda                                                                      | Estado  | Respuesta, o quién la resuelve |
+| ----- | ------------------------------------------------------------------------------- | ------- | ------------------------------------ |
+| Q-001 | ¿Cómo identifica Datealo, sin pedirle cuenta a nadie, que la persona que deja una reseña es la misma que generó un contacto real? | abierta | Se resuelve en `producto.md` de misión 07, cuando esa misión se trabaje — su brief ya apunta a explorar OTP por teléfono al momento de reseñar, no decisión cerrada |
 
 <a id="q-001"></a>
 
-### Q-001 — <la pregunta en una frase que se entiende sola>
+### Q-001 — ¿Cómo se ata una reseña futura a un contacto real sin pedirle cuenta a nadie?
 
-- **La duda, con un ejemplo:** <el caso concreto que muestra por qué hay dos respuestas posibles>.
-- **Afecta a:** D-001 o F-001.
-- **Cómo se resolverá:** <quién y con qué método>.
-- **¿Bloquea algo?:** <qué bloquea y su fecha límite, o no>.
+- **La duda, con un ejemplo:** la señora Carmen contacta a Marcelo por WhatsApp desde su perfil (F-002).
+  Semanas después, cuando exista misión 07, quiere dejarle una reseña. El registro de F-002 solo sabe que
+  "hubo un contacto en el perfil de Marcelo el sábado a las 22:14" — no sabe que fue Carmen. ¿Cómo evita
+  Datealo que cualquiera diga "yo lo contacté" y deje una reseña falsa?
+- **Afecta a:** [D-002](#d-002), y por completo al diseño de misión 07.
+- **Cómo se resolverá:** producto de misión 07 — el brief de esa misión ya explora verificar por teléfono
+  (OTP puntual) al momento de dejar la reseña, en vez de exigirle cuenta al buscador desde antes.
+- **¿Bloquea algo?:** no bloquea esta misión — F-002 registra el contacto igual, sin esa identidad. Sí
+  bloquea que misión 07 pueda cerrar su propio producto.md sin responderla.

--- a/docs/missions/README.md
+++ b/docs/missions/README.md
@@ -13,7 +13,7 @@ abrieron y de dónde salió cada una.
 | 02  | [base de datos, Auth y correo (config)](./02-base-de-datos-y-auth/) | técnica | 2026-08-13 | cerrada 2026-08-17 | — | A-001, A-002, A-003 |
 | 03  | [taxonomía: categorías y comunas](./03-taxonomia-categorias-y-comunas/) | producto | 2026-08-13 | cerrada 2026-08-20 | — | — |
 | 04  | [registro y perfil de profesional](./04-registro-perfil-profesional/) | producto | 2026-08-13 | cerrada 2026-08-28 | — | — |
-| 05  | [perfil público de profesional](./05-perfil-publico-profesional/) | producto | 2026-08-13 | exploración | — | — |
+| 05  | [perfil público de profesional](./05-perfil-publico-profesional/) | producto | 2026-08-13 | lista para construir | — | — |
 | 06  | [búsqueda y resultados](./06-busqueda-resultados/) | producto | 2026-08-13 | exploración | — | — |
 | 07  | [reseñas verificadas por contacto](./07-resenas-verificadas-por-contacto/) | producto | 2026-08-13 | exploración | — | — |
 

--- a/server/api/professionals/[id].get.ts
+++ b/server/api/professionals/[id].get.ts
@@ -1,0 +1,11 @@
+export default defineEventHandler(async (event) => {
+  const id = getRouterParam(event, 'id') ?? ''
+  const professional = await findPublicProfessionalProfile(id)
+
+  if (!professional) {
+    setResponseStatus(event, 404)
+    return { error: 'not_found' }
+  }
+
+  return { professional }
+})

--- a/server/utils/professionals.ts
+++ b/server/utils/professionals.ts
@@ -1,9 +1,18 @@
-import { eq, sql } from 'drizzle-orm'
+import { and, eq, sql } from 'drizzle-orm'
 import { existsActiveCategoria } from './categorias'
 import { existsActiveComuna } from './comunas'
+import { categorias } from '../db/schema/categorias'
+import { comunas } from '../db/schema/comunas'
 import { professionals } from '../db/schema/professionals'
 
 const CONTACT_REGEX = /^\+56\d{9}$/
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+// professionals.id es uuid en el schema — sin este chequeo, un id mal formado llega a Postgres y falla
+// con 22P02 (tipo inválido) en vez de devolver simplemente ninguna fila.
+function isUuid(value: string): boolean {
+  return UUID_REGEX.test(value)
+}
 
 export type ProfessionalCoreFields = {
   displayName: string
@@ -29,6 +38,20 @@ export type Professional = {
   priceFrom: number | null
   photoUrls: string[]
   active: boolean
+}
+
+// Forma que ve un buscador sin sesión (misión 05): categoría/comuna ya resueltas a su nombre (nunca el
+// slug/código, que no significa nada para quien mira el perfil) y createdAt, que Professional no expone.
+export type PublicProfessionalProfile = {
+  id: string
+  displayName: string
+  categoriaNombre: string
+  comunaNombre: string
+  contact: string
+  description: string | null
+  priceFrom: number | null
+  photoUrls: string[]
+  createdAt: string
 }
 
 type ProfessionalRow = {
@@ -79,8 +102,14 @@ export async function validateProfessionalFields(
   return null
 }
 
-function toPublicProfessional(row: ProfessionalRow): Professional {
+// Compartido entre Professional (esta forma) y PublicProfessionalProfile (misión 05) — las dos guardan
+// solo el path del bucket y calculan la URL pública recién al responder.
+function buildPhotoUrls(photoPaths: string[]): string[] {
   const { public: pub } = useRuntimeConfig()
+  return photoPaths.map(path => `${pub.supabaseUrl}/storage/v1/object/public/professional-photos/${path}`)
+}
+
+function toPublicProfessional(row: ProfessionalRow): Professional {
   return {
     id: row.id,
     displayName: row.displayName,
@@ -89,10 +118,50 @@ function toPublicProfessional(row: ProfessionalRow): Professional {
     contact: row.contact,
     description: row.description,
     priceFrom: row.priceFrom,
-    photoUrls: row.photoPaths.map(
-      path => `${pub.supabaseUrl}/storage/v1/object/public/professional-photos/${path}`,
-    ),
+    photoUrls: buildPhotoUrls(row.photoPaths),
     active: row.active,
+  }
+}
+
+// Sin sesión, para cualquiera (misión 05). categoriaNombre/comunaNombre se resuelven en la misma consulta
+// (leftJoin) en vez de con findCategoriaNombre()/findComunaNombre() por separado — este endpoint es el
+// de más tráfico esperado del diseño (destino de las cards de la futura misión 06), a diferencia del
+// correo de bienvenida (buildProfessionalWelcomeEmail más abajo), que corre una vez por registro y sí
+// puede pagar dos queries encadenadas.
+export async function findPublicProfessionalProfile(id: string): Promise<PublicProfessionalProfile | null> {
+  if (!isUuid(id)) return null
+
+  const [row] = await useDb()
+    .select({
+      id: professionals.id,
+      displayName: professionals.displayName,
+      categoriaSlug: professionals.categoriaSlug,
+      categoriaNombre: categorias.nombre,
+      comunaCodigo: professionals.comunaCodigo,
+      comunaNombre: comunas.nombre,
+      contact: professionals.contact,
+      description: professionals.description,
+      priceFrom: professionals.priceFrom,
+      photoPaths: professionals.photoPaths,
+      createdAt: professionals.createdAt,
+    })
+    .from(professionals)
+    .leftJoin(categorias, eq(professionals.categoriaSlug, categorias.slug))
+    .leftJoin(comunas, eq(professionals.comunaCodigo, comunas.codigo))
+    .where(and(eq(professionals.id, id), eq(professionals.active, true)))
+
+  if (!row) return null
+
+  return {
+    id: row.id,
+    displayName: row.displayName,
+    categoriaNombre: row.categoriaNombre ?? row.categoriaSlug,
+    comunaNombre: row.comunaNombre ?? row.comunaCodigo,
+    contact: row.contact,
+    description: row.description,
+    priceFrom: row.priceFrom,
+    photoUrls: buildPhotoUrls(row.photoPaths),
+    createdAt: row.createdAt.toISOString(),
   }
 }
 


### PR DESCRIPTION
## Summary

- `GET /api/professionals/[id]` — perfil público de un profesional, sin sesión. Devuelve nombre, categoría/comuna (nombre legible, resuelto en un solo `leftJoin`), contacto, descripción, precio, fotos y `createdAt` ("En Datealo desde..."). Un `id` inactivo, inexistente o mal formado devuelve el mismo `404`, sin distinguir los casos.
- `server/utils/professionals.ts`: `buildPhotoUrls()` extraído como helper compartido (evita duplicar la regla de armar URLs desde el bucket entre la forma de misión 04 y la nueva forma pública); `findPublicProfessionalProfile()` nueva.
- Cierra el discovery completo de la misión 05 (`investigacion.md` → `producto.md` → `experiencia.md` → `ingenieria.md`, los cuatro vigentes) y anota este issue en su plan de construcción.

Cierra #87. Sustento: F-001, D-001, D-002, TC-001, CL-001, CL-002, CL-003.

## Test plan

- [x] `npx nuxi typecheck` — cero errores
- [x] `npm run build` — compila
- [x] Manual contra la base de desarrollo: `GET` de un perfil activo real devuelve 200 con `categoriaNombre`/`comunaNombre` resueltos y sin `userId`; un `id` inexistente y uno mal formado devuelven 404 en ambos casos

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bm1f7a56c5VM2jELoaKQTQ