### PR TITLE
feat(app): UI para subir, reemplazar y quitar la foto de perfil

### DIFF
--- a/app/components/professional/ProfessionalAvatar.vue
+++ b/app/components/professional/ProfessionalAvatar.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+import { Camera, Loader2 } from '@lucide/vue'
+
+const { professional } = useProfessionalProfile()
+const { uploading, uploadError, removing, removeError, upload, remove } = useProfessionalAvatar()
+
+const hasAvatar = computed(() => Boolean(professional.value?.avatarUrl))
+
+const fileInput = ref<HTMLInputElement | null>(null)
+
+function openPicker() {
+  fileInput.value?.click()
+}
+
+function onFileSelected(event: Event) {
+  const file = (event.target as HTMLInputElement).files?.[0]
+  if (file) upload(file)
+  if (fileInput.value) fileInput.value.value = ''
+}
+</script>
+
+<template>
+  <div class="rounded-2xl border border-datealo-surface p-4">
+    <p class="text-sm font-semibold text-datealo-text">Foto de perfil</p>
+
+    <div class="mt-3 flex items-center gap-4">
+      <button
+        type="button"
+        class="relative flex h-[4.5rem] w-[4.5rem] shrink-0 items-center justify-center overflow-hidden rounded-full disabled:opacity-50"
+        :class="hasAvatar ? '' : 'border-2 border-dashed border-datealo-surface text-datealo-muted'"
+        :disabled="uploading || removing"
+        @click="openPicker"
+      >
+        <img v-if="hasAvatar" :src="professional!.avatarUrl!" alt="" class="h-full w-full object-cover">
+        <Camera v-else-if="!uploading" class="h-6 w-6" />
+
+        <Loader2 v-if="uploading && !hasAvatar" class="h-5 w-5 animate-spin" />
+        <div v-if="uploading && hasAvatar" class="absolute inset-0 flex items-center justify-center bg-black/40">
+          <Loader2 class="h-5 w-5 animate-spin text-white" />
+        </div>
+      </button>
+
+      <p v-if="!hasAvatar" class="text-xs text-datealo-muted">
+        Para que te reconozcan antes de escribirte. Opcional.
+      </p>
+      <div v-else>
+        <p class="text-xs font-semibold text-datealo-text">Toca la foto para cambiarla</p>
+        <button
+          type="button"
+          class="-m-2 mt-1 inline-block p-2 text-xs font-semibold text-error underline disabled:opacity-50"
+          :disabled="removing"
+          @click="remove"
+        >
+          Quitar foto
+        </button>
+      </div>
+    </div>
+
+    <input ref="fileInput" type="file" accept="image/*" class="hidden" @change="onFileSelected">
+
+    <p v-if="uploadError" class="mt-2 text-xs font-semibold text-error" aria-live="polite">{{ uploadError }}</p>
+    <p v-if="removeError" class="mt-2 text-xs font-semibold text-error" aria-live="polite">{{ removeError }}</p>
+  </div>
+</template>

--- a/app/composables/useProfessionalAvatar.ts
+++ b/app/composables/useProfessionalAvatar.ts
@@ -1,0 +1,45 @@
+export function useProfessionalAvatar() {
+  const { professional } = useProfessionalProfile()
+
+  const uploading = useState('professional-avatar-uploading', () => false)
+  const uploadError = useState<string | null>('professional-avatar-upload-error', () => null)
+  const removing = useState('professional-avatar-removing', () => false)
+  const removeError = useState<string | null>('professional-avatar-remove-error', () => null)
+
+  async function upload(file: File) {
+    uploadError.value = null
+    uploading.value = true
+
+    try {
+      const compressed = await compressPhoto(file)
+      const body = new FormData()
+      body.append('file', compressed, 'avatar.jpg')
+
+      const { avatarUrl } = await $fetch<{ avatarUrl: string }>('/api/professionals/me/avatar', {
+        method: 'POST',
+        body,
+      })
+      if (professional.value) professional.value = { ...professional.value, avatarUrl }
+    } catch {
+      uploadError.value = 'No pudimos subir la foto. Intenta de nuevo.'
+    } finally {
+      uploading.value = false
+    }
+  }
+
+  async function remove() {
+    removeError.value = null
+    removing.value = true
+
+    try {
+      await $fetch('/api/professionals/me/avatar', { method: 'DELETE' })
+      if (professional.value) professional.value = { ...professional.value, avatarUrl: null }
+    } catch {
+      removeError.value = 'No pudimos quitar la foto. Intenta de nuevo.'
+    } finally {
+      removing.value = false
+    }
+  }
+
+  return { uploading, uploadError, removing, removeError, upload, remove }
+}

--- a/app/pages/profesional/perfil.vue
+++ b/app/pages/profesional/perfil.vue
@@ -72,7 +72,9 @@ function commitPrice() {
       <h1 class="text-xl font-extrabold text-datealo-text">{{ professional.displayName }}</h1>
       <p class="mt-0.5 text-sm text-datealo-muted">{{ categoriaNombre }} · {{ comunaNombre }}</p>
 
-      <ProfessionalPhotos class="mt-5" />
+      <ProfessionalAvatar class="mt-5" />
+
+      <ProfessionalPhotos class="mt-3" />
 
       <div class="mt-3 rounded-2xl border border-datealo-surface p-4">
         <div class="flex items-center justify-between">

--- a/app/types/professional.ts
+++ b/app/types/professional.ts
@@ -9,6 +9,7 @@ export type Professional = {
   description: string | null
   priceFrom: number | null
   photoUrls: string[]
+  avatarUrl: string | null
   active: boolean
 }
 


### PR DESCRIPTION
## Resumen

- S-003 del [Plan de construcción](https://github.com/PatricioTabilo/datealo/blob/main/docs/missions/08-foto-perfil-profesional/ingenieria.md#plan-de-construcción) de la [misión 08](https://github.com/PatricioTabilo/datealo/blob/main/docs/missions/08-foto-perfil-profesional/README.md).
- `ProfessionalAvatar.vue`, en "Editar perfil" (`app/pages/profesional/perfil.vue`), arriba de "Fotos de tus trabajos" — mismo orden que el mockup validado.
- `useProfessionalAvatar.ts`: sube/reemplaza vía `POST`, quita vía `DELETE`, mismo patrón que `useProfessionalPhotos.ts`.
- Cuatro estados de [UXF-001](https://github.com/PatricioTabilo/datealo/blob/main/docs/missions/08-foto-perfil-profesional/experiencia.md#uxf-001-subir-la-foto-de-perfil): sin foto (círculo punteado + cámara), subiendo (spinner reemplaza la cámara si no había foto, o se dibuja **sobre** la foto actual si se está reemplazando), con foto ("Toca la foto para cambiarla" + "Quitar foto", sin confirmación), error ("No pudimos subir la foto. Intenta de nuevo.", vuelve al punteado).
- Extiende el tipo `Professional` de `app/types/professional.ts` con `avatarUrl`.

## Test plan

- [x] `npx nuxi typecheck` sin errores.
- [x] `npm run build` compila.
- [x] Verificación visual en browser (390px, mobile) con una página de preview temporal (no incluida en el commit) que fuerza los tres estados vía `useState` — confirmé sin foto, con foto, y el spinner dibujado sobre la foto existente al reemplazar (no sobre un círculo vacío), como pide `experiencia.md`.
- [ ] No probado contra el endpoint real (`POST`/`DELETE /api/professionals/me/avatar` de #133) con una sesión autenticada de verdad — necesita login real, que no armé para esta verificación.

https://claude.ai/code/session_01B36NwwyTxP2JgUQL1m396k