### PR TITLE
feat(app): UI de reseñas verificadas en el perfil público

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -1,5 +1,7 @@
 <template>
-  <NuxtLayout>
-    <NuxtPage />
-  </NuxtLayout>
+  <UApp :toaster="{ position: 'bottom-right' }">
+    <NuxtLayout>
+      <NuxtPage />
+    </NuxtLayout>
+  </UApp>
 </template>

--- a/app/components/professional-public/ProfessionalPublicReviewCard.vue
+++ b/app/components/professional-public/ProfessionalPublicReviewCard.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import { Check } from '@lucide/vue'
+import type { PublicReview } from '~/types/review'
+
+const props = defineProps<{
+  review: PublicReview
+}>()
+
+const relativeDate = computed(() => formatRelativeDate(props.review.updatedAt))
+</script>
+
+<template>
+  <div class="rounded-2xl border border-datealo-surface bg-white p-4">
+    <div class="flex items-center justify-between gap-2">
+      <span class="text-sm font-bold text-datealo-text">{{ review.name }}</span>
+      <span
+        class="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2 py-0.5 text-[0.6875rem] font-semibold text-emerald-700"
+      >
+        <Check class="h-2.5 w-2.5" />
+        verificada por contacto
+      </span>
+    </div>
+
+    <div class="mt-1 flex items-center gap-1">
+      <ProfessionalPublicStarRating :model-value="review.rating" readonly />
+      <span class="ml-1 text-[0.6875rem] text-datealo-muted">{{ relativeDate }}</span>
+    </div>
+
+    <p v-if="review.comment" class="mt-2 text-sm text-datealo-text">{{ review.comment }}</p>
+  </div>
+</template>

--- a/app/components/professional-public/ProfessionalPublicReviewSheet.vue
+++ b/app/components/professional-public/ProfessionalPublicReviewSheet.vue
@@ -1,0 +1,87 @@
+<script setup lang="ts">
+const props = defineProps<{
+  open: boolean
+  mode: 'new' | 'editing'
+  displayName: string
+  categoriaNombre: string
+  rating: number
+  comment: string
+  name: string
+  submitting: boolean
+  errorMessage: string | null
+}>()
+
+const emit = defineEmits<{
+  'update:open': [value: boolean]
+  'update:rating': [value: number]
+  'update:comment': [value: string]
+  'update:name': [value: string]
+  submit: []
+}>()
+
+const title = computed(() => props.mode === 'editing' ? 'Editar tu reseña' : 'Dejar una reseña')
+const commentCount = computed(() => [...props.comment].length)
+</script>
+
+<template>
+  <USlideover
+    :open="open"
+    side="bottom"
+    :title="title"
+    :description="`Para ${displayName} · ${categoriaNombre}`"
+    @update:open="emit('update:open', $event)"
+  >
+    <template #body>
+      <div>
+        <p class="text-sm font-bold text-datealo-text">¿Cómo calificarías a {{ displayName }}?</p>
+        <ProfessionalPublicStarRating
+          class="mt-2"
+          size="lg"
+          :model-value="rating"
+          @update:model-value="emit('update:rating', $event)"
+        />
+
+        <label class="mt-4 block text-sm font-bold text-datealo-text" for="review-comment">
+          Cuéntale a otros cómo te fue (opcional)
+        </label>
+        <UTextarea
+          id="review-comment"
+          class="mt-1.5 w-full"
+          :rows="3"
+          :model-value="comment"
+          placeholder="Ej: fue simpático, explicó bien el problema y no dejó ningún cable pelado"
+          @update:model-value="emit('update:comment', String($event))"
+        />
+        <p class="mt-1 text-right text-[0.6875rem] text-datealo-muted">{{ commentCount }}/500</p>
+
+        <label class="mt-2 block text-sm font-bold text-datealo-text" for="review-name">
+          Tu nombre (opcional)
+        </label>
+        <UInput
+          id="review-name"
+          class="mt-1.5 w-full"
+          :model-value="name"
+          placeholder="Ej: Carmen"
+          @update:model-value="emit('update:name', String($event))"
+        />
+        <p class="mt-1 text-[0.6875rem] text-datealo-muted">
+          Si lo dejas en blanco, aparecerás como "un cliente de Datealo"
+        </p>
+
+        <p v-if="errorMessage" class="mt-3 text-center text-[0.8125rem] font-medium text-red-600" aria-live="polite">
+          {{ errorMessage }}
+        </p>
+
+        <UButton
+          class="mt-4 w-full justify-center"
+          size="xl"
+          :disabled="rating < 1"
+          :loading="submitting"
+          @click="emit('submit')"
+        >
+          Publicar reseña
+        </UButton>
+      </div>
+    </template>
+  </USlideover>
+</template>

--- a/app/components/professional-public/ProfessionalPublicReviews.vue
+++ b/app/components/professional-public/ProfessionalPublicReviews.vue
@@ -1,0 +1,83 @@
+<script setup lang="ts">
+import type { PublicReview } from '~/types/review'
+
+const props = defineProps<{
+  professionalId: string
+  displayName: string
+  categoriaNombre: string
+  reviews: PublicReview[]
+}>()
+
+const emit = defineEmits<{
+  published: [review: PublicReview]
+}>()
+
+const { getToken, getMyReview } = useReviewToken(props.professionalId)
+const sheet = useReviewSheet(props.professionalId)
+const toast = useToast()
+
+// El token y el borrador solo existen en el navegador — en SSR no hay forma de saberlo, así que arrancan
+// en false y se corrigen apenas monta. El "pop-in" de la card es aceptable: es la misma personalización
+// que cualquier dato que solo vive en localStorage.
+const hasToken = ref(false)
+const hasMyReview = ref(false)
+
+onMounted(() => {
+  hasToken.value = Boolean(getToken())
+  hasMyReview.value = Boolean(getMyReview())
+})
+
+const cardHeading = computed(() => {
+  if (hasMyReview.value) return 'Editar tu reseña'
+  if (props.reviews.length === 0) return `Sé el primero en contarle a otros cómo te fue con ${props.displayName}`
+  return `¿Cómo te fue con ${props.displayName}?`
+})
+
+const cardButtonLabel = computed(() => hasMyReview.value ? 'Editar tu reseña' : 'Dejar una reseña')
+
+async function handleSubmit() {
+  const published = await sheet.submit()
+  if (!published) return
+
+  hasMyReview.value = true
+  emit('published', published)
+  toast.add({ title: 'Reseña publicada', color: 'success' })
+}
+</script>
+
+<template>
+  <div v-if="reviews.length > 0 || hasToken">
+    <h2 class="text-sm font-extrabold text-datealo-text">Reseñas</h2>
+
+    <div
+      v-if="hasToken"
+      class="mt-3 rounded-2xl border-[1.5px] border-dashed border-datealo-surface bg-datealo-surface/40 p-4"
+    >
+      <p class="text-sm font-bold text-datealo-text">{{ cardHeading }}</p>
+      <UButton class="mt-2.5 w-full justify-center" @click="sheet.open()">
+        {{ cardButtonLabel }}
+      </UButton>
+    </div>
+
+    <div class="mt-3 space-y-2.5">
+      <ProfessionalPublicReviewCard v-for="review in reviews" :key="review.id" :review="review" />
+    </div>
+
+    <ProfessionalPublicReviewSheet
+      :open="sheet.isOpen.value"
+      :mode="sheet.mode.value"
+      :display-name="displayName"
+      :categoria-nombre="categoriaNombre"
+      :rating="sheet.rating.value"
+      :comment="sheet.comment.value"
+      :name="sheet.name.value"
+      :submitting="sheet.submitting.value"
+      :error-message="sheet.errorMessage.value"
+      @update:open="sheet.isOpen.value = $event"
+      @update:rating="sheet.rating.value = $event"
+      @update:comment="sheet.comment.value = $event"
+      @update:name="sheet.name.value = $event"
+      @submit="handleSubmit"
+    />
+  </div>
+</template>

--- a/app/components/professional-public/ProfessionalPublicStarRating.vue
+++ b/app/components/professional-public/ProfessionalPublicStarRating.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import { Star } from '@lucide/vue'
+
+const props = withDefaults(defineProps<{
+  modelValue: number
+  readonly?: boolean
+  size?: 'sm' | 'lg'
+}>(), { readonly: false, size: 'sm' })
+
+const emit = defineEmits<{ 'update:modelValue': [value: number] }>()
+
+const STARS = [1, 2, 3, 4, 5]
+const iconClass = computed(() => props.size === 'lg' ? 'h-7 w-7' : 'h-3 w-3')
+// El botón, no el ícono, define el objetivo táctil — 44×44px en el sheet interactivo (UX-001 de
+// experiencia.md); el tamaño chico de la card de lectura no necesita ese mínimo, no es interactivo.
+const targetClass = computed(() => props.size === 'lg' ? 'h-11 w-11' : 'h-4 w-4')
+</script>
+
+<template>
+  <div
+    :role="readonly ? undefined : 'radiogroup'"
+    :aria-label="readonly ? undefined : 'Calificación'"
+    class="flex gap-1"
+  >
+    <button
+      v-for="star in STARS"
+      :key="star"
+      type="button"
+      :disabled="readonly"
+      :role="readonly ? undefined : 'radio'"
+      :aria-checked="readonly ? undefined : star === modelValue"
+      :aria-label="`${star} ${star > 1 ? 'estrellas' : 'estrella'}`"
+      class="flex items-center justify-center"
+      :class="[targetClass, readonly ? 'cursor-default' : 'cursor-pointer']"
+      @click="!readonly && emit('update:modelValue', star)"
+    >
+      <Star :class="[iconClass, star <= modelValue ? 'fill-amber-400 text-amber-400' : 'text-gray-300']" />
+    </button>
+  </div>
+</template>

--- a/app/components/professional-public/ProfessionalPublicStarRating.vue
+++ b/app/components/professional-public/ProfessionalPublicStarRating.vue
@@ -11,8 +11,8 @@ const emit = defineEmits<{ 'update:modelValue': [value: number] }>()
 
 const STARS = [1, 2, 3, 4, 5]
 const iconClass = computed(() => props.size === 'lg' ? 'h-7 w-7' : 'h-3 w-3')
-// El botón, no el ícono, define el objetivo táctil — 44×44px en el sheet interactivo (UX-001 de
-// experiencia.md); el tamaño chico de la card de lectura no necesita ese mínimo, no es interactivo.
+// El botón, no el ícono, define el objetivo táctil — 44×44px en el sheet interactivo; el tamaño
+// chico de la card de lectura no necesita ese mínimo, no es interactivo.
 const targetClass = computed(() => props.size === 'lg' ? 'h-11 w-11' : 'h-4 w-4')
 </script>
 

--- a/app/composables/usePublicProfessionalProfile.ts
+++ b/app/composables/usePublicProfessionalProfile.ts
@@ -14,5 +14,13 @@ export function usePublicProfessionalProfile(id: string) {
   const notFound = computed(() => !validId || Boolean(error.value))
   const slow = useSlowLoad(pending)
 
-  return { professional, pending, notFound, slow, refresh }
+  // useFetch guarda `data` en un shallowRef — mutar una propiedad anidada (professional.value.reviews =
+  // ...) no dispara ningún re-render, solo reasignar data.value entero lo hace. Esto es lo que permite
+  // que una reseña recién publicada aparezca sin recargar la página, sin pagar un segundo round-trip.
+  function updateProfessional(patch: Partial<PublicProfessionalProfile>) {
+    if (!data.value?.professional) return
+    data.value = { professional: { ...data.value.professional, ...patch } }
+  }
+
+  return { professional, pending, notFound, slow, refresh, updateProfessional }
 }

--- a/app/composables/useReviewSheet.ts
+++ b/app/composables/useReviewSheet.ts
@@ -4,7 +4,7 @@ import type { PublicReview } from '~/types/review'
 export type ReviewSheetMode = 'new' | 'editing'
 
 // Publicar y reemplazar son la misma acción del lado del servidor (upsert) — acá solo cambia qué
-// título y qué valores iniciales ve quien reseña, según si ya tenía un borrador guardado (CL-003).
+// título y qué valores iniciales ve quien reseña, según si ya tenía un borrador guardado.
 export function useReviewSheet(professionalId: string) {
   const { ensureToken, getMyReview, saveMyReview } = useReviewToken(professionalId)
 
@@ -57,7 +57,8 @@ export function useReviewSheet(professionalId: string) {
       return review
     } catch {
       // El mismo mensaje genérico cubre una falla de red y un rechazo del servidor — nunca menciona el
-      // token ni la verificación, para no convertir el error en un mapa de cómo funciona D-001.
+      // token ni la verificación, para no darle a quien prueba el flujo una pista de cómo distinguir
+      // un rechazo por falta de contacto real de cualquier otro error.
       errorMessage.value = 'No pudimos publicar tu reseña. Inténtalo de nuevo.'
       return null
     } finally {

--- a/app/composables/useReviewSheet.ts
+++ b/app/composables/useReviewSheet.ts
@@ -1,0 +1,69 @@
+import { ref } from 'vue'
+import type { PublicReview } from '~/types/review'
+
+export type ReviewSheetMode = 'new' | 'editing'
+
+// Publicar y reemplazar son la misma acción del lado del servidor (upsert) — acá solo cambia qué
+// título y qué valores iniciales ve quien reseña, según si ya tenía un borrador guardado (CL-003).
+export function useReviewSheet(professionalId: string) {
+  const { ensureToken, getMyReview, saveMyReview } = useReviewToken(professionalId)
+
+  const isOpen = ref(false)
+  const mode = ref<ReviewSheetMode>('new')
+  const rating = ref(0)
+  const comment = ref('')
+  const name = ref('')
+  const submitting = ref(false)
+  const errorMessage = ref<string | null>(null)
+
+  function open() {
+    const draft = getMyReview()
+
+    mode.value = draft ? 'editing' : 'new'
+    rating.value = draft?.rating ?? 0
+    comment.value = draft?.comment ?? ''
+    name.value = draft?.name ?? ''
+    errorMessage.value = null
+    isOpen.value = true
+  }
+
+  // Cerrar (X o backdrop) nunca guarda nada, ni siquiera el rating ya marcado — es todo o nada.
+  function close() {
+    isOpen.value = false
+  }
+
+  async function submit(): Promise<PublicReview | null> {
+    if (rating.value < 1) return null
+
+    submitting.value = true
+    errorMessage.value = null
+
+    try {
+      const { review } = await $fetch<{ review: PublicReview }>(
+        `/api/professionals/${professionalId}/reviews`,
+        {
+          method: 'POST',
+          body: {
+            token: ensureToken(),
+            rating: rating.value,
+            comment: comment.value || undefined,
+            name: name.value || undefined,
+          },
+        },
+      )
+
+      saveMyReview({ rating: rating.value, comment: comment.value, name: name.value })
+      isOpen.value = false
+      return review
+    } catch {
+      // El mismo mensaje genérico cubre una falla de red y un rechazo del servidor — nunca menciona el
+      // token ni la verificación, para no convertir el error en un mapa de cómo funciona D-001.
+      errorMessage.value = 'No pudimos publicar tu reseña. Inténtalo de nuevo.'
+      return null
+    } finally {
+      submitting.value = false
+    }
+  }
+
+  return { isOpen, mode, rating, comment, name, submitting, errorMessage, open, close, submit }
+}

--- a/app/composables/useReviewToken.test.ts
+++ b/app/composables/useReviewToken.test.ts
@@ -29,4 +29,31 @@ describe('useReviewToken', () => {
 
     expect(tokenA).not.toBe(tokenB)
   })
+
+  it('getToken nunca genera uno nuevo, solo lee', () => {
+    const { getToken } = useReviewToken('profesional-1')
+
+    expect(getToken()).toBeNull()
+    expect(window.localStorage.getItem('datealo:review-token:profesional-1')).toBeNull()
+  })
+
+  it('getToken devuelve el token ya guardado por ensureToken', () => {
+    const { ensureToken, getToken } = useReviewToken('profesional-1')
+    const token = ensureToken()
+
+    expect(getToken()).toBe(token)
+  })
+
+  it('getMyReview sin nada guardado devuelve null', () => {
+    expect(useReviewToken('profesional-1').getMyReview()).toBeNull()
+  })
+
+  it('saveMyReview + getMyReview redondean el viaje completo', () => {
+    const { saveMyReview, getMyReview } = useReviewToken('profesional-1')
+    const draft = { rating: 4, comment: 'Buena atención', name: 'Carmen' }
+
+    saveMyReview(draft)
+
+    expect(getMyReview()).toEqual(draft)
+  })
 })

--- a/app/composables/useReviewToken.ts
+++ b/app/composables/useReviewToken.ts
@@ -1,6 +1,11 @@
 const STORAGE_KEY_PREFIX = 'datealo:review-token:'
 const MY_REVIEW_KEY_PREFIX = 'datealo:my-review:'
 
+// Si localStorage falla (modo privado estricto, cuota agotada), este token de repuesto vive acá en vez
+// de generarse de nuevo en cada llamada — sin esto, registrar el contacto y publicar la reseña
+// terminarían mandando dos tokens distintos al servidor y la reseña nunca pasaría la verificación.
+const fallbackTokens = new Map<string, string>()
+
 export type MyReviewDraft = {
   rating: number
   comment: string
@@ -25,12 +30,17 @@ export function useReviewToken(professionalId: string) {
       window.localStorage.setItem(tokenKey, token)
       return token
     } catch {
-      return crypto.randomUUID()
+      const cached = fallbackTokens.get(tokenKey)
+      if (cached) return cached
+
+      const token = crypto.randomUUID()
+      fallbackTokens.set(tokenKey, token)
+      return token
     }
   }
 
   // Nunca genera un token — a diferencia de ensureToken, esto solo pregunta "¿este navegador ya
-  // contactó?" para decidir si mostrar la opción de reseñar (UX-001). Generar uno acá inventaría un
+  // contactó?" para decidir si mostrar la opción de reseñar. Generar uno acá inventaría un
   // token sin que haya ocurrido ningún contacto real.
   function getToken(): string | null {
     if (typeof window === 'undefined') return null
@@ -43,7 +53,7 @@ export function useReviewToken(professionalId: string) {
   }
 
   // La única forma de saber qué escribió este navegador la última vez, para prellenar el sheet al
-  // editar (CL-003) — el servidor nunca devuelve el token asociado a una reseña, así que no hay ningún
+  // editar — el servidor nunca devuelve el token asociado a una reseña, así que no hay ningún
   // endpoint del que leerlo de vuelta.
   function getMyReview(): MyReviewDraft | null {
     if (typeof window === 'undefined') return null

--- a/app/composables/useReviewToken.ts
+++ b/app/composables/useReviewToken.ts
@@ -1,25 +1,71 @@
 const STORAGE_KEY_PREFIX = 'datealo:review-token:'
+const MY_REVIEW_KEY_PREFIX = 'datealo:my-review:'
+
+export type MyReviewDraft = {
+  rating: number
+  comment: string
+  name: string
+}
 
 // El token nace en el cliente, antes de cualquier request al servidor, y se guarda de inmediato en
 // localStorage — nunca depende de una respuesta. Si localStorage no está disponible (SSR, modo privado
 // estricto), igual devuelve un token usable para esta sola request, solo que no persiste para la próxima.
 export function useReviewToken(professionalId: string) {
-  function ensureToken(): string {
-    const key = STORAGE_KEY_PREFIX + professionalId
+  const tokenKey = STORAGE_KEY_PREFIX + professionalId
+  const myReviewKey = MY_REVIEW_KEY_PREFIX + professionalId
 
+  function ensureToken(): string {
     if (typeof window === 'undefined') return crypto.randomUUID()
 
     try {
-      const existing = window.localStorage.getItem(key)
+      const existing = window.localStorage.getItem(tokenKey)
       if (existing) return existing
 
       const token = crypto.randomUUID()
-      window.localStorage.setItem(key, token)
+      window.localStorage.setItem(tokenKey, token)
       return token
     } catch {
       return crypto.randomUUID()
     }
   }
 
-  return { ensureToken }
+  // Nunca genera un token — a diferencia de ensureToken, esto solo pregunta "¿este navegador ya
+  // contactó?" para decidir si mostrar la opción de reseñar (UX-001). Generar uno acá inventaría un
+  // token sin que haya ocurrido ningún contacto real.
+  function getToken(): string | null {
+    if (typeof window === 'undefined') return null
+
+    try {
+      return window.localStorage.getItem(tokenKey)
+    } catch {
+      return null
+    }
+  }
+
+  // La única forma de saber qué escribió este navegador la última vez, para prellenar el sheet al
+  // editar (CL-003) — el servidor nunca devuelve el token asociado a una reseña, así que no hay ningún
+  // endpoint del que leerlo de vuelta.
+  function getMyReview(): MyReviewDraft | null {
+    if (typeof window === 'undefined') return null
+
+    try {
+      const raw = window.localStorage.getItem(myReviewKey)
+      return raw ? JSON.parse(raw) as MyReviewDraft : null
+    } catch {
+      return null
+    }
+  }
+
+  function saveMyReview(review: MyReviewDraft) {
+    if (typeof window === 'undefined') return
+
+    try {
+      window.localStorage.setItem(myReviewKey, JSON.stringify(review))
+    } catch {
+      // La reseña ya se publicó en el servidor — perder este borrador local solo significa que el
+      // próximo "Editar tu reseña" no prellena, no que la reseña se haya perdido.
+    }
+  }
+
+  return { ensureToken, getToken, getMyReview, saveMyReview }
 }

--- a/app/pages/profesionales/[id].vue
+++ b/app/pages/profesionales/[id].vue
@@ -1,12 +1,19 @@
 <script setup lang="ts">
-import { Hourglass, SearchX } from '@lucide/vue'
+import { Hourglass, SearchX, Star } from '@lucide/vue'
+import type { PublicReview } from '~/types/review'
 
 const route = useRoute()
 const id = route.params.id as string
 
-const { professional, pending, notFound, slow, refresh } = usePublicProfessionalProfile(id)
+const { professional, pending, notFound, slow, refresh, updateProfessional } = usePublicProfessionalProfile(id)
 
 const memberSince = computed(() => professional.value ? formatMemberSince(professional.value.createdAt) : '')
+
+function onReviewPublished(review: PublicReview) {
+  if (!professional.value) return
+  const reviews = upsertLocalReview(professional.value.reviews, review)
+  updateProfessional({ reviews, ratingAverage: averageRating(reviews), reviewCount: reviews.length })
+}
 
 useSeoMeta({
   title: () => professional.value
@@ -61,6 +68,12 @@ useSeoMeta({
         <h1 class="text-xl font-extrabold text-datealo-text lg:text-2xl">{{ professional.displayName }}</h1>
         <p class="mt-0.5 text-sm text-datealo-muted">{{ professional.categoriaNombre }} · {{ professional.comunaNombre }}</p>
 
+        <div v-if="professional.ratingAverage !== null" class="mt-2 flex items-center gap-1 text-sm">
+          <Star class="h-3.5 w-3.5 fill-amber-400 text-amber-400" />
+          <span class="font-bold text-datealo-text">{{ professional.ratingAverage.toFixed(1).replace('.', ',') }}</span>
+          <span class="text-datealo-muted">· {{ professional.reviewCount }} reseñas</span>
+        </div>
+
         <p v-if="professional.description" class="mt-4 text-sm leading-relaxed text-datealo-text">
           {{ professional.description }}
         </p>
@@ -68,6 +81,15 @@ useSeoMeta({
         <p v-if="professional.priceFrom" class="mt-3 text-base font-bold text-datealo-text lg:text-lg">
           Desde ${{ formatPriceFrom(professional.priceFrom) }}
         </p>
+
+        <ProfessionalPublicReviews
+          class="mt-6"
+          :professional-id="professional.id"
+          :display-name="professional.displayName"
+          :categoria-nombre="professional.categoriaNombre"
+          :reviews="professional.reviews"
+          @published="onReviewPublished"
+        />
 
         <p class="mt-3 text-xs text-datealo-muted">En Datealo desde {{ memberSince }}</p>
 

--- a/app/types/professional.ts
+++ b/app/types/professional.ts
@@ -1,3 +1,5 @@
+import type { PublicReview } from './review'
+
 export type Professional = {
   id: string
   displayName: string
@@ -30,4 +32,7 @@ export type PublicProfessionalProfile = {
   priceFrom: number | null
   photoUrls: string[]
   createdAt: string
+  reviews: PublicReview[]
+  ratingAverage: number | null
+  reviewCount: number
 }

--- a/app/types/review.ts
+++ b/app/types/review.ts
@@ -3,6 +3,5 @@ export type PublicReview = {
   name: string
   rating: number
   comment: string | null
-  verified: true
   updatedAt: string
 }

--- a/app/types/review.ts
+++ b/app/types/review.ts
@@ -1,0 +1,8 @@
+export type PublicReview = {
+  id: string
+  name: string
+  rating: number
+  comment: string | null
+  verified: true
+  updatedAt: string
+}

--- a/app/utils/professional-reviews.test.ts
+++ b/app/utils/professional-reviews.test.ts
@@ -3,7 +3,7 @@ import { averageRating, upsertLocalReview } from './professional-reviews'
 import type { PublicReview } from '~/types/review'
 
 function review(id: string, rating: number): PublicReview {
-  return { id, name: 'Carmen', rating, comment: null, verified: true, updatedAt: '2026-08-31T00:00:00.000Z' }
+  return { id, name: 'Carmen', rating, comment: null, updatedAt: '2026-08-31T00:00:00.000Z' }
 }
 
 describe('upsertLocalReview', () => {

--- a/app/utils/professional-reviews.test.ts
+++ b/app/utils/professional-reviews.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { averageRating, upsertLocalReview } from './professional-reviews'
+import type { PublicReview } from '~/types/review'
+
+function review(id: string, rating: number): PublicReview {
+  return { id, name: 'Carmen', rating, comment: null, verified: true, updatedAt: '2026-08-31T00:00:00.000Z' }
+}
+
+describe('upsertLocalReview', () => {
+  it('agrega una reseña nueva al principio', () => {
+    const result = upsertLocalReview([review('a', 4)], review('b', 5))
+    expect(result.map(r => r.id)).toEqual(['b', 'a'])
+  })
+
+  it('reemplaza una reseña existente por id, sin duplicar', () => {
+    const result = upsertLocalReview([review('a', 4), review('b', 5)], review('a', 3))
+    expect(result).toHaveLength(2)
+    expect(result[0]).toEqual(review('a', 3))
+  })
+})
+
+describe('averageRating', () => {
+  it('devuelve null sin reseñas', () => {
+    expect(averageRating([])).toBeNull()
+  })
+
+  it('redondea a un decimal', () => {
+    expect(averageRating([review('a', 5), review('b', 4)])).toBe(4.5)
+  })
+})

--- a/app/utils/professional-reviews.ts
+++ b/app/utils/professional-reviews.ts
@@ -1,0 +1,14 @@
+import type { PublicReview } from '~/types/review'
+
+// La reseña publicada va primero — si ya existía una del mismo id (reemplazo, D-003), la vieja
+// desaparece de la lista en vez de quedar duplicada.
+export function upsertLocalReview(reviews: PublicReview[], published: PublicReview): PublicReview[] {
+  return [published, ...reviews.filter(review => review.id !== published.id)]
+}
+
+export function averageRating(reviews: PublicReview[]): number | null {
+  if (reviews.length === 0) return null
+
+  const sum = reviews.reduce((total, review) => total + review.rating, 0)
+  return Math.round((sum / reviews.length) * 10) / 10
+}

--- a/app/utils/professional-reviews.ts
+++ b/app/utils/professional-reviews.ts
@@ -1,6 +1,6 @@
 import type { PublicReview } from '~/types/review'
 
-// La reseña publicada va primero — si ya existía una del mismo id (reemplazo, D-003), la vieja
+// La reseña publicada va primero — si ya existía una del mismo id (reemplazo), la vieja
 // desaparece de la lista en vez de quedar duplicada.
 export function upsertLocalReview(reviews: PublicReview[], published: PublicReview): PublicReview[] {
   return [published, ...reviews.filter(review => review.id !== published.id)]

--- a/app/utils/relative-date.test.ts
+++ b/app/utils/relative-date.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { formatRelativeDate } from './relative-date'
+
+const NOW = new Date('2026-08-31T12:00:00.000Z')
+
+function minutesAgo(minutes: number): string {
+  return new Date(NOW.getTime() - minutes * 60 * 1000).toISOString()
+}
+
+describe('formatRelativeDate', () => {
+  it('devuelve "recién" para menos de un minuto', () => {
+    expect(formatRelativeDate(minutesAgo(0.5), NOW)).toBe('recién')
+  })
+
+  it('formatea en días, semanas y meses en español', () => {
+    expect(formatRelativeDate(minutesAgo(60 * 24 * 3), NOW)).toBe('hace 3 días')
+    expect(formatRelativeDate(minutesAgo(60 * 24 * 14), NOW)).toBe('hace 2 semanas')
+    expect(formatRelativeDate(minutesAgo(60 * 24 * 30), NOW)).toBe('hace 1 mes')
+  })
+})

--- a/app/utils/relative-date.ts
+++ b/app/utils/relative-date.ts
@@ -1,0 +1,26 @@
+const RELATIVE_TIME_FORMATTER = new Intl.RelativeTimeFormat('es-CL', { numeric: 'always' })
+
+const UNITS: { unit: Intl.RelativeTimeFormatUnit, seconds: number }[] = [
+  { unit: 'year', seconds: 31536000 },
+  { unit: 'month', seconds: 2592000 },
+  { unit: 'week', seconds: 604800 },
+  { unit: 'day', seconds: 86400 },
+  { unit: 'hour', seconds: 3600 },
+  { unit: 'minute', seconds: 60 },
+]
+
+// Menos de un minuto se lee "recién" — Intl.RelativeTimeFormat diría "hace 0 minutos", que no es cómo
+// nadie habla.
+export function formatRelativeDate(dateIso: string, now: Date = new Date()): string {
+  const diffSeconds = (now.getTime() - new Date(dateIso).getTime()) / 1000
+
+  if (diffSeconds < 60) return 'recién'
+
+  for (const { unit, seconds } of UNITS) {
+    if (diffSeconds >= seconds) {
+      return RELATIVE_TIME_FORMATTER.format(-Math.floor(diffSeconds / seconds), unit)
+    }
+  }
+
+  return 'recién'
+}

--- a/server/api/professionals/[id].get.ts
+++ b/server/api/professionals/[id].get.ts
@@ -1,15 +1,14 @@
-export default defineEventHandler(async (event) => {
+type ProfessionalWithReviews = PublicProfessionalProfile & ReviewsSummary
+
+export default defineEventHandler(async (event): Promise<{ professional: ProfessionalWithReviews } | { error: string }> => {
   const id = getRouterParam(event, 'id') ?? ''
 
-  const [professional, reviewsSummary] = await Promise.all([
-    findPublicProfessionalProfile(id),
-    findReviewsForProfessional(id),
-  ])
-
+  const professional = await findPublicProfessionalProfile(id)
   if (!professional) {
     setResponseStatus(event, 404)
     return { error: 'not_found' }
   }
 
+  const reviewsSummary = await findReviewsForProfessional(id)
   return { professional: { ...professional, ...reviewsSummary } }
 })

--- a/server/api/professionals/[id]/reviews.post.ts
+++ b/server/api/professionals/[id]/reviews.post.ts
@@ -1,16 +1,18 @@
 export default defineEventHandler(async (event) => {
   const id = getRouterParam(event, 'id') ?? ''
 
-  if (!(await professionalExists(id))) {
+  const body = await readBody(event).catch(() => null)
+  const token = typeof body?.token === 'string' ? body.token : ''
+
+  const [exists, verified] = await Promise.all([professionalExists(id), hasContactToken(id, token)])
+
+  if (!exists) {
     setResponseStatus(event, 404)
     return { error: 'not_found' }
   }
 
-  const body = await readBody(event).catch(() => null)
-  const token = typeof body?.token === 'string' ? body.token : ''
-
   // Nunca se publica una reseña sin verificar primero que el token corresponde a un contacto real.
-  if (!(await hasContactToken(id, token))) {
+  if (!verified) {
     setResponseStatus(event, 403)
     return { error: 'not_verified' }
   }

--- a/server/utils/professional-contact-events.ts
+++ b/server/utils/professional-contact-events.ts
@@ -1,16 +1,10 @@
-import { eq } from 'drizzle-orm'
-import { isUuid } from './validation'
 import { professionalContactEvents } from '../db/schema/professional-contact-events'
-import { professionals } from '../db/schema/professionals'
 
 // Sin cuenta ni sesión: quien contacta nunca queda identificado, a propósito. Devuelve false cuando el
 // id no corresponde a ningún profesional, para que el handler responda 404 en vez de dejar que Postgres
 // rechace el insert por violación de FK.
 export async function registerProfessionalContact(professionalId: string): Promise<boolean> {
-  if (!isUuid(professionalId)) return false
-
-  const [exists] = await useDb().select({ id: professionals.id }).from(professionals).where(eq(professionals.id, professionalId))
-  if (!exists) return false
+  if (!(await professionalExists(professionalId))) return false
 
   await useDb().insert(professionalContactEvents).values({ professionalId })
   return true

--- a/server/utils/professional-contact-tokens.ts
+++ b/server/utils/professional-contact-tokens.ts
@@ -16,7 +16,7 @@ export async function registerContactToken(professionalId: string, token: string
 
 // Una reseña solo se publica si existe un contacto real detrás de este token para este profesional.
 export async function hasContactToken(professionalId: string, token: string): Promise<boolean> {
-  if (!isUuid(token)) return false
+  if (!isUuid(professionalId) || !isUuid(token)) return false
 
   const [row] = await useDb()
     .select({ token: professionalContactTokens.token })

--- a/server/utils/reviews.ts
+++ b/server/utils/reviews.ts
@@ -9,7 +9,6 @@ export type PublicReview = {
   name: string
   rating: number
   comment: string | null
-  verified: true
   updatedAt: string
 }
 
@@ -61,7 +60,6 @@ function toPublicReview(row: {
     name: resolveReviewerName(row.name),
     rating: row.rating,
     comment: row.comment,
-    verified: true,
     updatedAt: row.updatedAt.toISOString(),
   }
 }


### PR DESCRIPTION
## Resumen

- Sheet (bottom-sheet, `USlideover side="bottom"`) para dejar o editar una reseña: rating, comentario opcional (≤500 caracteres, contado en code points) y nombre opcional.
- Resumen de rating promedio + cantidad de reseñas, y lista de reseñas verificadas en `/profesionales/[id]`.
- `useReviewToken` (ya existente desde S-004) decide si el visitante ve "Dejar reseña" o "Editar tu reseña", según si `getMyReview()` encuentra un borrador guardado en localStorage.
- Publicar/editar actualiza la página al instante, sin recargar.

## Por qué un componente de estrellas propio

`UInputRating` de Nuxt UI usa íconos vía CSS-mask de Iconify, que solo puede "rellenar" con color un ícono ya sólido — un Lucide outline no se puede rellenar así. Al reemplazar el ícono con un slot custom (`Star fill-amber-400`) se rompió el mecanismo de clip de Reka UI (`--reka-rating-item-step-width`): el botón "inactivo" quedaba sin clipear y las 5 estrellas se veían siempre llenas, sin importar el rating real (confirmado en DB y en el DOM). `ProfessionalPublicStarRating.vue` es un reemplazo simple, con `role="radiogroup"`/`radio` y objetivos táctiles de 44×44px en el modo interactivo.

## Bug de reactividad corregido

`useFetch` guarda `data` en un `shallowRef`. Mutar `professional.value.reviews` no disparaba re-render. `updateProfessional()` en `usePublicProfessionalProfile.ts` reasigna `data.value` entero para que la reseña recién publicada aparezca sin recargar.

## Verificación

- `npx nuxi typecheck` — 0 errores
- `npm run build` — compila
- `npm test` — 49/49
- Verificado en browser contra la base de desarrollo con un profesional QA dedicado: publicar reseña nueva, editar reseña existente (prefill correcto), validación de rating/comentario, render correcto de estrellas parciales (interactivo y readonly), actualización sin reload del resumen y la lista.

Closes #111

https://claude.ai/code/session_01B36NwwyTxP2JgUQL1m396k