### PR TITLE
feat(app): vista pública del perfil de profesional (/profesionales/[id])

### DIFF
--- a/app/components/professional-public/ProfessionalPublicContactBar.vue
+++ b/app/components/professional-public/ProfessionalPublicContactBar.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import { MessageCircle, Phone } from '@lucide/vue'
+
+const props = defineProps<{
+  professionalId: string
+  contact: string
+  displayName: string
+  categoriaNombre: string
+}>()
+
+const message = buildContactMessage(props.displayName, props.categoriaNombre)
+const whatsappUrl = computed(() => buildWhatsAppUrl(props.contact, message))
+const telUrl = computed(() => buildTelUrl(props.contact))
+
+// sendBeacon, no fetch: dispara el registro antes de que el navegador salga hacia wa.me/tel:, sin
+// esperar la respuesta ni arriesgar que un fetch en vuelo se cancele al abandonar la página — el
+// contacto real nunca debe esperar a que este registro termine.
+function registerContact() {
+  navigator.sendBeacon?.(`/api/professionals/${props.professionalId}/contacts`)
+}
+</script>
+
+<template>
+  <div class="flex gap-2">
+    <UButton :to="whatsappUrl" size="lg" class="flex-1 justify-center font-bold" @click="registerContact">
+      <MessageCircle class="h-5 w-5" />
+      Escribir por WhatsApp
+    </UButton>
+    <UButton
+      :to="telUrl"
+      size="lg"
+      variant="outline"
+      color="neutral"
+      class="px-4"
+      aria-label="Llamar"
+      @click="registerContact"
+    >
+      <Phone class="h-5 w-5" />
+    </UButton>
+  </div>
+</template>

--- a/app/components/professional-public/ProfessionalPublicPhotos.vue
+++ b/app/components/professional-public/ProfessionalPublicPhotos.vue
@@ -7,20 +7,53 @@ defineProps<{
 function initials(name: string): string {
   return name.trim().split(/\s+/).slice(0, 2).map(part => part[0]?.toUpperCase() ?? '').join('')
 }
+
+// La tira de miniaturas es solo un atajo de navegación sobre el mismo carrusel — activeIndex refleja
+// el slide actual (evento select de UCarousel) para resaltar cuál mira el visitante, y clickear una
+// miniatura mueve ese mismo carrusel en vez de duplicar su estado.
+const carousel = useTemplateRef('carousel')
+const activeIndex = ref(0)
+
+function selectPhoto(index: number) {
+  carousel.value?.emblaApi?.scrollTo(index)
+}
 </script>
 
 <template>
-  <UCarousel v-if="photoUrls.length" :items="photoUrls" dots class="aspect-4/3 w-full overflow-hidden">
-    <template #default="{ item, index }">
-      <img
-        :src="item"
-        :alt="`Foto de trabajo de ${displayName}, ${index + 1} de ${photoUrls.length}`"
-        class="h-full w-full object-cover"
-      >
-    </template>
-  </UCarousel>
+  <div v-if="photoUrls.length">
+    <UCarousel
+      ref="carousel"
+      :items="photoUrls"
+      dots
+      class="aspect-4/3 w-full overflow-hidden lg:rounded-2xl"
+      @select="activeIndex = $event"
+    >
+      <template #default="{ item, index }">
+        <img
+          :src="item"
+          :alt="`Foto de trabajo de ${displayName}, ${index + 1} de ${photoUrls.length}`"
+          class="h-full w-full object-cover"
+        >
+      </template>
+    </UCarousel>
 
-  <div v-else class="flex aspect-4/3 w-full items-center justify-center bg-datealo-surface">
+    <div v-if="photoUrls.length > 1" class="mt-2 hidden gap-2 lg:flex">
+      <button
+        v-for="(url, index) in photoUrls"
+        :key="url"
+        type="button"
+        class="aspect-square w-16 overflow-hidden rounded-lg ring-2 ring-offset-2"
+        :class="index === activeIndex ? 'ring-primary' : 'ring-transparent'"
+        :aria-label="`Ver foto ${index + 1} de ${photoUrls.length}`"
+        :aria-current="index === activeIndex"
+        @click="selectPhoto(index)"
+      >
+        <img :src="url" :alt="`Miniatura ${index + 1} de ${displayName}`" class="h-full w-full object-cover">
+      </button>
+    </div>
+  </div>
+
+  <div v-else class="flex aspect-4/3 w-full items-center justify-center bg-datealo-surface lg:rounded-2xl">
     <div class="flex h-22 w-22 items-center justify-center rounded-full bg-primary text-2xl font-extrabold text-white">
       {{ initials(displayName) }}
     </div>

--- a/app/components/professional-public/ProfessionalPublicPhotos.vue
+++ b/app/components/professional-public/ProfessionalPublicPhotos.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+defineProps<{
+  photoUrls: string[]
+  displayName: string
+}>()
+
+function initials(name: string): string {
+  return name.trim().split(/\s+/).slice(0, 2).map(part => part[0]?.toUpperCase() ?? '').join('')
+}
+</script>
+
+<template>
+  <UCarousel v-if="photoUrls.length" :items="photoUrls" dots class="aspect-4/3 w-full overflow-hidden">
+    <template #default="{ item, index }">
+      <img
+        :src="item"
+        :alt="`Foto de trabajo de ${displayName}, ${index + 1} de ${photoUrls.length}`"
+        class="h-full w-full object-cover"
+      >
+    </template>
+  </UCarousel>
+
+  <div v-else class="flex aspect-4/3 w-full items-center justify-center bg-datealo-surface">
+    <div class="flex h-22 w-22 items-center justify-center rounded-full bg-primary text-2xl font-extrabold text-white">
+      {{ initials(displayName) }}
+    </div>
+  </div>
+</template>

--- a/app/composables/usePublicProfessionalProfile.ts
+++ b/app/composables/usePublicProfessionalProfile.ts
@@ -5,13 +5,15 @@ const SLOW_LOAD_MS = 10_000
 // Estado local, no useState: cada visita a /profesionales/[id] es un profesional distinto, no algo que
 // deba compartirse entre páginas como useProfessionalProfile() (el propio perfil del dueño).
 export function usePublicProfessionalProfile(id: string) {
+  const validId = isUuid(id)
+
   const { data, pending, error, refresh } = useFetch<{ professional: PublicProfessionalProfile }>(
     `/api/professionals/${id}`,
-    { key: `public-professional-${id}` },
+    { key: `public-professional-${id}`, immediate: validId },
   )
 
   const professional = computed(() => data.value?.professional ?? null)
-  const notFound = computed(() => Boolean(error.value))
+  const notFound = computed(() => !validId || Boolean(error.value))
 
   // "Tardando": sigue pending pasados los 10s, sin haber resuelto ni a encontrado ni a 404.
   const slow = ref(false)

--- a/app/composables/usePublicProfessionalProfile.ts
+++ b/app/composables/usePublicProfessionalProfile.ts
@@ -1,0 +1,36 @@
+import type { PublicProfessionalProfile } from '~/types/professional'
+
+const SLOW_LOAD_MS = 10_000
+
+// Estado local, no useState: cada visita a /profesionales/[id] es un profesional distinto, no algo que
+// deba compartirse entre páginas como useProfessionalProfile() (el propio perfil del dueño).
+export function usePublicProfessionalProfile(id: string) {
+  const { data, pending, error, refresh } = useFetch<{ professional: PublicProfessionalProfile }>(
+    `/api/professionals/${id}`,
+    { key: `public-professional-${id}` },
+  )
+
+  const professional = computed(() => data.value?.professional ?? null)
+  const notFound = computed(() => Boolean(error.value))
+
+  // "Tardando": sigue pending pasados los 10s, sin haber resuelto ni a encontrado ni a 404.
+  const slow = ref(false)
+  let slowTimer: ReturnType<typeof setTimeout> | undefined
+
+  function clearSlowTimer() {
+    if (slowTimer) clearTimeout(slowTimer)
+    slowTimer = undefined
+  }
+
+  watch(pending, (isPending) => {
+    clearSlowTimer()
+    slow.value = false
+    if (isPending && import.meta.client) {
+      slowTimer = setTimeout(() => { slow.value = true }, SLOW_LOAD_MS)
+    }
+  }, { immediate: true })
+
+  onUnmounted(clearSlowTimer)
+
+  return { professional, pending, notFound, slow, refresh }
+}

--- a/app/pages/profesionales/[id].vue
+++ b/app/pages/profesionales/[id].vue
@@ -1,0 +1,83 @@
+<script setup lang="ts">
+import { Hourglass, SearchX } from '@lucide/vue'
+
+const route = useRoute()
+const id = route.params.id as string
+
+const { professional, pending, notFound, slow, refresh } = usePublicProfessionalProfile(id)
+
+const memberSince = computed(() => professional.value ? formatMemberSince(professional.value.createdAt) : '')
+
+useSeoMeta({
+  title: () => professional.value
+    ? `${professional.value.displayName} · ${professional.value.categoriaNombre} en ${professional.value.comunaNombre}`
+    : 'Perfil de profesional',
+})
+</script>
+
+<template>
+  <div class="min-h-screen">
+    <!-- tardando (>10s) -->
+    <div v-if="slow" class="flex min-h-screen flex-col items-center justify-center gap-4 p-8 text-center">
+      <Hourglass class="h-10 w-10 text-datealo-muted" />
+      <h1 class="text-lg font-extrabold text-datealo-text">Esto está tardando más de lo normal</h1>
+      <UButton size="lg" @click="refresh()">Reintentar</UButton>
+    </div>
+
+    <!-- cargando -->
+    <div v-else-if="pending" class="mx-auto max-w-5xl lg:flex lg:gap-8 lg:px-8 lg:py-8" aria-busy="true">
+      <div class="aspect-4/3 w-full animate-pulse bg-datealo-surface lg:w-[55%] lg:rounded-2xl" />
+      <div class="space-y-3 px-5 pt-5 lg:flex-1 lg:px-0 lg:pt-0">
+        <div class="h-6 w-48 animate-pulse rounded bg-datealo-surface" />
+        <div class="h-4 w-32 animate-pulse rounded bg-datealo-surface" />
+        <div class="h-4 w-full animate-pulse rounded bg-datealo-surface" />
+        <div class="h-4 w-2/3 animate-pulse rounded bg-datealo-surface" />
+      </div>
+    </div>
+
+    <!-- no encontrado -->
+    <div v-else-if="notFound" class="flex min-h-screen flex-col items-center justify-center gap-4 p-8 text-center">
+      <SearchX class="h-10 w-10 text-datealo-muted" />
+      <div>
+        <h1 class="text-lg font-extrabold text-datealo-text">No encontramos este perfil</h1>
+        <p class="mt-2 text-sm text-datealo-muted">Puede que ya no esté disponible o que el link esté mal escrito.</p>
+      </div>
+      <UButton to="/" size="lg">Buscar profesionales</UButton>
+    </div>
+
+    <!-- encontrado -->
+    <div v-else-if="professional" class="mx-auto max-w-5xl lg:flex lg:items-start lg:gap-8 lg:px-8 lg:py-8">
+      <ProfessionalPublicPhotos
+        :photo-urls="professional.photoUrls"
+        :display-name="professional.displayName"
+        class="lg:w-[55%] lg:overflow-hidden lg:rounded-2xl"
+      />
+
+      <div class="px-5 pb-28 pt-5 lg:flex-1 lg:sticky lg:top-8 lg:self-start lg:px-0 lg:pb-0 lg:pt-0">
+        <h1 class="text-xl font-extrabold text-datealo-text lg:text-2xl">{{ professional.displayName }}</h1>
+        <p class="mt-0.5 text-sm text-datealo-muted">{{ professional.categoriaNombre }} · {{ professional.comunaNombre }}</p>
+
+        <p v-if="professional.description" class="mt-4 text-sm leading-relaxed text-datealo-text">
+          {{ professional.description }}
+        </p>
+
+        <p v-if="professional.priceFrom" class="mt-3 text-base font-bold text-datealo-text lg:text-lg">
+          Desde ${{ formatPriceFrom(professional.priceFrom) }}
+        </p>
+
+        <p class="mt-3 text-xs text-datealo-muted">En Datealo desde {{ memberSince }}</p>
+
+        <div
+          class="fixed inset-x-0 bottom-0 z-10 border-t border-datealo-surface bg-datealo-bg p-4 lg:static lg:mt-8 lg:border-0 lg:bg-transparent lg:p-0"
+        >
+          <ProfessionalPublicContactBar
+            :professional-id="professional.id"
+            :contact="professional.contact"
+            :display-name="professional.displayName"
+            :categoria-nombre="professional.categoriaNombre"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/app/pages/profesionales/[id].vue
+++ b/app/pages/profesionales/[id].vue
@@ -27,7 +27,9 @@ useSeoMeta({
     <!-- cargando -->
     <div v-else-if="pending" class="mx-auto max-w-5xl lg:flex lg:gap-8 lg:px-8 lg:py-8" aria-busy="true">
       <div class="aspect-4/3 w-full animate-pulse bg-datealo-surface lg:w-[55%] lg:rounded-2xl" />
-      <div class="space-y-3 px-5 pt-5 lg:flex-1 lg:px-0 lg:pt-0">
+      <div
+        class="space-y-3 px-5 pt-5 lg:flex-1 lg:rounded-2xl lg:border lg:border-datealo-surface lg:px-6 lg:py-6"
+      >
         <div class="h-6 w-48 animate-pulse rounded bg-datealo-surface" />
         <div class="h-4 w-32 animate-pulse rounded bg-datealo-surface" />
         <div class="h-4 w-full animate-pulse rounded bg-datealo-surface" />
@@ -50,10 +52,12 @@ useSeoMeta({
       <ProfessionalPublicPhotos
         :photo-urls="professional.photoUrls"
         :display-name="professional.displayName"
-        class="lg:w-[55%] lg:overflow-hidden lg:rounded-2xl"
+        class="lg:w-[55%]"
       />
 
-      <div class="px-5 pb-28 pt-5 lg:flex-1 lg:sticky lg:top-8 lg:self-start lg:px-0 lg:pb-0 lg:pt-0">
+      <div
+        class="px-5 pb-28 pt-5 lg:flex-1 lg:sticky lg:top-8 lg:self-start lg:rounded-2xl lg:border lg:border-datealo-surface lg:p-6"
+      >
         <h1 class="text-xl font-extrabold text-datealo-text lg:text-2xl">{{ professional.displayName }}</h1>
         <p class="mt-0.5 text-sm text-datealo-muted">{{ professional.categoriaNombre }} · {{ professional.comunaNombre }}</p>
 

--- a/app/types/professional.ts
+++ b/app/types/professional.ts
@@ -17,3 +17,17 @@ export type ProfessionalField =
   | 'contact'
   | 'description'
   | 'priceFrom'
+
+// Lo que ve un buscador sin sesión (misión 05): categoría/comuna ya resueltas a su nombre, y desde
+// cuándo existe el perfil — ninguna de las dos cosas está en Professional (la forma del propio dueño).
+export type PublicProfessionalProfile = {
+  id: string
+  displayName: string
+  categoriaNombre: string
+  comunaNombre: string
+  contact: string
+  description: string | null
+  priceFrom: number | null
+  photoUrls: string[]
+  createdAt: string
+}

--- a/app/utils/professional-contact-links.ts
+++ b/app/utils/professional-contact-links.ts
@@ -1,0 +1,15 @@
+// wa.me exige el número sin el símbolo + (documentación de WhatsApp); tel: usa el mismo E.164 con el +
+// tal cual lo guarda professionals.contact.
+export function buildWhatsAppUrl(contact: string, message: string): string {
+  const digits = contact.replace(/\D/g, '')
+  return `https://wa.me/${digits}?text=${encodeURIComponent(message)}`
+}
+
+export function buildTelUrl(contact: string): string {
+  return `tel:${contact}`
+}
+
+export function buildContactMessage(displayName: string, categoriaNombre: string): string {
+  const firstName = displayName.trim().split(/\s+/)[0] ?? displayName
+  return `Hola ${firstName}, vi tu perfil de ${categoriaNombre} en Datealo y quería consultarte algo`
+}

--- a/app/utils/professional-since.ts
+++ b/app/utils/professional-since.ts
@@ -1,0 +1,7 @@
+const MEMBER_SINCE_FORMATTER = new Intl.DateTimeFormat('es-CL', { month: 'long', year: 'numeric' })
+
+// Mes y año, nunca el día exacto — un dato tan preciso no aporta nada extra y puede sentirse como
+// vigilancia sobre el profesional.
+export function formatMemberSince(createdAt: string): string {
+  return MEMBER_SINCE_FORMATTER.format(new Date(createdAt))
+}

--- a/app/utils/uuid.ts
+++ b/app/utils/uuid.ts
@@ -1,0 +1,8 @@
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+// El id del perfil público viaja en la URL (/profesionales/[id]). "me" no es un uuid pero sí existe
+// como GET /api/professionals/me (el propio perfil del dueño, con sesión) — sin este chequeo antes de
+// pedir el perfil público, ese valor terminaría golpeando el endpoint equivocado.
+export function isUuid(value: string): boolean {
+  return UUID_REGEX.test(value)
+}

--- a/docs/missions/05-perfil-publico-profesional/design-mockups/perfil-publico.html
+++ b/docs/missions/05-perfil-publico-profesional/design-mockups/perfil-publico.html
@@ -86,6 +86,21 @@
       .hero-scrim {
         background: linear-gradient(to top, rgba(0, 0, 0, 0.45), transparent);
       }
+      .section-card {
+        border: 1px solid var(--ui-border);
+        border-radius: 0.875rem;
+        background: var(--ui-bg);
+      }
+      .thumb {
+        width: 4rem;
+        aspect-ratio: 1;
+        border-radius: 0.5rem;
+        background: var(--ui-bg-accented);
+        box-shadow: 0 0 0 2px transparent;
+      }
+      .thumb-active {
+        box-shadow: 0 0 0 2px var(--ui-primary);
+      }
     </style>
   </head>
 
@@ -234,21 +249,28 @@
       <section class="frame frame-desktop">
         <div class="frame-label">
           V-001 · modo encontrado — perfil completo, desktop
-          <small>dos columnas: fotos a la izquierda; a la derecha, datos y el bloque de contacto en
-            `position: sticky` dentro de la columna (no fijo a toda la pantalla) — la columna de fotos
-            suele ser más alta que el texto</small>
+          <small>dos columnas: fotos a la izquierda con miniaturas debajo; a la derecha, una tarjeta con
+            borde con los datos y el contacto en `position: sticky` dentro de la columna — sin la tarjeta,
+            la columna de texto quedaba flotando sin ningún límite visual (revisión 2026-08-29)</small>
         </div>
         <div class="frame-viewport">
-          <div class="flex h-full">
-            <div class="hero-photo" style="width: 55%; aspect-ratio: auto;">
-              <div class="hero-scrim absolute inset-x-0 bottom-0 h-20"></div>
-              <div class="absolute bottom-4 left-1/2 flex -translate-x-1/2 gap-1.5">
-                <div class="dot active"></div>
-                <div class="dot"></div>
-                <div class="dot"></div>
+          <div class="flex h-full gap-8 p-8" style="background: var(--ui-bg-muted)">
+            <div style="width: 55%;">
+              <div class="hero-photo" style="aspect-ratio: 4 / 3;">
+                <div class="hero-scrim absolute inset-x-0 bottom-0 h-20"></div>
+                <div class="absolute bottom-4 left-1/2 flex -translate-x-1/2 gap-1.5">
+                  <div class="dot active"></div>
+                  <div class="dot"></div>
+                  <div class="dot"></div>
+                </div>
+              </div>
+              <div class="mt-2 flex gap-2">
+                <div class="thumb thumb-active"></div>
+                <div class="thumb"></div>
+                <div class="thumb"></div>
               </div>
             </div>
-            <div class="flex-1 p-10" style="position: sticky; top: 0; align-self: flex-start;">
+            <div class="section-card flex-1 p-6" style="position: sticky; top: 0; align-self: flex-start;">
               <h1 class="text-2xl font-extrabold" style="color: var(--ui-text-highlighted)">Marcelo Rojas</h1>
               <p class="mt-1 text-sm" style="color: var(--ui-text-muted)">Electricidad · Ñuñoa</p>
 

--- a/docs/missions/05-perfil-publico-profesional/experiencia.md
+++ b/docs/missions/05-perfil-publico-profesional/experiencia.md
@@ -2,7 +2,7 @@
 
 **Estado:** vigente — aprobado por Patricio el 2026-08-28
 
-**Última actualización:** 2026-08-28
+**Última actualización:** 2026-08-29
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
@@ -146,6 +146,14 @@ orden es:
   toda la pantalla — la columna de fotos suele ser más alta que el bloque de texto, así que "fijo abajo" de
   móvil se traduce a "pegado arriba de su columna mientras se hace scroll" en desktop, no al mismo mecanismo
   literal.
+- En desktop, el bloque de datos y contacto va encerrado en una tarjeta con borde (mismo patrón que ya usan
+  las secciones de "Editar perfil" de misión 04) — sin eso, la columna de texto queda flotando sobre el
+  fondo de la página sin ningún límite visual, y se siente incompleta frente a la foto grande de al lado.
+- Cuando el perfil tiene más de una foto, en desktop aparece además una fila de miniaturas debajo de la
+  foto principal — tocar una mueve el carrusel a esa foto, con un aro de color marcando cuál se está
+  viendo. Es un atajo de navegación sobre el mismo carrusel, no un segundo estado ni una fuente de verdad
+  aparte: si se toca una miniatura o se hace swipe en la foto grande, ambos quedan sincronizados al mismo
+  índice. En móvil no aparece — ahí ya alcanza con el swipe y los puntos del carrusel.
 
 ## UXF-002 — Contactar al profesional desde el perfil
 
@@ -243,6 +251,10 @@ volver de WhatsApp o de la llamada, la pantalla está exactamente donde la dejó
   adentro, en vez de una composición aparte — ya corregido en el mockup y en "Decisiones que no deben
   quedar implícitas" de UXF-001.
 - **Impacto en producto:** ninguno.
+- **Revisión (2026-08-29):** al probar la vista real, la columna de datos en desktop se sentía incompleta
+  sin ningún límite visual propio — se le agregó una tarjeta con borde (mismo patrón que misión 04), y una
+  fila de miniaturas debajo de la foto principal cuando hay más de una, sincronizada con el mismo carrusel.
+  Ninguna de las dos cosas cambia el layout de móvil ni la elección de Enfoque A sobre B o C.
 
 <a id="ux-002"></a>
 

--- a/server/utils/professional-contact-events.ts
+++ b/server/utils/professional-contact-events.ts
@@ -3,9 +3,9 @@ import { isUuid } from './validation'
 import { professionalContactEvents } from '../db/schema/professional-contact-events'
 import { professionals } from '../db/schema/professionals'
 
-// Sin cuenta ni sesión: quien contacta nunca queda identificado, a propósito (D-002 de producto,
-// misión 05). Devuelve false cuando el id no corresponde a ningún profesional, para que el handler
-// responda 404 en vez de dejar que Postgres rechace el insert por violación de FK.
+// Sin cuenta ni sesión: quien contacta nunca queda identificado, a propósito. Devuelve false cuando el
+// id no corresponde a ningún profesional, para que el handler responda 404 en vez de dejar que Postgres
+// rechace el insert por violación de FK.
 export async function registerProfessionalContact(professionalId: string): Promise<boolean> {
   if (!isUuid(professionalId)) return false
 


### PR DESCRIPTION
## Summary

- `/profesionales/[id].vue` — los cinco modos de V-001: cargando (skeleton), encontrado con o sin fotos (avatar de iniciales dentro de la misma banda que ocuparía la foto — nunca una composición distinta, corrección que salió de la auditoría de `experiencia.md`), no encontrado, y tardando (>10s, con "Reintentar").
- Fotos vía `UCarousel` de Nuxt UI (swipe real, sin interacción propia); alt descriptivo por foto (nombre + posición).
- `ProfessionalPublicContactBar`: "Escribir por WhatsApp" (principal) + "Llamar" (ícono, secundario) desde el mismo `contact` — fijo abajo en móvil, `sticky` dentro de su columna en desktop. Dispara el registro de contacto (#88) con `navigator.sendBeacon`, sin esperar su respuesta.
- `usePublicProfessionalProfile()` envuelve `useFetch` con el timer de 10s para "tardando". `professional-contact-links.ts` arma `wa.me`/`tel:` y el mensaje pre-armado (primer nombre + categoría). `professional-since.ts` formatea "En Datealo desde...".

Cierra #89 y el plan de construcción completo de la misión 05 (S-001 a S-003).
Sustento: F-001, F-002, UXF-001, UXF-002, CL-001 a CL-005.

## Test plan

- [x] `npx nuxi typecheck` — cero errores
- [x] `npm run build` — compila
- [x] `npm test` — mismos 21 tests propios pasan
- [x] Verificación visual en el browser, 390px y desktop (1500px), contra un perfil real de la base de desarrollo: layout correcto en ambos, avatar de iniciales en la misma banda que la foto, botón fijo abajo en móvil / sticky en desktop
- [x] Estado "no encontrado" verificado con un `id` inexistente
- [x] Links verificados en el DOM real: `https://wa.me/56940199286?text=Hola%20Patricio%2C%20vi%20tu%20perfil%20de%20Electricidad...` y `tel:+56940199286`
- [x] `sendBeacon` verificado end-to-end: ejecutado en el browser real, confirmado que insertó la fila en `professional_contact_events`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bm1f7a56c5VM2jELoaKQTQ