### PR TITLE
feat(app): vista de resultados de búsqueda /buscar

### DIFF
--- a/app/components/CatalogSelect.vue
+++ b/app/components/CatalogSelect.vue
@@ -121,6 +121,8 @@ function selectItem(item: CatalogOption) {
 function retry() {
   emit('retry')
 }
+
+defineExpose({ focus: () => uInputRef.value?.inputRef?.focus() })
 </script>
 
 <template>

--- a/app/components/ComunaSelect.vue
+++ b/app/components/ComunaSelect.vue
@@ -1,10 +1,14 @@
 <script setup lang="ts">
 const modelValue = defineModel<string | null>()
 const { items, pending, error, refresh } = useComunasCatalog()
+const catalogSelect = useTemplateRef('catalogSelect')
+
+defineExpose({ focus: () => catalogSelect.value?.focus() })
 </script>
 
 <template>
   <CatalogSelect
+    ref="catalogSelect"
     v-model="modelValue"
     :items
     :pending

--- a/app/components/professional-public/ProfessionalPublicPhotos.vue
+++ b/app/components/professional-public/ProfessionalPublicPhotos.vue
@@ -4,10 +4,6 @@ defineProps<{
   displayName: string
 }>()
 
-function initials(name: string): string {
-  return name.trim().split(/\s+/).slice(0, 2).map(part => part[0]?.toUpperCase() ?? '').join('')
-}
-
 // La tira de miniaturas es solo un atajo de navegación sobre el mismo carrusel — activeIndex refleja
 // el slide actual (evento select de UCarousel) para resaltar cuál mira el visitante, y clickear una
 // miniatura mueve ese mismo carrusel en vez de duplicar su estado.

--- a/app/components/search/SearchEmptyState.vue
+++ b/app/components/search/SearchEmptyState.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+import { Search } from '@lucide/vue'
+
+defineProps<{ title: string, subtitle: string }>()
+</script>
+
+<template>
+  <div class="flex flex-1 flex-col items-center justify-center gap-2 p-8 text-center">
+    <Search class="h-10 w-10 text-datealo-muted" />
+    <h1 class="mt-2 text-base font-extrabold text-datealo-text">{{ title }}</h1>
+    <p class="text-sm text-datealo-muted">{{ subtitle }}</p>
+  </div>
+</template>

--- a/app/components/search/SearchResultCard.vue
+++ b/app/components/search/SearchResultCard.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import type { SearchResultProfessional } from '~/types/search'
+
+const props = defineProps<{
+  professional: SearchResultProfessional
+  vecina?: boolean
+}>()
+
+const memberSince = computed(() => formatMemberSince(props.professional.createdAt))
+</script>
+
+<template>
+  <NuxtLink
+    :to="`/profesionales/${professional.id}`"
+    class="flex gap-3 rounded-2xl border border-datealo-surface p-3.5"
+  >
+    <div
+      class="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-primary text-[0.9375rem] font-extrabold text-white"
+    >
+      {{ initials(professional.displayName) }}
+    </div>
+    <div class="min-w-0 flex-1">
+      <p class="truncate text-sm font-bold text-datealo-text">{{ professional.displayName }}</p>
+      <!-- en negrita en modo vecina: el peso visual, no solo el texto, tiene que avisar que esta comuna
+           no es la que se pidió — así el fallback nunca se lee como un resultado real de la exacta -->
+      <p class="truncate text-xs" :class="vecina ? 'font-bold text-datealo-text' : 'text-datealo-muted'">
+        {{ professional.comunaNombre }}
+      </p>
+      <p v-if="professional.priceFrom" class="mt-1 text-xs font-bold text-datealo-text">
+        Desde ${{ formatPriceFrom(professional.priceFrom) }}
+      </p>
+      <p class="mt-0.5 text-[0.6875rem] text-datealo-muted">En Datealo desde {{ memberSince }}</p>
+    </div>
+  </NuxtLink>
+</template>

--- a/app/components/search/SearchResultCard.vue
+++ b/app/components/search/SearchResultCard.vue
@@ -12,7 +12,7 @@ const memberSince = computed(() => formatMemberSince(props.professional.createdA
 <template>
   <NuxtLink
     :to="`/profesionales/${professional.id}`"
-    class="flex gap-3 rounded-2xl border border-datealo-surface p-3.5"
+    class="flex gap-3 rounded-2xl border border-datealo-surface bg-white p-3.5"
   >
     <div
       class="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-primary text-[0.9375rem] font-extrabold text-white"

--- a/app/composables/useSearchResults.ts
+++ b/app/composables/useSearchResults.ts
@@ -1,0 +1,36 @@
+import type { Ref } from 'vue'
+import type { SearchApiResponse, SearchMatchType, SearchResultProfessional } from '~/types/search'
+
+// immediate/watch en false: no dispara ninguna request hasta que categoría y comuna tengan valor —
+// "todavía no se buscó" y "se buscó y no hay nada" tienen que quedar como dos estados distintos, y
+// dejar que useFetch dispare solo con la query vacía los mezclaría en uno.
+export function useSearchResults(categoriaSlug: Ref<string | null>, comunaCodigo: Ref<string | null>) {
+  const ready = computed(() => Boolean(categoriaSlug.value) && Boolean(comunaCodigo.value))
+
+  const { data, pending, error, refresh } = useFetch<SearchApiResponse>('/api/search', {
+    key: 'search-results',
+    query: computed(() => ({ categoria: categoriaSlug.value, comuna: comunaCodigo.value })),
+    immediate: false,
+    watch: false,
+  })
+
+  watch([categoriaSlug, comunaCodigo], () => {
+    if (ready.value) refresh()
+  }, { immediate: true })
+
+  const results = computed<SearchResultProfessional[]>(() => data.value?.results ?? [])
+  const matchType = computed<SearchMatchType | null>(() => data.value?.matchType ?? null)
+  const categoryHasResultsInChile = computed(() => data.value?.categoryHasResultsInChile ?? true)
+  const slow = useSlowLoad(pending)
+
+  return {
+    ready,
+    pending,
+    error: computed(() => Boolean(error.value)),
+    results,
+    matchType,
+    categoryHasResultsInChile,
+    slow,
+    refresh,
+  }
+}

--- a/app/pages/buscar/index.vue
+++ b/app/pages/buscar/index.vue
@@ -39,8 +39,18 @@ useSeoMeta({
 <template>
   <div class="flex min-h-screen flex-col">
     <div class="sticky top-0 z-10 flex gap-2 border-b border-datealo-surface bg-datealo-bg p-3.5">
-      <CategoriaSelect v-model="categoriaSlug" class="flex-1" />
-      <ComunaSelect ref="comunaSelect" v-model="comunaCodigo" class="flex-1" />
+      <div class="flex-1">
+        <label for="buscar-categoria" class="mb-1 block text-[0.625rem] font-bold uppercase tracking-wide text-datealo-muted">
+          Categoría
+        </label>
+        <CategoriaSelect id="buscar-categoria" v-model="categoriaSlug" />
+      </div>
+      <div class="flex-1">
+        <label for="buscar-comuna" class="mb-1 block text-[0.625rem] font-bold uppercase tracking-wide text-datealo-muted">
+          Comuna
+        </label>
+        <ComunaSelect id="buscar-comuna" ref="comunaSelect" v-model="comunaCodigo" />
+      </div>
     </div>
 
     <SearchEmptyState

--- a/app/pages/buscar/index.vue
+++ b/app/pages/buscar/index.vue
@@ -70,7 +70,7 @@ useSeoMeta({
 
     <!-- cargando -->
     <div v-else-if="pending" class="flex flex-col gap-3 p-4" aria-busy="true">
-      <div v-for="n in 4" :key="n" class="flex gap-3 rounded-2xl border border-datealo-surface p-3.5">
+      <div v-for="n in 4" :key="n" class="flex gap-3 rounded-2xl border border-datealo-surface bg-white p-3.5">
         <div class="h-12 w-12 shrink-0 animate-pulse rounded-full bg-datealo-surface" />
         <div class="flex-1 space-y-2">
           <div class="h-4 w-32 animate-pulse rounded bg-datealo-surface" />

--- a/app/pages/buscar/index.vue
+++ b/app/pages/buscar/index.vue
@@ -1,0 +1,116 @@
+<script setup lang="ts">
+import { Hourglass } from '@lucide/vue'
+
+const route = useRoute()
+const router = useRouter()
+
+const categoriaSlug = ref(typeof route.query.categoria === 'string' ? route.query.categoria : null)
+const comunaCodigo = ref(typeof route.query.comuna === 'string' ? route.query.comuna : null)
+
+// Refleja la elección en la URL para que un link de búsqueda ya armado se pueda compartir — replace, no
+// push, así cada cambio de selector no le agrega una entrada nueva al historial.
+watch([categoriaSlug, comunaCodigo], ([categoria, comuna]) => {
+  const query: Record<string, string> = {}
+  if (categoria) query.categoria = categoria
+  if (comuna) query.comuna = comuna
+  router.replace({ query })
+})
+
+const { items: categorias } = useCategoriasCatalog()
+const { items: comunas } = useComunasCatalog()
+const categoriaNombre = computed(() => categorias.value.find(item => item.value === categoriaSlug.value)?.label ?? '')
+const comunaNombre = computed(() => comunas.value.find(item => item.value === comunaCodigo.value)?.label ?? '')
+
+const { ready, pending, error, slow, results, matchType, categoryHasResultsInChile, refresh } =
+  useSearchResults(categoriaSlug, comunaCodigo)
+
+const comunaSelect = useTemplateRef('comunaSelect')
+watch(categoriaSlug, (value) => {
+  if (value && !comunaCodigo.value) comunaSelect.value?.focus()
+})
+
+useSeoMeta({
+  title: () => categoriaNombre.value && comunaNombre.value
+    ? `${categoriaNombre.value} en ${comunaNombre.value}`
+    : 'Buscar profesionales',
+})
+</script>
+
+<template>
+  <div class="flex min-h-screen flex-col">
+    <div class="sticky top-0 z-10 flex gap-2 border-b border-datealo-surface bg-datealo-bg p-3.5">
+      <CategoriaSelect v-model="categoriaSlug" class="flex-1" />
+      <ComunaSelect ref="comunaSelect" v-model="comunaCodigo" class="flex-1" />
+    </div>
+
+    <SearchEmptyState
+      v-if="!ready"
+      :title="categoriaSlug && !comunaCodigo ? 'Elige tu comuna' : 'Elige una categoría y tu comuna'"
+      :subtitle="categoriaSlug && !comunaCodigo
+        ? `para ver profesionales de ${categoriaNombre} cerca de ti`
+        : 'para ver profesionales disponibles'"
+    />
+
+    <!-- tardando (>10s) -->
+    <div v-else-if="slow" class="flex flex-1 flex-col items-center justify-center gap-4 p-8 text-center">
+      <Hourglass class="h-10 w-10 text-datealo-muted" />
+      <h1 class="text-base font-extrabold text-datealo-text">Esto está tardando más de lo normal</h1>
+      <UButton size="lg" @click="refresh()">Reintentar</UButton>
+    </div>
+
+    <!-- cargando -->
+    <div v-else-if="pending" class="flex flex-col gap-3 p-4" aria-busy="true">
+      <div v-for="n in 4" :key="n" class="flex gap-3 rounded-2xl border border-datealo-surface p-3.5">
+        <div class="h-12 w-12 shrink-0 animate-pulse rounded-full bg-datealo-surface" />
+        <div class="flex-1 space-y-2">
+          <div class="h-4 w-32 animate-pulse rounded bg-datealo-surface" />
+          <div class="h-3 w-20 animate-pulse rounded bg-datealo-surface" />
+          <div class="h-3 w-24 animate-pulse rounded bg-datealo-surface" />
+        </div>
+      </div>
+    </div>
+
+    <div v-else-if="error" class="flex flex-1 flex-col items-center justify-center gap-4 p-8 text-center">
+      <h1 class="text-base font-extrabold text-datealo-text">No pudimos cargar los resultados</h1>
+      <UButton size="lg" @click="refresh()">Reintentar</UButton>
+    </div>
+
+    <!-- con resultados / comunas vecinas -->
+    <div v-else-if="matchType === 'exacta' || matchType === 'vecina'" class="flex flex-col gap-3 p-4 lg:p-8">
+      <template v-if="matchType === 'vecina'">
+        <div class="rounded-xl bg-datealo-surface p-3.5 text-sm text-datealo-text">
+          Todavía no hay profesionales de {{ categoriaNombre }} en {{ comunaNombre }}.
+        </div>
+        <p class="px-0.5 text-[0.6875rem] font-bold uppercase tracking-wide text-datealo-muted">
+          Cerca de {{ comunaNombre }}
+        </p>
+      </template>
+      <p v-else class="px-0.5 text-xs text-datealo-muted">
+        {{ results.length }} {{ results.length === 1 ? 'resultado' : 'resultados' }}
+      </p>
+
+      <div class="flex flex-col gap-3 lg:grid lg:grid-cols-3 lg:gap-4">
+        <SearchResultCard
+          v-for="professional in results"
+          :key="professional.id"
+          :professional="professional"
+          :vecina="matchType === 'vecina'"
+        />
+      </div>
+    </div>
+
+    <!-- sin resultados: la comuna y sus vecinas no tienen nada, pero la categoría existe en otra parte -->
+    <SearchEmptyState
+      v-else-if="matchType === 'ninguna' && categoryHasResultsInChile"
+      :title="`Todavía no hay profesionales de ${categoriaNombre} cerca de ${comunaNombre}`"
+      subtitle="Prueba con otra comuna."
+    />
+
+    <!-- sin resultados: la categoría no existe en ninguna comuna activa del país -->
+    <SearchEmptyState
+      v-else-if="matchType === 'ninguna'"
+      :title="`Todavía no hay profesionales de ${categoriaNombre} en Datealo`"
+      subtitle="Prueba con otra categoría."
+    />
+  </div>
+</template>

--- a/app/types/search.ts
+++ b/app/types/search.ts
@@ -1,0 +1,15 @@
+export type SearchMatchType = 'exacta' | 'vecina' | 'ninguna'
+
+export type SearchResultProfessional = {
+  id: string
+  displayName: string
+  comunaNombre: string
+  priceFrom: number | null
+  createdAt: string
+}
+
+export type SearchApiResponse = {
+  results: SearchResultProfessional[]
+  matchType: SearchMatchType
+  categoryHasResultsInChile: boolean
+}

--- a/app/utils/professional-initials.ts
+++ b/app/utils/professional-initials.ts
@@ -1,0 +1,3 @@
+export function initials(displayName: string): string {
+  return displayName.trim().split(/\s+/).slice(0, 2).map(part => part[0]?.toUpperCase() ?? '').join('')
+}


### PR DESCRIPTION
## Summary
- `app/pages/buscar/index.vue`: página reactiva a `?categoria=&comuna=` (ambos opcionales en la URL, sincronizados con `router.replace` al cambiar los selectores). Cubre los 8 modos del mockup validado (`design-mockups/resultados-busqueda.html`): eligiendo (con y sin categoría pre-elegida — autofoco en comuna cuando llega con categoría), cargando, tardando, con resultados, comunas vecinas y sin resultados en sus dos variantes (comuna sin oferta / categoría sin oferta en el país).
- `app/composables/useSearchResults.ts` (nuevo): fetch reactivo a `/api/search`, `immediate`/`watch` en `false` con un watch propio — así "todavía no se buscó" y "se buscó y no hay nada" quedan como dos estados distintos en vez de que useFetch dispare con la query vacía. Usa `useSlowLoad()` de #96.
- `app/components/search/SearchResultCard.vue` y `SearchEmptyState.vue` (nuevos): la card de cada resultado (comuna en negrita cuando es modo vecina) y el bloque icono+título+subtítulo que se reutiliza en eligiendo y en las dos variantes de sin resultados.
- `initials()` se extrae de `ProfessionalPublicPhotos.vue` a `app/utils/professional-initials.ts` — ya la necesitan dos componentes reales, no uno.
- `CatalogSelect.vue`/`ComunaSelect.vue` ganan un `focus()` expuesto, para el autofoco en comuna que pide `experiencia.md` al llegar con categoría pre-elegida.
- `CategoriaSelect`/`ComunaSelect` llevan su `<label>` (`Categoría`/`Comuna`, con `id`/`for`) en la barra de búsqueda — mismo patrón que ya usa `profesional/registro.vue`, corregido después de una primera versión que se apoyaba solo en el placeholder interno.
- Agrega un modo de error genérico (fetch fallido, con "Reintentar") que el mockup no cubre — no hay ningún estado documentado para una query inválida vía URL manual, pero dejar la petición fallar en silencio no es aceptable.

## Test plan
- [x] `npx nuxi typecheck` — cero errores
- [x] `npm run build` — compila
- [x] `npx vitest run` — 27 tests en verde (sin regresiones)
- [x] Verificación visual contra la base de desarrollo real (`npm run dev` + Chrome), con el único profesional activo hoy (Electricidad, Puerto Varas):
  - Eligiendo, sin categoría ni comuna → texto genérico ✓
  - Elegir "Electricidad" → autofoco real en el campo comuna, texto "Elige tu comuna para ver profesionales de Electricidad cerca de ti" ✓
  - `categoria=electricidad&comuna=10109` (Puerto Varas) → "1 resultado", card correcta ✓
  - `categoria=electricidad&comuna=10101` (Puerto Montt, vecina de Puerto Varas) → aviso + "CERCA DE PUERTO MONTT" + card con comuna real en negrita, nunca "Puerto Montt" ✓
  - `categoria=jardineria&comuna=10109` → "Todavía no hay profesionales de Jardinería en Datealo" / "Prueba con otra categoría" ✓
  - `categoria=electricidad&comuna=13120` (Ñuñoa) → "Todavía no hay profesionales de Electricidad cerca de Ñuñoa" / "Prueba con otra comuna" ✓
  - Tocar la card navega a `/profesionales/<id>` ✓
  - Labels "CATEGORÍA"/"COMUNA" visibles sobre cada campo ✓
- [ ] Grilla de 3 columnas en desktop (modo con resultados) — no verificada visualmente poblada: hoy solo existe un profesional real en la base de dev, y no correspondía fabricar datos para esto. La clase es Tailwind estándar (`lg:grid lg:grid-cols-3`), ya validada por el build.
- [ ] Modo "tardando" (>10s) — no simulado (requeriría mockear latencia de red); la lógica es la misma `useSlowLoad()` ya cubierta por sus propios tests unitarios en #96.

Detalle completo en `docs/missions/06-busqueda-resultados/ingenieria.md` (S-004) y `experiencia.md` (V-001, UXF-001).

Depende de #95 y #96 (ambos ya mergeados).

Closes #97

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011MB6Hu1twxCxMY8LxmVWfj