### PR TITLE
fix(app): mostrar la opción de reseñar sin recargar tras contactar en la misma visita

### DIFF
--- a/app/components/professional-public/ProfessionalPublicReviews.vue
+++ b/app/components/professional-public/ProfessionalPublicReviews.vue
@@ -12,18 +12,18 @@ const emit = defineEmits<{
   published: [review: PublicReview]
 }>()
 
-const { getToken, getMyReview } = useReviewToken(props.professionalId)
+const { hasToken, getToken, getMyReview } = useReviewToken(props.professionalId)
 const sheet = useReviewSheet(props.professionalId)
 const toast = useToast()
 
-// El token y el borrador solo existen en el navegador — en SSR no hay forma de saberlo, así que arrancan
-// en false y se corrigen apenas monta. El "pop-in" de la card es aceptable: es la misma personalización
-// que cualquier dato que solo vive en localStorage.
-const hasToken = ref(false)
+// El borrador de reseña solo existe en el navegador — en SSR no hay forma de saberlo, así que arranca
+// en false y se corrige apenas monta. El "pop-in" de la card es aceptable: es la misma personalización
+// que cualquier dato que solo vive en localStorage. hasToken es estado compartido (useReviewToken) y no
+// necesita este mismo tratamiento acá — se actualiza solo, incluso si el contacto ocurre después de montar.
 const hasMyReview = ref(false)
 
 onMounted(() => {
-  hasToken.value = Boolean(getToken())
+  getToken()
   hasMyReview.value = Boolean(getMyReview())
 })
 

--- a/app/composables/useReviewToken.ts
+++ b/app/composables/useReviewToken.ts
@@ -1,3 +1,6 @@
+import { ref } from 'vue'
+import type { Ref } from 'vue'
+
 const STORAGE_KEY_PREFIX = 'datealo:review-token:'
 const MY_REVIEW_KEY_PREFIX = 'datealo:my-review:'
 
@@ -5,6 +8,23 @@ const MY_REVIEW_KEY_PREFIX = 'datealo:my-review:'
 // de generarse de nuevo en cada llamada — sin esto, registrar el contacto y publicar la reseña
 // terminarían mandando dos tokens distintos al servidor y la reseña nunca pasaría la verificación.
 const fallbackTokens = new Map<string, string>()
+
+// Compartido por clave entre la barra de contacto y la sección de reseñas, dos componentes hermanos en
+// la misma página — sin este estado en común, tocar "Escribir por WhatsApp"/"Llamar" y mirar la sección
+// de reseñas en la misma visita no mostraría la opción de reseñar hasta recargar la página. No usa
+// useState() de Nuxt: nunca se muta durante SSR (todo camino que lo toca empieza con el guard de
+// `window`), así que no hay riesgo de que este módulo filtre estado entre requests distintos, y queda
+// testeable con Vitest a secas, igual que el resto de este archivo.
+const hasTokenRefs = new Map<string, Ref<boolean>>()
+
+function getHasTokenRef(tokenKey: string): Ref<boolean> {
+  let existing = hasTokenRefs.get(tokenKey)
+  if (!existing) {
+    existing = ref(false)
+    hasTokenRefs.set(tokenKey, existing)
+  }
+  return existing
+}
 
 export type MyReviewDraft = {
   rating: number
@@ -19,22 +39,32 @@ export function useReviewToken(professionalId: string) {
   const tokenKey = STORAGE_KEY_PREFIX + professionalId
   const myReviewKey = MY_REVIEW_KEY_PREFIX + professionalId
 
+  const hasToken = getHasTokenRef(tokenKey)
+
   function ensureToken(): string {
     if (typeof window === 'undefined') return crypto.randomUUID()
 
     try {
       const existing = window.localStorage.getItem(tokenKey)
-      if (existing) return existing
+      if (existing) {
+        hasToken.value = true
+        return existing
+      }
 
       const token = crypto.randomUUID()
       window.localStorage.setItem(tokenKey, token)
+      hasToken.value = true
       return token
     } catch {
       const cached = fallbackTokens.get(tokenKey)
-      if (cached) return cached
+      if (cached) {
+        hasToken.value = true
+        return cached
+      }
 
       const token = crypto.randomUUID()
       fallbackTokens.set(tokenKey, token)
+      hasToken.value = true
       return token
     }
   }
@@ -46,7 +76,9 @@ export function useReviewToken(professionalId: string) {
     if (typeof window === 'undefined') return null
 
     try {
-      return window.localStorage.getItem(tokenKey)
+      const token = window.localStorage.getItem(tokenKey)
+      if (token) hasToken.value = true
+      return token
     } catch {
       return null
     }
@@ -77,5 +109,5 @@ export function useReviewToken(professionalId: string) {
     }
   }
 
-  return { ensureToken, getToken, getMyReview, saveMyReview }
+  return { hasToken, ensureToken, getToken, getMyReview, saveMyReview }
 }

--- a/docs/missions/07-resenas-verificadas-por-contacto/ingenieria.md
+++ b/docs/missions/07-resenas-verificadas-por-contacto/ingenieria.md
@@ -174,9 +174,9 @@ edite sin ver el efecto sobre el token, o viceversa.
   aditiva.
 - **Invariantes:** sin reseñas, `reviews: []`, `ratingAverage: null`, `reviewCount: 0` — F-002 hereda el
   comportamiento sin reseñas de misión 05 (CL-003 de esa misión: la sección de reseñas ni siquiera aparece).
-  El handler compone dos queries independientes (`findPublicProfessionalProfile` de `professionals.ts` y
-  una nueva de `reviews.ts`) con `Promise.all`, nunca encadenadas — misión 05 ya identificó este endpoint
-  como el de mayor tráfico esperado del diseño. No hace falta un índice adicional para el `order by
+  El handler pide primero `findPublicProfessionalProfile` de `professionals.ts` y solo si existe pide la
+  de `reviews.ts` — encadenadas, no con `Promise.all`: un id que no corresponde a ningún profesional (o
+  uno inactivo) nunca debe pagar la segunda consulta. No hace falta un índice adicional para el `order by
   updated_at`: `experiencia.md` ya fija sin paginación ni "ver más" en esta entrega, porque con la oferta y
   el volumen esperados ningún perfil va a acumular reseñas suficientes para que un `sort` sobre unas pocas
   filas importe.

--- a/server/db/sql/rls.sql
+++ b/server/db/sql/rls.sql
@@ -48,8 +48,9 @@ alter table professionals enable row level security;
 
 -- Si algún día se revierte el revoke de abajo para servir esta tabla por PostgREST (ej. un perfil
 -- público futuro), esta policy tiene que ajustarse en el mismo cambio: hoy es `using (true)` porque
--- nada la evalúa, pero expone `user_id` (el id de auth.users, que no debería quedar público) y las
--- filas con `active = false`. Acotarla a columnas públicas y a `using (active)` antes de reabrir el grant.
+-- nada la evalúa, pero expone `user_id` (el id de auth.users, que no debería quedar público), `email`
+-- (dato interno, nunca parte de un perfil público) y las filas con `active = false`. Acotarla a
+-- columnas públicas y a `using (active)` antes de reabrir el grant.
 drop policy if exists professionals_select_public on professionals;
 create policy professionals_select_public on professionals
   for select to authenticated, anon using (true);

--- a/server/utils/reviews.ts
+++ b/server/utils/reviews.ts
@@ -95,9 +95,8 @@ export async function upsertReview(
   return toPublicReview(row!)
 }
 
-// Corre en paralelo con la lectura del perfil (Promise.all en el handler), incluso antes de saber si el
-// profesional existe — por eso guarda el mismo chequeo de forma de id que ya hace findPublicProfessionalProfile,
-// para no romper con un 22P02 de Postgres cuando el id ni siquiera tiene forma de uuid.
+// Guarda el mismo chequeo de forma de id que ya hace findPublicProfessionalProfile, para no romper con
+// un 22P02 de Postgres cuando el id ni siquiera tiene forma de uuid.
 export async function findReviewsForProfessional(professionalId: string): Promise<ReviewsSummary> {
   if (!isUuid(professionalId)) {
     return { reviews: [], ratingAverage: null, reviewCount: 0 }


### PR DESCRIPTION
## Contexto

Una segunda revisión crítica (corrida en el contexto de S-006, pero sobre el estado completo de la rama tras el merge de #119) encontró un bug funcional real en código ya mergeado de S-005, más algunos comentarios/documentación que quedaron desalineados con cambios posteriores.

## Qué corrige

- **Bug real:** `experiencia.md` (V-001, "Punto de entrada") exige que la opción de reseñar aparezca cuando el usuario "acaba de tocar WhatsApp/Llamar en esta misma visita". `hasToken` en `ProfessionalPublicReviews.vue` solo se leía una vez en `onMounted()`, sin ninguna conexión con `ProfessionalPublicContactBar.vue` (el componente que registra el token al contactar) — contactar sin recargar la página nunca hacía aparecer la card. `useReviewToken()` ahora expone `hasToken` como estado compartido por profesional entre ambos componentes hermanos.
- **Comentario/doc desactualizados:** un comentario en `reviews.ts` y la sección TC-003 de `ingenieria.md` seguían describiendo un `Promise.all` que ya no existe — se cambió a secuencial en la revisión de #119 para no pagar la consulta de reseñas cuando el profesional no existe, pero el comentario no se actualizó en ese momento.
- **RLS:** el comentario de la policy `professionals_select_public` enumeraba qué columnas se expondrían si se reabre el grant a PostgREST, sin mencionar `email` (agregada en paralelo por #120/S-006).

## Por qué estado compartido y no `useState()` de Nuxt

`useReviewToken.ts` está deliberadamente escrito para ser testeable con Vitest sin contexto de Nuxt (mismo criterio que otros composables del repo). `useState()` no está disponible fuera del runtime de Nuxt. Como `hasToken` nunca se muta durante SSR (todo camino que lo toca arranca con el guard de `window`), un `Map` a nivel de módulo con `ref()` de Vue a secas da la misma reactividad compartida sin ese riesgo ni esa dependencia.

## Verificación

- `npx nuxi typecheck` — 0 errores
- `npm run build` — compila
- `npm test` — 49/49 (incluye la suite de `useReviewToken.test.ts`, que corre en Vitest puro)
- Verificado en browser contra la base de desarrollo: `localStorage` limpio → perfil sin sección de reseñas → clic en "Llamar" → la card "Dejar una reseña" aparece de inmediato, sin recargar.

https://claude.ai/code/session_01B36NwwyTxP2JgUQL1m396k