### PR TITLE
feat(server): registrar el evento de contacto — tabla y POST /contacts

### DIFF
--- a/server/api/professionals/[id]/contacts.post.ts
+++ b/server/api/professionals/[id]/contacts.post.ts
@@ -1,0 +1,12 @@
+export default defineEventHandler(async (event) => {
+  const id = getRouterParam(event, 'id') ?? ''
+  const registered = await registerProfessionalContact(id)
+
+  if (!registered) {
+    setResponseStatus(event, 404)
+    return { error: 'not_found' }
+  }
+
+  setResponseStatus(event, 204)
+  return null
+})

--- a/server/db/migrations/0003_demonic_rockslide.sql
+++ b/server/db/migrations/0003_demonic_rockslide.sql
@@ -1,0 +1,8 @@
+CREATE TABLE "professional_contact_events" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"professional_id" uuid NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "professional_contact_events" ADD CONSTRAINT "professional_contact_events_professional_id_professionals_id_fk" FOREIGN KEY ("professional_id") REFERENCES "public"."professionals"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "professional_contact_events_professional_id_idx" ON "professional_contact_events" USING btree ("professional_id");

--- a/server/db/migrations/meta/0003_snapshot.json
+++ b/server/db/migrations/meta/0003_snapshot.json
@@ -1,0 +1,302 @@
+{
+  "id": "2479850c-7667-4db9-9b20-c1b3c3e0e0cc",
+  "prevId": "617d5cec-211e-4950-a96d-6d48dbd0956a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.categorias": {
+      "name": "categorias",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "nombre": {
+          "name": "nombre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activa": {
+          "name": "activa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comunas": {
+      "name": "comunas",
+      "schema": "",
+      "columns": {
+        "codigo": {
+          "name": "codigo",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "nombre": {
+          "name": "nombre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activa": {
+          "name": "activa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.professional_contact_events": {
+      "name": "professional_contact_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "professional_id": {
+          "name": "professional_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "professional_contact_events_professional_id_idx": {
+          "name": "professional_contact_events_professional_id_idx",
+          "columns": [
+            {
+              "expression": "professional_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "professional_contact_events_professional_id_professionals_id_fk": {
+          "name": "professional_contact_events_professional_id_professionals_id_fk",
+          "tableFrom": "professional_contact_events",
+          "tableTo": "professionals",
+          "columnsFrom": [
+            "professional_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.professionals": {
+      "name": "professionals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "categoria_slug": {
+          "name": "categoria_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comuna_codigo": {
+          "name": "comuna_codigo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact": {
+          "name": "contact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_from": {
+          "name": "price_from",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_paths": {
+          "name": "photo_paths",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "professionals_categoria_slug_idx": {
+          "name": "professionals_categoria_slug_idx",
+          "columns": [
+            {
+              "expression": "categoria_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "professionals_comuna_codigo_idx": {
+          "name": "professionals_comuna_codigo_idx",
+          "columns": [
+            {
+              "expression": "comuna_codigo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "professionals_categoria_slug_categorias_slug_fk": {
+          "name": "professionals_categoria_slug_categorias_slug_fk",
+          "tableFrom": "professionals",
+          "tableTo": "categorias",
+          "columnsFrom": [
+            "categoria_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "professionals_comuna_codigo_comunas_codigo_fk": {
+          "name": "professionals_comuna_codigo_comunas_codigo_fk",
+          "tableFrom": "professionals",
+          "tableTo": "comunas",
+          "columnsFrom": [
+            "comuna_codigo"
+          ],
+          "columnsTo": [
+            "codigo"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "professionals_user_id_unique": {
+          "name": "professionals_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/db/migrations/meta/_journal.json
+++ b/server/db/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1787716231842,
       "tag": "0002_charming_micromax",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1787964351415,
+      "tag": "0003_demonic_rockslide",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/schema/index.ts
+++ b/server/db/schema/index.ts
@@ -1,3 +1,4 @@
 export * from './categorias'
 export * from './comunas'
+export * from './professional-contact-events'
 export * from './professionals'

--- a/server/db/schema/professional-contact-events.ts
+++ b/server/db/schema/professional-contact-events.ts
@@ -1,0 +1,18 @@
+import { index, pgTable, timestamp, uuid } from 'drizzle-orm/pg-core'
+import { professionals } from './professionals'
+
+export const professionalContactEvents = pgTable(
+  'professional_contact_events',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    // onDelete: 'restrict' — hoy ningún flujo borra un professionals row, así que nunca se ejerce;
+    // decidido explícito para no heredar el default silencioso de Postgres el día que sí exista un borrado.
+    professionalId: uuid('professional_id')
+      .notNull()
+      .references(() => professionals.id, { onDelete: 'restrict' }),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  table => [
+    index('professional_contact_events_professional_id_idx').on(table.professionalId),
+  ],
+)

--- a/server/db/sql/rls.sql
+++ b/server/db/sql/rls.sql
@@ -100,3 +100,13 @@ create policy professional_photos_delete_own on storage.objects
 
 -- Sin policy de update: cada foto sube con un uuid nuevo, el código nunca llama upload() con
 -- upsert: true.
+
+-- professional_contact_events: el evento de contacto (misión 05) nunca identifica a quien contacta
+-- (decisión de producto), así que nada en el diseño necesita que ningún rol lo lea ni lo escriba vía
+-- PostgREST — solo Drizzle (rol dueño) lo toca, desde el endpoint público de contacto. Por eso va sin
+-- ninguna policy: el revoke ya cierra el camino, y sin policy Postgres deniega por default para
+-- anon/authenticated de todas formas.
+
+alter table professional_contact_events enable row level security;
+
+revoke all on public.professional_contact_events from anon, authenticated;

--- a/server/utils/professional-contact-events.ts
+++ b/server/utils/professional-contact-events.ts
@@ -1,0 +1,17 @@
+import { eq } from 'drizzle-orm'
+import { isUuid } from './validation'
+import { professionalContactEvents } from '../db/schema/professional-contact-events'
+import { professionals } from '../db/schema/professionals'
+
+// Sin cuenta ni sesión: quien contacta nunca queda identificado, a propósito (D-002 de producto,
+// misión 05). Devuelve false cuando el id no corresponde a ningún profesional, para que el handler
+// responda 404 en vez de dejar que Postgres rechace el insert por violación de FK.
+export async function registerProfessionalContact(professionalId: string): Promise<boolean> {
+  if (!isUuid(professionalId)) return false
+
+  const [exists] = await useDb().select({ id: professionals.id }).from(professionals).where(eq(professionals.id, professionalId))
+  if (!exists) return false
+
+  await useDb().insert(professionalContactEvents).values({ professionalId })
+  return true
+}

--- a/server/utils/professionals.ts
+++ b/server/utils/professionals.ts
@@ -1,18 +1,12 @@
 import { and, eq, sql } from 'drizzle-orm'
 import { existsActiveCategoria } from './categorias'
 import { existsActiveComuna } from './comunas'
+import { isUuid } from './validation'
 import { categorias } from '../db/schema/categorias'
 import { comunas } from '../db/schema/comunas'
 import { professionals } from '../db/schema/professionals'
 
 const CONTACT_REGEX = /^\+56\d{9}$/
-const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
-
-// professionals.id es uuid en el schema — sin este chequeo, un id mal formado llega a Postgres y falla
-// con 22P02 (tipo inválido) en vez de devolver simplemente ninguna fila.
-function isUuid(value: string): boolean {
-  return UUID_REGEX.test(value)
-}
 
 export type ProfessionalCoreFields = {
   displayName: string

--- a/server/utils/validation.ts
+++ b/server/utils/validation.ts
@@ -1,0 +1,7 @@
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+// Un id mal formado contra una columna uuid de Postgres falla con 22P02 en vez de devolver ninguna
+// fila — cada lookup público por id lo descarta antes de tocar la base.
+export function isUuid(value: string): boolean {
+  return UUID_REGEX.test(value)
+}


### PR DESCRIPTION
## Summary

- Tabla nueva `professional_contact_events` (`professionalId` FK a `professionals.id` con `onDelete: 'restrict'`, `createdAt`) — sin ninguna columna que identifique a quien contacta, a propósito (D-002 de producto, misión 05). RLS habilitada, sin ninguna policy, con `revoke` que cierra PostgREST por completo (A-007).
- `POST /api/professionals/[id]/contacts` — sin sesión, sin body. `204` si el `id` corresponde a un profesional real; `404` si no. La lógica vive en su propio archivo de dominio (`server/utils/professional-contact-events.ts`), separado de `professionals.ts` (A-006).
- `isUuid()` se extrajo a `server/utils/validation.ts`, compartido con el chequeo que ya usaba `GET /api/professionals/[id]` (#90).

Cierra #88. Sustento: F-002, D-002, TC-002, M-002, A-006, A-007.

## Test plan

- [x] `npx nuxi typecheck` — cero errores
- [x] `npm run build` — compila
- [x] `npm test` — 21 tests pasan, ninguno roto
- [x] Manual contra la base de desarrollo: `POST` con un `id` real inserta la fila (`professionalId` + `createdAt`, sin ningún otro dato); `id` inexistente y `id` mal formado devuelven `404` sin insertar
- [x] Manual, vía PostgREST directo con la publishable key (`anon`, sin sesión): `select` e `insert` sobre `professional_contact_events` devuelven `401`/`insufficient_privilege` — el `revoke` bloquea antes de evaluar cualquier policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bm1f7a56c5VM2jELoaKQTQ