### PR TITLE
feat(db): agregar avatarPath a professionals

### DIFF
--- a/server/db/migrations/0008_open_harrier.sql
+++ b/server/db/migrations/0008_open_harrier.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "professionals" ADD COLUMN "avatar_path" text;

--- a/server/db/migrations/meta/0008_snapshot.json
+++ b/server/db/migrations/meta/0008_snapshot.json
@@ -1,0 +1,539 @@
+{
+  "id": "c9d1e7a5-aae6-4e46-b843-15e6b176757c",
+  "prevId": "7aff137e-0cd0-4de8-a6e3-9490e6ddee7a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.categorias": {
+      "name": "categorias",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "nombre": {
+          "name": "nombre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activa": {
+          "name": "activa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comuna_vecinas": {
+      "name": "comuna_vecinas",
+      "schema": "",
+      "columns": {
+        "comuna_codigo": {
+          "name": "comuna_codigo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vecina_codigo": {
+          "name": "vecina_codigo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comuna_vecinas_comuna_codigo_comunas_codigo_fk": {
+          "name": "comuna_vecinas_comuna_codigo_comunas_codigo_fk",
+          "tableFrom": "comuna_vecinas",
+          "tableTo": "comunas",
+          "columnsFrom": [
+            "comuna_codigo"
+          ],
+          "columnsTo": [
+            "codigo"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "comuna_vecinas_vecina_codigo_comunas_codigo_fk": {
+          "name": "comuna_vecinas_vecina_codigo_comunas_codigo_fk",
+          "tableFrom": "comuna_vecinas",
+          "tableTo": "comunas",
+          "columnsFrom": [
+            "vecina_codigo"
+          ],
+          "columnsTo": [
+            "codigo"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "comuna_vecinas_comuna_codigo_vecina_codigo_pk": {
+          "name": "comuna_vecinas_comuna_codigo_vecina_codigo_pk",
+          "columns": [
+            "comuna_codigo",
+            "vecina_codigo"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comunas": {
+      "name": "comunas",
+      "schema": "",
+      "columns": {
+        "codigo": {
+          "name": "codigo",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "nombre": {
+          "name": "nombre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activa": {
+          "name": "activa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.professional_contact_events": {
+      "name": "professional_contact_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "professional_id": {
+          "name": "professional_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "professional_contact_events_professional_id_idx": {
+          "name": "professional_contact_events_professional_id_idx",
+          "columns": [
+            {
+              "expression": "professional_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "professional_contact_events_professional_id_professionals_id_fk": {
+          "name": "professional_contact_events_professional_id_professionals_id_fk",
+          "tableFrom": "professional_contact_events",
+          "tableTo": "professionals",
+          "columnsFrom": [
+            "professional_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.professional_contact_tokens": {
+      "name": "professional_contact_tokens",
+      "schema": "",
+      "columns": {
+        "professional_id": {
+          "name": "professional_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "professional_contact_tokens_professional_id_professionals_id_fk": {
+          "name": "professional_contact_tokens_professional_id_professionals_id_fk",
+          "tableFrom": "professional_contact_tokens",
+          "tableTo": "professionals",
+          "columnsFrom": [
+            "professional_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "professional_contact_tokens_professional_id_token_pk": {
+          "name": "professional_contact_tokens_professional_id_token_pk",
+          "columns": [
+            "professional_id",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.professionals": {
+      "name": "professionals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "categoria_slug": {
+          "name": "categoria_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comuna_codigo": {
+          "name": "comuna_codigo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact": {
+          "name": "contact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_from": {
+          "name": "price_from",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_paths": {
+          "name": "photo_paths",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "avatar_path": {
+          "name": "avatar_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "professionals_categoria_slug_idx": {
+          "name": "professionals_categoria_slug_idx",
+          "columns": [
+            {
+              "expression": "categoria_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "professionals_comuna_codigo_idx": {
+          "name": "professionals_comuna_codigo_idx",
+          "columns": [
+            {
+              "expression": "comuna_codigo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "professionals_categoria_slug_categorias_slug_fk": {
+          "name": "professionals_categoria_slug_categorias_slug_fk",
+          "tableFrom": "professionals",
+          "tableTo": "categorias",
+          "columnsFrom": [
+            "categoria_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "professionals_comuna_codigo_comunas_codigo_fk": {
+          "name": "professionals_comuna_codigo_comunas_codigo_fk",
+          "tableFrom": "professionals",
+          "tableTo": "comunas",
+          "columnsFrom": [
+            "comuna_codigo"
+          ],
+          "columnsTo": [
+            "codigo"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "professionals_user_id_unique": {
+          "name": "professionals_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "professional_id": {
+          "name": "professional_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reviews_professional_id_professionals_id_fk": {
+          "name": "reviews_professional_id_professionals_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "professionals",
+          "columnsFrom": [
+            "professional_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "reviews_professional_id_token_fk": {
+          "name": "reviews_professional_id_token_fk",
+          "tableFrom": "reviews",
+          "tableTo": "professional_contact_tokens",
+          "columnsFrom": [
+            "professional_id",
+            "token"
+          ],
+          "columnsTo": [
+            "professional_id",
+            "token"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reviews_professional_id_token_key": {
+          "name": "reviews_professional_id_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "professional_id",
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "reviews_rating_check": {
+          "name": "reviews_rating_check",
+          "value": "\"reviews\".\"rating\" between 1 and 5"
+        },
+        "reviews_comment_length_check": {
+          "name": "reviews_comment_length_check",
+          "value": "char_length(\"reviews\".\"comment\") <= 500"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/db/migrations/meta/_journal.json
+++ b/server/db/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1788192040483,
       "tag": "0007_salty_medusa",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1788299814878,
+      "tag": "0008_open_harrier",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/schema/professionals.ts
+++ b/server/db/schema/professionals.ts
@@ -26,6 +26,9 @@ export const professionals = pgTable(
     // Paths dentro del bucket professional-photos, nunca URLs completas — la URL pública se
     // calcula al responder, no se guarda.
     photoPaths: text('photo_paths').array().notNull().default([]),
+    // Un solo path, a diferencia de photoPaths: nunca hay más de una foto de perfil vigente.
+    // Mismo bucket y patrón de path que las fotos de trabajo (misión 08).
+    avatarPath: text('avatar_path'),
     active: boolean('active').notNull().default(true),
     createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),

--- a/server/db/sql/rls.sql
+++ b/server/db/sql/rls.sql
@@ -49,8 +49,9 @@ alter table professionals enable row level security;
 -- Si algún día se revierte el revoke de abajo para servir esta tabla por PostgREST (ej. un perfil
 -- público futuro), esta policy tiene que ajustarse en el mismo cambio: hoy es `using (true)` porque
 -- nada la evalúa, pero expone `user_id` (el id de auth.users, que no debería quedar público), `email`
--- (dato interno, nunca parte de un perfil público) y las filas con `active = false`. Acotarla a
--- columnas públicas y a `using (active)` antes de reabrir el grant.
+-- (dato interno, nunca parte de un perfil público), `avatar_path` (path interno del bucket, no la URL
+-- pública) y las filas con `active = false`. Acotarla a columnas públicas y a `using (active)` antes
+-- de reabrir el grant.
 drop policy if exists professionals_select_public on professionals;
 create policy professionals_select_public on professionals
   for select to authenticated, anon using (true);


### PR DESCRIPTION
## Resumen

- S-001 del [Plan de construcción](https://github.com/PatricioTabilo/datealo/blob/main/docs/missions/08-foto-perfil-profesional/ingenieria.md#plan-de-construcción) de la [misión 08](https://github.com/PatricioTabilo/datealo/blob/main/docs/missions/08-foto-perfil-profesional/README.md) (foto de perfil de profesional).
- Agrega `professionals.avatarPath` (nullable, un solo path — no array, a diferencia de `photoPaths`), mismo bucket y patrón de path que las fotos de trabajo. Sin policies de Storage nuevas (verificado contra `rls.sql`, ya cubierto por las tres existentes).
- Actualiza el comentario de `professionals_select_public` para incluir `avatar_path` en la lista de columnas a acotar si algún día se reabre el grant a PostgREST.
- Cierra #125.

## Test plan

- [x] `npx nuxi typecheck` sin errores.
- [x] `npm run build` compila.
- [x] `Professional`, `PublicProfessionalProfile` y `SearchResultProfessional` siguen sin incluir `avatarPath` — grep confirmado, ningún archivo de `app/`/`server/` lo referencia todavía.

https://claude.ai/code/session_01B36NwwyTxP2JgUQL1m396k