### PR TITLE
docs(docs): cerrar la misión 05

### DIFF
--- a/docs/missions/05-perfil-publico-profesional/README.md
+++ b/docs/missions/05-perfil-publico-profesional/README.md
@@ -2,9 +2,9 @@
 
 **Tipo:** producto. **Abierta el** 2026-08-13. **Nace de:** ninguna.
 
-**Estado de la misión:** lista para construir
+**Estado de la misión:** cerrada 2026-08-29
 
-**Última actualización:** 2026-08-28
+**Última actualización:** 2026-08-29
 
 Cuarta de seis misiones hacia el MVP (registrarse, mostrarse, buscar, reseñar). Depende de
 [misión 04](../04-registro-perfil-profesional/): sin perfiles de profesional reales, no hay qué mostrar.
@@ -12,8 +12,11 @@ Cuarta de seis misiones hacia el MVP (registrarse, mostrarse, buscar, reseñar).
 **Documentos:** [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-**Próximo hito:** crear los issues de S-001 a S-003 (`ingenieria.md#plan-de-construcción`) y empezar a
-construir.
+**Construida:** [#90](https://github.com/PatricioTabilo/datealo/pull/90) (perfil público,
+`GET /api/professionals/[id]`), [#91](https://github.com/PatricioTabilo/datealo/pull/91) (evento de
+contacto, tabla y `POST /contacts`), [#92](https://github.com/PatricioTabilo/datealo/pull/92) (vista
+`/profesionales/[id]`, con el refinamiento de desktop del 2026-08-29). El perfil público de un profesional
+ya es alcanzable en producción con su `id` real.
 
 ## Brief
 

--- a/docs/missions/README.md
+++ b/docs/missions/README.md
@@ -13,7 +13,7 @@ abrieron y de dónde salió cada una.
 | 02  | [base de datos, Auth y correo (config)](./02-base-de-datos-y-auth/) | técnica | 2026-08-13 | cerrada 2026-08-17 | — | A-001, A-002, A-003 |
 | 03  | [taxonomía: categorías y comunas](./03-taxonomia-categorias-y-comunas/) | producto | 2026-08-13 | cerrada 2026-08-20 | — | — |
 | 04  | [registro y perfil de profesional](./04-registro-perfil-profesional/) | producto | 2026-08-13 | cerrada 2026-08-28 | — | — |
-| 05  | [perfil público de profesional](./05-perfil-publico-profesional/) | producto | 2026-08-13 | lista para construir | — | — |
+| 05  | [perfil público de profesional](./05-perfil-publico-profesional/) | producto | 2026-08-13 | cerrada 2026-08-29 | — | — |
 | 06  | [búsqueda y resultados](./06-busqueda-resultados/) | producto | 2026-08-13 | exploración | — | — |
 | 07  | [reseñas verificadas por contacto](./07-resenas-verificadas-por-contacto/) | producto | 2026-08-13 | exploración | — | — |
 


### PR DESCRIPTION
## Summary

- Misión 05 (perfil público de profesional) queda `cerrada 2026-08-29` — los tres slices de su plan de construcción están mergeados: #90, #91, #92.
- El README de la misión anota dónde vive cada pieza construida.

## Test plan

N/A — solo documentación.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bm1f7a56c5VM2jELoaKQTQ