### PR TITLE
feat(server): avisar por correo al profesional cuando le llega una reseña

### DIFF
--- a/server/api/professionals/[id]/reviews.post.ts
+++ b/server/api/professionals/[id]/reviews.post.ts
@@ -29,6 +29,24 @@ export default defineEventHandler(async (event) => {
 
   const name = typeof body?.name === 'string' ? body.name : undefined
 
-  const review = await upsertReview(id, token, { rating, comment, name })
+  const [review, professional] = await Promise.all([
+    upsertReview(id, token, { rating, comment, name }),
+    findProfessionalNotificationInfo(id),
+  ])
+
+  // Sin email guardado (perfiles de antes de esta columna) o si sendEmail() falla, la reseña ya quedó
+  // publicada igual — event.waitUntil evita que el aviso demore la respuesta, y el catch evita que un
+  // fallo de Resend la haga fallar.
+  if (professional?.email) {
+    const { subject, html } = buildReviewNotificationEmail({
+      displayName: professional.displayName,
+      reviewerName: name,
+      rating: review.rating,
+      comment: review.comment,
+      profileUrl: `${getRequestURL(event).origin}/profesionales/${id}`,
+    })
+    event.waitUntil(sendEmail({ to: professional.email, subject, html }).catch(() => {}))
+  }
+
   return { review }
 })

--- a/server/utils/professionals.ts
+++ b/server/utils/professionals.ts
@@ -173,6 +173,18 @@ export async function findProfessionalByUserId(userId: string): Promise<Professi
   return row ? toPublicProfessional(row) : null
 }
 
+// Lo único que necesita el correo de aviso de reseña nueva (misión 07) — nunca active, que ya decidió
+// professionalExists() que no aplica acá, y nunca ninguna otra columna.
+export async function findProfessionalNotificationInfo(
+  id: string,
+): Promise<{ displayName: string, email: string | null } | null> {
+  const [row] = await useDb()
+    .select({ displayName: professionals.displayName, email: professionals.email })
+    .from(professionals)
+    .where(eq(professionals.id, id))
+  return row ?? null
+}
+
 export async function createProfessional(
   userId: string,
   fields: ProfessionalCoreFields,
@@ -234,7 +246,7 @@ export async function professionalHasPhotoPath(userId: string, path: string): Pr
   return Boolean(row)
 }
 
-function escapeHtml(value: string): string {
+export function escapeHtml(value: string): string {
   const entities: Record<string, string> = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }
   return value.replace(/[&<>"']/g, char => entities[char]!)
 }

--- a/server/utils/reviews.test.ts
+++ b/server/utils/reviews.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { computeRatingAverage, isValidComment, isValidRating, resolveReviewerName } from './reviews'
+import { buildReviewNotificationEmail, computeRatingAverage, isValidComment, isValidRating, resolveReviewerName } from './reviews'
 
 describe('isValidRating', () => {
   it('acepta enteros de 1 a 5', () => {
@@ -52,5 +52,66 @@ describe('resolveReviewerName', () => {
 
   it('reemplaza null por el nombre genérico', () => {
     expect(resolveReviewerName(null)).toBe('un cliente de Datealo')
+  })
+})
+
+describe('buildReviewNotificationEmail', () => {
+  const base = {
+    displayName: 'Marcelo Rojas',
+    profileUrl: 'https://datealo.cl/profesionales/abc-123',
+  }
+
+  it('el asunto nunca cambia con el rating', () => {
+    const uno = buildReviewNotificationEmail({ ...base, reviewerName: 'Carmen', rating: 1, comment: null })
+    const cinco = buildReviewNotificationEmail({ ...base, reviewerName: 'Carmen', rating: 5, comment: null })
+
+    expect(uno.subject).toBe('Marcelo, te llegó una reseña nueva')
+    expect(cinco.subject).toBe(uno.subject)
+  })
+
+  it('usa el nombre de quien reseñó cuando existe', () => {
+    const { html } = buildReviewNotificationEmail({ ...base, reviewerName: 'Carmen', rating: 4, comment: null })
+    expect(html).toContain('Carmen te dejó una reseña en Datealo:')
+  })
+
+  it('sin nombre, usa el reemplazo genérico en una frase distinta', () => {
+    const { html } = buildReviewNotificationEmail({ ...base, reviewerName: undefined, rating: 4, comment: null })
+    expect(html).toContain('Te llegó una reseña de un cliente de Datealo:')
+  })
+
+  it('un nombre en blanco cuenta como sin nombre', () => {
+    const { html } = buildReviewNotificationEmail({ ...base, reviewerName: '   ', rating: 4, comment: null })
+    expect(html).toContain('Te llegó una reseña de un cliente de Datealo:')
+  })
+
+  it('muestra el comentario completo cuando existe', () => {
+    const { html } = buildReviewNotificationEmail({
+      ...base,
+      reviewerName: 'Carmen',
+      rating: 5,
+      comment: 'Llegó puntual y dejó todo funcionando.',
+    })
+    expect(html).toContain('Llegó puntual y dejó todo funcionando.')
+  })
+
+  it('sin comentario, no deja ninguna línea vacía en su lugar', () => {
+    const { html } = buildReviewNotificationEmail({ ...base, reviewerName: 'Carmen', rating: 5, comment: null })
+    expect(html).not.toContain('<p></p>')
+  })
+
+  it('las estrellas reflejan el rating exacto, llenas primero', () => {
+    const { html } = buildReviewNotificationEmail({ ...base, reviewerName: 'Carmen', rating: 2, comment: null })
+    expect(html).toContain('★★☆☆☆')
+  })
+
+  it('escapa HTML en el nombre y el comentario', () => {
+    const { html } = buildReviewNotificationEmail({
+      ...base,
+      reviewerName: '<b>Carmen</b>',
+      rating: 5,
+      comment: '<script>alert(1)</script>',
+    })
+    expect(html).not.toContain('<b>Carmen</b>')
+    expect(html).not.toContain('<script>alert(1)</script>')
   })
 })

--- a/server/utils/reviews.ts
+++ b/server/utils/reviews.ts
@@ -1,4 +1,5 @@
 import { desc, eq, sql } from 'drizzle-orm'
+import { escapeHtml } from './professionals'
 import { isUuid } from './validation'
 import { reviews } from '../db/schema/reviews'
 
@@ -122,5 +123,40 @@ export async function findReviewsForProfessional(professionalId: string): Promis
     reviews: rows.map(toPublicReview),
     ratingAverage: computeRatingAverage(rows.map(row => row.rating)),
     reviewCount: rows.length,
+  }
+}
+
+// El asunto nunca adelanta el rating (ni número ni estrellas): una reseña de 1 estrella con eso en el
+// asunto se leería duro antes de que el profesional tenga cualquier contexto. Mismo asunto para las
+// cinco notas posibles.
+export function buildReviewNotificationEmail({
+  displayName,
+  reviewerName,
+  rating,
+  comment,
+  profileUrl,
+}: {
+  displayName: string
+  reviewerName: string | undefined
+  rating: number
+  comment: string | null
+  profileUrl: string
+}): { subject: string, html: string } {
+  const firstName = escapeHtml(displayName.trim().split(/\s+/)[0] ?? displayName)
+  const name = normalizeReviewerName(reviewerName)
+  const stars = '★'.repeat(rating) + '☆'.repeat(5 - rating)
+
+  const intro = name
+    ? `${escapeHtml(name)} te dejó una reseña en Datealo:`
+    : `Te llegó una reseña de ${GENERIC_REVIEWER_NAME}:`
+
+  return {
+    subject: `${firstName}, te llegó una reseña nueva`,
+    html: `
+      <p>${intro}</p>
+      <p style="font-size: 20px; letter-spacing: 2px;">${stars}</p>
+      ${comment ? `<p>${escapeHtml(comment)}</p>` : ''}
+      <p><a href="${profileUrl}">Ver mi perfil</a></p>
+    `.trim(),
   }
 }


### PR DESCRIPTION
## Resumen

Al publicar o reemplazar una reseña, si el profesional tiene `professionals.email` guardado (S-006), dispara `sendEmail()` con `buildReviewNotificationEmail()` sin esperar su resultado (`event.waitUntil`, mismo patrón que el correo de bienvenida de misión 04). Un fallo de `sendEmail()` o un email ausente nunca afectan la respuesta `200` de publicar la reseña.

## Contenido del correo (UXF-003)

- Asunto: "<Nombre>, te llegó una reseña nueva" — nunca adelanta el rating, mismo texto para las 5 notas posibles.
- Cuerpo: nombre de quien reseñó (o "un cliente de Datealo") + estrellas + comentario completo si existe.
- Cierre: link al perfil público del profesional.

## Verificación

- `npx nuxi typecheck` — 0 errores
- `npm run build` — compila
- `npm test` — 57/57 (8 tests nuevos para `buildReviewNotificationEmail`: asunto estable con el rating, las dos variantes de intro, comentario presente/ausente sin línea vacía, estrellas exactas, escape de HTML)
- Verificado contra la base de desarrollo con un profesional QA dedicado:
  - Email inválido guardado → la reseña se publica igual con `200`, `sendEmail()` falla internamente sin afectar la respuesta (criterio de aceptación 2).
  - Sin email guardado (`null`) → la reseña se publica con `200`, sin ningún intento de envío (criterio de aceptación 3).
  - Sin enviar ningún correo real a una casilla externa en ninguna de las dos pruebas.

Closes #113

https://claude.ai/code/session_01B36NwwyTxP2JgUQL1m396k