### PR TITLE
feat(server): GET /api/professionals/[id] expone avatarUrl

### DIFF
--- a/server/utils/professionals.ts
+++ b/server/utils/professionals.ts
@@ -46,6 +46,7 @@ export type PublicProfessionalProfile = {
   description: string | null
   priceFrom: number | null
   photoUrls: string[]
+  avatarUrl: string | null
   createdAt: string
 }
 
@@ -148,6 +149,7 @@ export async function findPublicProfessionalProfile(id: string): Promise<PublicP
       description: professionals.description,
       priceFrom: professionals.priceFrom,
       photoPaths: professionals.photoPaths,
+      avatarPath: professionals.avatarPath,
       createdAt: professionals.createdAt,
     })
     .from(professionals)
@@ -166,6 +168,7 @@ export async function findPublicProfessionalProfile(id: string): Promise<PublicP
     description: row.description,
     priceFrom: row.priceFrom,
     photoUrls: buildPhotoUrls(row.photoPaths),
+    avatarUrl: buildAvatarUrl(row.avatarPath),
     createdAt: row.createdAt.toISOString(),
   }
 }


### PR DESCRIPTION
## Resumen

- S-004 del [Plan de construcción](https://github.com/PatricioTabilo/datealo/blob/main/docs/missions/08-foto-perfil-profesional/ingenieria.md#plan-de-construcción) de la [misión 08](https://github.com/PatricioTabilo/datealo/blob/main/docs/missions/08-foto-perfil-profesional/README.md).
- `PublicProfessionalProfile` (`server/utils/professionals.ts`) se extiende con `avatarUrl: string | null` — extensión aditiva, mismo patrón que `photoUrls`. Ningún campo existente cambia.
- Cierra #128.

## Test plan

- [x] `npx nuxi typecheck` sin errores.
- [x] `npm run build` compila.
- [x] Revisé que ningún otro archivo construye un `PublicProfessionalProfile` fuera de `findPublicProfessionalProfile` (`grep` confirmado), así que no queda ningún otro lugar por actualizar.

https://claude.ai/code/session_01B36NwwyTxP2JgUQL1m396k