### PR TITLE
docs(docs): dejar vigentes producto, experiencia e ingeniería de la misión 07

### DIFF
--- a/.claude/skills/discovery-ux/SKILL.md
+++ b/.claude/skills/discovery-ux/SKILL.md
@@ -382,6 +382,22 @@ del stack:
 - **Errores de campo enlazados por accesibilidad.** Todo error de validación inline lleva
   `aria-describedby` apuntando al mensaje de error, para que un lector de pantalla lo lea junto al campo —
   nunca solo color o posición visual como señal.
+- **Toast en `bottom-right`, sin variar por dispositivo.** Una sola posición para toda la app, mobile y
+  desktop — no hay una posición distinta por breakpoint (Nuxt UI no lo soporta de forma nativa, ver
+  [issue #4370](https://github.com/nuxt/ui/issues/4370) sin resolver). `bottom-right` es el default real de
+  `useToast()` de Nuxt UI, coincide con la convención de notificaciones de Windows, y con la esquina
+  derecha en la que Windows y macOS igual convergen aunque difieran en arriba/abajo. La razón de fondo para
+  elegir abajo y no arriba: casi toda acción que dispara un toast en Datealo ocurre abajo de la pantalla
+  (un bottom sheet, el CTA de contacto fijo, un submit dentro del scroll) — el toast confirma cerca de
+  donde el usuario ya estaba mirando, sin que el ojo salte lejos de la acción que lo causó. Duración: los
+  5000ms por defecto de Nuxt UI, sin sobreescribir por flujo salvo una razón real (`duration: 0` para el
+  caso puntual que necesite cierre manual). Cierre con botón + swipe-to-dismiss en mobile (nativos del
+  componente), `aria-live="polite"`, y un `toaster.max` bajo (2-3) como resguardo barato si alguna vez se
+  disparan varios a la vez — sin lógica de cola custom. En mobile, si hay una barra fija abajo (el CTA de
+  contacto de un perfil, por ejemplo), el toast se desplaza por encima de ella con un offset de espaciado,
+  nunca cambia de posición. Un toast es solo para confirmación no crítica y transitoria — un error
+  bloqueante o cualquier información que el usuario no puede permitirse perder va inline, en un banner o en
+  un modal, nunca en un toast.
 
 ## Relación entre `experiencia.md` y `producto.md`
 

--- a/docs/missions/07-resenas-verificadas-por-contacto/README.md
+++ b/docs/missions/07-resenas-verificadas-por-contacto/README.md
@@ -2,19 +2,37 @@
 
 **Tipo:** producto. **Abierta el** 2026-08-13. **Nace de:** ninguna.
 
-**Estado de la misión:** exploración
+**Estado de la misión:** en construcción
 
-**Última actualización:** 2026-08-13
+**Última actualización:** 2026-08-31
 
 Sexta y última misión hacia el MVP (registrarse, mostrarse, buscar, reseñar). Depende de
-[misión 02](../02-base-de-datos-y-auth/) (la identidad ligera del buscador, cualquiera sea el mecanismo que
-esa misión ratifique, y el `sendEmail()` para notificar al profesional) y de
-[misión 05](../05-perfil-publico-profesional/) (el evento de contacto al que se ata cada reseña).
+[misión 02](../02-base-de-datos-y-auth/) (`sendEmail()` para notificar al profesional — la identidad
+ligera del buscador que este README mencionaba ya no aplica: [D-001](./producto.md#d-001) resuelve la
+verificación con un token de navegador, sin cuenta de ningún tipo) y de
+[misión 05](../05-perfil-publico-profesional/) (el evento de contacto al que se ata cada reseña, y su
+[Q-001](../05-perfil-publico-profesional/producto.md#q-001), que esta misión responde en
+[D-001](./producto.md#d-001)).
 
 **Documentos:** [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-**Próximo hito:** ninguno todavía — esta misión no se ha empezado a trabajar.
+**En foco:** Construcción — los cuatro documentos de discovery están vigentes. `producto.md` con sus tres
+funcionalidades y tres decisiones ([D-001](./producto.md#d-001), [D-002](./producto.md#d-002),
+[D-003](./producto.md#d-003)); `experiencia.md` **vigente — aprobado el 2026-08-30**, tras evaluación
+heurística en un agente aislado; `ingenieria.md` **vigente — aprobado el 2026-08-31**, tras dos auditorías
+independientes (la primera tumbó un diseño del token que no verificaba nada contra un contacto real; la
+segunda encontró que el documento implicaba más protección de la que hay, corregido con TR-003). De paso,
+esta misión dejó un patrón universal nuevo en "Patrones de interacción que ya están decididos" del skill
+`discovery-ux`: todo toast de Datealo va en `bottom-right`, 5000ms, sin variar por dispositivo.
+
+El plan de construcción quedó cortado en 7 slices (walking skeleton del mecanismo de verificación primero,
+UI después, correo al final — ver "Plan de construcción" de `ingenieria.md`), con sus issues ya creados:
+[#107](https://github.com/PatricioTabilo/datealo/issues/107) a
+[#113](https://github.com/PatricioTabilo/datealo/issues/113).
+
+**Próximo hito:** construir S-001 ([#107](https://github.com/PatricioTabilo/datealo/issues/107)) — extender
+`POST /contacts` con el token opcional, la base de todo lo demás.
 
 ## Brief
 
@@ -22,12 +40,15 @@ Después de contactar a un profesional, el buscador puede dejar una reseña — 
 contacto realmente ocurrió, no un formulario abierto que cualquiera llena. Es la pieza que sostiene la
 promesa de "reseñas reales, sin inventadas" que la landing ya le mostró a gente real.
 
-**Dirección a confirmar, no decisión cerrada:** la conversación de roadmap (2026-08-13) exploró verificar
-por teléfono (OTP puntual, no cuenta completa) en vez de pedirle cuenta persistente al buscador — el
-buscador no la necesita para buscar ni para contactar, por el principio de "sin fricción" de `CLAUDE.md`.
-Hay research general sobre verificación de reviews sin transacción dentro de la plataforma que la respalda,
-pero el mecanismo exacto (qué se verifica, cuándo, con qué fricción real) se define en el `producto.md` y
-`experiencia.md` de esta misión, no acá.
+**Dirección confirmada (reemplaza la propuesta original de este brief):** la conversación de roadmap
+(2026-08-13) exploró verificar por teléfono (OTP puntual) en vez de pedirle cuenta persistente al
+buscador. La investigación de esta misión ([investigacion.md](./investigacion.md)) encontró que ese
+mecanismo repite, sin razón nueva, el mismo costo de infraestructura (contratar Twilio) que
+[misión 04 ya rechazó](../04-registro-perfil-profesional/producto.md#d-001) para el profesional. La
+dirección que `producto.md` deja en su lugar — [D-001](./producto.md#d-001), aceptada el 2026-08-29 — es
+un token que el navegador guarda en el momento del contacto, sin vencimiento por tiempo: sin OTP, sin
+cuenta, sin costo de proveedor externo. `producto.md` también agrega [D-002](./producto.md#d-002): la
+reseña lleva un nombre de texto libre y opcional, nunca un teléfono.
 
 **También entra en el alcance:** cuando llega una reseña nueva, el profesional recibe un correo —
 individual por reseña, no un digest agrupado (no hay volumen todavía que lo justifique), y siempre, buena o

--- a/docs/missions/07-resenas-verificadas-por-contacto/design-mockups/perfil-resenas.html
+++ b/docs/missions/07-resenas-verificadas-por-contacto/design-mockups/perfil-resenas.html
@@ -1,0 +1,563 @@
+<!doctype html>
+<html lang="es-CL">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>V-001 Perfil con reseñas — misión 07</title>
+
+    <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+    <link
+      href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&family=Plus+Jakarta+Sans:wght@600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../../design/datealo-mockup-kit.css" />
+    <style type="text/tailwindcss">
+      @theme {
+        --color-primary: var(--ui-primary);
+        --color-secondary: var(--ui-secondary);
+        --color-success: var(--ui-success);
+        --color-error: var(--ui-error);
+      }
+    </style>
+    <style>
+      .hero-photo {
+        aspect-ratio: 4 / 3;
+        background: var(--ui-bg-accented);
+        position: relative;
+      }
+      .avatar-initials {
+        width: 5.5rem;
+        height: 5.5rem;
+        border-radius: 999px;
+        background: var(--ui-primary);
+        color: #fff;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-weight: 800;
+        font-size: 1.5rem;
+      }
+      .btn-whatsapp {
+        background: var(--ui-primary);
+        color: #fff;
+        font-weight: 700;
+        border-radius: var(--ui-radius, 0.5rem);
+      }
+      .btn-call {
+        border: 1.5px solid var(--ui-border-accented);
+        color: var(--ui-text-highlighted);
+        border-radius: var(--ui-radius, 0.5rem);
+      }
+      .since-pill {
+        display: inline-block;
+        color: var(--ui-text-muted);
+      }
+      .hero-scrim {
+        background: linear-gradient(to top, rgba(0, 0, 0, 0.45), transparent);
+      }
+      .section-card {
+        border: 1px solid var(--ui-border);
+        border-radius: 0.875rem;
+        background: var(--ui-bg);
+      }
+      .star {
+        color: #d1d5db;
+      }
+      .star.filled {
+        color: #f5b400;
+      }
+      .verified-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.25rem;
+        background: color-mix(in oklab, var(--ui-success) 12%, white);
+        color: #0d7a5f;
+        font-weight: 600;
+        border-radius: 999px;
+        padding: 0.125rem 0.5rem 0.125rem 0.375rem;
+      }
+      .cta-card {
+        border: 1.5px dashed var(--ui-border-accented);
+        border-radius: 0.875rem;
+        background: var(--ui-bg-muted);
+      }
+      .sheet-backdrop {
+        position: absolute;
+        inset: 0;
+        background: rgba(17, 24, 39, 0.45);
+      }
+      .sheet {
+        position: absolute;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background: var(--ui-bg);
+        border-radius: 1.25rem 1.25rem 0 0;
+        box-shadow: 0 -8px 24px -8px rgb(31 41 55 / 0.3);
+      }
+      .sheet-handle {
+        width: 2.5rem;
+        height: 4px;
+        border-radius: 999px;
+        background: var(--ui-border-accented);
+        margin: 0.625rem auto 0;
+      }
+      .toast {
+        position: absolute;
+        right: 1.25rem;
+        bottom: 5.5rem;
+        max-width: 80%;
+        background: var(--ui-text-highlighted);
+        color: #fff;
+        border-radius: 0.75rem;
+        font-weight: 600;
+        box-shadow: 0 8px 20px -6px rgb(31 41 55 / 0.35);
+      }
+    </style>
+  </head>
+
+  <body>
+    <div class="frames">
+      <!-- 1. encontrado, con reseñas y CTA (con token) -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-001 · modo encontrado — con reseñas, con token (buscador que ya contactó)
+          <small>extiende V-001 de misión 05: resumen de rating junto al nombre, sección de reseñas entre
+            precio y "En Datealo desde", con la card para dejar la propia (UX-001, UX-002)</small>
+        </div>
+        <div class="frame-viewport is-auto">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="pb-4">
+            <div class="hero-photo">
+              <div class="hero-scrim absolute inset-x-0 bottom-0 h-16"></div>
+            </div>
+            <div class="p-5">
+              <h1 class="text-xl font-extrabold" style="color: var(--ui-text-highlighted)">Marcelo Rojas</h1>
+              <p class="mt-0.5 text-sm" style="color: var(--ui-text-muted)">Electricidad · Ñuñoa</p>
+              <div class="mt-2 flex items-center gap-1 text-sm">
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="#f5b400"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                <span class="font-bold" style="color: var(--ui-text-highlighted)">4,7</span>
+                <span style="color: var(--ui-text-muted)">· 12 reseñas</span>
+              </div>
+
+              <p class="mt-4 text-sm leading-relaxed" style="color: var(--ui-text-highlighted)">
+                Electricista hace 8 años, atiendo Ñuñoa y Providencia.
+              </p>
+              <p class="mt-3 text-base font-bold" style="color: var(--ui-text-highlighted)">Desde $15.000</p>
+
+              <div class="mt-6">
+                <h2 class="text-sm font-extrabold" style="color: var(--ui-text-highlighted)">Reseñas</h2>
+
+                <div class="cta-card mt-3 p-4">
+                  <p class="text-sm font-bold" style="color: var(--ui-text-highlighted)">¿Cómo te fue con Marcelo?</p>
+                  <button class="btn-whatsapp mt-2.5 w-full py-2.5 text-[0.875rem]">Dejar una reseña</button>
+                </div>
+
+                <div class="section-card mt-3 p-4">
+                  <div class="flex items-center justify-between">
+                    <span class="text-sm font-bold" style="color: var(--ui-text-highlighted)">Carmen R.</span>
+                    <span class="verified-badge text-[0.6875rem]">
+                      <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M20 6L9 17l-5-5"/></svg>
+                      verificada por contacto
+                    </span>
+                  </div>
+                  <div class="mt-1 flex gap-0.5">
+                    <svg class="star filled" width="13" height="13" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                    <svg class="star filled" width="13" height="13" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                    <svg class="star filled" width="13" height="13" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                    <svg class="star filled" width="13" height="13" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                    <svg class="star filled" width="13" height="13" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                    <span class="ml-1 text-[0.6875rem]" style="color: var(--ui-text-muted)">hace 2 semanas</span>
+                  </div>
+                  <p class="mt-2 text-sm" style="color: var(--ui-text-highlighted)">
+                    Llegó puntual y dejó todo funcionando. Muy recomendado.
+                  </p>
+                </div>
+
+                <div class="section-card mt-2.5 p-4">
+                  <div class="flex items-center justify-between">
+                    <span class="text-sm font-bold" style="color: var(--ui-text-highlighted)">un cliente de Datealo</span>
+                    <span class="verified-badge text-[0.6875rem]">
+                      <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M20 6L9 17l-5-5"/></svg>
+                      verificada por contacto
+                    </span>
+                  </div>
+                  <div class="mt-1 flex gap-0.5">
+                    <svg class="star filled" width="13" height="13" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                    <svg class="star filled" width="13" height="13" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                    <svg class="star filled" width="13" height="13" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                    <svg class="star filled" width="13" height="13" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                    <svg class="star" width="13" height="13" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                    <span class="ml-1 text-[0.6875rem]" style="color: var(--ui-text-muted)">hace 1 mes</span>
+                  </div>
+                  <p class="mt-2 text-sm" style="color: var(--ui-text-highlighted)">
+                    Buena atención, precio justo. Volvería a llamarlo.
+                  </p>
+                </div>
+              </div>
+
+              <p class="since-pill mt-4 text-xs">En Datealo desde julio de 2026</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- 2. encontrado, con reseñas, sin token (CL-001: sin CTA) -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-001 · modo encontrado — con reseñas, sin token (CL-001)
+          <small>misma sección de reseñas, pero sin la card de "¿Cómo te fue?" — nadie que no contactó ve
+            una forma de dejar una reseña (UX-001)</small>
+        </div>
+        <div class="frame-viewport is-auto">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="pb-4">
+            <div class="hero-photo">
+              <div class="hero-scrim absolute inset-x-0 bottom-0 h-16"></div>
+            </div>
+            <div class="p-5">
+              <h1 class="text-xl font-extrabold" style="color: var(--ui-text-highlighted)">Marcelo Rojas</h1>
+              <p class="mt-0.5 text-sm" style="color: var(--ui-text-muted)">Electricidad · Ñuñoa</p>
+              <div class="mt-2 flex items-center gap-1 text-sm">
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="#f5b400"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                <span class="font-bold" style="color: var(--ui-text-highlighted)">4,7</span>
+                <span style="color: var(--ui-text-muted)">· 12 reseñas</span>
+              </div>
+              <p class="mt-4 text-sm leading-relaxed" style="color: var(--ui-text-highlighted)">
+                Electricista hace 8 años, atiendo Ñuñoa y Providencia.
+              </p>
+              <p class="mt-3 text-base font-bold" style="color: var(--ui-text-highlighted)">Desde $15.000</p>
+              <div class="mt-6">
+                <h2 class="text-sm font-extrabold" style="color: var(--ui-text-highlighted)">Reseñas</h2>
+                <div class="section-card mt-3 p-4">
+                  <div class="flex items-center justify-between">
+                    <span class="text-sm font-bold" style="color: var(--ui-text-highlighted)">Carmen R.</span>
+                    <span class="verified-badge text-[0.6875rem]">
+                      <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M20 6L9 17l-5-5"/></svg>
+                      verificada por contacto
+                    </span>
+                  </div>
+                  <div class="mt-1 flex gap-0.5">
+                    <svg class="star filled" width="13" height="13" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                    <svg class="star filled" width="13" height="13" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                    <svg class="star filled" width="13" height="13" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                    <svg class="star filled" width="13" height="13" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                    <svg class="star filled" width="13" height="13" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                    <span class="ml-1 text-[0.6875rem]" style="color: var(--ui-text-muted)">hace 2 semanas</span>
+                  </div>
+                  <p class="mt-2 text-sm" style="color: var(--ui-text-highlighted)">
+                    Llegó puntual y dejó todo funcionando. Muy recomendado.
+                  </p>
+                </div>
+              </div>
+              <p class="since-pill mt-4 text-xs">En Datealo desde julio de 2026</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- 3. encontrado, sin reseñas, con token (sé el primero) -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-001 · modo encontrado — sin reseñas todavía, con token
+          <small>Carmen sería la primera — la card invita a serlo en vez de mostrar un contador en cero</small>
+        </div>
+        <div class="frame-viewport is-auto">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="pb-4">
+            <div class="hero-photo flex items-center justify-center">
+              <div class="avatar-initials">HS</div>
+            </div>
+            <div class="p-5">
+              <h1 class="text-xl font-extrabold" style="color: var(--ui-text-highlighted)">Héctor Silva</h1>
+              <p class="mt-0.5 text-sm" style="color: var(--ui-text-muted)">Electricidad · Ñuñoa</p>
+              <div class="mt-6">
+                <h2 class="text-sm font-extrabold" style="color: var(--ui-text-highlighted)">Reseñas</h2>
+                <div class="cta-card mt-3 p-4">
+                  <p class="text-sm font-bold" style="color: var(--ui-text-highlighted)">Sé el primero en contarle a otros cómo te fue con Héctor</p>
+                  <button class="btn-whatsapp mt-2.5 w-full py-2.5 text-[0.875rem]">Dejar una reseña</button>
+                </div>
+              </div>
+              <p class="since-pill mt-4 text-xs">En Datealo desde agosto de 2026</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- 4. reseñando, formulario vacío -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-001 · modo reseñando — formulario nuevo, vacío
+          <small>bottom sheet sobre el perfil (Patrones de interacción ya decididos); estrellas con
+            objetivo táctil de 44×44px, comentario y nombre opcionales</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="hero-photo" style="height: 30%"></div>
+          <div class="sheet-backdrop"></div>
+          <div class="sheet p-5" style="padding-bottom: 1.5rem">
+            <div class="sheet-handle"></div>
+            <div class="mt-4 flex items-center justify-between">
+              <h2 class="text-base font-extrabold" style="color: var(--ui-text-highlighted)">Dejar una reseña</h2>
+              <button aria-label="Cerrar" style="color: var(--ui-text-muted)">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18M6 6l12 12"/></svg>
+              </button>
+            </div>
+            <p class="mt-1 text-xs" style="color: var(--ui-text-muted)">Para Marcelo Rojas · Electricidad</p>
+
+            <p class="mt-5 text-sm font-bold" style="color: var(--ui-text-highlighted)">¿Cómo calificarías a Marcelo?</p>
+            <div class="mt-2 flex gap-2">
+              <div class="star flex items-center justify-center" style="width:44px;height:44px"><svg width="28" height="28" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg></div>
+              <div class="star flex items-center justify-center" style="width:44px;height:44px"><svg width="28" height="28" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg></div>
+              <div class="star flex items-center justify-center" style="width:44px;height:44px"><svg width="28" height="28" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg></div>
+              <div class="star flex items-center justify-center" style="width:44px;height:44px"><svg width="28" height="28" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg></div>
+              <div class="star flex items-center justify-center" style="width:44px;height:44px"><svg width="28" height="28" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg></div>
+            </div>
+
+            <label class="mt-4 block text-sm font-bold" style="color: var(--ui-text-highlighted)">Cuéntale a otros cómo te fue (opcional)</label>
+            <textarea class="section-card mt-1.5 w-full p-3 text-sm" rows="3" placeholder="Ej: fue simpático, explicó bien el problema y no dejó ningún cable pelado" style="color: var(--ui-text-highlighted)"></textarea>
+            <p class="mt-1 text-right text-[0.6875rem]" style="color: var(--ui-text-muted)">0/500</p>
+
+            <label class="mt-2 block text-sm font-bold" style="color: var(--ui-text-highlighted)">Tu nombre (opcional)</label>
+            <input class="section-card mt-1.5 w-full p-3 text-sm" placeholder="Ej: Carmen" style="color: var(--ui-text-highlighted)" />
+            <p class="mt-1 text-[0.6875rem]" style="color: var(--ui-text-muted)">Si lo dejas en blanco, aparecerás como "un cliente de Datealo"</p>
+
+            <button class="btn-whatsapp mt-4 w-full py-3.5 text-[0.9375rem]" style="opacity:.5">Publicar reseña</button>
+          </div>
+        </div>
+      </section>
+
+      <!-- 5. reseñando, error de envío -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-001 · modo reseñando — error de envío
+          <small>el sheet no se cierra, todo lo tecleado sigue intacto, el mensaje nunca menciona el token
+            ni la verificación (Decisiones que no deben quedar implícitas, UXF-001)</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="hero-photo" style="height: 30%"></div>
+          <div class="sheet-backdrop"></div>
+          <div class="sheet p-5" style="padding-bottom: 1.5rem">
+            <div class="sheet-handle"></div>
+            <div class="mt-4 flex items-center justify-between">
+              <h2 class="text-base font-extrabold" style="color: var(--ui-text-highlighted)">Dejar una reseña</h2>
+              <button aria-label="Cerrar" style="color: var(--ui-text-muted)">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18M6 6l12 12"/></svg>
+              </button>
+            </div>
+            <p class="mt-1 text-xs" style="color: var(--ui-text-muted)">Para Marcelo Rojas · Electricidad</p>
+
+            <p class="mt-5 text-sm font-bold" style="color: var(--ui-text-highlighted)">¿Cómo calificarías a Marcelo?</p>
+            <div class="mt-2 flex gap-2">
+              <div class="star filled flex items-center justify-center" style="width:44px;height:44px"><svg width="28" height="28" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg></div>
+              <div class="star filled flex items-center justify-center" style="width:44px;height:44px"><svg width="28" height="28" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg></div>
+              <div class="star filled flex items-center justify-center" style="width:44px;height:44px"><svg width="28" height="28" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg></div>
+              <div class="star flex items-center justify-center" style="width:44px;height:44px"><svg width="28" height="28" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg></div>
+              <div class="star flex items-center justify-center" style="width:44px;height:44px"><svg width="28" height="28" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg></div>
+            </div>
+
+            <label class="mt-4 block text-sm font-bold" style="color: var(--ui-text-highlighted)">Cuéntale a otros cómo te fue (opcional)</label>
+            <textarea class="section-card mt-1.5 w-full p-3 text-sm" rows="3" style="color: var(--ui-text-highlighted)">Fue simpático, explicó bien el problema y quedó todo funcionando.</textarea>
+            <p class="mt-1 text-right text-[0.6875rem]" style="color: var(--ui-text-muted)">65/500</p>
+
+            <label class="mt-2 block text-sm font-bold" style="color: var(--ui-text-highlighted)">Tu nombre (opcional)</label>
+            <input class="section-card mt-1.5 w-full p-3 text-sm" value="Carmen" style="color: var(--ui-text-highlighted)" />
+
+            <p class="mt-3 text-center text-[0.8125rem] font-medium" style="color: var(--ui-error)">No pudimos publicar tu reseña. Inténtalo de nuevo.</p>
+            <button class="btn-whatsapp mt-2 w-full py-3.5 text-[0.9375rem]">Publicar reseña</button>
+          </div>
+        </div>
+      </section>
+
+      <!-- 6. reseñando, editar reseña existente (CL-003) -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-001 · modo reseñando — editando la reseña existente (CL-003)
+          <small>mismo formulario, prellenado con lo que ya publicó — Carmen entiende que está
+            reemplazando, no duplicando</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="hero-photo" style="height: 30%"></div>
+          <div class="sheet-backdrop"></div>
+          <div class="sheet p-5" style="padding-bottom: 1.5rem">
+            <div class="sheet-handle"></div>
+            <div class="mt-4 flex items-center justify-between">
+              <h2 class="text-base font-extrabold" style="color: var(--ui-text-highlighted)">Editar tu reseña</h2>
+              <button aria-label="Cerrar" style="color: var(--ui-text-muted)">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18M6 6l12 12"/></svg>
+              </button>
+            </div>
+            <p class="mt-1 text-xs" style="color: var(--ui-text-muted)">Para Marcelo Rojas · Electricidad</p>
+
+            <p class="mt-5 text-sm font-bold" style="color: var(--ui-text-highlighted)">¿Cómo calificarías a Marcelo?</p>
+            <div class="mt-2 flex gap-2">
+              <div class="star filled flex items-center justify-center" style="width:44px;height:44px"><svg width="28" height="28" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg></div>
+              <div class="star filled flex items-center justify-center" style="width:44px;height:44px"><svg width="28" height="28" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg></div>
+              <div class="star filled flex items-center justify-center" style="width:44px;height:44px"><svg width="28" height="28" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg></div>
+              <div class="star filled flex items-center justify-center" style="width:44px;height:44px"><svg width="28" height="28" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg></div>
+              <div class="star flex items-center justify-center" style="width:44px;height:44px"><svg width="28" height="28" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg></div>
+            </div>
+
+            <label class="mt-4 block text-sm font-bold" style="color: var(--ui-text-highlighted)">Cuéntale a otros cómo te fue (opcional)</label>
+            <textarea class="section-card mt-1.5 w-full p-3 text-sm" rows="3" style="color: var(--ui-text-highlighted)">Llegó puntual y dejó todo funcionando. Muy recomendado.</textarea>
+            <p class="mt-1 text-right text-[0.6875rem]" style="color: var(--ui-text-muted)">57/500</p>
+
+            <label class="mt-2 block text-sm font-bold" style="color: var(--ui-text-highlighted)">Tu nombre (opcional)</label>
+            <input class="section-card mt-1.5 w-full p-3 text-sm" value="Carmen" style="color: var(--ui-text-highlighted)" />
+
+            <button class="btn-whatsapp mt-4 w-full py-3.5 text-[0.9375rem]">Publicar reseña</button>
+          </div>
+        </div>
+      </section>
+
+      <!-- 7. encontrado, tras publicar (toast) -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-001 · modo encontrado — justo después de publicar
+          <small>tras confirmar el servidor, el sheet se cierra y la reseña aparece arriba de la lista; el
+            toast en `bottom-right` (patrón universal de Datealo, ver discovery-ux) se cierra solo a los
+            5 segundos — sin pantalla de confirmación aparte</small>
+        </div>
+        <div class="frame-viewport is-auto">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="pb-4" style="position: relative;">
+            <div class="p-5">
+              <div class="mt-2">
+                <h2 class="text-sm font-extrabold" style="color: var(--ui-text-highlighted)">Reseñas</h2>
+                <div class="section-card mt-3 p-4" style="border-color: var(--ui-primary)">
+                  <div class="flex items-center justify-between">
+                    <span class="text-sm font-bold" style="color: var(--ui-text-highlighted)">Carmen</span>
+                    <span class="verified-badge text-[0.6875rem]">
+                      <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M20 6L9 17l-5-5"/></svg>
+                      verificada por contacto
+                    </span>
+                  </div>
+                  <div class="mt-1 flex gap-0.5">
+                    <svg class="star filled" width="13" height="13" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                    <svg class="star filled" width="13" height="13" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                    <svg class="star filled" width="13" height="13" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                    <svg class="star filled" width="13" height="13" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                    <svg class="star" width="13" height="13" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                    <span class="ml-1 text-[0.6875rem]" style="color: var(--ui-text-muted)">recién</span>
+                  </div>
+                  <p class="mt-2 text-sm" style="color: var(--ui-text-highlighted)">
+                    Llegó puntual y dejó todo funcionando. Muy recomendado.
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div class="toast px-4 py-3 text-center text-sm">Reseña publicada</div>
+          </div>
+        </div>
+      </section>
+
+      <!-- 8. desktop, con reseñas -->
+      <section class="frame frame-desktop">
+        <div class="frame-label">
+          V-001 · modo encontrado — con reseñas, desktop
+          <small>la columna de datos conserva la tarjeta con borde de misión 05; las reseñas van debajo,
+            dentro de la misma columna, no en una tercera columna aparte</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="flex h-full gap-8 p-8" style="background: var(--ui-bg-muted)">
+            <div style="width: 45%;">
+              <div class="hero-photo" style="aspect-ratio: 4 / 3;"></div>
+            </div>
+            <div class="flex-1 overflow-y-auto" style="max-height: 100%;">
+              <div class="section-card p-6">
+                <h1 class="text-2xl font-extrabold" style="color: var(--ui-text-highlighted)">Marcelo Rojas</h1>
+                <p class="mt-1 text-sm" style="color: var(--ui-text-muted)">Electricidad · Ñuñoa</p>
+                <div class="mt-2 flex items-center gap-1 text-sm">
+                  <svg width="15" height="15" viewBox="0 0 24 24" fill="#f5b400"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                  <span class="font-bold" style="color: var(--ui-text-highlighted)">4,7</span>
+                  <span style="color: var(--ui-text-muted)">· 12 reseñas</span>
+                </div>
+                <p class="mt-4 text-sm leading-relaxed" style="color: var(--ui-text-highlighted)">
+                  Electricista hace 8 años, atiendo Ñuñoa y Providencia.
+                </p>
+                <p class="mt-3 text-lg font-bold" style="color: var(--ui-text-highlighted)">Desde $15.000</p>
+                <div class="mt-6 flex gap-2">
+                  <button class="btn-whatsapp flex-1 py-3.5 text-[0.9375rem]">Escribir por WhatsApp</button>
+                  <button class="btn-call w-14 py-3.5" aria-label="Llamar"></button>
+                </div>
+              </div>
+              <div class="mt-4">
+                <h2 class="text-sm font-extrabold" style="color: var(--ui-text-highlighted)">Reseñas</h2>
+                <div class="section-card mt-3 p-4">
+                  <div class="flex items-center justify-between">
+                    <span class="text-sm font-bold" style="color: var(--ui-text-highlighted)">Carmen R.</span>
+                    <span class="verified-badge text-[0.6875rem]">verificada por contacto</span>
+                  </div>
+                  <p class="mt-2 text-sm" style="color: var(--ui-text-highlighted)">Llegó puntual y dejó todo funcionando. Muy recomendado.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- 9. desktop, justo después de publicar (toast bottom-right) -->
+      <section class="frame frame-desktop">
+        <div class="frame-label">
+          V-001 · modo encontrado — desktop, justo después de publicar
+          <small>mismo toast que en mobile, mismo `bottom-right` — patrón universal de Datealo, sin variar
+            por dispositivo (ver discovery-ux)</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="flex h-full gap-8 p-8" style="background: var(--ui-bg-muted); position: relative;">
+            <div style="width: 45%;">
+              <div class="hero-photo" style="aspect-ratio: 4 / 3;"></div>
+            </div>
+            <div class="flex-1 overflow-y-auto" style="max-height: 100%;">
+              <div class="section-card p-6">
+                <h1 class="text-2xl font-extrabold" style="color: var(--ui-text-highlighted)">Marcelo Rojas</h1>
+                <p class="mt-1 text-sm" style="color: var(--ui-text-muted)">Electricidad · Ñuñoa</p>
+                <div class="mt-2 flex items-center gap-1 text-sm">
+                  <svg width="15" height="15" viewBox="0 0 24 24" fill="#f5b400"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                  <span class="font-bold" style="color: var(--ui-text-highlighted)">4,8</span>
+                  <span style="color: var(--ui-text-muted)">· 13 reseñas</span>
+                </div>
+                <p class="mt-4 text-sm leading-relaxed" style="color: var(--ui-text-highlighted)">
+                  Electricista hace 8 años, atiendo Ñuñoa y Providencia.
+                </p>
+                <p class="mt-3 text-lg font-bold" style="color: var(--ui-text-highlighted)">Desde $15.000</p>
+                <div class="mt-6 flex gap-2">
+                  <button class="btn-whatsapp flex-1 py-3.5 text-[0.9375rem]">Escribir por WhatsApp</button>
+                  <button class="btn-call w-14 py-3.5" aria-label="Llamar"></button>
+                </div>
+              </div>
+              <div class="mt-4">
+                <h2 class="text-sm font-extrabold" style="color: var(--ui-text-highlighted)">Reseñas</h2>
+                <div class="section-card mt-3 p-4" style="border-color: var(--ui-primary)">
+                  <div class="flex items-center justify-between">
+                    <span class="text-sm font-bold" style="color: var(--ui-text-highlighted)">Carmen</span>
+                    <span class="verified-badge text-[0.6875rem]">verificada por contacto</span>
+                  </div>
+                  <div class="mt-1 flex gap-0.5">
+                    <svg class="star filled" width="13" height="13" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                    <svg class="star filled" width="13" height="13" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                    <svg class="star filled" width="13" height="13" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                    <svg class="star filled" width="13" height="13" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                    <svg class="star" width="13" height="13" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                    <span class="ml-1 text-[0.6875rem]" style="color: var(--ui-text-muted)">recién</span>
+                  </div>
+                  <p class="mt-2 text-sm" style="color: var(--ui-text-highlighted)">Llegó puntual y dejó todo funcionando. Muy recomendado.</p>
+                </div>
+                <div class="section-card mt-2.5 p-4">
+                  <div class="flex items-center justify-between">
+                    <span class="text-sm font-bold" style="color: var(--ui-text-highlighted)">un cliente de Datealo</span>
+                    <span class="verified-badge text-[0.6875rem]">verificada por contacto</span>
+                  </div>
+                  <p class="mt-2 text-sm" style="color: var(--ui-text-highlighted)">Buena atención, precio justo. Volvería a llamarlo.</p>
+                </div>
+              </div>
+            </div>
+            <div class="toast px-4 py-3 text-sm" style="position: absolute; right: 2rem; bottom: 2rem; max-width: 280px;">Reseña publicada</div>
+          </div>
+        </div>
+      </section>
+    </div>
+  </body>
+</html>

--- a/docs/missions/07-resenas-verificadas-por-contacto/experiencia.md
+++ b/docs/missions/07-resenas-verificadas-por-contacto/experiencia.md
@@ -1,183 +1,380 @@
-# Misión: <nombre> — Experiencia
+# Misión: reseñas verificadas por contacto — Experiencia
 
-**Estado:** borrador
+**Estado:** vigente — aprobado por Patricio el 2026-08-30
 
-**Última actualización:** AAAA-MM-DD
+**Última actualización:** 2026-08-30
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-<!--
-Fuente de verdad para flujos, estados, contenido e interacción. No redefine reglas de producto: si el
-diseño descubre una regla nueva o invalida una, abre o actualiza una decisión en producto.md.
+## Decisión de experiencia: la reseña vive dentro del mismo perfil, sin pantalla propia
 
-Núcleo obligatorio: vistas, mapa de estados, flujos críticos y estados por superficie. Las secciones bajo
-demanda (modelo mental, jerarquía de información, validación) se agregan solo cuando una decisión las
-necesita.
+Esta misión no crea ninguna vista nueva — extiende **V-001**, el perfil público que misión 05 ya definió y
+cerró. Todo lo que agrega ocurre sobre esa misma pantalla: un resumen de rating junto al nombre, una
+sección de reseñas entre el precio y "En Datealo desde", y un formulario que se abre como bottom sheet
+sobre el perfil, nunca como una página aparte. Nada de lo que misión 05 ya decidió (jerarquía de fotos,
+botón de contacto fijo abajo, los dos botones WhatsApp/Llamar) cambia — se audita y se hereda sin tocarlo.
 
-Gate de salida — experiencia.md está lista para ingenieria.md cuando:
-- cada flujo crítico tiene secuencia, variantes, recuperación y criterio de término
-- cada estado tiene contenido concreto (texto real, información visible, acción disponible)
-- cada vista lista sus modos, y el mapa de estados cubre todas las transiciones entre ellos
-- cada modo tiene su indicador permanente de estado, y cada flujo tiene todas sus salidas documentadas
-- los casos límite de producto.md tienen flujo o estado mapeado
-- cada flujo crítico está mockeado en móvil (390px), y en desktop si también vive ahí
-- ninguna pantalla queda descrita como "similar a X" sin especificar qué cambia
--->
+La pieza que sí es nueva de verdad es que la interfaz nunca le habla al buscador del mecanismo de
+verificación (D-001 de producto.md): no hay ningún mensaje de "necesitas haber contactado para reseñar".
+Quien no tiene el token simplemente no ve ninguna forma de dejar una reseña — ni un botón bloqueado, ni una
+explicación. Es la misma filosofía que ya usa el registro de contacto de misión 05 ("el buscador nunca
+necesita saber que Datealo guardó algo"), aplicada acá: el filtro de D-001 es invisible, no un obstáculo
+visible que alguien pueda estudiar para intentar sortearlo.
 
-## Decisión de experiencia: <qué cambia para quien usa el producto>
-
-<Modelo de interacción elegido, flujo más importante y la incertidumbre que sigue abierta.>
-
-- **Funcionalidades cubiertas:** F-001, <otras>.
-- **Pendiente bloqueante:** <pregunta o "ninguna">.
+- **Funcionalidades cubiertas:** F-001, F-002, F-003.
+- **Pendiente bloqueante:** ninguna.
 
 ## Vistas
 
-<!--
-El listado de pantallas que define la experiencia — el mapa que se entrega antes de los flujos. Una línea
-por vista, sin tabla, con sus modos anidados debajo. Una vista es un destino: se llega a ella. Un modo es
-un estado de esa vista que cambia qué se puede hacer y qué se ve — se anida, nunca se lista como vista
-hermana.
+- **V-001 — Perfil público de profesional** (vista de misión 05, extendida acá) · móvil / desktop ·
+  resuelve [F-001](./producto.md#f-001), [F-002](./producto.md#f-002) · flujos UXF-001, UXF-002
+  - modo **encontrado** (de misión 05, sin cambios de fondo) — ahora su contenido puede incluir, además de
+    lo que ya definía misión 05, un resumen de rating y una sección de reseñas; ninguna de las dos cosas
+    convierte "encontrado" en un modo distinto, igual que un perfil con o sin fotos sigue siendo el mismo
+    modo (criterio ya fijado por misión 05)
+  - modo **reseñando** (nuevo) — un bottom sheet abierto sobre el perfil, con el formulario de reseña
+    activo; el perfil de atrás no se desmonta, solo queda tapado
 
-El porqué de cada vista, su trade-off o su justificación no van aquí: viven en su flujo (UXF) o en una
-decisión (UX-xxx). Regla de formato para todo el documento: las tablas se reservan para índices de celdas
-cortas; lo que lleva justificación extensa va en secciones con header + bullets, nunca en una celda.
--->
-
-- **V-001 — <vista>** · móvil / desktop · resuelve F-001 · flujos UXF-001 · pendiente
-  - modo **<nombre>** — <qué lo distingue y qué se puede hacer en él>
-  - modo **<nombre>** — <ídem>
+No hay una vista nueva para "recibir el correo de reseña nueva" (F-003) — ese contenido se documenta en
+[UXF-003](#uxf-003) como el contenido del correo mismo, no como una pantalla de Datealo.
 
 ## Mapa de estados
 
-<!--
-Vistas y flujos son listas, y una lista no muestra un camino. Esta tabla conecta los modos: qué acción
-lleva de uno a otro y qué pasa con el trabajo del usuario en cada salto. Cada fila que falte es una
-pregunta que ingeniería resuelve inventando.
--->
+| Desde                              | Acción                                              | Queda en                           | Qué pasa con el trabajo |
+| ---------------------------------------- | -------------------------------------------------------- | --------------------------------------- | ------------------------------ |
+| encontrado, con token                     | toca "Dejar una reseña"                                   | reseñando (formulario vacío)             | ninguno todavía |
+| encontrado, con token y reseña ya publicada | toca "Editar tu reseña"                                 | reseñando (formulario prellenado)        | se cargan sus datos actuales |
+| reseñando                                 | toca "Publicar reseña"                                    | encontrado, con la reseña arriba de la lista y un toast | la reseña queda guardada; si reemplazaba una anterior, esa desaparece de la lista |
+| reseñando                                 | toca cerrar (X), o el backdrop                            | encontrado, sin cambios                  | se descarta todo lo tecleado, no se guarda ni a medias |
+| reseñando                                 | falla el envío (red, servidor)                            | reseñando, con el formulario intacto y un error | nada se pierde — puede reintentar sin volver a escribir |
 
-| Desde  | Acción             | Queda en | Qué pasa con el trabajo              |
-| ------ | ------------------ | -------- | ------------------------------------ |
-| <modo> | <acción concreta>  | <modo>   | <qué se aplicó, qué quedó pendiente> |
-| <modo> | <salir sin cerrar> | <modo>   | <qué se pierde o se conserva>        |
+## UXF-001 — Dejar una reseña de un profesional
 
-## UXF-001 — <flujo principal en verbo>
+**Objetivo:** que quien ya contactó a un profesional pueda contarle a otros cómo le fue, sin crear cuenta
+ni recordar nada del contacto original. **Contrato:** [F-001](./producto.md#f-001).
 
-<!--
-Duplica por flujo crítico. Cada paso describe acción → respuesta al nivel de "el usuario toca X → Datealo
-muestra Y". Un mockup no reemplaza la secuencia porque no explica estados ni recuperación.
--->
+**Punto de entrada:** el buscador está en V-001, modo encontrado, en un perfil con el que su navegador
+generó un contacto real en algún momento (D-001 de producto.md) — sea porque acaba de tocar "Escribir por
+WhatsApp"/"Llamar" en esta misma visita, o porque volvió semanas después, como en el ejemplo de
+[Q-001 de producto.md](./producto.md#q-001).
 
-**Objetivo:** <qué se completa o comprende>. **Contrato:** [F-001](./producto.md#f-001).
+**Criterio de término:** la reseña queda publicada y visible en la sección de reseñas del mismo perfil, sin
+recargar la página ni navegar a ningún otro lado.
 
-**Punto de entrada:** <estado y superficie inicial, y qué acción trae al usuario hasta acá>.
+**Cómo sabe el usuario dónde está:** el título del sheet ("Dejar una reseña" o "Editar tu reseña") y la
+línea "Para <nombre del profesional> · <categoría>" debajo, siempre visibles arriba del formulario mientras
+está abierto.
 
-**Criterio de término:** <estado observable que confirma que el flujo terminó bien>.
+### Divergencia antes de converger
 
-**Cómo sabe el usuario dónde está:** <el elemento concreto y permanente en pantalla que se lo dice, por
-cada modo que toca este flujo>.
+Para resolver el mismo JTBD (contarle a otros cómo le fue con un profesional, sin cuenta) se generaron tres
+enfoques genuinamente distintos:
+
+- **Enfoque A — CTA oculta hasta que hay token, formulario en bottom sheet:** nadie ve una forma de
+  reseñar hasta que su navegador tiene el token de D-001; al tocar "Dejar una reseña", un bottom sheet se
+  abre sobre el perfil con el formulario.
+- **Enfoque B — CTA siempre visible junto al botón de contacto fijo, deshabilitada sin token:** un tercer
+  botón ("Reseñar") vive en la misma barra fija que ya tienen "Escribir por WhatsApp" y "Llamar"
+  (UX-002 de misión 05), atenuado y con un mensaje ("Contacta primero para poder reseñar") si no hay token.
+- **Enfoque C — formulario inline, expandido directamente en el scroll de la sección de reseñas:** sin
+  sheet ni modal; tocar "Dejar una reseña" expande el formulario ahí mismo, entre la card y la lista, como
+  un comentario de blog.
+
+**Elegido: A.** El Enfoque B mete un tercer elemento en la barra de contacto que UX-001 y UX-002 de misión
+05 dejaron deliberadamente con solo dos botones — invadir ese espacio, ya protegido por una decisión
+vigente, necesitaría una razón nueva que no existe acá, y el mensaje "Contacta primero para poder reseñar"
+le explicaría el mecanismo de D-001 a cualquiera que lo vea, exactamente lo que la Decisión de experiencia
+de este documento evita a propósito. El Enfoque C funciona, pero un formulario que vive expandido en medio
+del scroll se pierde más fácil a medio llenar (basta con seguir bajando la página) y no tiene una salida
+tan clara como "cerrar el sheet" — el usuario no sabe si scrollear lejos cuenta como cancelar o no. El
+Enfoque A además ya es un patrón decidido para Datealo ("Bottom sheets en móvil" en Patrones de interacción
+ya decididos del skill `discovery-ux`), así que no introduce nada nuevo que ingeniería tenga que resolver
+desde cero.
 
 ### Salidas
 
-<!--
-Todas las formas de irse, no solo terminar bien. El criterio de término cubre la salida buena; las otras
-son las que el usuario encuentra primero. Un modo del que no se sabe salir es un modo donde el usuario se
-pierde.
--->
-
-| Salida                | Cómo se ejecuta       | Qué queda del trabajo           |
-| --------------------- | --------------------- | ------------------------------- |
-| <termina bien>        | <acción>              | <qué se aplicó y dónde>         |
-| <descarta>            | <acción, Esc, cerrar> | <nada, ni a medias>             |
-| <abandona sin cerrar> | <navega a otra parte> | <se conserva, se pierde, avisa> |
+| Salida                       | Cómo se ejecuta                              | Qué queda del trabajo |
+| --------------------------------- | -------------------------------------------------- | -------------------------- |
+| Publica la reseña                 | toca "Publicar reseña" con al menos el rating puesto | la reseña queda visible arriba de la lista, con un toast de confirmación |
+| Cierra sin publicar                | toca la X, o el backdrop detrás del sheet           | nada se guarda — ni el rating, ni el texto tecleado |
+| El envío falla                    | error de red o del servidor al tocar "Publicar"     | el formulario sigue abierto con todo lo tecleado intacto, listo para reintentar |
+| Sale de Datealo y vuelve           | cambia de app (por ejemplo, a WhatsApp para revisar la conversación con el profesional antes de escribir el comentario) y regresa a la pestaña | si el navegador mantuvo la pestaña viva, el sheet sigue abierto con todo lo tecleado; si el sistema la descargó por falta de memoria, vuelve al perfil sin el sheet y sin lo tecleado — limitación conocida, sin borrador guardado en esta entrega |
 
 ### Secuencia principal
 
-| Paso | Acción            | Respuesta del sistema         | Información visible |
-| ---- | ----------------- | ----------------------------- | ------------------- |
-| 1    | <acción concreta> | <feedback o cambio de estado> | <dato y jerarquía>  |
+| Paso | Acción                                                         | Respuesta del sistema                                                                                             | Información visible |
+| ---- | ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| 1    | Toca "Dejar una reseña" en la card de la sección de reseñas          | Se abre el bottom sheet sobre el perfil, con transición de 200ms; el perfil de atrás queda tapado pero no se descarga | Título "Dejar una reseña", "Para Marcelo Rojas · Electricidad", 5 estrellas sin marcar |
+| 2    | Toca una estrella (objetivo táctil de 44×44px cada una)              | Se marcan esa estrella y todas las anteriores; el botón "Publicar reseña" pasa de atenuado a activo en cuanto hay al menos 1 estrella | El número de estrellas marcadas |
+| 3    | (opcional) Escribe un comentario                                     | El contador bajo el campo sube en tiempo real, hasta el máximo de 500 caracteres                                    | "<n>/500" |
+| 4    | (opcional) Escribe su nombre                                         | Se guarda tal cual lo escribe, sin validación de formato                                                            | El texto tecleado |
+| 5    | Toca "Publicar reseña"                                                | El botón muestra un spinner breve mientras se envía; si el servidor confirma, el sheet se cierra, la reseña aparece arriba de la lista y un toast en `bottom-right` confirma "Reseña publicada" por 5 segundos. Si falla, ver Variantes y recuperación — el sheet no llega a cerrarse | La reseña nueva, con su nombre (o el reemplazo si quedó en blanco), estrellas, comentario y "recién" |
 
 ### Variantes y recuperación
 
-| Condición          | Qué cambia              | Cómo se entiende    | Cómo se recupera             |
-| ------------------ | ----------------------- | ------------------- | ---------------------------- |
-| <sin resultados>   | <estado>                | <mensaje concreto>  | <acción disponible>          |
-| <sin permiso de ubicación> | <comportamiento> | <indicador visible> | <alternativa manual>         |
-| <conexión lenta>   | <skeleton, no spinner>  | <qué se ve mientras>| <qué pasa si falla>          |
+| Condición                                                        | Qué cambia                                                                              | Cómo se entiende                                                    | Cómo se recupera |
+| ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- | --------------------- |
+| Sin token para este profesional ([CL-001](./producto.md#cl-001))          | La card "¿Cómo te fue?" no existe en la sección de reseñas — no hay ningún botón que tocar         | No hay ningún indicador — el buscador nunca ve algo que no puede usar          | No aplica — es el comportamiento esperado |
+| Cambió de dispositivo desde que contactó ([CL-002](./producto.md#cl-002)) | Mismo que sin token: la card no aparece en el dispositivo nuevo                                    | Ninguno — Datealo no distingue "nunca contactó" de "contactó desde otro aparato" | No aplica — limitación conocida de D-001 |
+| Ya tiene una reseña publicada para este profesional ([CL-003](./producto.md#cl-003)) | La card dice "Editar tu reseña" en vez de "¿Cómo te fue con Marcelo?", y el sheet abre prellenado con su rating, comentario y nombre actuales | El título del sheet cambia a "Editar tu reseña"                              | Puede tocar "Publicar reseña" de nuevo sin cambiar nada, o modificar lo que quiera antes |
+| Intenta publicar sin ninguna estrella marcada                             | El botón "Publicar reseña" permanece atenuado y no responde al toque                               | El rating es el único campo con un asterisco visual junto a su pregunta        | Marca al menos una estrella |
+| El envío falla (red o servidor)                                           | El sheet no se cierra; aparece un mensaje breve sobre el botón                                     | "No pudimos publicar tu reseña. Inténtalo de nuevo."                          | Toca "Publicar reseña" de nuevo — todo lo tecleado sigue ahí |
 
 ### Decisiones que no deben quedar implícitas
 
-- <qué ocurre al cancelar, volver atrás, reintentar o confirmar>.
-- <qué cambio se guarda inmediato y cuál necesita confirmación>.
+- El botón "Publicar reseña" solo se activa con al menos 1 estrella marcada — comentario y nombre son
+  siempre opcionales, consistente con las reglas de F-001 de `producto.md`.
+- El comentario tiene un máximo de 500 caracteres, con contador visible desde el primer carácter escrito —
+  no se trunca en silencio.
+- Cerrar el sheet (X o backdrop) nunca guarda nada, ni siquiera el rating ya marcado — es una decisión de
+  todo o nada, coherente con que publicar sea la única acción que persiste algo.
+- El mensaje de error de envío nunca menciona el token ni la verificación — el mismo texto genérico cubre
+  una falla de red y una falla del filtro de D-001, para no convertir el mensaje de error en un mapa de
+  cómo funciona el mecanismo.
+- El toast usa el patrón universal de Datealo ("Patrones de interacción que ya están decididos" del skill
+  `discovery-ux`): posición `bottom-right` en mobile y desktop por igual, 5000ms (el default de Nuxt UI,
+  sin sobreescribir), botón de cerrar, y `aria-live="polite"` para que un lector de pantalla lo lea sin
+  interrumpir lo que el usuario estaba haciendo.
+- Las 5 estrellas forman un control agrupado (`role="radiogroup"`, un `aria-label` de "1 estrella" a "5
+  estrellas" por opción), operable por teclado con las flechas para moverse y espacio o enter para marcar —
+  no son solo íconos clicables sin semántica.
+- Al abrirse el sheet, el foco se mueve al título ("Dejar una reseña" o "Editar tu reseña"); al cerrarse (X,
+  backdrop, o tras publicar), el foco vuelve al botón que abrió el sheet — nunca queda flotando sobre el
+  perfil tapado.
+- Si el buscador cambia de app (por ejemplo, a WhatsApp para revisar la conversación con el profesional
+  antes de escribir el comentario) y la pestaña de Datealo sigue viva, el sheet lo espera exactamente como
+  lo dejó al volver. Si el sistema operativo descargó la pestaña por memoria, vuelve al perfil sin el sheet
+  y sin lo tecleado — riesgo aceptado en esta entrega, sin autoguardado de borrador.
+
+<a id="uxf-002"></a>
+
+## UXF-002 — Leer las reseñas de un profesional en su perfil
+
+**Objetivo:** que cualquiera que abre un perfil pueda evaluar al profesional con lo que dijeron otros que
+ya lo contactaron, sin salir de la pantalla que ya estaba leyendo. **Contrato:**
+[F-002](./producto.md#f-002). Sin divergencia propia — es una extensión de contenido sobre UXF-001 de
+misión 05 (ver el perfil), no un flujo con decisiones de interacción nuevas; el único punto de diseño
+propio es dónde entra el resumen de rating y la sección completa en la jerarquía ya fijada por misión 05,
+resuelto en [UX-002](#ux-002).
+
+**Punto de entrada:** el buscador ya está en V-001, modo encontrado — no hay una acción separada para
+"entrar" a leer reseñas, es parte del mismo scroll del perfil.
+
+**Criterio de término:** no es una acción que se completa — es contenido de lectura, igual que el resto del
+perfil. Su criterio de término es que la información esté ahí cuando el buscador llega a esa parte del
+scroll, sin tener que tocar nada para revelarla.
+
+**Cómo sabe el usuario dónde está:** el título "Reseñas" encabeza la sección, igual que cualquier otro
+bloque del perfil.
+
+### Salidas
+
+No aplica — es contenido de lectura dentro de V-001; las salidas son las mismas de UXF-001 de misión 05
+(contactar, o irse de la pantalla).
+
+### Secuencia principal
+
+| Paso | Acción                                        | Respuesta del sistema                                                                                          | Información visible |
+| ---- | -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| 1    | Hace scroll hasta después del precio                 | Ve el resumen de rating ya visible desde arriba (junto al nombre) y, más abajo, la sección "Reseñas" completa      | Rating promedio, número de reseñas, y cada reseña con nombre, estrellas, comentario, fecha relativa y su marca |
+| 2    | (si tiene token) ve la card para dejar la suya arriba de la lista | Nada cambia todavía — es solo contenido, ver UXF-001 para la interacción                              | "¿Cómo te fue con <nombre>?" o "Editar tu reseña" |
+
+### Variantes y recuperación
+
+| Condición                                                   | Qué cambia                                                                                       | Cómo se entiende                                                | Cómo se recupera |
+| ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ | --------------------- |
+| Sin ninguna reseña, sin token ([CL-003](../05-perfil-publico-profesional/producto.md#cl-003) de misión 05, sin cambios) | La sección "Reseñas" no aparece — mismo comportamiento que misión 05 ya definió para este caso            | "En Datealo desde..." ocupa el lugar donde iría, igual que hoy             | No aplica |
+| Sin ninguna reseña, con token                                       | La sección "Reseñas" aparece solo con la card "Sé el primero en contarle a otros cómo te fue con <nombre>" | El texto deja claro que sería la primera, no un error ni un estado vacío genérico | Toca "Dejar una reseña" (UXF-001) |
+| Con reseñas, sin token                                              | Aparece el resumen y la lista completa, sin ninguna card de "dejar la tuya"                                | No hay ningún indicador de por qué falta la card — invisible a propósito (ver Decisión de experiencia) | No aplica |
+| Una reseña sin comentario (solo rating)                             | La card muestra nombre, estrellas, fecha y marca, sin ningún espacio vacío donde iría el comentario         | El bloque de comentario simplemente no existe para esa card                | No aplica |
+
+### Decisiones que no deben quedar implícitas
+
+- El promedio se calcula sobre todas las reseñas visibles del profesional y se redondea a un decimal
+  ("4,7"), nunca a un entero — un promedio entero pierde precisión justo cuando hay pocas reseñas, que es
+  el caso típico al lanzamiento.
+- Las reseñas se listan de la más reciente a la más antigua, sin paginación ni "ver más" en esta entrega —
+  con la oferta y el volumen que Datealo va a tener el primer año, ningún perfil va a acumular suficientes
+  reseñas para que la lista sea incómoda de leer completa.
+- La marca "verificada por contacto" nunca se acorta a solo "verificada" en ningún lugar de la interfaz,
+  ver [UX-004](#ux-004).
+- Dos o más reseñas del mismo profesional sin nombre, sin comentario y con fechas cercanas pueden verse
+  indistinguibles entre sí — un riesgo real de que se lean como fabricadas o duplicadas, el efecto contrario
+  al que esta misión persigue. Es un riesgo conocido de [D-002 de producto.md](./producto.md#d-002) (nombre
+  opcional): no hay mitigación en esta entrega porque inventar un diferenciador artificial (ej. "reseña
+  #2") crearía una distinción que no existe en la realidad. **Reapertura:** si en la práctica varios
+  perfiles acumulan varias reseñas genéricas seguidas, se revisa junto con la reapertura de D-002.
+
+<a id="uxf-003"></a>
+
+## UXF-003 — El profesional recibe el aviso de una reseña nueva por correo
+
+**Objetivo:** que el profesional se entere de una reseña nueva sin tener que revisar Datealo por su
+cuenta. **Contrato:** [F-003](./producto.md#f-003). Sin divergencia propia — el canal (correo individual,
+vía `sendEmail()`) ya lo fija [C-005 de investigacion.md](./investigacion.md#c-005); acá se especifica solo
+el contenido.
+
+**Punto de entrada:** una reseña se publica (fin de UXF-001); no hay ninguna acción del profesional que lo
+dispare.
+
+**Criterio de término:** el correo llega a la casilla del profesional con el contenido completo de la
+reseña, sin que tenga que abrir Datealo para leerlo.
+
+**Cómo sabe el usuario dónde está:** no aplica — es un correo, no una pantalla de Datealo.
+
+### Contenido del correo
+
+| Elemento | Contenido |
+| -------- | --------- |
+| Asunto   | "Marcelo, te llegó una reseña nueva" — siempre igual, sin adelantar el rating |
+| Remitente | El mismo remitente que ya usa `sendEmail()` (misión 02) |
+| Cuerpo   | "Carmen R. te dejó una reseña en Datealo:" seguido de las estrellas y el comentario completo, tal cual se publicó — sin recortar ni resumir |
+| Si no dejó nombre | "Te llegó una reseña de un cliente de Datealo:" — mismo reemplazo que ve cualquier buscador en el perfil |
+| Si no dejó comentario | El correo muestra solo las estrellas, sin una línea vacía donde iría el comentario |
+| Cierre   | Link directo al perfil público del profesional, para que pueda ver la reseña en contexto si quiere |
+
+### Decisiones que no deben quedar implícitas
+
+- El asunto nunca adelanta el rating (ni en número ni en estrellas de emoji): una reseña de 1 estrella con
+  un solo "⭐" suelto en el asunto se leería duro antes de que el profesional tenga cualquier contexto —
+  justo lo contrario de lo que F-003 busca ("poder reaccionar", no sentirse golpeado antes de abrir el
+  correo). El mismo asunto sirve para una reseña de 5 estrellas y una de 1, sin distinción.
+- El correo no tiene ningún botón de "responder la reseña" ni de "reportarla" — ninguna de las dos existe
+  todavía (ver Fuera de alcance de `producto.md`).
+- Si `sendEmail()` falla, no hay ningún reintento visible ni aviso al buscador — la reseña ya está
+  publicada de todas formas (regla de F-003 de `producto.md`); el fallo es interno.
 
 ## Estados por superficie
 
-<!--
-El contenido es concreto: texto real, no "mensaje apropiado". El estado vacío de un marketplace
-pre-lanzamiento no es un detalle: para muchas búsquedas será el estado principal durante meses.
--->
-
-| Estado  | Qué se muestra (texto e información real) | Acción disponible                   |
-| ------- | ----------------------------------------- | ----------------------------------- |
-| inicial | <contenido>                               | <acción>                            |
-| vacío   | <por qué está vacío, con texto concreto>  | <cómo avanzar, o ninguna y por qué> |
-| carga   | <skeleton de qué forma>                   | <ninguna>                           |
-| error   | <causa útil y alcance>                    | <recuperación>                      |
+| Estado                                          | Qué se muestra (texto e información real)                                                                     | Acción disponible |
+| ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- | ---------------------- |
+| V-001, con reseñas y token                              | "Marcelo Rojas · Electricidad · Ñuñoa", "★ 4,7 · 12 reseñas", card "¿Cómo te fue con Marcelo?", lista de reseñas con nombre, estrellas, comentario, fecha y "verificada por contacto" cada una | "Dejar una reseña" + la lista para leer |
+| V-001, con reseñas, sin token                           | Igual que arriba, sin la card de dejar reseña                                                                          | Solo leer |
+| V-001, sin reseñas, con token                           | "Sé el primero en contarle a otros cómo te fue con Héctor" en vez de la lista                                          | "Dejar una reseña" |
+| V-001, sin reseñas, sin token                           | Ninguna sección de reseñas — igual que misión 05 ya definía antes de esta misión                                       | Ninguna |
+| V-001, reseñando (nueva)                                | Sheet con "Dejar una reseña", "Para Marcelo Rojas · Electricidad", 5 estrellas vacías, comentario y nombre en blanco   | "Publicar reseña" (atenuado hasta marcar una estrella) |
+| V-001, reseñando (editando)                             | Sheet con "Editar tu reseña", prellenado con rating, comentario y nombre ya guardados                                  | "Publicar reseña" |
+| V-001, reseñando, error de envío                        | "No pudimos publicar tu reseña. Inténtalo de nuevo." sobre el botón, formulario intacto                               | "Publicar reseña" (reintentar) |
+| V-001, justo después de publicar                        | La reseña nueva arriba de la lista, "recién" como fecha, toast "Reseña publicada" en `bottom-right` por 5 segundos      | Ninguna — es confirmación |
 
 ## Mockups
 
-<!--
-Los mockups viven en design-mockups/ como HTML (ver el skill discovery-ux y docs/design/README.md).
-Exploran o materializan una decisión; no son fuente de verdad de reglas de producto.
--->
+| Mockup           | Cubre                        | Estado      | Ruta |
+| ----------------- | ------------------------------- | -------------- | ------ |
+| perfil-resenas     | UXF-001, UXF-002 (V-001, extendida) | validado    | `./design-mockups/perfil-resenas.html` |
 
-| Mockup   | Cubre   | Estado                 | Ruta                              |
-| -------- | ------- | ---------------------- | --------------------------------- |
-| <nombre> | UXF-001 | exploración o validado | `./design-mockups/<archivo>.html` |
+UXF-003 (el correo) no tiene mockup en `design-mockups/` porque no es una pantalla de Datealo — su
+contenido completo está especificado como texto en la sección de UXF-003 arriba.
 
 ## Cobertura
 
-<!-- Detecta huecos antes de construir. Una funcionalidad sin pantalla nueva igual tiene estados. -->
-
-| Funcionalidad | Flujo   | Estados cubiertos       | Estado    |
-| ------------- | ------- | ----------------------- | --------- |
-| F-001         | UXF-001 | principal, vacío, error | pendiente |
+| Funcionalidad | Flujo   | Estados cubiertos                                                                                      | Estado    |
+| ------------- | ------- | ------------------------------------------------------------------------------------------------------- | --------- |
+| F-001         | UXF-001 | vacío, editando (CL-003), sin token (CL-001, CL-002), sin estrella marcada, error de envío, éxito         | vigente |
+| F-002         | UXF-002 | con reseñas + token, con reseñas sin token, sin reseñas + token, sin reseñas sin token (heredado de misión 05) | vigente |
+| F-003         | UXF-003 | contenido con nombre, contenido sin nombre, contenido sin comentario, fallo de envío                       | vigente |
 
 ## Secciones bajo demanda
 
-<!--
-Agregar solo cuando una decisión las necesite, con estos títulos:
+### Modelo mental y lenguaje
 
-- "Modelo mental y lenguaje": cuando un concepto de producto pueda confundirse en la interfaz.
-- "Jerarquía de información": cuando una superficie densa exija decidir qué se ve primero (una card de
-  resultado con foto, rating, distancia, precio y disponibilidad es exactamente ese caso).
-- "Validación (UXV-xxx)": cuando una incertidumbre de diseño necesite prueba con usuarios.
-- "Accesibilidad y adaptación": cuando el contexto de uso cambie el flujo o la representación.
--->
+"Verificada por contacto" es el único concepto de esta misión con riesgo real de confusión — puede leerse
+como "Datealo confirmó que esta persona es quien dice ser". No es eso (C-001 de `investigacion.md`), así
+que la interfaz nunca lo deja como una afirmación suelta sin poder explicarse:
+
+- La marca lleva siempre las tres palabras completas, "verificada por contacto" — nunca solo "verificada",
+  en ningún lugar (badge, `aria-label`, el asunto del correo si algún día lo menciona).
+- No hay tooltip ni ícono de información adicional sobre la marca en esta entrega — agregar una explicación
+  aparte solo para una frase de tres palabras sería resolver con UI algo que ya intenta resolver el copy.
+  **Riesgo aceptado:** esa lectura no está probada con usuarios reales — Datealo sigue sin ellos, así que
+  "ya se explica sola" es una hipótesis, no un hecho verificado. **Reapertura:** en las primeras entrevistas
+  post-lanzamiento (skill `mom-test`) preguntar explícitamente si alguien interpretó la marca como que
+  Datealo verificó la identidad de quien escribió; o si un profesional escribe preguntando qué significa —
+  cualquiera de las dos señales reabre esto como UX-xxx, sin esperar a un volumen que hoy no existe.
 
 ## Decisiones de experiencia
 
 <a id="ux-001"></a>
 
-### UX-001 — <decisión en una frase>
+### UX-001 — La opción de dejar una reseña es invisible para quien no tiene el token, nunca un botón bloqueado con explicación
 
-- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
-- **Sustento:** F-001 o <hallazgo>.
-- **Alternativas descartadas:** <opciones relevantes y trade-off, con el porqué del rechazo>.
-- **Decisión y consecuencia:** <qué flujo o superficie cambia>.
-- **Impacto en producto:** <ninguno o enlace a D-xxx/F-xxx actualizado>.
+- **Estado:** aceptada. **Fecha:** 2026-08-29.
+- **Sustento:** [D-001](./producto.md#d-001) de producto; [C-001](./investigacion.md#c-001) de
+  investigación.
+- **Alternativas descartadas:** ver "Divergencia antes de converger" de UXF-001 — CTA siempre visible junto
+  al botón de contacto, deshabilitada sin token (invade el espacio que UX-001/UX-002 de misión 05 ya
+  protegieron para solo dos botones, y el mensaje de "contacta primero" documenta el mecanismo de
+  verificación exactamente para quien más interesado está en sortearlo) y formulario inline en el scroll
+  (más fácil de abandonar a medias, sin una salida tan clara como cerrar un sheet).
+- **Decisión y consecuencia:** la sección de reseñas solo incluye la card de "dejar la tuya" cuando el
+  navegador tiene el token de D-001 para ese profesional — nunca un botón visible pero inactivo.
+- **Impacto en producto:** ninguno — es una decisión de cómo se ve, no cambia ninguna regla de F-001.
+- **Riesgo aceptado:** alguien que sí contactó de verdad pero cambió de dispositivo desde entonces
+  ([CL-002](./producto.md#cl-002)) tampoco ve ninguna señal de que la opción de reseñar existe — la
+  invisibilidad total protege contra quien nunca contactó, pero no distingue ese caso de alguien que sí lo
+  hizo, y ese costo juega en contra de [M-001](./producto.md#m-001) (cuántos contactos reales vuelven como
+  reseña). Se acepta porque cualquier señal intermedia ("parece que contactaste desde otro dispositivo")
+  seguiría exponiendo que existe un mecanismo, y hoy no hay volumen real para saber si el caso es frecuente.
+  **Reapertura:** si el seguimiento de M-001 muestra una proporción de contactos-a-reseñas más baja de lo
+  esperado y el cambio de dispositivo resulta ser una causa frecuente, se revisa una señal mínima que no
+  revele el mecanismo de D-001.
+
+<a id="ux-002"></a>
+
+### UX-002 — El resumen de rating sube junto al nombre; la sección de reseñas entra entre el precio y "En Datealo desde"
+
+- **Estado:** aceptada. **Fecha:** 2026-08-29.
+- **Sustento:** [C-001](./investigacion.md#c-001) de investigación (fotos y reseñas son las señales de
+  confianza más fuertes que Datealo puede mostrar); jerarquía de información ya fijada por UXF-001 de
+  misión 05.
+- **Alternativas descartadas:** dejar todo el contenido de reseñas junto, sin adelantar ningún resumen
+  arriba — se descarta porque esconde la señal de confianza más fuerte hasta el fondo del scroll, perdiendo
+  su efecto justo en el momento en que el buscador recién está formándose una impresión del profesional.
+  Reemplazar "En Datealo desde..." por el resumen de rating en su misma posición — se descarta porque ambos
+  datos son útiles y no hace falta sacrificar uno por el otro; conviven en dos lugares distintos del mismo
+  perfil.
+- **Decisión y consecuencia:** la jerarquía de misión 05 (foto → nombre/categoría/comuna → descripción →
+  precio → "En Datealo desde" → contacto) queda extendida así: el resumen de rating se agrega en la línea
+  siguiente a nombre/categoría/comuna (no la reemplaza), y la sección completa de reseñas se inserta entre
+  precio y "En Datealo desde".
+- **Impacto en producto:** ninguno.
+
+<a id="ux-003"></a>
+
+### UX-003 — El formulario de reseña es un bottom sheet sobre el perfil, no una página ni un modal de pantalla completa
+
+- **Estado:** aceptada. **Fecha:** 2026-08-29.
+- **Sustento:** "Patrones de interacción que ya están decididos" del skill `discovery-ux` (bottom sheets en
+  móvil); ver "Divergencia antes de converger" de UXF-001.
+- **Alternativas descartadas:** ver UXF-001 — formulario inline expandido en el scroll (más fácil de
+  perder a medio llenar) y una página nueva dedicada (rompería la Decisión de experiencia de esta misión de
+  no crear ninguna vista nueva, sin ninguna razón que lo justifique: tres campos no necesitan su propia URL).
+- **Decisión y consecuencia:** el sheet cubre parcialmente el perfil (el hero de foto queda visible arriba,
+  recortado), con backdrop semitransparente y `border-radius` solo en las esquinas superiores — layout
+  exacto en el mockup.
+- **Impacto en producto:** ninguno.
+
+<a id="ux-004"></a>
+
+### UX-004 — "Verificada por contacto" nunca se abrevia, en ningún texto de la interfaz
+
+- **Estado:** aceptada. **Fecha:** 2026-08-29.
+- **Sustento:** [C-001](./investigacion.md#c-001) de investigación — Datealo solo puede respaldar que hubo
+  un contacto real, no la identidad de quien reseñó.
+- **Alternativas descartadas:** usar solo "verificada" por espacio (la card es angosta en móvil) — se
+  descarta porque es exactamente la lectura equivocada que C-001 identificó como riesgo: sonaría a que
+  Datealo verificó a la persona, no el contacto.
+- **Decisión y consecuencia:** el badge siempre lleva el texto completo "verificada por contacto", incluso
+  si eso obliga a que ocupe dos líneas en pantallas angostas — nunca se trunca ni se reemplaza por un ícono
+  solo.
+- **Impacto en producto:** ninguno — ya era la redacción de [F-002 de producto.md](./producto.md#f-002);
+  esta decisión solo fija que la interfaz nunca la abrevia.
 
 ## Preguntas
 
-<!--
-Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
-Estado: abierta | resuelta AAAA-MM-DD | disuelta AAAA-MM-DD. Solo las abiertas llevan bloque de detalle.
--->
+Ninguna pregunta abierta bloquea esta misión.
 
-<Una frase que responde "¿qué falta?": la pregunta que bloquea construcción y qué bloquea.>
-
-| ID      | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
-| ------- | ---------------------- | ------------------- | --------------------------------------------------------------- |
-| UXQ-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
-| UXQ-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |
+| ID | La duda | Estado | Respuesta, o quién la resuelve |
+| -- | ------- | ------ | ------------------------------- |
+| —  | —       | —      | sin preguntas abiertas propias de experiencia |

--- a/docs/missions/07-resenas-verificadas-por-contacto/ingenieria.md
+++ b/docs/missions/07-resenas-verificadas-por-contacto/ingenieria.md
@@ -1,162 +1,372 @@
-# Misión: <nombre> — Ingeniería
+# Misión: reseñas verificadas por contacto — Ingeniería
 
-**Estado:** borrador
+**Estado:** vigente — aprobado por Patricio el 2026-08-31
 
-**Última actualización:** AAAA-MM-DD
+**Última actualización:** 2026-08-31
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-<!--
-Fuente de verdad para arquitectura, datos, contratos, factibilidad y pruebas. Consume el comportamiento
-definido en producto. Una limitación técnica cambia el alcance solo mediante una decisión explícita en
-producto.md.
+## Decisión técnica: el token nace atado al contacto real, no a un endpoint aparte
 
-Núcleo obligatorio: contratos, modelo de datos, RLS y riesgos de factibilidad. Las secciones bajo demanda
-(migración, rendimiento, entrega por etapas) se agregan solo cuando el riesgo lo justifica.
+Una primera versión de este diseño registraba el token en un endpoint nuevo, separado del que ya registra
+el contacto (`POST /api/professionals/[id]/contacts`, TC-002 de misión 05). Una auditoría independiente lo
+tumbó: sin ninguna relación entre las dos tablas, cualquiera podía llamar al endpoint del token directo
+(público, sin sesión, descubrible en el bundle del cliente) y obtener un token "válido" sin haber tocado
+nunca "Escribir por WhatsApp" ni "Llamar" — funcionalmente igual al formulario completamente abierto que
+[D-001 de producto.md](./producto.md#d-001) descarta explícitamente por exponer a los profesionales al
+mismo patrón de reseñas falsas que sufren los negocios chicos sin defensa
+([C-004 de investigacion.md](./investigacion.md#c-004)).
 
-Gate de salida — ingenieria.md está lista para construir cuando:
-- los contratos definen qué entra, qué sale y qué invariantes se mantienen, sin ambigüedad
-- el modelo de datos soporta los casos límite de producto.md sin workarounds
-- el impacto en RLS está resuelto: qué policy se crea o cambia, o por qué ninguna
-- la migración de datos existentes tiene estrategia o está explícitamente fuera del alcance
-- los escenarios verificables de producto están mapeados a pruebas
-- el plan de construcción corta el diseño en slices atómicos ordenados (un slice = un Issue = un PR)
--->
+La corrección: el token se registra **en la misma request** que ya registra el contacto real. Eso significa
+extender `POST /api/professionals/[id]/contacts` (TC-001 de este documento, que reemplaza y extiende TC-002
+de misión 05) con un body JSON opcional — el primer cambio real a un contrato de una misión cerrada que
+hace este diseño, nombrado explícito acá y no en silencio. Sigue disparándose con `sendBeacon`, sigue sin
+leer la respuesta (T-003 de misión 05 intacto); lo único que cambia es que ahora puede llevar un `token`
+opaco que no identifica a nadie (D-002 de esa misma misión sigue vigente). Con esto, un token solo puede
+existir si nació en el mismo momento que una fila real de `professional_contact_events` — fabricar uno
+cuesta exactamente lo mismo que fabricar un contacto falso, que ya era el límite aceptado por D-001 desde
+antes de esta misión, no una puerta nueva.
 
-## Decisión técnica: <arquitectura y riesgo principal>
+Las reseñas viven en su propia tabla (`reviews`), con un `token` que nunca se expone en ninguna respuesta
+pública. El correo al profesional (F-003) necesita su email, que hoy solo vive en `auth.users` de Supabase
+— se copia a una columna nueva `professionals.email` en el registro (extiende misión 04), en vez de leer el
+schema interno de Supabase Auth desde Drizzle.
 
-<Dirección técnica, trade-off principal y el riesgo que todavía podría invalidarla.>
+**Qué protege este mecanismo, dicho en voz alta, y qué no.** Una segunda auditoría marcó que el documento
+implicaba más protección de la que hay: el costo real de fabricar una reseña falsa sigue siendo dos llamadas
+HTTP sin sesión (`POST /contacts` con un `token` inventado, después `POST /reviews` con ese mismo token) —
+sin rate limit, sin CAPTCHA, sin ninguna verificación adicional. Es, en los hechos, casi el mismo costo que
+el formulario completamente abierto que D-001 rechaza — pero solo para quien está dispuesto a escribir dos
+`fetch()`. Lo que el mecanismo eleva es la fricción para un buscador casual usando la interfaz (que nunca ve
+un botón de reseñar sin haber contactado de verdad, UX-001 de `experiencia.md`), no la resistencia contra un
+script. Esto es consistente con lo que D-001 ya acepta explícitamente ("no impide el abuso al cien por
+ciento"), pero el documento no lo decía con esta claridad — queda dicho acá, y como TR-003 en Riesgos.
 
-- **Contratos de producto cubiertos:** F-001, <otros>.
-- **Riesgo bloqueante:** <incertidumbre o "ninguna">.
+- **Contratos de producto cubiertos:** F-001, F-002, F-003, D-001, D-002, D-003.
+- **Riesgo bloqueante:** ninguno — los riesgos reales (TR-001 a TR-003 más abajo) son conocidos y aceptados,
+  no bloquean esta entrega.
 
-## Arquitectura: <cómo se divide la responsabilidad>
+## Vocabulario ↔ entidades
 
-<!--
-La lógica de negocio se separa de la infraestructura: funciones puras en utils/ y server/utils/,
-reactividad en composables, acceso a datos en server/api/ con Drizzle. Incluye diagrama solo cuando tres o
-más partes interactúan.
--->
+| Término de producto        | Entidad/campo en código                                                          |
+| --------------------------- | --------------------------------------------------------------------------------- |
+| reseña                      | `reviews`                                                                          |
+| token de contacto (D-001)   | `professional_contact_tokens.token`                                               |
+| "verificada por contacto"   | no es una columna — es que exista una fila en `professional_contact_tokens` con ese `(professionalId, token)`, nacida en el mismo request que un contacto real |
+| "un cliente de Datealo"     | `reviews.name IS NULL`, resuelto en la capa de presentación, nunca guardado como texto |
 
-<Descripción del enfoque y por qué satisface los contratos con menor riesgo.>
+## Arquitectura: el token nace atado al contacto real; el servidor nunca confía en un token que no vino acompañado de uno
 
-| Componente | Responsabilidad       | No debe decidir | Contratos |
-| ---------- | --------------------- | --------------- | --------- |
-| <nombre>   | <una responsabilidad> | <frontera>      | F-001     |
+```
+Buscador (browser)                                    Servidor                                          DB
+  crypto.randomUUID() → localStorage
+  click "WhatsApp"/"Llamar"
+    └─ sendBeacon(…/contacts, body: {token}) ──POST, sin esperar──> TC-001 (extiende TC-002 misión 05) ──> professional_contact_events
+                                                                        └─ si el token tiene forma válida ──> professional_contact_tokens
+
+  bottom sheet "Publicar reseña"     ──fetch, espera──────────────> TC-002 (nuevo, upsert)              ──> reviews
+                                                                        └─ event.waitUntil(sendEmail()) ──> Resend (F-003)
+
+  GET /profesionales/[id]            ──fetch───────────────────────> TC-003 (extiende TC-001 misión 05)  ──> professionals + reviews (Promise.all)
+```
+
+| Componente                                                   | Responsabilidad                                                        | No debe decidir                              | Contratos      |
+| -------------------------------------------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------ | -------------- |
+| `server/utils/professional-contact-tokens.ts` (nuevo)          | Registrar un token junto a un contacto real; verificar que un token corresponde a uno | Forma de la reseña, envío de correo                | TC-001, TC-002 |
+| `server/utils/reviews.ts` (nuevo)                               | Reglas puras: validar rating/comentario, resolver nombre en blanco, upsert, promedio, construir el correo de F-003 (`buildReviewNotificationEmail`, igual que `buildProfessionalWelcomeEmail` en misión 04) | Verificar el token (capa anterior)               | TC-002, TC-003 |
+| `server/utils/professionals.ts` (extendido)                    | Exponer `email` internamente para F-003, sin agregarlo a ninguna forma pública | Enviar el correo (eso es el handler), construir su contenido (eso es `reviews.ts`) | TC-002         |
+| `server/api/professionals/[id]/contacts.post.ts` (extendido, misión 05) | I/O: valida forma de `id`, llama a `professional-contact-events.ts` y, si viene `token`, a `professional-contact-tokens.ts` | Generar el token (lo genera el cliente)          | TC-001         |
+| `server/api/professionals/[id]/reviews.post.ts` (nuevo)        | I/O: verifica token, llama a `reviews.ts`, dispara el correo sin esperarlo   | Construir el HTML del correo                     | TC-002, F-003  |
+| `server/api/professionals/[id].get.ts` (extendido)              | Orquesta `professionals` + `reviews` en una sola respuesta                  | Ninguna regla propia — solo compone               | TC-003         |
+| `app/composables/useReviewToken.ts` (nuevo)                    | Generar, guardar y leer el token por profesional en `localStorage`          | Nada de red                                       | UXF-001        |
+| `app/components/professional-public/ProfessionalPublicContactBar.vue` (extendido) | Lee/genera el token antes de disparar `sendBeacon`, ahora con body | Nada — sigue sin saber qué hace el servidor con eso | UXF-001        |
+
+`server/utils/professional-contact-tokens.ts` y `server/utils/reviews.ts` quedan como dos archivos de
+dominio separados (A-006): verificar un token y aplicar las reglas de una reseña son dos responsabilidades
+distintas que cambian por motivos distintos. La tabla del token tampoco se fusiona dentro de
+`professional_contact_events` como una columna nullable — esa tabla existe, por diseño de misión 05, para
+nunca llevar nada que identifique a quien contacta (D-002 de esa misión); agregarle una columna que sirve
+exactamente como credencial de verificación cambiaría lo que esa tabla promete ser, incluso en las filas
+donde quedara en blanco. Son dos conceptos de dominio distintos — un registro anónimo de hechos, y un
+registro de autorización — aunque nazcan en el mismo request.
+
+**Ownership de `server/api/professionals/[id]/contacts.post.ts`:** este archivo pasa a ser infraestructura
+compartida entre misión 05 (registrar el contacto) y misión 07 (registrar el token), no exclusivo de
+ninguna de las dos — queda nombrado acá para que quien lo toque después no asuma que es "de misión 05" y
+edite sin ver el efecto sobre el token, o viceversa.
 
 ## Contratos
 
-<!--
-Cada contrato especifica entrada, salida e invariantes al nivel en que se puede implementar sin reuniones
-de aclaración. Incluye los errores observables y el código HTTP cuando es un endpoint.
--->
+### TC-001 — `POST /api/professionals/[id]/contacts` (extiende TC-002 de misión 05) — registrar el contacto y, si viene, su token
 
-### TC-001 — <contrato en una frase>
+- **Entrada:** path param `id`. Body JSON opcional `{ token?: string }` (formato UUID). Sin sesión — D-002 de
+  misión 05 sigue vigente: nada que identifique a la persona; un token opaco sin ningún dato personal no lo
+  viola, aunque sí actualiza el invariante literal "sin body" del contrato original de esa misión, que queda
+  reemplazado por este. El token viaja en el body, no en la URL — a diferencia de un query param, no queda
+  en logs de acceso ni en el historial del navegador.
+- **Salida:** sin cambio respecto a misión 05 — `204` sin cuerpo. Se dispara con `sendBeacon`, el cliente
+  nunca la lee (T-003 de misión 05, intacto).
+- **Invariantes:** todo lo que TC-002 de misión 05 ya garantizaba, sin cambios — un `id` sin forma de UUID
+  se descarta antes de tocar la base; inserta una fila en `professional_contact_events`; no exige `active`,
+  solo que el profesional exista. Además: si el body trae un `token` con forma de UUID válida, en la misma
+  request se inserta también `(professionalId, token, createdAt)` en `professional_contact_tokens`
+  (`onConflictDoNothing` — un reintento de `sendBeacon` nunca produce un error que nadie vería). Un `token`
+  ausente o mal formado nunca es un error y nunca bloquea el registro del contacto real — mismo espíritu que
+  el invariante ya vigente de misión 05 ("D-002 — el registro nunca bloquea el contacto real"). El insert
+  del contacto y el del token son dos sentencias separadas, no una transacción conjunta: si el insert del
+  token falla por una razón ajena a su forma (ej. un error transitorio de la base), el insert del contacto
+  ya se completó y la respuesta sigue siendo `204` — el contacto real nunca queda condicionado a que el
+  token se haya guardado con éxito.
+- **Errores:** sin cambio — `404 { error: 'not_found' }` si `id` no tiene forma de UUID o el profesional no
+  existe. Un `token` mal formado nunca produce error, se ignora.
+- **Contrato de producto:** [F-002 de misión 05](../05-perfil-publico-profesional/producto.md#f-002)
+  (sin cambio), [D-001](./producto.md#d-001) de esta misión.
 
-- **Entrada:** <datos y precondiciones, con tipos y forma concreta>.
-- **Salida:** <resultado y su forma concreta>.
-- **Invariantes:** <qué se cumple siempre: atomicidad, consistencia, idempotencia>.
-- **Errores:** <condición → código HTTP y cuerpo `{ error, code? }`, y qué puede hacer el llamador>.
-- **Contrato de producto:** [F-001](./producto.md#f-001).
+### TC-002 — `POST /api/professionals/[id]/reviews` — publicar o reemplazar la reseña de este navegador
+
+- **Entrada:** path param `id`. Body JSON `{ token: string, rating: number, comment?: string, name?: string }`.
+  Usa `fetch` normal, no `sendBeacon` — a diferencia de TC-001, acá el cliente sí necesita leer la respuesta
+  (spinner mientras espera, mensaje de error si falla, cierre del sheet solo si el servidor confirma —
+  UXF-001 de `experiencia.md`).
+- **Salida:** `200 { review: PublicReview }`. `PublicReview = { id, name: string, rating: number, comment:
+  string | null, verified: true, createdAt: string }` — `name` ya resuelto ("un cliente de Datealo" si
+  llegó vacío, D-002).
+- **Invariantes:**
+  - El `token` debe corresponder a una fila en `professional_contact_tokens` para ese `professionalId` — si
+    no existe, la reseña no se publica (F-001: "Datealo nunca publica una reseña sin verificar primero...").
+  - `rating`: entero 1-5, obligatorio, con `check (rating between 1 and 5)` también a nivel de base — no
+    solo en el código de la aplicación, mismo espíritu que A-002 ("RLS es la red de seguridad, no el único
+    mecanismo") aplicado acá a la integridad de datos, no a la autorización.
+  - `comment`: opcional, máximo 500 caracteres — se rechaza si lo supera, nunca se trunca en silencio
+    (experiencia.md, UXF-001), con `check (char_length(comment) <= 500)` también a nivel de base, mismo
+    criterio que el `check` de `rating`: la aplicación no es la única barrera contra una fila fuera de
+    forma. `name`: opcional, texto libre sin validación de formato.
+  - `name` en blanco o ausente se guarda como `NULL` — el reemplazo por "un cliente de Datealo" ocurre al
+    leer (`toPublicReview`), no al escribir: si el copy cambia algún día, no hace falta un backfill de filas
+    ya escritas con el texto viejo.
+  - Upsert atómico por `(professionalId, token)` a nivel de base (`onConflictDoUpdate`, ver T-003) — CL-003:
+    una segunda reseña del mismo token reemplaza a la primera, nunca inserta una fila nueva.
+  - Dispara F-003 (correo al profesional) sin esperar su resultado —
+    `event.waitUntil(sendEmail(...).catch(() => {}))`, mismo patrón que `server/api/professionals/index.post.ts`
+    (misión 04). El asunto/cuerpo los construye `buildReviewNotificationEmail` en `reviews.ts` (ver
+    Arquitectura), no el handler. Si `professionals.email` es `null` (perfil sin email registrado, ver
+    T-002), F-003 simplemente no dispara — no es un error.
+- **Errores:**
+  - `404 { error: 'not_found' }` si `id` no tiene forma de UUID o el profesional no existe.
+  - `403 { error: 'not_verified' }` si el `token` no corresponde a un contacto real de ese profesional — la
+    UI nunca debería llegar a este caso (el formulario está oculto sin token, UX-001 de experiencia.md);
+    solo lo alcanza quien le pega directo al endpoint.
+  - `400 { error: 'invalid_rating' }` si `rating` no es un entero 1-5.
+  - `400 { error: 'comment_too_long' }` si `comment` supera 500 caracteres.
+- **Contrato de producto:** [F-001](./producto.md#f-001), [D-001](./producto.md#d-001),
+  [D-002](./producto.md#d-002), [D-003](./producto.md#d-003), [CL-001, CL-002, CL-003](./producto.md#casos-límite-que-cruzan-funcionalidades).
+
+### TC-003 — `GET /api/professionals/[id]` (extiende TC-001 de misión 05) — el perfil incluye sus reseñas
+
+- **Entrada:** sin cambio (path param `id`).
+- **Salida:** `PublicProfessionalProfile` de misión 05 se extiende con `reviews: PublicReview[]` (de la más
+  reciente a la más antigua por `updatedAt`), `ratingAverage: number | null` (redondeado a un decimal, `null`
+  sin reseñas), `reviewCount: number`. Ningún campo existente de TC-001 de misión 05 cambia — extensión
+  aditiva.
+- **Invariantes:** sin reseñas, `reviews: []`, `ratingAverage: null`, `reviewCount: 0` — F-002 hereda el
+  comportamiento sin reseñas de misión 05 (CL-003 de esa misión: la sección de reseñas ni siquiera aparece).
+  El handler compone dos queries independientes (`findPublicProfessionalProfile` de `professionals.ts` y
+  una nueva de `reviews.ts`) con `Promise.all`, nunca encadenadas — misión 05 ya identificó este endpoint
+  como el de mayor tráfico esperado del diseño. No hace falta un índice adicional para el `order by
+  updated_at`: `experiencia.md` ya fija sin paginación ni "ver más" en esta entrega, porque con la oferta y
+  el volumen esperados ningún perfil va a acumular reseñas suficientes para que un `sort` sobre unas pocas
+  filas importe.
+- **Errores:** sin cambio respecto a TC-001 de misión 05 (`404` si no existe o `active = false`).
+- **Contrato de producto:** [F-002](./producto.md#f-002), [D-002](./producto.md#d-002).
 
 ## Modelo de datos
 
-<!-- Entidades con significado, escritura y ciclo de vida. El schema completo vive en server/db/. -->
-
-| Entidad o campo | Significado             | Escritura          | Retención o historial |
-| --------------- | ----------------------- | ------------------ | --------------------- |
-| <dato>          | <semántica de producto> | <endpoint o acción>| <política>            |
+| Entidad o campo                              | Significado                                                        | Escritura                           | Retención               |
+| --------------------------------------------- | -------------------------------------------------------------------- | -------------------------------------- | -------------------------- |
+| `professional_contact_tokens.id`              | Identificador de la fila                                              | TC-001                                 | Permanente                 |
+| `professional_contact_tokens.professionalId`  | FK a `professionals.id`                                               | TC-001                                 | Permanente                 |
+| `professional_contact_tokens.token`           | `uuid`, opaco, generado por el cliente, sin significado propio        | TC-001                                 | Permanente                 |
+| `professional_contact_tokens.createdAt`       | Cuándo se registró                                                    | TC-001                                 | Permanente                 |
+| `reviews.id`                                  | Identificador de la reseña                                            | TC-002                                 | Permanente                 |
+| `reviews.professionalId`                      | FK a `professionals.id`                                               | TC-002                                 | Permanente                 |
+| `reviews.token`                               | `uuid`, el mismo token que autorizó la reseña — nunca sale en una respuesta. FK compuesta `(professional_id, token)` hacia `professional_contact_tokens(professional_id, token)`, `onDelete: 'restrict'` (mismo criterio explícito que `professional_contact_events.professionalId` de misión 05: hoy nada borra un token, pero queda decidido en vez de heredar el default de Postgres) | TC-002                            | Permanente                 |
+| `reviews.rating`                              | 1 a 5, obligatorio, con `check` a nivel de base                       | TC-002                                 | Se sobreescribe al reemplazar |
+| `reviews.comment`                             | Texto libre, opcional, máx. 500 caracteres, con `check` a nivel de base | TC-002                                 | Se sobreescribe al reemplazar |
+| `reviews.name`                                | Texto libre, opcional; `NULL` se resuelve a "un cliente de Datealo" al leer | TC-002                            | Se sobreescribe al reemplazar |
+| `reviews.createdAt`                           | Cuándo se publicó por primera vez                                     | TC-002, solo en el insert original      | Permanente, no cambia al reemplazar |
+| `reviews.updatedAt`                           | Cuándo se reemplazó por última vez — ordena la lista y es la fecha relativa que se muestra | TC-002                | Se actualiza en cada reemplazo |
+| `professionals.email`                         | Copia del email de `auth.users` al momento del registro, para F-003    | `POST /api/professionals` (misión 04, extendido) | Permanente, sin sincronización posterior (ver TR-001) |
 
 ### Invariantes de datos
 
-- <unicidad, pertenencia, orden o consistencia temporal>.
-- <qué operación es atómica o qué dato tiene una única fuente de verdad>.
+- Un token solo puede existir si nació en la misma request que un contacto real — `professional_contact_tokens`
+  solo se escribe desde TC-001, nunca desde un endpoint que no escriba también `professional_contact_events`
+  en la misma llamada (ver Decisión técnica).
+- `unique index` en `professional_contact_tokens(professional_id, token)` — sin él, el `onConflictDoNothing`
+  de TC-001 no tiene contra qué resolver el conflicto y falla en runtime; es la base de que un reintento de
+  `sendBeacon` nunca duplique fila.
+- Un dispositivo (token) mantiene como máximo una reseña vigente por profesional — `unique index` en
+  `reviews(professional_id, token)`; TC-002 hace upsert sobre esa unicidad a nivel de base, nunca en dos
+  pasos desde el código (ver T-003).
+- `reviews(professional_id, token)` lleva además una FK compuesta hacia
+  `professional_contact_tokens(professional_id, token)` — sin ella, una reseña podría sobrevivir en la base
+  a un token que ya no existe en ningún lado (hoy nada borra un token, pero D-001 no descarta que algún día
+  se agregue una expiración), y seguiría mostrándose "verificada por contacto" con la prueba ya desaparecida,
+  sin que ninguna restricción lo marcara.
+- `reviews.createdAt` no cambia en un reemplazo; `reviews.updatedAt` sí, y es el campo que ordena "más
+  reciente primero" y que se muestra como fecha relativa — un reemplazo empuja la reseña arriba de la lista,
+  coherente con que D-003 lo trata como editar, no como un evento nuevo sin relación con el anterior.
+- `reviews.token` nunca se expone en ninguna respuesta pública (`PublicReview` no lo incluye) — es un
+  secreto de correlación, no un dato de la reseña.
+- Ninguna de las dos tablas nuevas lleva un índice de un solo campo sobre `professionalId` — el `unique
+  index` compuesto `(professional_id, token)` ya cubre las consultas filtradas solo por `professionalId`
+  (regla de "leftmost prefix": un índice sobre `(a, b)` sirve también para filtrar solo por `a`), mismo
+  criterio que ya deja explícito `professional_contact_events` de misión 05 para su propio índice.
 
 ### Impacto en RLS
 
-<!--
-Obligatorio. Fuente de verdad: server/db/sql/rls.sql. Si el cambio no toca ownership ni relaciones usadas
-en policies, decirlo explícitamente con esa razón — no dejar la sección vacía.
--->
+| Tabla                          | Cambio        | Policy afectada                                    | Acción                                                                                          |
+| -------------------------------- | ------------- | ----------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `professional_contact_tokens`    | tabla nueva   | ninguna (sin `select`/`insert`/`update`/`delete`)      | `alter table professional_contact_tokens enable row level security;` + `revoke all ... from anon, authenticated;` — mismo criterio que `professional_contact_events` de misión 05: todo pasa por Drizzle (rol dueño, A-002), PostgREST cerrado por completo (A-007) |
+| `reviews`                        | tabla nueva   | ninguna                                                | `alter table reviews enable row level security;` + `revoke all ... from anon, authenticated;` — misma razón; la lectura pública de reseñas pasa por TC-003 (Drizzle), nunca por PostgREST directo |
+| `professionals`                  | columna nueva (`email`) | `professionals_select_public` (sin cambio de condición) | ninguna acción sobre la policy — la tabla ya está cerrada a `anon`/`authenticated` por su `revoke` de misión 04 (A-007), así que RLS no es lo que protege `email`. La protección real es de código (A-005): el `select` explícito de `Professional`/`PublicProfessionalProfile` en `professionals.ts` no debe listar `email` — hay que mantenerlo así a mano al agregar la columna, el mismo punto que ya anota TC-001 de misión 05 sobre `userId` |
 
-| Tabla    | Cambio                 | Policy afectada | Acción                    |
-| -------- | ---------------------- | --------------- | ------------------------- |
-| <tabla>  | <nueva, ownership, FK> | <nombre>        | <crear, actualizar, nada> |
+`force row level security` no se usa en ninguna de las dos tablas nuevas, mismo motivo que misión 05: Drizzle
+escribe con el rol dueño, donde `auth.uid()` es `NULL` — forzarlo rompería el `insert` del propio servidor.
 
 ## Riesgos y experimentos de factibilidad
 
-<!--
-Un riesgo que podría cambiar el producto se enlaza como pregunta o decisión en producto.md. Un experimento
-tiene pregunta, límite de tiempo y resultado capaz de cerrar la incertidumbre.
--->
-
-| ID     | Riesgo o pregunta | Qué invalida        | Experimento o mitigación  | Criterio de salida      | Estado  |
-| ------ | ----------------- | ------------------- | ------------------------- | ----------------------- | ------- |
-| TR-001 | <incertidumbre>   | <alcance en riesgo> | <spike, prueba o recorte> | <resultado concluyente> | abierto |
+| ID     | Riesgo o pregunta                                                                                  | Qué invalida                                       | Experimento o mitigación | Criterio de salida | Estado |
+| ------ | ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------ | ---------------------------- | ------------------------ | ------ |
+| TR-001 | `professionals.email` se desincroniza si el profesional cambia su email en Supabase Auth (sin trigger ni sync) | F-003 podría enviar a una dirección vieja | Aceptado sin mitigación — hoy no existe ningún flujo de "cambiar email" en Datealo (misión 04 no lo construyó), así que la desincronización no tiene ningún camino real para ocurrir todavía | Si Datealo agrega cambio de email de cuenta, ese diseño decide si sincroniza `professionals.email` o lo reemplaza por una lectura en vivo | abierto, no bloqueante |
+| TR-002 | Si el `sendBeacon` de TC-001 falla en silencio (navegador viejo, bloqueador de contenido) o si el `token` de `localStorage` se pierde (limpieza de datos del sitio, modo privado), el buscador ve WhatsApp/Llamar funcionar normal (misión 05 ya blindó eso) pero nunca puede reseñar después, sin ningún error visible | Reduce el volumen real de reseñas sin que nadie se entere por qué — a diferencia de misión 05, donde fallar solo pierde una fila de analytics, acá fallar le quita a alguien la posibilidad completa de dejar una reseña | Ninguna en esta entrega — mismo límite que T-003 de misión 05 ya aceptó para el contacto mismo (sin fallback a `fetch`), y limitación ya reconocida por D-001 de producto (el mecanismo "no impide el abuso al cien por ciento" en ninguna dirección) | Si [M-001](./producto.md#m-001) muestra una proporción de contactos-a-reseñas muy por debajo de lo esperado, descartar esta causa antes de asumir que es solo cambio de dispositivo (CL-002) | abierto, no bloqueante |
+| TR-003 | El mecanismo no resiste a un atacante que escribe código: dos llamadas HTTP sin sesión (`POST /contacts` con un `token` inventado, después `POST /reviews` con ese mismo token) bastan para publicar una reseña falsa "verificada por contacto" — el mismo costo, en la práctica, que el formulario completamente abierto que D-001 rechaza, para quien esté dispuesto a escribir dos `fetch()` en vez de usar la interfaz | Vacía parcialmente la promesa de D-001 para cualquiera que no sea un buscador casual usando el navegador; además, este ataque infla `professional_contact_events` y `professional_contact_tokens`/`reviews` a la vez, en el mismo script — el guardrail de [M-001](./producto.md#m-001) ("ningún profesional termina con más reseñas que contactos") es ciego a este caso específico, porque los dos contadores suben juntos | Aceptado tal como está: D-001 ya renuncia explícitamente a impedir el abuso al cien por ciento, y lo que este mecanismo sí sube es la fricción para el buscador casual de la interfaz (nunca ve la opción de reseñar sin haber contactado, UX-001), no la resistencia contra un script — nombrado acá para que quede explícito, no implícito | Si aparece evidencia real de reseñas fabricadas en volumen (patrones de rating/comentario repetidos, ráfagas de reseñas sin el contacto correspondiente en un rango de tiempo razonable), reabrir D-001 con un mecanismo que sí cueste algo real (rate limit por IP, un desafío tipo CAPTCHA, o similar) | abierto, no bloqueante |
 
 ## Estrategia de pruebas
 
-<!-- Mapea los ejemplos verificables de producto.md a niveles de prueba. Qué demuestra cada una. -->
-
-| Contrato o riesgo | Nivel                          | Caso principal | Límite o falla |
-| ----------------- | ------------------------------ | -------------- | -------------- |
-| F-001, CL-001     | <unidad, contrato, integración>| <caso>         | <caso>         |
+| Contrato                    | Nivel               | Caso principal                                                                 | Límite o falla                                                                                                    |
+| ------------------------------ | ---------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| TC-001                          | contrato (endpoint)    | `id` real + `token` con forma válida → `204`, filas en `professional_contact_events` y `professional_contact_tokens` | `id` inválido → `404` sin insertar nada; `token` mal formado o ausente → `204`, solo se inserta el contacto; token repetido → `204`, sin duplicar fila |
+| TC-002                          | contrato + unidad      | token que existe en `professional_contact_tokens`, rating 5 → `200` con la reseña  | token inexistente o inventado sin contacto real → `403`; rating fuera de 1-5 → `400`; comentario > 500 → `400`; segunda reseña del mismo token → reemplaza, no duplica (CL-003) |
+| TC-002 (F-003)                  | unidad                 | reseña publicada → `sendEmail()` llamado con el asunto y cuerpo de `buildReviewNotificationEmail` | `sendEmail()` rechaza (mock) → la respuesta `200` se envía igual; `professionals.email` nulo → `sendEmail()` nunca se llama |
+| `reviews.ts` (funciones puras)  | unidad                 | `resolveReviewerName(null)` → `"un cliente de Datealo"`; `resolveReviewerName("Carmen")` → `"Carmen"` | rating no entero, `0`, `6` → todos inválidos                                                                        |
+| TC-003                          | contrato               | profesional con 2 reseñas → `ratingAverage` correcto a un decimal, orden por `updatedAt` desc | profesional sin reseñas → `reviews: []`, `ratingAverage: null`, `reviewCount: 0`                                     |
+| RLS (`professional_contact_tokens`, `reviews`) | integración/manual | —                                                                                   | vía PostgREST (consola del navegador, con o sin sesión): `select`/`insert` sobre las dos tablas nuevas devuelven `permission denied` |
 
 ### Propiedades que deben probarse
 
-- <invariante bajo reintentos, concurrencia o distintas entradas>.
-- <ausencia de efectos parciales en falla>.
+- Un token nunca puede quedar registrado en `professional_contact_tokens` sin una fila correspondiente en
+  `professional_contact_events` de la misma request — no hay ningún camino de código que escriba uno sin el
+  otro.
+- El upsert de TC-002 es atómico: dos requests concurrentes con el mismo token nunca producen dos filas —
+  la garantía es del `unique index` de la base, no de un `select`-then-`insert` en dos pasos del código.
+- Un `rating` inválido nunca deja una reseña anterior en un estado parcial — la validación corre antes de
+  tocar la base.
+- `sendEmail()` fallando nunca revierte ni bloquea la publicación de la reseña (F-003).
+- Un insert directo en `reviews` con un `(professionalId, token)` que no existe en `professional_contact_tokens`
+  falla por la FK compuesta, a nivel de base — no solo por el chequeo `403` de la aplicación.
 
 ## Plan de construcción
 
-<!--
-Se completa al final, cuando el gate de salida se cumple y ninguna pregunta bloqueante sigue abierta —
-cortar sobre decisiones abiertas produce issues que mueren. Cada slice es un cambio funcional atómico: un
-Issue, un PR, ejecutable sin haber leído la misión (el issue lleva su contrato inline) y con criterios
-pass/fail enumerables como tests. Guía completa en el skill discovery-engineering.
--->
+El riesgo de esta misión está en la integración (¿el mecanismo de verificación aguanta punta a punta?), no
+en un algoritmo — el corte es vertical: un walking skeleton que prueba el camino completo del mecanismo por
+API antes de tocar ninguna UI (S-001 a S-003), después la UI que lo hace usable en la app real (S-004 a
+S-005), y al final el correo (F-003), que no bloquea ni depende de nada del camino principal y puede
+construirse en paralelo desde S-006.
 
-| ID    | Slice (una frase, sin "y") | Sustento      | Criterio de aceptación principal          | Depende de |
-| ----- | -------------------------- | ------------- | ----------------------------------------- | ---------- |
-| S-001 | <cambio atómico>           | TC-001, D-001 | <entrada concreta → resultado observable> | —          |
+| ID    | Slice (una frase, sin "y")                                                              | Sustento                  | Criterio de aceptación principal                                                                 | Depende de | Issue |
+| ----- | ------------------------------------------------------------------------------------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------ | ---------- | ----- |
+| S-001 | Extender `POST …/contacts` con un `token` opcional (tabla `professional_contact_tokens` + RLS + revoke) | D-001, TC-001                 | `id` real + `token` válido inserta fila en las dos tablas; `token` ausente/inválido inserta solo el contacto, sin error; token repetido no duplica; PostgREST deniega `select`/`insert` | —          | [#107](https://github.com/PatricioTabilo/datealo/issues/107) |
+| S-002 | Publicar o reemplazar la reseña de un profesional, verificando el token (tabla `reviews` con RLS/revoke, `check` de rating y de largo de comentario, FK compuesta hacia `professional_contact_tokens`, endpoint `POST …/reviews`, sin el correo todavía) | F-001, D-001, D-002, D-003, CL-001 a CL-003, TC-002 | Token con contacto real + rating publica la reseña; token sin contacto real → `403`; rating/comment inválidos → `400`; segunda reseña del mismo token reemplaza, nunca duplica; PostgREST deniega `select`/`insert` | S-001      | [#108](https://github.com/PatricioTabilo/datealo/issues/108) |
+| S-003 | `GET /api/professionals/[id]` extendido con `reviews`/`ratingAverage`/`reviewCount`           | F-002, TC-003                 | Perfil con reseñas devuelve el arreglo ordenado y el promedio correcto; perfil sin reseñas devuelve `[]`/`null`/`0`, sin romper la forma que misión 05 ya expone | S-002      | [#109](https://github.com/PatricioTabilo/datealo/issues/109) |
 
-## Secciones bajo demanda
+*(con S-001 a S-003 mergeados, el mecanismo completo — contactar con token, publicar reseña, verla en el
+perfil — ya es verificable por API/`curl`, sin ninguna UI todavía)*
 
-<!--
-Agregar solo cuando el riesgo lo justifique, con estos títulos:
+| S-004 | `useReviewToken` + `ProfessionalPublicContactBar.vue` envían el token en el body del beacon existente | D-001, UXF-001                | Tocar "Escribir por WhatsApp"/"Llamar" genera un token si no existía, lo guarda en `localStorage`, y lo manda en el mismo `sendBeacon` que ya dispara el contacto | S-001      | [#110](https://github.com/PatricioTabilo/datealo/issues/110) |
+| S-005 | UI de reseñas en `/profesionales/[id].vue`: sección de reseñas, card "dejar la tuya", bottom sheet (nuevo y editando, UXF-001/UXF-002), estados vacío/error, toast `bottom-right` | F-001, F-002, todos los UXF de experiencia.md | Con token, aparece la card y el sheet publica/edita una reseña real; sin token, no aparece ninguna forma de reseñar; toast en `bottom-right` (patrón universal de `discovery-ux`) | S-003, S-004 | [#111](https://github.com/PatricioTabilo/datealo/issues/111) |
 
-- "Migración y compatibilidad": cuando existan datos o consumidores que deben llegar al nuevo contrato.
-  Incluye rollback lógico si la migración física no puede revertirse.
-- "Rendimiento y observabilidad": cuando haya presupuesto de latencia o volumen que defender (búsqueda
-  geográfica y listados paginados son los candidatos naturales).
-- "SEO e indexación": cuando la superficie deba ser indexable (páginas por categoría + comuna, datos
-  estructurados).
-- "Entrega por etapas": cuando el cambio necesite despliegue incremental o feature flags.
--->
+*(con S-005 mergeado, el walking skeleton está completo y usable en la app real — 5 slices, no 7)*
+
+| S-006 | Columna `professionals.email`, poblada al registrar el perfil                                | F-003, T-002                  | `POST /api/professionals` con sesión guarda `email`; `email` nunca aparece en `Professional` ni en `PublicProfessionalProfile` | —          | [#112](https://github.com/PatricioTabilo/datealo/issues/112) |
+| S-007 | Correo de aviso al profesional cuando se publica una reseña — contenido (UXF-003) y disparo (`sendEmail()` sin esperar) | F-003, TR-001, UXF-003        | Reseña publicada con `professionals.email` no nulo dispara `sendEmail()` con el contenido exacto de UXF-003 (asunto sin adelantar rating, cuerpo con/sin nombre, con/sin comentario); `sendEmail()` fallando no afecta la respuesta `200` | S-002, S-006 | [#113](https://github.com/PatricioTabilo/datealo/issues/113) |
+
+S-006 no depende de nada del camino principal — puede construirse en paralelo con S-001 a S-005.
 
 ## Decisiones técnicas
 
 <a id="t-001"></a>
 
-### T-001 — <decisión en una frase>
+### T-001 — El token nace en la misma request que el contacto real, extendiendo TC-002 de misión 05, no en un endpoint aparte
 
-- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
-- **Contratos:** F-001 y <regla relevante>.
-- **Alternativas descartadas:** <opciones y trade-offs, con el porqué del rechazo>.
-- **Decisión y consecuencias:** <enfoque elegido, beneficio, costo y trabajo futuro aceptado>.
-- **Reapertura:** <medición o cambio que justificaría revisar>.
+- **Estado:** propuesta. **Fecha:** 2026-08-30. Reemplaza una versión anterior de esta misma decisión, tumbada
+  en auditoría el 2026-08-30 por no verificar nada contra un contacto real (ver Decisión técnica).
+- **Contratos:** [D-001](./producto.md#d-001) de producto; TC-002 de misión 05 (extendido, ver TC-001 de
+  este documento).
+- **Alternativas descartadas:**
+  - Un endpoint nuevo y desconectado para el token (la versión original de esta decisión) — descartada tras
+    la auditoría: sin ninguna relación con `professional_contact_events`, cualquiera puede fabricar un token
+    válido sin haber contactado nunca, vaciando la promesa de D-001.
+  - Que el servidor emita el token en la respuesta de TC-002 de misión 05 — descartada porque ese endpoint
+    se dispara con `sendBeacon`, que nunca permite leer la respuesta (T-003 de esa misión, decisión vigente).
+  - Agregar el `token` como query param en vez de body — descartada porque un valor que funciona como
+    credencial de escritura no debería terminar en logs de acceso, proxies o historial del navegador; un
+    body cumple la misma función sin ese costo.
+  - Extender `professional_contact_events` con una columna `token` nullable, en vez de una tabla nueva —
+    descartada porque cambiaría lo que esa tabla promete ser (D-002 de misión 05: nunca lleva nada que
+    identifique a quien contacta), incluso en las filas donde el token quedara en blanco; un registro
+    anónimo de hechos y un registro de autorización son dos conceptos de dominio distintos, aunque nazcan en
+    el mismo request.
+- **Decisión y consecuencia:** `POST /api/professionals/[id]/contacts` (TC-002 de misión 05) se extiende con
+  un body JSON opcional `{ token? }`. El cliente genera el token (`crypto.randomUUID()`) antes de disparar el
+  beacon y lo guarda en `localStorage` de inmediato — no depende de ninguna respuesta del servidor. El
+  servidor, en la misma request, inserta el contacto (sin cambios) y, si el token tiene forma válida, una
+  fila en `professional_contact_tokens`. Un token solo puede existir atado a un contacto real.
+- **Reapertura:** ninguna prevista — si en producción aparece evidencia de que el token igual se fabrica en
+  volumen (ej. scripts que llaman a `/contacts` con tokens inventados en bucle), eso reabre D-001 de
+  producto, no esta decisión técnica: el mecanismo de verificación en sí ya asume ese límite.
+
+<a id="t-002"></a>
+
+### T-002 — El email del profesional se copia a `professionals.email` en el registro, no se lee `auth.users` directo
+
+- **Estado:** propuesta. **Fecha:** 2026-08-30.
+- **Contratos:** F-003.
+- **Alternativas descartadas:** query cruda de Drizzle contra el schema `auth` de Supabase — técnicamente
+  alcanzable (misma base), pero es un schema que Supabase gestiona y migra por su cuenta, sin definición de
+  Drizzle; acoplar `reviews.ts`/`professionals.ts` a su forma interna es la fuga que un anti-corruption
+  layer existe para evitar, y ninguna otra parte del código lo hace hoy. Consultar el cliente admin de
+  Supabase en cada envío — agrega una dependencia de red extra a un flujo que hoy es 100% Drizzle, por un
+  dato que ya está disponible gratis en el momento del registro.
+- **Decisión y consecuencia:** `professionals` gana una columna `email` (nullable), poblada por
+  `POST /api/professionals` en el mismo request donde `user.email` ya está disponible (igual que
+  `buildProfessionalWelcomeEmail` hoy). Perfiles creados antes de esta misión quedan con `email = null` —
+  F-003 no envía el correo para esos casos, sin error (TR-001). Nunca se agrega a `Professional` ni a
+  `PublicProfessionalProfile` (A-005): es un dato interno.
+- **Reapertura:** si Datealo agrega un flujo de cambio de email de cuenta, revisar si `professionals.email`
+  debe sincronizarse ahí mismo.
+
+<a id="t-003"></a>
+
+### T-003 — El reemplazo de una reseña (D-003) es un upsert a nivel de base, no un select-then-insert en el código
+
+- **Estado:** propuesta. **Fecha:** 2026-08-30.
+- **Contratos:** [D-003](./producto.md#d-003) de producto; CL-003.
+- **Alternativas descartadas:** verificar en el handler si ya existe una reseña y decidir `insert` vs.
+  `update` en JS — descartada porque dos requests concurrentes del mismo token (doble tap en una conexión
+  lenta) podrían leer "no existe" las dos antes de que la primera termine de insertar, produciendo dos filas
+  — justo lo que CL-003 prohíbe.
+- **Decisión y consecuencia:** `unique index` en `reviews(professional_id, token)`; el insert usa
+  `onConflictDoUpdate` para que la base garantice la unicidad, no el código de la aplicación.
+- **Reapertura:** ninguna prevista.
 
 ## Preguntas
 
-<!--
-Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
-Estado: abierta | resuelta AAAA-MM-DD | disuelta AAAA-MM-DD. Solo las abiertas llevan bloque de detalle.
--->
+Ninguna pregunta bloquea la construcción — los puntos que podrían haber quedado abiertos (cómo verificar el
+token sin tocar TC-002 de misión 05 en falso, de dónde sale el email del profesional, cómo garantizar el
+upsert) se resolvieron como T-001, T-002 y T-003 arriba.
 
-<Una frase que responde "¿qué falta?": la pregunta que bloquea construcción y qué bloquea.>
-
-| ID     | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
-| ------ | ---------------------- | ------------------- | --------------------------------------------------------------- |
-| TQ-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
-| TQ-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |
+| ID | La duda | Estado | Respuesta, o quién la resuelve |
+| -- | ------- | ------ | ------------------------------- |
+| —  | —       | —      | sin preguntas abiertas propias de ingeniería |

--- a/docs/missions/07-resenas-verificadas-por-contacto/investigacion.md
+++ b/docs/missions/07-resenas-verificadas-por-contacto/investigacion.md
@@ -1,8 +1,8 @@
-# Misión: <nombre> — Investigación
+# Misión: reseñas verificadas por contacto — Investigación
 
 **Estado:** activo
 
-**Última actualización:** AAAA-MM-DD
+**Última actualización:** 2026-08-29
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
@@ -18,21 +18,29 @@ Gate de salida — la investigación sostiene un producto.md cuando:
 - el ideal describe capacidades observables, no intenciones
 -->
 
-## El problema aparece cuando <historia concreta>
+## El problema aparece cuando Carmen quiere avisarle a la próxima persona que Marcelo cumple
 
-<!--
-Una situación real o reconstruida con precisión. No abras con una categoría como "falta de confianza" —
-abre con quién estaba haciendo qué y qué salió mal. Nombra a la persona y el servicio concreto.
--->
+**Situación:** Carmen encontró a Marcelo, gasfiter de Ñuñoa, en el perfil público que dejó misión 05. Lo
+contactó por WhatsApp un sábado a las 22:14, coordinaron por ese mismo chat y Marcelo le arregló la llave
+que goteaba el lunes siguiente. Todo el intercambio — precio, horario, el trabajo mismo — ocurrió fuera de
+Datealo, como D-001 de misión 04 y D-002 de misión 05 decidieron a propósito.
 
-**Situación:** <qué está ocurriendo antes del problema>.
+**Acción o necesidad:** Carmen quiere dejar una reseña de Marcelo, para que la próxima persona que busque
+un gasfiter en Ñuñoa sepa que cumple. Es exactamente el gesto que sostiene la promesa de la landing:
+"reseñas reales, sin inventadas".
 
-**Acción o necesidad:** <qué se intenta resolver o decidir>.
+**Respuesta actual:** hoy Datealo no tiene dónde dejarla. Fuera de Datealo, Carmen lo comentaría en el
+grupo de WhatsApp del edificio, o buscaría si Marcelo tiene ficha en Google Maps — ninguna de las dos
+opciones ayuda a alguien que está buscando específicamente en Datealo.
 
-**Respuesta actual:** <qué hace hoy la persona: grupo de WhatsApp, Google, recomendación de un vecino,
-Datealo si ya existe la superficie>.
-
-**Consecuencia:** <error, demora, riesgo o decisión que no puede tomarse>.
+**Consecuencia:** si Datealo abre un formulario de reseña sin ningún filtro, dos cosas rompen la promesa el
+mismo día que se lanza: un competidor de Marcelo puede dejarle una reseña de una estrella sin haberlo
+contactado nunca, y Marcelo (o cualquier profesional) puede autoreseñarse con una cuenta falsa. Lo que hace
+única a esta misión no es "cómo se ve una reseña" — es que **el evento de contacto del que depende, por
+diseño de misión 05, no guarda ninguna identidad**: `professional_contact_events` (D-002 de
+[producto.md de misión 05](../05-perfil-publico-profesional/producto.md#d-002)) solo sabe que "hubo un
+contacto en el perfil de Marcelo el sábado a las 22:14" — no sabe que fue Carmen. Esa misma misión dejó la
+pregunta abierta y apuntando acá: [Q-001 de producto.md de misión 05](../05-perfil-publico-profesional/producto.md#q-001).
 
 ## Preguntas que la investigación debe resolver
 
@@ -41,7 +49,15 @@ Solo preguntas capaces de cambiar el ideal o una decisión. Al resolver una, mov
 conclusión. No es un backlog.
 -->
 
-- ¿<pregunta y decisión que depende de ella>?
+- ¿Qué puede significar realmente "verificado por contacto" cuando el registro del contacto (D-002 de
+  misión 05) no guarda ninguna identidad? ¿Probar que esta reseña corresponde a un contacto real y
+  específico, o solo elevar el costo de fabricar una reseña falsa lo suficiente para que no valga la pena?
+- Misión 04 evaluó y descartó OTP por SMS/WhatsApp para autenticar al profesional, por el costo real de
+  contratar Twilio antes de tener un solo profesional registrado (D-001 de producto.md de misión 04). El
+  brief de esta misión propone el mismo mecanismo para el buscador. ¿Sigue siendo válido el mismo rechazo,
+  o hay una razón distinta que lo justifique acá?
+- ¿Existe un mecanismo que ate la reseña al momento del contacto sin pedirle nada al buscador — ni cuenta,
+  ni teléfono, ni código — aprovechando que el contacto y la reseña pueden ocurrir en el mismo dispositivo?
 
 ## Evidencia
 
@@ -54,22 +70,14 @@ Datealo no tiene datos de uso propios todavía. Cuando la única evidencia dispo
 una entrevista, la columna "límite" es lo que impide que se lea como dato duro.
 -->
 
-| ID    | Tipo                                              | Fuente                | Hecho verificable | Límite de la evidencia |
-| ----- | ------------------------------------------------- | --------------------- | ----------------- | ---------------------- |
-| E-001 | <entrevista, benchmark, uso, código, observación> | <enlace o referencia> | <hecho>           | <qué no demuestra>     |
-
-<a id="e-001"></a>
-
-### E-001 — <fuente o hecho en una frase>
-
-<!--
-Desarrollar solo cuando la tabla no alcanza para evaluar la calidad de la evidencia. Cierra con la
-consecuencia para la investigación.
--->
-
-<Observación precisa y contexto necesario.>
-
-Esto permite afirmar <alcance>, pero no demuestra <límite>.
+| ID    | Tipo   | Fuente                                                                                  | Hecho verificable                                                                                                    | Límite de la evidencia |
+| ----- | ------ | ---------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| E-001 | código | [D-002 y Q-001, producto.md misión 05](../05-perfil-publico-profesional/producto.md#d-002) | `professional_contact_events` no tiene ninguna columna que identifique a quien contactó — decisión explícita, con reapertura condicionada a que misión 07 la necesite | Es la restricción vigente hoy; no dice si conviene revisarla, solo que existe |
+| E-002 | código | [D-001, producto.md misión 04](../04-registro-perfil-profesional/producto.md#d-001)        | OTP por SMS/WhatsApp para el profesional se descartó por el costo real de contratar Twilio antes de tener un profesional registrado, no por dudas de que funcionara | Es sobre autenticar al profesional, no al buscador — el costo es el mismo proveedor, pero el problema que resuelve es distinto |
+| E-003 | benchmark | [Trustworthy Shopping at Amazon](https://trustworthyshopping.aboutamazon.com/how-amazon-maintains-a-trusted-review-experience) | El badge "Verified Purchase" se calcula comparando la reseña contra el historial de compra de la cuenta del comprador — no le pide nada nuevo en el momento de reseñar | Depende de que exista un registro de transacción ligado a una cuenta persistente — justo lo que D-002 de misión 05 decidió no tener |
+| E-004 | benchmark | [Search Engine Land — cómo Google y Yelp manejan reseñas falsas](https://searchengineland.com/how-google-and-yelp-handle-fake-reviews-and-policy-violations-374071), [Google: nuevas formas de proteger negocios en Maps](https://blog.google/products-and-platforms/products/maps/new-ways-were-protecting-businesses-on-maps/) | Google Maps no verifica que una reseña corresponda a una visita o compra real; en 2025 removió más de 292 millones de reseñas que violaban sus políticas, y hay estafas activas de extorsión con reseñas negativas falsas contra negocios pequeños | La escala de moderación de Google (equipos + ML) no es transferible a Datealo, pero el patrón de abuso — reseña falsa como arma contra un negocio chico sin defensa — sí es comparable: los profesionales de Datealo son ese mismo perfil de negocio |
+| E-005 | benchmark | [Twilio Verify pricing](https://www.twilio.com/en-us/pricing) | Un OTP con Twilio Verify parte en USD 0,05 por verificación — no es gratis, y exige cuenta y contrato con un proveedor internacional de SMS | El costo por verificación es bajo en términos absolutos; lo que ya bloqueó a misión 04 no fue el precio unitario sino contratar el proveedor antes de tener tracción — ese argumento no cambia por el precio |
+| E-006 | código | [`CLAUDE.md`](../../../CLAUDE.md), sección "Tipos de usuario" | El profesional "no es un usuario técnico y gestiona su perfil entre trabajos" — no una persona que entra a revisar un dashboard seguido | Es una descripción de producto ya aceptada como perfil de usuario, no una medición de comportamiento real todavía |
 
 ## Conclusiones
 
@@ -80,14 +88,89 @@ hallazgo, no el tema.
 
 <a id="c-001"></a>
 
-### C-001 — <conclusión en una frase>
+### C-001 — "Verificado por contacto" no puede significar prueba de que este contacto específico ocurrió
 
 - **Sustento:** [E-001](#e-001).
-- **Razonamiento:** <por qué la evidencia conduce a esta lectura y no a otra>.
-- **Implicación:** <qué deberá ser cierto en el producto o qué alternativa queda debilitada>.
-- **Confianza:** <alta, media o baja> porque <razón o validación pendiente>.
+- **Razonamiento:** el evento de contacto que misión 05 registra es, a propósito, anónimo — solo sabe
+  "hubo un contacto en este perfil, a esta hora". No existe ningún dato en el sistema que diga que fue
+  Carmen quien generó ese contacto específico. Ningún mecanismo que Datealo agregue del lado de la reseña
+  puede cruzar contra un dato que nunca se guardó del lado del contacto.
+- **Implicación:** el nombre "reseña verificada por contacto" describe una intención de producto —reducir
+  el costo de una reseña inventada—, no una garantía criptográfica de que ese contacto puntual ocurrió.
+  `producto.md` tiene que decidir qué nivel de prueba es honesto de comunicar, sin prometer más de lo que
+  el sistema entrega — el guardrail de "confianza primero" de `CLAUDE.md` se rompe si el badge promete algo
+  que Datealo no puede respaldar.
+- **Confianza:** alta — no es una interpretación disputable, es la consecuencia directa de una decisión de
+  diseño ya tomada y documentada en otra misión.
 
-## El ideal: <resultado completo, sin recortar>
+<a id="c-002"></a>
+
+### C-002 — Repetir el camino de OTP por SMS que misión 04 ya rechazó, para un problema secundario, necesita una razón nueva
+
+- **Sustento:** [E-002](#e-002), [E-005](#e-005).
+- **Razonamiento:** misión 04 evaluó exactamente este mecanismo (OTP por SMS/WhatsApp vía Twilio) para
+  autenticar al profesional — el lado del marketplace que sí necesita identidad persistente — y lo descartó
+  por el costo de contratar un proveedor de SMS antes de tener el primer profesional. El costo por mensaje
+  es bajo (E-005), pero eso no fue lo que lo descartó: fue contratar el proveedor mismo. Reseñas es un
+  problema con menos necesidad de identidad persistente que autenticación (la reseña no necesita que
+  Carmen vuelva a entrar mañana), así que el mismo argumento pesa igual o más fuerte acá.
+- **Implicación:** si `producto.md` igual elige OTP por teléfono para el buscador, tiene que declarar
+  explícitamente por qué el costo que bloqueó a misión 04 deja de ser bloqueante acá — o buscar un mecanismo
+  que no dependa de contratar Twilio.
+- **Confianza:** alta — el precedente es interno, de una misión hermana, con la misma restricción de
+  pre-lanzamiento que sigue vigente hoy.
+
+<a id="c-003"></a>
+
+### C-003 — Un token del navegador, guardado en el momento del contacto, ata la reseña a un contacto real sin pedirle nada a nadie
+
+- **Sustento:** [E-001](#e-001) (la reapertura de D-002 de misión 05 contempla exactamente este caso —
+  "si misión 07 concluye que necesita datos adicionales del momento del contacto").
+- **Razonamiento:** Carmen contacta y reseña casi siempre desde el mismo teléfono, en el mismo navegador.
+  Si el evento de contacto (F-002 de misión 05) deja algo en ese navegador —sin identificar a Carmen, sin
+  pedirle nada—, ese mismo algo puede exigirse al momento de reseñar. No prueba que fue Carmen la persona
+  física, pero sí prueba que ese dispositivo generó un contacto real con Marcelo antes de intentar
+  reseñarlo — el mismo nivel de prueba que C-001 concluye que es honesto prometer.
+- **Implicación:** esta es la alternativa más barata y menos fricciosa de las tres preguntas abiertas, y no
+  tiene el costo de infraestructura de C-002. Su debilidad — que el token es copiable o se pierde si Carmen
+  cambia de dispositivo o borra datos del navegador — es un caso límite real que `producto.md` tiene que
+  resolver (ej. qué pasa si Carmen quiere reseñar desde el computador después de haber contactado desde el
+  celular), no una razón para descartarla de plano.
+- **Confianza:** media — no hay precedente externo directo porque es una construcción a medida de la
+  restricción que D-002 de misión 05 ya impuso; la solidez real depende del diseño técnico que
+  `ingenieria.md` tendría que definir, y de qué tan seguido ocurre el caso de cambio de dispositivo.
+
+<a id="c-004"></a>
+
+### C-004 — Dejar el formulario de reseña completamente abierto expone a profesionales sin defensa al mismo abuso que sufren los negocios chicos en Google Maps
+
+- **Sustento:** [E-004](#e-004).
+- **Razonamiento:** el patrón de abuso que describe E-004 —reseña negativa falsa usada para extorsionar a
+  un negocio chico— no depende de la escala de la plataforma, depende de que el formulario de reseña esté
+  abierto sin ningún costo de fabricarla. Marcelo es exactamente el perfil de negocio que ese patrón
+  ataca: una persona sola, sin equipo legal ni de moderación propio.
+- **Implicación:** algún filtro —aunque no sea prueba criptográfica, ver C-001— no es opcional. La pregunta
+  que resuelve `producto.md` no es "¿hace falta un filtro?", es "¿cuál, con qué costo de fricción y de
+  infraestructura?" — entre C-002 (OTP, costo de proveedor) y C-003 (token de navegador, costo de robustez).
+- **Confianza:** media — la evidencia es de la escala de Google, no transferible en volumen absoluto, pero
+  el mecanismo de abuso no depende de volumen, solo de que exista la superficie sin filtro.
+
+<a id="c-005"></a>
+
+### C-005 — Un profesional que no entra seguido a la plataforma solo se entera de una reseña nueva si Datealo se lo empuja
+
+- **Sustento:** [E-006](#e-006).
+- **Razonamiento:** si el profesional gestiona su perfil "entre trabajos", desde el celular, y no es un
+  usuario técnico de dashboards, el canal correcto para avisarle de algo que afecta su reputación no puede
+  ser "que entre a revisar" — tiene que llegarle a un lugar que ya revisa por otro motivo. El correo ya es
+  ese lugar: es el mismo canal que misión 04 usa para su enlace mágico de ingreso, así que un profesional
+  activo ya lo revisa con regularidad.
+- **Implicación:** el aviso de reseña nueva se justifica como correo individual, no como algo que el
+  profesional descubre solo si entra a Datealo por su cuenta.
+- **Confianza:** media — la descripción del profesional como usuario poco técnico está aceptada en
+  `CLAUDE.md`, pero no hay todavía un profesional real que confirme el hábito de revisar correo.
+
+## El ideal: cualquier reseña en Datealo viene de alguien que de verdad contactó al profesional, sin pedirle cuenta a nadie
 
 <!--
 El ideal es el producto de la investigación: la dirección que la evidencia sostiene, sin restricciones de
@@ -97,22 +180,42 @@ alcance. Esta sección sí se reescribe cuando nueva evidencia cambia la direcci
 
 ### El resultado ideal se ve así
 
-<Narra de principio a fin una situación futura con datos concretos: nombres, comunas, oficios, horarios.
-Qué acción ocurre, qué responde Datealo, qué decisión puede tomar la persona. Evita "una experiencia
-simple" sin comportamiento observable.>
+Carmen contactó a Marcelo un sábado por la noche desde el celular. El lunes, con la llave ya arreglada,
+vuelve a abrir el perfil de Marcelo en el mismo celular y encuentra el botón "Dejar una reseña" ya
+habilitado — no tuvo que guardar ningún código ni recordar una fecha. Escribe cuatro líneas y elige cuatro
+estrellas, sin crear cuenta ni poner contraseña. La reseña aparece en el perfil de Marcelo con una marca
+que dice, en el lenguaje de la landing, algo como "esta persona contactó a Marcelo por Datealo" — no "reseña
+verificada" a secas, que prometería más de lo que el sistema puede probar (C-001). Si alguien que nunca
+contactó a Marcelo —un competidor, un curioso— intenta dejarle una reseña desde un perfil que nunca abrió
+el botón de contacto, Datealo no le muestra el formulario. Marcelo recibe un correo individual cada vez que
+le llega una reseña nueva, buena o mala, con el contenido completo en el cuerpo del correo — sin tener que
+entrar a la plataforma para leerla.
 
 ### Capacidades del ideal
 
-| Capacidad | Acción habilitada    | Respuesta esperada              | Conclusión que la justifica |
-| --------- | -------------------- | ------------------------------- | --------------------------- |
-| <nombre>  | <qué se puede hacer> | <qué produce o explica Datealo> | [C-001](#c-001)             |
+| Capacidad                          | Acción habilitada                                             | Respuesta esperada                                                            | Conclusión que la justifica |
+| ----------------------------------- | --------------------------------------------------------------- | --------------------------------------------------------------------------------- | ---------------------------- |
+| Reseñar sin cuenta                  | Dejar una reseña de un profesional sin crear cuenta ni contraseña | El formulario se completa y publica sin pedir identidad persistente               | [C-001](#c-001), [C-003](#c-003) |
+| Filtro de acceso al formulario      | El formulario de reseña solo aparece o se acepta si hubo un contacto real desde ese dispositivo | Un intento sin contacto previo no llega a publicar una reseña                    | [C-003](#c-003), [C-004](#c-004) |
+| Marca honesta en la reseña publicada| Cualquier buscador que lee el perfil ve qué nivel de garantía tiene la reseña | El texto de la marca no promete una verificación que Datealo no puede respaldar | [C-001](#c-001) |
+| Aviso al profesional                | El profesional se entera de cada reseña nueva sin tener que entrar a Datealo | Correo individual por reseña, con el contenido completo, buena o mala             | [C-005](#c-005) |
 
-### El ideal no significa <confusión probable>
+### El ideal no significa que Datealo audita cada reseña a mano ni que hay 100% de certeza de que el contacto ocurrió
 
-- <límite conceptual que evita una interpretación incorrecta>.
+- "Verificado por contacto" significa que existe una barrera real que sube el costo de fabricar una reseña
+  falsa — no que Datealo revisó cada caso ni que es matemáticamente imposible falsear una.
+- No significa pedirle al buscador que cree una cuenta persistente, recuerde una contraseña o teclee un
+  código — eso es exactamente la fricción que D-001 de misión 04 y D-001/D-002 de misión 05 ya evitaron del
+  lado del contacto, y que esta misión no debería reintroducir del lado de la reseña sin una razón nueva
+  (C-002).
+- No significa que el profesional puede impugnar o borrar una reseña real que no le gustó — eso es un
+  problema distinto (moderación/disputas), fuera de esta misión salvo que la evidencia lo traiga de vuelta.
 
 ## Referencias
 
 <!-- Fuentes primarias citadas por las evidencias. El enlace no sustituye el hecho y el límite en E-xxx. -->
 
-- [<título descriptivo>](URL): usado en E-001 para <afirmación concreta>.
+- [How Amazon maintains a trusted review experience](https://trustworthyshopping.aboutamazon.com/how-amazon-maintains-a-trusted-review-experience): usado en E-003 para cómo Amazon verifica sin exponer datos nuevos del comprador.
+- [How Google and Yelp handle fake reviews and policy violations](https://searchengineland.com/how-google-and-yelp-handle-fake-reviews-and-policy-violations-374071): usado en E-004 para el patrón de abuso sin verificación.
+- [New ways we're protecting businesses on Maps](https://blog.google/products-and-platforms/products/maps/new-ways-were-protecting-businesses-on-maps/): usado en E-004 para la escala de reseñas removidas por Google en 2025.
+- [Twilio Pricing](https://www.twilio.com/en-us/pricing): usado en E-005 para el costo por verificación de Twilio Verify.

--- a/docs/missions/07-resenas-verificadas-por-contacto/producto.md
+++ b/docs/missions/07-resenas-verificadas-por-contacto/producto.md
@@ -1,8 +1,8 @@
-# Misión: <nombre> — Producto
+# Misión: reseñas verificadas por contacto — Producto
 
-**Estado:** borrador
+**Estado:** vigente — aprobado por Patricio el 2026-08-29, con [D-003](#d-003) aceptada el 2026-08-30
 
-**Última actualización:** AAAA-MM-DD
+**Última actualización:** 2026-08-30
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
@@ -19,131 +19,292 @@ Gate de salida — producto.md está listo para experiencia.md cuando:
 - las decisiones propuestas tienen fecha límite en el README
 -->
 
-## Qué construimos: <resultado en una frase>
+## Qué construimos: el buscador deja una reseña sin cuenta, filtrada por si su navegador generó un contacto real
 
-<!--
-El recorte vigente del ideal y por qué sigue entregando el resultado central. Máximo cuatro párrafos
-cortos. El ideal completo vive en investigacion.md.
--->
+**Resultado:** Carmen puede dejar una reseña de Marcelo después de haberlo contactado, sin crear cuenta ni
+teclear ningún código; cualquier otro buscador que abra el perfil de Marcelo ve esa reseña; Marcelo recibe
+un correo cada vez que le llega una nueva.
 
-**Resultado:** <qué podrá lograr una persona al finalizar esta entrega>.
+**Recorte respecto del ideal:** el ideal ([investigacion.md](./investigacion.md)) sostiene una barrera real contra reseñas fabricadas, sin pedirle nada a nadie. Esta entrega la resuelve con
+un token que el navegador guarda en el momento del contacto ([D-001](#d-001)) — no con OTP por teléfono,
+que el brief original de esta misión proponía como dirección a confirmar, y que la investigación desaconseja
+por el mismo costo de infraestructura que misión 04 ya rechazó ([C-002 de investigacion.md](./investigacion.md#c-002)).
+Queda fuera de esta entrega poder reseñar desde un dispositivo distinto al que contactó, borrar una reseña
+sin dejar otra en su lugar ([D-003](#d-003)), y cualquier moderación humana de contenido.
 
-**Recorte respecto del ideal:** <qué dimensión se reduce y por qué sigue siendo suficiente>
-(ver [el ideal](./investigacion.md)).
-
-**Restricciones aceptadas:** <plataforma, cobertura geográfica, categorías, volumen inicial de
-profesionales>.
+**Restricciones aceptadas:** una reseña es rating (1 a 5 estrellas, obligatorio), comentario de texto
+(opcional) y nombre de quien reseña (texto libre, opcional, ver [D-002](#d-002)); un dispositivo mantiene
+como máximo una reseña vigente por profesional; no hay límite de categoría ni comuna — aplica a cualquier
+profesional con perfil activo (misión 04) y evento de contacto registrado (misión 05).
 
 ## Funcionalidades
 
-| ID    | Funcionalidad                  | Lado         | Sustento     | Éxito |
-| ----- | ------------------------------ | ------------ | ------------ | ----- |
-| F-001 | <verbo + resultado observable> | buscador     | C-001, D-001 | M-001 |
+| ID    | Funcionalidad                                              | Lado         | Sustento             | Éxito |
+| ----- | ------------------------------------------------------------ | ------------ | ---------------------- | ----- |
+| F-001 | Dejar una reseña de un profesional que se contactó de verdad | buscador     | C-001, C-003, D-001, D-002 | M-001 |
+| F-002 | Ver las reseñas de un profesional en su perfil                | buscador     | C-001                  | M-001 |
+| F-003 | Avisar por correo al profesional cuando le llega una reseña   | profesional  | C-005                  | M-002 |
 
 <a id="f-001"></a>
 
-### F-001 — <verbo + resultado observable>
+### F-001 — Dejar una reseña de un profesional que se contactó de verdad
 
-<!--
-Duplica este bloque por funcionalidad. Se escribe desde el resultado del usuario (working backwards):
-primero el JTBD, después las reglas. Si la respuesta de Datealo no se puede describir sin hablar de tablas
-o componentes, falta cerrar la decisión de producto.
--->
+Cuando Carmen ya contactó a Marcelo por WhatsApp desde el perfil de Datealo y el trabajo terminó,
+quiero dejarle una reseña con estrellas y un comentario,
+para que la próxima persona que busque un gasfiter en Ñuñoa sepa que cumple.
 
-Cuando <usuario en contexto concreto>,
-quiero <acción>,
-para <resultado observable>.
+**Lado del marketplace:** buscador. **Qué necesita del otro lado:** que exista al menos un perfil de
+profesional activo (misión 04) con el que el mismo navegador haya generado un evento de contacto
+(F-002 de misión 05) — sin eso, el formulario nunca se habilita.
 
-**Lado del marketplace:** buscador, profesional o ambos. **Qué necesita del otro lado:** <volumen mínimo
-de perfiles, reseñas o cobertura sin el cual esta funcionalidad no entrega su resultado>.
-
-**Sustento:** [C-001](./investigacion.md#c-001) y [D-001](#d-001). **Éxito:** [M-001](#m-001).
+**Sustento:** [C-001](./investigacion.md#c-001) y [C-003](./investigacion.md#c-003) de investigación,
+[D-001](#d-001) y [D-002](#d-002) de esta misión. **Éxito:** [M-001](#m-001).
 
 **Reglas:**
 
-- Si <condición>, Datealo <comportamiento esperado>.
-- Si <caso límite>, Datealo <comportamiento seguro y qué información muestra>.
-- Datealo nunca <comportamiento que rompería el significado o la confianza>.
+- Si el navegador de Carmen tiene el token que dejó un contacto real con Marcelo (D-001), Datealo habilita
+  el formulario de reseña en el perfil de Marcelo.
+- Si el navegador no tiene ese token para Marcelo, Datealo no permite publicar una reseña para él —
+  el comportamiento exacto de la pantalla (formulario oculto vs. visible pero bloqueado) lo define
+  `experiencia.md`.
+- Si Carmen ya dejó una reseña vigente para Marcelo y publica otra desde el mismo navegador — sea porque
+  cambió de opinión, corrige algo que escribió, o le encargó un segundo trabajo meses después — Datealo
+  reemplaza la reseña anterior por la nueva, sin exigir un contacto nuevo entre una y otra ([D-003](#d-003)).
+  Nunca acumula dos reseñas del mismo dispositivo para el mismo profesional.
+- El rating (1 a 5 estrellas) es obligatorio; el comentario de texto es opcional.
+- El formulario incluye un campo "Tu nombre" de texto libre, opcional ([D-002](#d-002)). Si Carmen lo deja
+  en blanco, la reseña se publica igual.
+- Datealo nunca publica una reseña sin verificar primero que el navegador tiene el token de contacto —
+  ni siquiera para el propio equipo de Datealo probando en producción.
 
-**Ejemplo verificable:** dado <estado con datos concretos>, cuando <acción>, entonces <resultado
-observable>.
+**Ejemplo verificable:** dado que Carmen contactó a Marcelo el sábado desde su celular y hoy es lunes,
+cuando abre el perfil de Marcelo desde el mismo celular, entonces ve el formulario de reseña habilitado y
+puede publicarla con 5 estrellas, un comentario y su nombre.
 
-**No incluye:** <variante del ideal excluida de esta funcionalidad>.
+**No incluye:** reseñar desde un dispositivo distinto al que generó el contacto ([D-001](#d-001), ver
+Fuera de alcance), borrar una reseña sin reemplazarla por otra ([D-003](#d-003)), subir fotos junto a la
+reseña.
 
-**Experiencia:** <enlace a UXF-xxx cuando exista>. **Ingeniería:** <enlace a T-xxx cuando exista>.
+**Experiencia:** vigente ([experiencia.md](./experiencia.md)). **Ingeniería:** pendiente.
+
+<a id="f-002"></a>
+
+### F-002 — Ver las reseñas de un profesional en su perfil
+
+Cuando alguien busca un gasfiter en Ñuñoa y abre el perfil de Marcelo,
+quiero leer lo que otras personas dijeron después de contactarlo,
+para decidir si lo llamo.
+
+**Lado del marketplace:** buscador. **Qué necesita del otro lado:** al menos una reseña publicada
+(F-001) — sin eso, el perfil se comporta como misión 05 ya definió para el estado sin reseñas
+([CL-003 de producto.md de misión 05](../05-perfil-publico-profesional/producto.md#cl-003)), que esta
+misión no repite ni reabre.
+
+**Sustento:** [C-001](./investigacion.md#c-001) de investigación, [D-002](#d-002) de esta misión. **Éxito:**
+[M-001](#m-001).
+
+**Reglas:**
+
+- Si el profesional tiene una o más reseñas, el perfil las muestra ordenadas de la más reciente a la más
+  antigua, cada una con su nombre (o el reemplazo de D-002 si quedó en blanco), su rating, su comentario
+  (si lo tiene) y su fecha relativa ("hace 2 semanas").
+- Si el profesional tiene dos o más reseñas, el perfil muestra también el promedio de estrellas arriba de
+  la lista.
+- Cada reseña muestra el mismo texto que comunica su nivel de garantía en toda la plataforma — "verificada
+  por contacto", nunca solo "verificada" a secas, porque lo único que Datealo puede respaldar es que el
+  dispositivo que la dejó generó un contacto real con ese profesional (D-001), no la identidad de quien la
+  escribió — el nombre que la acompaña (D-002) tampoco cambia eso: es de quien lo escribió, no verificado.
+- Datealo nunca muestra un badge de "verificada" en una reseña que no pasó por el filtro de D-001.
+
+**Ejemplo verificable:** dado que Marcelo tiene tres reseñas (Carmen R., 5 estrellas; un cliente de
+Datealo, 4 estrellas; Jorge, 5 estrellas), cuando alguien abre su perfil, entonces ve "4,7 de 5" arriba y
+las tres reseñas debajo, cada una con su nombre (o el reemplazo genérico) y marcada "verificada por
+contacto".
+
+**No incluye:** filtrar u ordenar reseñas por rating, responder a una reseña desde el perfil del
+profesional, reportar una reseña.
+
+**Experiencia:** vigente ([experiencia.md](./experiencia.md)). **Ingeniería:** pendiente.
+
+<a id="f-003"></a>
+
+### F-003 — Avisar por correo al profesional cuando le llega una reseña nueva
+
+Cuando a Marcelo le dejan una reseña nueva,
+quiero enterarme sin tener que entrar a Datealo,
+para poder reaccionar si algo salió mal, o simplemente saber que le fue bien.
+
+**Lado del marketplace:** profesional. **Qué necesita del otro lado:** que exista al menos un buscador
+dejando reseñas (F-001) — sin eso, este correo nunca se dispara.
+
+**Sustento:** [C-005](./investigacion.md#c-005) de investigación, brief de la misión
+([README](./README.md)). **Éxito:** [M-002](#m-002).
+
+**Reglas:**
+
+- Si se publica una reseña nueva para un profesional, Datealo le envía un correo individual con el
+  contenido completo (estrellas y comentario), usando `sendEmail()` (misión 02).
+- Se envía siempre, sea una reseña buena o mala — no hay forma de silenciarlo en esta entrega, porque
+  afecta la reputación del profesional igual en ambos casos.
+- Si `sendEmail()` falla, la reseña queda publicada de todas formas — el correo nunca bloquea ni revierte
+  la publicación (mismo criterio que ya usa `sendEmail()` en misión 02).
+- Datealo nunca agrupa varias reseñas en un solo correo (sin digest) — cada reseña dispara el suyo.
+
+**Ejemplo verificable:** dado que Carmen publica una reseña de 5 estrellas para Marcelo, cuando la reseña
+se guarda, entonces Marcelo recibe un correo con el rating y el comentario dentro de los minutos
+siguientes.
+
+**No incluye:** digest agrupado, notificación push, responder la reseña desde el correo.
+
+**Experiencia:** vigente ([experiencia.md](./experiencia.md)). **Ingeniería:** pendiente.
 
 ## Casos límite que cruzan funcionalidades
 
-<!--
-Solo condiciones que afectan varias funcionalidades. Las propias de una viven en su bloque. Un caso
-retirado no se borra ni se reutiliza: conserva su fila, o se nombra con su motivo en una línea debajo.
-
-Los casos límite propios de un marketplace pre-lanzamiento aparecen acá: cero resultados en una comuna,
-un profesional sin reseñas, una categoría con un solo perfil, un perfil sin verificar.
--->
-
-| ID     | Condición concreta     | Comportamiento esperado | Funcionalidades |
-| ------ | ---------------------- | ----------------------- | --------------- |
-| CL-001 | <estado o combinación> | <qué hace Datealo>      | F-001           |
+| ID     | Condición concreta                                                                  | Comportamiento esperado                                                                                  | Funcionalidades |
+| ------ | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | ---------------- |
+| CL-001 | Un navegador sin ningún token de contacto con ese profesional intenta dejar una reseña | Datealo no publica la reseña — el formulario está oculto o bloqueado, nunca acepta el envío                 | F-001            |
+| CL-002 | Carmen contactó a Marcelo desde el celular pero quiere reseñarlo desde el computador    | El token vive solo en el celular; desde el computador, Datealo trata a Carmen como si nunca lo hubiera contactado — limitación conocida de D-001, no un bug | F-001            |
+| CL-003 | El mismo navegador ya tiene una reseña vigente para un profesional y publica otra, sin necesitar un contacto nuevo entre medio | La reseña nueva reemplaza a la anterior de inmediato — funciona como editar ([D-003](#d-003)); nunca quedan dos reseñas del mismo dispositivo para el mismo profesional | F-001, F-002 |
 
 ## Fuera de alcance
 
-<!-- Distingue postergado de descartado y qué condición justificaría reabrirlo. -->
-
-| Capacidad o caso      | Estado                  | Razón del recorte | Condición para reconsiderar |
-| --------------------- | ----------------------- | ----------------- | --------------------------- |
-| <capacidad del ideal> | postergada o descartada | <trade-off>       | <evidencia o hito>          |
+| Capacidad o caso                                                  | Estado     | Razón del recorte                                                                                                 | Condición para reconsiderar                                                             |
+| --------------------------------------------------------------------- | ---------- | --------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| Borrar una reseña sin dejar otra en su lugar                           | postergada | El mecanismo de reemplazo ([D-003](#d-003)) ya cubre corregir o cambiar de opinión sin agregar un flujo de eliminación aparte | Si en la práctica alguien necesita que un profesional quede sin ninguna reseña suya (ej. la publicó por error y no quiere reemplazarla) |
+| Responder a una reseña (profesional)                                   | postergada | El README de la misión ya lo nombra como el gancho natural una vez que el correo de aviso (F-003) esté funcionando   | Cuando F-003 esté construido y haya volumen real de reseñas                                    |
+| Reseñar desde un dispositivo distinto al que generó el contacto        | postergada | Moverlo a un mecanismo cross-device (OTP, cuenta) tiene el mismo costo de infraestructura que D-001 evitó a propósito | Si el caso de cambio de dispositivo resulta frecuente en los primeros meses (ver CL-002)       |
+| Moderación humana de contenido de una reseña real                      | postergada | No hay volumen ni equipo que la sostenga hoy                                                                          | Cuando el volumen de reseñas produzca el primer caso real de abuso de contenido               |
 
 ## Señales de éxito
 
 <a id="m-001"></a>
 
-### M-001 — <señal que demuestra el resultado>
+### M-001 — De los contactos reales que ocurren, una parte razonable vuelve como reseña
 
-- **Pregunta:** ¿<qué queremos comprobar>?
-- **Señal:** <comportamiento o resultado observable>.
-- **Método y umbral:** <instrumentación o revisión, qué resultado, en qué población y ventana>.
-- **Guardrail:** <daño que no debe aumentar para conseguir la señal>.
+- **Pregunta:** ¿el filtro de D-001 deja pasar suficientes reseñas reales sin abrirle la puerta a spam?
+- **Señal:** de cada 10 contactos registrados por un profesional (`professional_contact_events`, misión
+  05), cuántos vuelven como una reseña publicada para ese mismo profesional en las semanas siguientes.
+- **Método y umbral:** revisión cualitativa de Patricio en los primeros meses, comparando a mano el
+  conteo de contactos contra el de reseñas por profesional — sin volumen todavía para fijar un número.
+- **Guardrail:** ningún profesional activo termina con más reseñas publicadas que contactos registrados —
+  si eso ocurre, el filtro de D-001 no está funcionando.
+
+<a id="m-002"></a>
+
+### M-002 — El correo de reseña nueva le llega al profesional y lo abre
+
+- **Pregunta:** ¿el correo de aviso (F-003) hace que el profesional se entere y, con el tiempo, vuelva a
+  la plataforma?
+- **Señal:** tasa de apertura del correo de "nueva reseña" — a diferencia del enlace mágico de misión 04
+  (D-001 de esa misión desactiva tracking porque corrompe un enlace de un solo uso), este correo no es de
+  autenticación, así que sí puede llevar tracking de apertura de Resend.
+- **Método y umbral:** revisión cualitativa, sin umbral numérico todavía por falta de volumen.
+- **Guardrail:** el correo nunca se convierte en spam — se hereda el mismo guardrail de `sendEmail()` de
+  misión 02 sobre no reventar el flujo cuando el envío falla.
 
 ## Decisiones de producto
 
-<!--
-Solo decisiones con alternativas reales. No borres decisiones reemplazadas: explican por qué el producto
-es como es. Toda decisión propuesta se refleja en el README con fecha límite.
--->
-
 <a id="d-001"></a>
 
-### D-001 — <decisión en una frase que se entiende sola>
+### D-001 — La reseña se habilita con un token que el navegador guarda al contactar, no con OTP por teléfono ni con cuenta
 
-- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
-- **Sustento:** [C-001](./investigacion.md#c-001).
-- **Tensión:** <criterios que no podían maximizarse al mismo tiempo>.
-- **Alternativas descartadas:** <opciones y razón concreta del rechazo, en la misma línea>.
-- **Decisión y consecuencia:** <qué se hará y qué habilita, limita o exige revisar en UX e ingeniería>.
-- **Reapertura:** <evidencia o cambio que justificaría revisarla>.
+- **Estado:** aceptada. **Fecha:** 2026-08-29.
+- **Sustento:** [C-001](./investigacion.md#c-001), [C-002](./investigacion.md#c-002),
+  [C-003](./investigacion.md#c-003), [C-004](./investigacion.md#c-004).
+- **Tensión:** una verificación fuerte (OTP por teléfono) cuesta contratar un proveedor de SMS antes de
+  tener tracción — el mismo argumento que ya cerró misión 04 para el profesional
+  ([D-001 de esa misión](../04-registro-perfil-profesional/producto.md#d-001)). Un formulario
+  completamente abierto, sin ningún filtro, expone a profesionales sin defensa al mismo patrón de abuso
+  que sufren los negocios chicos en Google Maps ([C-004](./investigacion.md#c-004)). Un token de navegador
+  no pide nada a nadie ni cuesta infraestructura, pero es débil si Carmen cambia de dispositivo entre
+  contactar y reseñar.
+- **Alternativas descartadas:** OTP por SMS/WhatsApp vía Twilio — la dirección que el brief original de
+  esta misión proponía a confirmar; se descarta porque repite exactamente el costo de infraestructura que
+  misión 04 ya rechazó, sin que exista una razón nueva que lo justifique acá (el problema que resuelve
+  reseñas necesita menos identidad persistente que autenticar a un profesional, no más). Código o enlace
+  mágico por correo, como el profesional en misión 04 — no aplica: a diferencia del profesional, que
+  entrega su correo al registrarse, Datealo nunca tiene el correo del buscador en ningún punto del flujo
+  de contacto (D-002 de misión 05), así que no hay a quién enviárselo. Formulario de reseña completamente
+  abierto, sin ningún filtro — descartado porque expone a los profesionales al mismo patrón de reseñas
+  falsas y extorsión que sufren negocios chicos sin defensa en plataformas sin verificación.
+- **Decisión y consecuencia:** cuando ocurre un evento de contacto (F-002 de misión 05), el navegador de
+  quien contactó guarda una referencia local a ese profesional. El formulario de reseña de ese profesional
+  solo se habilita en un navegador que tenga esa referencia. No identifica a la persona ni impide el abuso
+  al cien por ciento, pero eleva el costo de fabricar una reseña falsa sin pedirle nada a nadie ni
+  contratar infraestructura nueva — y es coherente con que la reseña se muestre marcada "verificada por
+  contacto" (F-002), no "verificada" a secas: lo que Datealo puede respaldar es que ese dispositivo generó
+  un contacto real, no quién lo tenía en la mano. El token no expira por tiempo transcurrido ([Q-001](#q-001),
+  resuelta): la debilidad real de este mecanismo es de quién generó el contacto, no de cuánto tiempo pasó
+  desde entonces, así que una fecha de vencimiento no cierra ningún riesgo — solo corta a gente real que se
+  demora en volver a reseñar, que es el caso típico porque una reseña honesta espera a que el trabajo
+  termine.
+- **Reapertura:** si, ya construido, se observa abuso real que este filtro no frena, si el caso de cambio
+  de dispositivo (CL-002) resulta frecuente, si aparece evidencia real de tokens reusados mucho después del
+  contacto original (lo que reabriría también Q-001), o si Datealo contrata un proveedor de SMS por otra
+  razón de negocio (misma condición de reapertura que D-001 de misión 04), este mecanismo se revisa.
+
+<a id="d-002"></a>
+
+### D-002 — La reseña muestra un nombre de texto libre y opcional, nunca un teléfono ni ningún dato verificado
+
+- **Estado:** aceptada. **Fecha:** 2026-08-29.
+- **Sustento:** [C-001](./investigacion.md#c-001) de investigación, [D-001](#d-001) de esta misión.
+- **Tensión:** una reseña sin ningún nombre arriba se lee vacía o fabricada — justo lo contrario de lo que
+  esta misión persigue ("reseñas reales, sin inventadas"). Pero pedir cualquier dato que suene a identidad
+  real (el teléfono, por ejemplo) reabre el mismo costo de fricción y de infraestructura que D-001 ya
+  evitó, sin que sirva para nada más: como C-001 ya concluye, ningún dato de esta reseña se verifica contra
+  nada, así que un teléfono no aporta más garantía real que un nombre escrito a mano.
+- **Alternativas descartadas:** reseña completamente anónima, sin ningún campo de nombre — es el diseño
+  que tenía esta misión antes de esta decisión; se descarta porque una lista de reseñas sin ningún nombre
+  se percibe vacía o fabricada, el problema concreto que motivó esta decisión. Pedir el teléfono del
+  buscador (se muestre o no) — descartada por el mismo argumento que cerró D-001: agrega fricción y además
+  se percibe raro pedir un teléfono para dejar un comentario, sin que suba el nivel real de garantía,
+  porque tampoco se verifica. Nombre obligatorio, sin poder dejarlo en blanco — descartada porque agrega
+  una fricción real (un campo más que completar, justo cuando alguien puede preferir no poner su nombre) a
+  cambio de nada: el nivel de confianza real no sube por obligarlo, solo baja la tasa de gente que termina
+  de publicar su reseña.
+- **Decisión y consecuencia:** el formulario de reseña (F-001) incluye un campo de texto libre "Tu nombre",
+  opcional. Si Carmen lo deja en blanco, la reseña se publica igual, mostrando "un cliente de Datealo" en
+  su lugar (F-002). El nombre no se verifica ni se cruza contra ningún dato — es exactamente el mismo nivel
+  de garantía que ya tiene el resto de la reseña por D-001 y C-001: cambia cómo se percibe la reseña, no
+  cuánto puede probar Datealo sobre quién la escribió.
+- **Reapertura:** si en la práctica la mayoría de las reseñas terminan con el reemplazo genérico (poca
+  gente pone su nombre) y eso sigue leyéndose como poco confiable, se revisa si conviene hacerlo obligatorio
+  o darle más énfasis en el flujo de `experiencia.md`.
+
+<a id="d-003"></a>
+
+### D-003 — Reemplazar una reseña ya publicada funciona como editarla, no solo como repetir el contacto
+
+- **Estado:** aceptada. **Fecha:** 2026-08-30.
+- **Sustento:** [CL-003](#cl-003) de esta misión; [D-001](#d-001) (el token no vence por tiempo).
+- **Tensión:** la redacción original de F-001 imaginaba el reemplazo solo para el caso de "un segundo
+  trabajo meses después" — pero como D-001 no vence, el mismo dispositivo puede reenviar el formulario en
+  cualquier momento después de la primera reseña, con cualquier rating, comentario o nombre distintos, sin
+  que haya ocurrido ningún contacto nuevo de por medio. Eso es editar, aunque el mecanismo interno siga
+  siendo "borra la anterior e inserta la nueva". La redacción anterior de F-001 y de "Fuera de alcance"
+  excluía "editar una reseña ya publicada" como si fuera otra cosa, lo que contradecía a la propia regla de
+  reemplazo.
+- **Alternativas descartadas:** exigir un contacto nuevo desde la última reseña para poder reemplazarla —
+  descartada porque D-001 no guarda cuándo ocurrió cada contacto, solo si existió alguno; construir ese
+  historial agrega el mismo costo de infraestructura que D-001 evitó a propósito, para resolver un caso
+  (alguien que quiere corregir un error de tipeo o cambiar de opinión) que no representa ningún riesgo de
+  abuso nuevo. Dejar "editar" fuera de alcance y bloquear el reemplazo salvo con contacto nuevo — descartada
+  por el mismo motivo: le niega a alguien real corregir su propia reseña sin ganar nada a cambio, porque
+  nada impedía ese mismo reemplazo hoy de todas formas.
+- **Decisión y consecuencia:** el mecanismo de reemplazo de F-001 es, en los hechos, la forma en que Carmen
+  edita su reseña — puede cambiar rating, comentario o nombre en cualquier momento posterior a la primera,
+  sin necesitar un contacto nuevo, y siempre queda como máximo una reseña vigente por dispositivo y
+  profesional. Solo queda fuera de alcance borrar la reseña sin reemplazarla por otra (dejar al profesional
+  sin ninguna).
+- **Reapertura:** si en producción se observa abuso de este flujo — alguien que cambia su reseña
+  reiteradamente de forma maliciosa, por ejemplo para extorsionar a un profesional — se revisa.
 
 ## Preguntas
 
-<!--
-Solo preguntas que pueden cambiar una decisión o funcionalidad. Lo demás va a un issue.
-Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
-Estado: abierta | resuelta AAAA-MM-DD (alguien la respondió) | disuelta AAAA-MM-DD (el producto cambió y la
-pregunta dejó de tener sentido). Solo las abiertas llevan bloque de detalle debajo de la tabla.
--->
+Ninguna pregunta abierta bloquea esta misión — Q-001 quedó resuelta y su respuesta ya vive en
+[D-001](#d-001).
 
-<Una frase que responde "¿qué falta?": la pregunta que bloquea y qué bloquea.>
-
-| ID    | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
-| ----- | ---------------------- | ------------------- | --------------------------------------------------------------- |
-| Q-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
-| Q-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |
-
-<a id="q-001"></a>
-
-### Q-001 — <la pregunta en una frase que se entiende sola>
-
-- **La duda, con un ejemplo:** <el caso concreto que muestra por qué hay dos respuestas posibles>.
-- **Afecta a:** D-001 o F-001.
-- **Cómo se resolverá:** <quién y con qué método>.
-- **¿Bloquea algo?:** <qué bloquea y su fecha límite, o no>.
+| ID    | La duda                                                                         | Estado             | Respuesta, o quién la resuelve                                                                         |
+| ----- | ---------------------------------------------------------------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------- |
+| Q-001 | ¿Por cuánto tiempo después de un contacto sigue habilitado el formulario de reseña? | resuelta 2026-08-29 | Sin vencimiento — Patricio la resolvió junto con D-001: el riesgo real que D-001 acepta no depende de cuánto tiempo pasó desde el contacto, así que una ventana no lo mitiga y sí corta a gente real que se demora en reseñar. |

--- a/docs/missions/README.md
+++ b/docs/missions/README.md
@@ -15,7 +15,7 @@ abrieron y de dónde salió cada una.
 | 04  | [registro y perfil de profesional](./04-registro-perfil-profesional/) | producto | 2026-08-13 | cerrada 2026-08-28 | — | — |
 | 05  | [perfil público de profesional](./05-perfil-publico-profesional/) | producto | 2026-08-13 | cerrada 2026-08-29 | — | — |
 | 06  | [búsqueda y resultados](./06-busqueda-resultados/) | producto | 2026-08-13 | exploración | — | — |
-| 07  | [reseñas verificadas por contacto](./07-resenas-verificadas-por-contacto/) | producto | 2026-08-13 | exploración | — | — |
+| 07  | [reseñas verificadas por contacto](./07-resenas-verificadas-por-contacto/) | producto | 2026-08-13 | en construcción | — | — |
 
 Misiones 02 a 07 son las seis que llevan al MVP (registrarse, mostrarse, buscar, reseñar), en el orden de
 dependencia definido en la conversación de roadmap del 2026-08-13 — el número no es prioridad, pero acá sí


### PR DESCRIPTION
## Resumen

Cierra el discovery completo de la misión 07 (reseñas verificadas por contacto):

- **producto.md**: vigente, con D-001 (token de navegador en vez de OTP), D-002 (nombre libre y opcional) y D-003 (el reemplazo de una reseña funciona como editarla) aceptadas.
- **experiencia.md**: vigente, aprobado tras evaluación heurística en un agente aislado (`ui-ux-pro-max`, `web-design-guidelines`, `frontend-design`, barrido de copy con `ux-writing`).
- **ingenieria.md**: vigente, aprobado tras dos auditorías independientes — la primera tumbó un diseño del token que no verificaba nada contra un contacto real (cualquiera podía fabricar uno sin haber contactado); la segunda encontró que el documento implicaba más protección de la que el mecanismo realmente da, corregido con TR-003 dicho explícito.
- **discovery-ux (skill)**: patrón universal nuevo — todo toast de Datealo va en `bottom-right`, 5000ms, sin variar por dispositivo.

Plan de construcción cortado en 7 slices (walking skeleton del mecanismo de verificación primero, UI después, correo al final), con sus issues ya creados (#107–#113).

## Test plan

- [x] Solo documentación y un mockup estático — sin código de aplicación.

🤖 Generado con [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B36NwwyTxP2JgUQL1m396k