### PR TITLE
refactor(app): extraer useSlowLoad() compartido desde usePublicProfessionalProfile

### DIFF
--- a/app/composables/usePublicProfessionalProfile.ts
+++ b/app/composables/usePublicProfessionalProfile.ts
@@ -1,7 +1,5 @@
 import type { PublicProfessionalProfile } from '~/types/professional'
 
-const SLOW_LOAD_MS = 10_000
-
 // Estado local, no useState: cada visita a /profesionales/[id] es un profesional distinto, no algo que
 // deba compartirse entre páginas como useProfessionalProfile() (el propio perfil del dueño).
 export function usePublicProfessionalProfile(id: string) {
@@ -14,25 +12,7 @@ export function usePublicProfessionalProfile(id: string) {
 
   const professional = computed(() => data.value?.professional ?? null)
   const notFound = computed(() => !validId || Boolean(error.value))
-
-  // "Tardando": sigue pending pasados los 10s, sin haber resuelto ni a encontrado ni a 404.
-  const slow = ref(false)
-  let slowTimer: ReturnType<typeof setTimeout> | undefined
-
-  function clearSlowTimer() {
-    if (slowTimer) clearTimeout(slowTimer)
-    slowTimer = undefined
-  }
-
-  watch(pending, (isPending) => {
-    clearSlowTimer()
-    slow.value = false
-    if (isPending && import.meta.client) {
-      slowTimer = setTimeout(() => { slow.value = true }, SLOW_LOAD_MS)
-    }
-  }, { immediate: true })
-
-  onUnmounted(clearSlowTimer)
+  const slow = useSlowLoad(pending)
 
   return { professional, pending, notFound, slow, refresh }
 }

--- a/app/composables/useSlowLoad.test.ts
+++ b/app/composables/useSlowLoad.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import { defineComponent, nextTick, ref } from 'vue'
+import type { Ref } from 'vue'
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useSlowLoad } from './useSlowLoad'
+
+function mountUseSlowLoad(pending: Ref<boolean>, ms?: number) {
+  let slow!: ReturnType<typeof useSlowLoad>
+  const wrapper = mount(defineComponent({
+    setup() {
+      slow = useSlowLoad(pending, ms)
+      return {}
+    },
+    template: '<div />',
+  }))
+  return { wrapper, slow }
+}
+
+describe('useSlowLoad', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('activa slow si pending sigue en true después de ms', () => {
+    const pending = ref(true)
+    const { slow } = mountUseSlowLoad(pending, 1000)
+
+    expect(slow.value).toBe(false)
+    vi.advanceTimersByTime(1000)
+    expect(slow.value).toBe(true)
+  })
+
+  it('no activa slow si pending vuelve a false antes de ms', async () => {
+    const pending = ref(true)
+    const { slow } = mountUseSlowLoad(pending, 1000)
+
+    vi.advanceTimersByTime(500)
+    pending.value = false
+    await nextTick()
+    vi.advanceTimersByTime(1000)
+
+    expect(slow.value).toBe(false)
+  })
+
+  it('desmontar el componente no deja ningún timer pendiente', () => {
+    const pending = ref(true)
+    const { wrapper } = mountUseSlowLoad(pending, 1000)
+
+    expect(vi.getTimerCount()).toBeGreaterThan(0)
+    wrapper.unmount()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})

--- a/app/composables/useSlowLoad.ts
+++ b/app/composables/useSlowLoad.ts
@@ -1,0 +1,29 @@
+import { onUnmounted, ref, watch } from 'vue'
+import type { Ref } from 'vue'
+
+const DEFAULT_SLOW_MS = 10_000
+
+// ref/watch/onUnmounted importados explícitos, y typeof window en vez de import.meta.client: así se
+// puede testear con Vitest + vi.useFakeTimers() sin levantar un contexto de Nuxt completo — mismo
+// criterio que CatalogSelect.vue.
+export function useSlowLoad(pending: Ref<boolean>, ms = DEFAULT_SLOW_MS): Ref<boolean> {
+  const slow = ref(false)
+  let timer: ReturnType<typeof setTimeout> | undefined
+
+  function clearSlowTimer() {
+    if (timer) clearTimeout(timer)
+    timer = undefined
+  }
+
+  watch(pending, (isPending) => {
+    clearSlowTimer()
+    slow.value = false
+    if (isPending && typeof window !== 'undefined') {
+      timer = setTimeout(() => { slow.value = true }, ms)
+    }
+  }, { immediate: true })
+
+  onUnmounted(clearSlowTimer)
+
+  return slow
+}


### PR DESCRIPTION
## Summary
- `app/composables/useSlowLoad.ts` (nuevo): `useSlowLoad(pending, ms = 10_000)` — el timer de "tardando" que hoy vivía a mano dentro de `usePublicProfessionalProfile`, sin cambiar ningún comportamiento observable. Lo necesita también la vista de búsqueda (#97).
- `ref`/`watch`/`onUnmounted` importados explícitos, y `typeof window` en vez de `import.meta.client`: mismo criterio ya usado en `CatalogSelect.vue` para poder testear con Vitest + Vue Test Utils sin levantar un contexto de Nuxt completo (el proyecto no tiene el plugin de auto-import de Nuxt cargado en `vitest.config.ts`, así que `import.meta.client` evalúa `undefined` en los tests — `typeof window` se comporta igual en SSR real y sí es verificable en jsdom).
- `usePublicProfessionalProfile.ts` ahora delega en `useSlowLoad(pending)` — pasa de 38 a 16 líneas.

## Test plan
- [x] `npx nuxi typecheck` — cero errores
- [x] `npm run build` — compila
- [x] `npx vitest run` — 27 tests en verde (los 3 nuevos de `useSlowLoad`: activa `slow` tras `ms`; no lo activa si `pending` baja antes; desmontar no deja timers pendientes, verificado con `vi.getTimerCount()`)
- [x] Contra la base de desarrollo real, `npm run dev` y `GET /profesionales/<id>` siguen sirviendo los datos sin error — el refactor no cambió el comportamiento observable

Detalle completo en `docs/missions/06-busqueda-resultados/ingenieria.md` (TC-002, T-004, S-003).

Closes #96

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011MB6Hu1twxCxMY8LxmVWfj