### PR TITLE
feat(server): subir, reemplazar y quitar la foto de perfil

### DIFF
--- a/server/api/professionals/me/avatar.delete.ts
+++ b/server/api/professionals/me/avatar.delete.ts
@@ -1,0 +1,31 @@
+export default defineEventHandler(async (event) => {
+  const user = await requireUser(event)
+
+  const professional = await findProfessionalByUserId(user.id)
+  if (!professional) {
+    setResponseStatus(event, 404)
+    return { error: 'not_found' }
+  }
+
+  // "Sin avatar" es un dato válido del perfil, no un error — un doble clic en "Quitar foto" vuelve a
+  // pasar por acá y debe responder éxito otra vez, no fallar la segunda vez.
+  if (!professional.avatarUrl) {
+    return { avatarUrl: null }
+  }
+
+  const path = await findProfessionalAvatarPath(user.id)
+  if (path) {
+    const { error: removeError } = await serverSupabase(event).storage.from('professional-photos').remove([path])
+    if (removeError) {
+      throw createError({ statusCode: 502, statusMessage: 'remove_failed' })
+    }
+  }
+
+  const updated = await clearProfessionalAvatar(user.id)
+  if (!updated) {
+    setResponseStatus(event, 404)
+    return { error: 'not_found' }
+  }
+
+  return { avatarUrl: null }
+})

--- a/server/api/professionals/me/avatar.post.ts
+++ b/server/api/professionals/me/avatar.post.ts
@@ -1,7 +1,5 @@
 import { randomUUID } from 'node:crypto'
 
-const MAX_PHOTOS = 12
-
 export default defineEventHandler(async (event) => {
   const user = await requireUser(event)
 
@@ -9,10 +7,6 @@ export default defineEventHandler(async (event) => {
   if (!professional) {
     setResponseStatus(event, 404)
     return { error: 'not_found' }
-  }
-  if (professional.photoUrls.length >= MAX_PHOTOS) {
-    setResponseStatus(event, 400)
-    return { error: 'too_many_photos' }
   }
 
   const formData = await readMultipartFormData(event)
@@ -36,12 +30,19 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 502, statusMessage: 'upload_failed' })
   }
 
-  const updated = await addProfessionalPhoto(user.id, path)
+  const previousPath = await findProfessionalAvatarPath(user.id)
+  const updated = await setProfessionalAvatar(user.id, path)
   if (!updated) {
     setResponseStatus(event, 404)
     return { error: 'not_found' }
   }
 
-  setResponseStatus(event, 201)
-  return { path, photoUrls: updated.photoUrls }
+  // El archivo nuevo ya quedó como el vigente en la columna — si el borrado del viejo falla acá, la
+  // respuesta igual es éxito; el viejo queda huérfano en el bucket, un costo de storage, no de
+  // correctitud.
+  if (previousPath) {
+    await serverSupabase(event).storage.from('professional-photos').remove([previousPath])
+  }
+
+  return { avatarUrl: updated.avatarUrl }
 })

--- a/server/utils/professional-photo-upload.ts
+++ b/server/utils/professional-photo-upload.ts
@@ -1,0 +1,24 @@
+import type { MultiPartData } from 'h3'
+
+export const MAX_PHOTO_FILE_SIZE = 4 * 1024 * 1024
+
+const EXTENSION_BY_MIME_TYPE: Record<string, string> = {
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/webp': 'webp',
+}
+
+export type PhotoUploadError = { error: 'invalid_file_type' | 'file_too_large' }
+
+// Compartida entre las fotos de trabajo (photos.post.ts) y la foto de perfil (avatar.post.ts): ambas
+// suben al mismo bucket, con el mismo límite de tamaño y los mismos tipos MIME.
+export function validatePhotoUpload(file: MultiPartData): { extension: string } | PhotoUploadError {
+  const extension = file.type ? EXTENSION_BY_MIME_TYPE[file.type] : undefined
+  if (!extension) {
+    return { error: 'invalid_file_type' }
+  }
+  if (file.data.length > MAX_PHOTO_FILE_SIZE) {
+    return { error: 'file_too_large' }
+  }
+  return { extension }
+}

--- a/server/utils/professionals.ts
+++ b/server/utils/professionals.ts
@@ -31,6 +31,7 @@ export type Professional = {
   description: string | null
   priceFrom: number | null
   photoUrls: string[]
+  avatarUrl: string | null
   active: boolean
 }
 
@@ -57,6 +58,7 @@ type ProfessionalRow = {
   description: string | null
   priceFrom: number | null
   photoPaths: string[]
+  avatarPath: string | null
   active: boolean
 }
 
@@ -71,6 +73,7 @@ const publicColumns = {
   description: professionals.description,
   priceFrom: professionals.priceFrom,
   photoPaths: professionals.photoPaths,
+  avatarPath: professionals.avatarPath,
   active: professionals.active,
 }
 
@@ -103,6 +106,13 @@ function buildPhotoUrls(photoPaths: string[]): string[] {
   return photoPaths.map(path => `${pub.supabaseUrl}/storage/v1/object/public/professional-photos/${path}`)
 }
 
+// Mismo patrón que buildPhotoUrls, para el único path de la foto de perfil en vez de un array.
+function buildAvatarUrl(avatarPath: string | null): string | null {
+  if (!avatarPath) return null
+  const { public: pub } = useRuntimeConfig()
+  return `${pub.supabaseUrl}/storage/v1/object/public/professional-photos/${avatarPath}`
+}
+
 function toPublicProfessional(row: ProfessionalRow): Professional {
   return {
     id: row.id,
@@ -113,6 +123,7 @@ function toPublicProfessional(row: ProfessionalRow): Professional {
     description: row.description,
     priceFrom: row.priceFrom,
     photoUrls: buildPhotoUrls(row.photoPaths),
+    avatarUrl: buildAvatarUrl(row.avatarPath),
     active: row.active,
   }
 }
@@ -231,6 +242,31 @@ export async function removeProfessionalPhoto(userId: string, path: string): Pro
   const [updated] = await useDb()
     .update(professionals)
     .set({ photoPaths: sql`array_remove(${professionals.photoPaths}, ${path})`, updatedAt: new Date() })
+    .where(eq(professionals.userId, userId))
+    .returning(publicColumns)
+  return updated ? toPublicProfessional(updated) : null
+}
+
+// Path crudo, no la URL pública — lo usan avatar.post.ts y avatar.delete.ts para borrar el archivo
+// viejo de Storage. El cliente solo ve avatarUrl, calculado por buildAvatarUrl.
+export async function findProfessionalAvatarPath(userId: string): Promise<string | null> {
+  const [row] = await useDb().select({ avatarPath: professionals.avatarPath }).from(professionals).where(eq(professionals.userId, userId))
+  return row?.avatarPath ?? null
+}
+
+export async function setProfessionalAvatar(userId: string, path: string): Promise<Professional | null> {
+  const [updated] = await useDb()
+    .update(professionals)
+    .set({ avatarPath: path, updatedAt: new Date() })
+    .where(eq(professionals.userId, userId))
+    .returning(publicColumns)
+  return updated ? toPublicProfessional(updated) : null
+}
+
+export async function clearProfessionalAvatar(userId: string): Promise<Professional | null> {
+  const [updated] = await useDb()
+    .update(professionals)
+    .set({ avatarPath: null, updatedAt: new Date() })
     .where(eq(professionals.userId, userId))
     .returning(publicColumns)
   return updated ? toPublicProfessional(updated) : null


### PR DESCRIPTION
## Resumen

- S-002 del [Plan de construcción](https://github.com/PatricioTabilo/datealo/blob/main/docs/missions/08-foto-perfil-profesional/ingenieria.md#plan-de-construcción) de la [misión 08](https://github.com/PatricioTabilo/datealo/blob/main/docs/missions/08-foto-perfil-profesional/README.md) — el walking skeleton: prueba que reutilizar el bucket `professional-photos` funciona punta a punta antes de construir ninguna UI encima.
- `POST /api/professionals/me/avatar` (TC-001): sube con `uuid` nuevo, actualiza `avatarPath`, borra el archivo anterior al final (si falla el borrado, no revierte la respuesta — queda huérfano en el bucket, costo de storage aceptado).
- `DELETE /api/professionals/me/avatar` (TC-002): idempotente si ya no había avatar; si había, borra del bucket antes de limpiar la columna.
- Extrae `server/utils/professional-photo-upload.ts` (validación de tipo MIME/tamaño) desde `photos.post.ts` para compartirla con `avatar.post.ts` — misma regla, mismo bucket, mismo límite.
- Extiende `Professional` (`server/utils/professionals.ts`) con `avatarUrl: string | null`, mismo patrón que `photoUrls`.
- Cierra #126.

## Test plan

- [x] `npx nuxi typecheck` sin errores.
- [x] `npm run build` compila.
- [ ] Manual contra Supabase real: subir un jpg válido → `avatarUrl` nuevo y el archivo anterior desaparece del bucket; tipo no soportado → 400; sin sesión → 401; `DELETE` sin avatar previo → 200 idempotente.

https://claude.ai/code/session_01B36NwwyTxP2JgUQL1m396k