### PR TITLE
feat(server): buscar profesionales por categoría y comuna — GET /api/search

### DIFF
--- a/server/api/search.get.ts
+++ b/server/api/search.get.ts
@@ -3,27 +3,15 @@ export default defineEventHandler(async (event) => {
   const categoriaSlug = typeof query.categoria === 'string' ? query.categoria : ''
   const comunaCodigo = typeof query.comuna === 'string' ? query.comuna : ''
 
-  if (!categoriaSlug) {
-    setResponseStatus(event, 400)
-    return { error: 'categoria_required' }
-  }
-  if (!comunaCodigo) {
-    setResponseStatus(event, 400)
-    return { error: 'comuna_required' }
-  }
+  if (!categoriaSlug) return badRequest(event, 'categoria_required')
+  if (!comunaCodigo) return badRequest(event, 'comuna_required')
 
   const [categoriaValid, comunaValid] = await Promise.all([
     existsActiveCategoria(categoriaSlug),
     existsActiveComuna(comunaCodigo),
   ])
-  if (!categoriaValid) {
-    setResponseStatus(event, 400)
-    return { error: 'invalid_categoria' }
-  }
-  if (!comunaValid) {
-    setResponseStatus(event, 400)
-    return { error: 'invalid_comuna' }
-  }
+  if (!categoriaValid) return badRequest(event, 'invalid_categoria')
+  if (!comunaValid) return badRequest(event, 'invalid_comuna')
 
   return findSearchResults(categoriaSlug, comunaCodigo)
 })

--- a/server/api/search.get.ts
+++ b/server/api/search.get.ts
@@ -1,0 +1,29 @@
+export default defineEventHandler(async (event) => {
+  const query = getQuery(event)
+  const categoriaSlug = typeof query.categoria === 'string' ? query.categoria : ''
+  const comunaCodigo = typeof query.comuna === 'string' ? query.comuna : ''
+
+  if (!categoriaSlug) {
+    setResponseStatus(event, 400)
+    return { error: 'categoria_required' }
+  }
+  if (!comunaCodigo) {
+    setResponseStatus(event, 400)
+    return { error: 'comuna_required' }
+  }
+
+  const [categoriaValid, comunaValid] = await Promise.all([
+    existsActiveCategoria(categoriaSlug),
+    existsActiveComuna(comunaCodigo),
+  ])
+  if (!categoriaValid) {
+    setResponseStatus(event, 400)
+    return { error: 'invalid_categoria' }
+  }
+  if (!comunaValid) {
+    setResponseStatus(event, 400)
+    return { error: 'invalid_comuna' }
+  }
+
+  return findSearchResults(categoriaSlug, comunaCodigo)
+})

--- a/server/utils/comunas.ts
+++ b/server/utils/comunas.ts
@@ -1,5 +1,6 @@
 import { and, asc, eq } from 'drizzle-orm'
 import { comunas } from '../db/schema/comunas'
+import { comunaVecinas } from '../db/schema/comuna-vecinas'
 
 export async function findActiveComunas() {
   return useDb()
@@ -20,4 +21,15 @@ export async function existsActiveComuna(codigo: string): Promise<boolean> {
 export async function findComunaNombre(codigo: string): Promise<string | null> {
   const [row] = await useDb().select({ nombre: comunas.nombre }).from(comunas).where(eq(comunas.codigo, codigo))
   return row?.nombre ?? null
+}
+
+// Nunca devuelve una comuna inactiva, aunque comparta límite real — activar una comuna nueva no exige
+// tocar esta query, el filtro ya vive acá.
+export async function findVecinasActivas(comunaCodigo: string): Promise<{ codigo: string, nombre: string }[]> {
+  return useDb()
+    .select({ codigo: comunas.codigo, nombre: comunas.nombre })
+    .from(comunaVecinas)
+    .innerJoin(comunas, eq(comunaVecinas.vecinaCodigo, comunas.codigo))
+    .where(and(eq(comunaVecinas.comunaCodigo, comunaCodigo), eq(comunas.activa, true)))
+    .orderBy(asc(comunas.nombre))
 }

--- a/server/utils/search.test.ts
+++ b/server/utils/search.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { rankByCompleteness, type ProfessionalCompletenessInput } from './search'
+
+function input(overrides: Partial<ProfessionalCompletenessInput> = {}): ProfessionalCompletenessInput {
+  return {
+    id: 'a',
+    createdAt: new Date('2026-01-01'),
+    hasPhotos: false,
+    hasDescription: false,
+    hasPrice: false,
+    ...overrides,
+  }
+}
+
+describe('rankByCompleteness', () => {
+  it('un perfil con fotos, descripción y precio queda antes que uno con solo los campos obligatorios', () => {
+    const completo = input({ id: 'completo', hasPhotos: true, hasDescription: true, hasPrice: true })
+    const minimo = input({ id: 'minimo' })
+
+    expect(rankByCompleteness([minimo, completo]).map(r => r.id)).toEqual(['completo', 'minimo'])
+  })
+
+  it('con la misma completitud, gana el más antiguo', () => {
+    const viejo = input({ id: 'viejo', createdAt: new Date('2026-01-01') })
+    const nuevo = input({ id: 'nuevo', createdAt: new Date('2026-06-01') })
+
+    expect(rankByCompleteness([nuevo, viejo]).map(r => r.id)).toEqual(['viejo', 'nuevo'])
+  })
+
+  it('con la misma completitud y la misma fecha, gana el id menor', () => {
+    const b = input({ id: 'b' })
+    const a = input({ id: 'a' })
+
+    expect(rankByCompleteness([b, a]).map(r => r.id)).toEqual(['a', 'b'])
+  })
+})

--- a/server/utils/search.ts
+++ b/server/utils/search.ts
@@ -1,0 +1,142 @@
+import { and, eq, inArray } from 'drizzle-orm'
+import { findVecinasActivas } from './comunas'
+import { comunas } from '../db/schema/comunas'
+import { professionals } from '../db/schema/professionals'
+
+export type SearchMatchType = 'exacta' | 'vecina' | 'ninguna'
+
+export type SearchResultProfessional = {
+  id: string
+  displayName: string
+  comunaNombre: string
+  priceFrom: number | null
+  createdAt: string
+}
+
+export type SearchResult = {
+  results: SearchResultProfessional[]
+  matchType: SearchMatchType
+  categoryHasResultsInChile: boolean
+}
+
+// La forma mínima que necesita el orden, no la fila completa de professionals — evita atar el criterio
+// a columnas que no usa (contacto, categoría, estado activo).
+export type ProfessionalCompletenessInput = {
+  id: string
+  createdAt: Date
+  hasPhotos: boolean
+  hasDescription: boolean
+  hasPrice: boolean
+}
+
+type ProfessionalSearchRow = {
+  id: string
+  displayName: string
+  comunaNombre: string
+  priceFrom: number | null
+  createdAt: Date
+  photoPaths: string[]
+  description: string | null
+}
+
+function completenessScore(input: ProfessionalCompletenessInput): number {
+  return Number(input.hasPhotos) + Number(input.hasDescription) + Number(input.hasPrice)
+}
+
+// Sin Drizzle ni forma de professionals: el día que exista una señal real de calidad (reseñas, tasa de
+// respuesta) el criterio cambia acá, sin tocar cómo se leen los profesionales.
+export function rankByCompleteness(
+  inputs: ProfessionalCompletenessInput[],
+): ProfessionalCompletenessInput[] {
+  return [...inputs].sort((a, b) =>
+    completenessScore(b) - completenessScore(a)
+    || a.createdAt.getTime() - b.createdAt.getTime()
+    || a.id.localeCompare(b.id),
+  )
+}
+
+function toCompletenessInput(row: ProfessionalSearchRow): ProfessionalCompletenessInput {
+  return {
+    id: row.id,
+    createdAt: row.createdAt,
+    hasPhotos: row.photoPaths.length > 0,
+    hasDescription: Boolean(row.description),
+    hasPrice: row.priceFrom != null,
+  }
+}
+
+function toSearchResult(row: ProfessionalSearchRow): SearchResultProfessional {
+  return {
+    id: row.id,
+    displayName: row.displayName,
+    comunaNombre: row.comunaNombre,
+    priceFrom: row.priceFrom,
+    createdAt: row.createdAt.toISOString(),
+  }
+}
+
+function orderResults(rows: ProfessionalSearchRow[]): SearchResultProfessional[] {
+  const ranked = rankByCompleteness(rows.map(toCompletenessInput))
+  const rowById = new Map(rows.map(row => [row.id, row]))
+  return ranked.map(({ id }) => toSearchResult(rowById.get(id)!))
+}
+
+async function findActiveProfessionals(
+  categoriaSlug: string,
+  comunaCodigos: string[],
+): Promise<ProfessionalSearchRow[]> {
+  return useDb()
+    .select({
+      id: professionals.id,
+      displayName: professionals.displayName,
+      comunaNombre: comunas.nombre,
+      priceFrom: professionals.priceFrom,
+      createdAt: professionals.createdAt,
+      photoPaths: professionals.photoPaths,
+      description: professionals.description,
+    })
+    .from(professionals)
+    .innerJoin(comunas, eq(professionals.comunaCodigo, comunas.codigo))
+    .where(and(
+      eq(professionals.categoriaSlug, categoriaSlug),
+      inArray(professionals.comunaCodigo, comunaCodigos),
+      eq(professionals.active, true),
+    ))
+}
+
+// Se une a comunas para excluir zonas que se desactivaron — "existe en otra parte de Chile" solo cuenta
+// comunas donde alguien podría buscar hoy, no cualquier fila histórica de professionals.
+async function existsActiveProfessionalForCategoria(categoriaSlug: string): Promise<boolean> {
+  const [row] = await useDb()
+    .select({ id: professionals.id })
+    .from(professionals)
+    .innerJoin(comunas, eq(professionals.comunaCodigo, comunas.codigo))
+    .where(and(
+      eq(professionals.categoriaSlug, categoriaSlug),
+      eq(professionals.active, true),
+      eq(comunas.activa, true),
+    ))
+    .limit(1)
+  return Boolean(row)
+}
+
+export async function findSearchResults(categoriaSlug: string, comunaCodigo: string): Promise<SearchResult> {
+  const exactRows = await findActiveProfessionals(categoriaSlug, [comunaCodigo])
+  if (exactRows.length > 0) {
+    return { results: orderResults(exactRows), matchType: 'exacta', categoryHasResultsInChile: true }
+  }
+
+  const vecinas = await findVecinasActivas(comunaCodigo)
+  if (vecinas.length > 0) {
+    const vecinaRows = await findActiveProfessionals(categoriaSlug, vecinas.map(vecina => vecina.codigo))
+    if (vecinaRows.length > 0) {
+      return { results: orderResults(vecinaRows), matchType: 'vecina', categoryHasResultsInChile: true }
+    }
+  }
+
+  return {
+    results: [],
+    matchType: 'ninguna',
+    categoryHasResultsInChile: await existsActiveProfessionalForCategoria(categoriaSlug),
+  }
+}

--- a/server/utils/validation.ts
+++ b/server/utils/validation.ts
@@ -1,7 +1,16 @@
+import type { H3Event } from 'h3'
+
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 // Un id mal formado contra una columna uuid de Postgres falla con 22P02 en vez de devolver ninguna
 // fila — cada lookup público por id lo descarta antes de tocar la base.
 export function isUuid(value: string): boolean {
   return UUID_REGEX.test(value)
+}
+
+// Cada endpoint define su propio código de error (el contrato lo exige), pero la forma de la
+// respuesta — status 400 más el JSON que el cliente lee — es siempre la misma.
+export function badRequest(event: H3Event, error: string, extra?: Record<string, unknown>) {
+  setResponseStatus(event, 400)
+  return { error, ...extra }
 }


### PR DESCRIPTION
## Summary
- `GET /api/search?categoria=<slug>&comuna=<codigo>`, sin sesión: busca profesionales activos en la comuna exacta; si no hay ninguno, cae a sus comunas vecinas activas (`findVecinasActivas`, nuevo en `server/utils/comunas.ts`); si tampoco hay ahí, devuelve vacío distinguiendo si la categoría existe en otra comuna activa del país.
- `server/utils/search.ts` (dominio nuevo, no extiende `professionals.ts`): orquesta exacta → vecina → ninguna, y `rankByCompleteness()` como función pura sobre `ProfessionalCompletenessInput` (fotos+descripción+precio), separada de la query — se puede reemplazar el criterio de orden más adelante sin tocar cómo se lee `professionals`.
- Respuesta nunca incluye foto — el avatar se arma en el cliente con las iniciales, mismo criterio que el perfil público.
- Sin cambios de schema ni de RLS: lee `professionals` vía Drizzle (rol dueño, bypassea RLS) y `comuna_vecinas`, ambas ya existentes.

## Test plan
- [x] `npx nuxi typecheck` — cero errores
- [x] `npm run build` — compila
- [x] `npx vitest run server/utils/search.test.ts` — 3 tests en verde (más completo primero; empate de completitud gana el más antiguo; empate total gana el id menor)
- [x] Contra la base de desarrollo real, los 6 escenarios del contrato:
  - `categoria=electricidad&comuna=10109` (Puerto Varas, con el único profesional activo) → `matchType: exacta`
  - `categoria=electricidad&comuna=10101` (Puerto Montt, activa, sin electricistas, vecina de Puerto Varas) → `matchType: vecina`, `comunaNombre: "Puerto Varas"` (nunca la comuna buscada)
  - `categoria=electricidad&comuna=13120` (Ñuñoa, sin electricistas ni vecinas con resultados) → `matchType: ninguna`, `categoryHasResultsInChile: true`
  - `categoria=jardineria&comuna=10109` (categoría sin ningún profesional activo en el país) → `matchType: ninguna`, `categoryHasResultsInChile: false`
  - Falta `categoria` → `400 categoria_required`; falta `comuna` → `400 comuna_required`; categoría inexistente → `400 invalid_categoria`; comuna inactiva/inexistente → `400 invalid_comuna`

Detalle completo en `docs/missions/06-busqueda-resultados/ingenieria.md` (TC-001, T-001, T-002, S-002).

Closes #95

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011MB6Hu1twxCxMY8LxmVWfj