### PR TITLE
feat(app): generar y enviar el token de reseña al contactar a un profesional

### DIFF
--- a/app/components/professional-public/ProfessionalPublicContactBar.vue
+++ b/app/components/professional-public/ProfessionalPublicContactBar.vue
@@ -12,11 +12,16 @@ const message = buildContactMessage(props.displayName, props.categoriaNombre)
 const whatsappUrl = computed(() => buildWhatsAppUrl(props.contact, message))
 const telUrl = computed(() => buildTelUrl(props.contact))
 
+const { ensureToken } = useReviewToken(props.professionalId)
+
 // sendBeacon, no fetch: dispara el registro antes de que el navegador salga hacia wa.me/tel:, sin
 // esperar la respuesta ni arriesgar que un fetch en vuelo se cancele al abandonar la página — el
-// contacto real nunca debe esperar a que este registro termine.
+// contacto real nunca debe esperar a que este registro termine. El body va como Blob con
+// application/json explícito: sendBeacon con un string a secas manda text/plain, y el servidor
+// descarta el token en silencio sin ese content-type.
 function registerContact() {
-  navigator.sendBeacon?.(`/api/professionals/${props.professionalId}/contacts`)
+  const body = new Blob([JSON.stringify({ token: ensureToken() })], { type: 'application/json' })
+  navigator.sendBeacon?.(`/api/professionals/${props.professionalId}/contacts`, body)
 }
 </script>
 

--- a/app/composables/useReviewToken.test.ts
+++ b/app/composables/useReviewToken.test.ts
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useReviewToken } from './useReviewToken'
+
+describe('useReviewToken', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  it('genera un token nuevo la primera vez y lo persiste', () => {
+    const { ensureToken } = useReviewToken('profesional-1')
+    const token = ensureToken()
+
+    expect(token).toMatch(/^[0-9a-f-]{36}$/)
+    expect(window.localStorage.getItem('datealo:review-token:profesional-1')).toBe(token)
+  })
+
+  it('reusa el mismo token en llamadas siguientes', () => {
+    const { ensureToken } = useReviewToken('profesional-1')
+    const first = ensureToken()
+    const second = ensureToken()
+
+    expect(second).toBe(first)
+  })
+
+  it('no mezcla tokens entre profesionales distintos', () => {
+    const tokenA = useReviewToken('profesional-a').ensureToken()
+    const tokenB = useReviewToken('profesional-b').ensureToken()
+
+    expect(tokenA).not.toBe(tokenB)
+  })
+})

--- a/app/composables/useReviewToken.ts
+++ b/app/composables/useReviewToken.ts
@@ -1,0 +1,25 @@
+const STORAGE_KEY_PREFIX = 'datealo:review-token:'
+
+// El token nace en el cliente, antes de cualquier request al servidor, y se guarda de inmediato en
+// localStorage — nunca depende de una respuesta. Si localStorage no está disponible (SSR, modo privado
+// estricto), igual devuelve un token usable para esta sola request, solo que no persiste para la próxima.
+export function useReviewToken(professionalId: string) {
+  function ensureToken(): string {
+    const key = STORAGE_KEY_PREFIX + professionalId
+
+    if (typeof window === 'undefined') return crypto.randomUUID()
+
+    try {
+      const existing = window.localStorage.getItem(key)
+      if (existing) return existing
+
+      const token = crypto.randomUUID()
+      window.localStorage.setItem(key, token)
+      return token
+    } catch {
+      return crypto.randomUUID()
+    }
+  }
+
+  return { ensureToken }
+}


### PR DESCRIPTION
## Qué hace

El navegador genera el token de reseña (`crypto.randomUUID()`) antes de tocar "Escribir por WhatsApp" o "Llamar", lo guarda en `localStorage` por profesional, y lo manda en el mismo `sendBeacon` que ya dispara el registro del contacto (#107/#115) — sin ninguna llamada extra.

**Sustento:** D-001, UXF-001.

## Detalle no obvio

`sendBeacon(url, data)` con `data` como string a secas manda `Content-Type: text/plain` — verificado contra el endpoint real, con ese content-type el servidor lee el body pero no lo parsea como JSON, así que `token` llega como `undefined` y **el token se pierde en silencio** (el endpoint sigue respondiendo `204`, nadie se entera). El fix es mandar un `Blob` con `type: 'application/json'` explícito.

## Qué se construye

- `app/composables/useReviewToken.ts` — generar, guardar y leer el token por profesional en `localStorage`.
- `app/components/professional-public/ProfessionalPublicContactBar.vue` (extendido).

## Verificación

Sin CI en el repo — verificado manual:

- [x] `npx nuxi typecheck` — limpio
- [x] `npm run build` — limpio
- [x] `npm test` — 39/39 (3 nuevos: genera y persiste, reusa el mismo token, no mezcla tokens entre profesionales)
- [x] Verificado contra el endpoint real que `text/plain` pierde el token en silencio y `application/json` (vía Blob) lo guarda — con datos en la base, no solo el código HTTP
- [x] **Navegador real** (no simulado): abrí el perfil de un profesional de prueba, hice click en "Escribir por WhatsApp" — navegó a WhatsApp de verdad y, confirmado en la base, quedaron registrados tanto el contacto como el token en la misma request

Datos de prueba limpiados de la base al terminar.

Cierra #110.

🤖 Generado con [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B36NwwyTxP2JgUQL1m396k