### PR TITLE
feat(app): mostrar la foto de perfil en el perfil público

### DIFF
--- a/app/components/professional-public/ProfessionalPublicPhotos.vue
+++ b/app/components/professional-public/ProfessionalPublicPhotos.vue
@@ -2,6 +2,7 @@
 defineProps<{
   photoUrls: string[]
   displayName: string
+  avatarUrl: string | null
 }>()
 
 // La tira de miniaturas es solo un atajo de navegación sobre el mismo carrusel — activeIndex refleja
@@ -50,7 +51,8 @@ function selectPhoto(index: number) {
   </div>
 
   <div v-else class="flex aspect-4/3 w-full items-center justify-center bg-datealo-surface lg:rounded-2xl">
-    <div class="flex h-22 w-22 items-center justify-center rounded-full bg-primary text-2xl font-extrabold text-white">
+    <img v-if="avatarUrl" :src="avatarUrl" :alt="displayName" class="h-22 w-22 rounded-full object-cover">
+    <div v-else class="flex h-22 w-22 items-center justify-center rounded-full bg-primary text-2xl font-extrabold text-white">
       {{ initials(displayName) }}
     </div>
   </div>

--- a/app/pages/profesionales/[id].vue
+++ b/app/pages/profesionales/[id].vue
@@ -59,14 +59,25 @@ useSeoMeta({
       <ProfessionalPublicPhotos
         :photo-urls="professional.photoUrls"
         :display-name="professional.displayName"
+        :avatar-url="professional.avatarUrl"
         class="lg:w-[55%]"
       />
 
       <div
         class="px-5 pb-28 pt-5 lg:flex-1 lg:sticky lg:top-8 lg:self-start lg:rounded-2xl lg:border lg:border-datealo-surface lg:p-6"
       >
-        <h1 class="text-xl font-extrabold text-datealo-text lg:text-2xl">{{ professional.displayName }}</h1>
-        <p class="mt-0.5 text-sm text-datealo-muted">{{ professional.categoriaNombre }} · {{ professional.comunaNombre }}</p>
+        <div class="flex items-center gap-3">
+          <img
+            v-if="professional.photoUrls.length && professional.avatarUrl"
+            :src="professional.avatarUrl"
+            :alt="professional.displayName"
+            class="h-12 w-12 shrink-0 rounded-full object-cover ring-2 ring-datealo-surface ring-offset-2 ring-offset-datealo-bg"
+          >
+          <div>
+            <h1 class="text-xl font-extrabold text-datealo-text lg:text-2xl">{{ professional.displayName }}</h1>
+            <p class="mt-0.5 text-sm text-datealo-muted">{{ professional.categoriaNombre }} · {{ professional.comunaNombre }}</p>
+          </div>
+        </div>
 
         <div v-if="professional.ratingAverage !== null" class="mt-2 flex items-center gap-1 text-sm">
           <Star class="h-3.5 w-3.5 fill-amber-400 text-amber-400" />

--- a/app/types/professional.ts
+++ b/app/types/professional.ts
@@ -32,6 +32,7 @@ export type PublicProfessionalProfile = {
   description: string | null
   priceFrom: number | null
   photoUrls: string[]
+  avatarUrl: string | null
   createdAt: string
   reviews: PublicReview[]
   ratingAverage: number | null


### PR DESCRIPTION
## Resumen

- S-005 del [Plan de construcción](https://github.com/PatricioTabilo/datealo/blob/main/docs/missions/08-foto-perfil-profesional/ingenieria.md#plan-de-construcción) de la [misión 08](https://github.com/PatricioTabilo/datealo/blob/main/docs/missions/08-foto-perfil-profesional/README.md), según [UX-001](https://github.com/PatricioTabilo/datealo/blob/main/docs/missions/08-foto-perfil-profesional/experiencia.md#ux-001).
- Sin fotos de trabajo: `ProfessionalPublicPhotos.vue` muestra la foto de perfil en vez del círculo grande de iniciales.
- Con fotos de trabajo: el carrusel ya ocupa ese espacio, así que la foto de perfil aparece como círculo chico (3rem) con anillo claro junto al nombre en `app/pages/profesionales/[id].vue` — ese bloque vive en la página, no en `ProfessionalPublicPhotos.vue`, que no tiene el nombre en su template.
- Extiende `PublicProfessionalProfile` (cliente) con `avatarUrl`.
- Cierra #129.

## Test plan

- [x] `npx nuxi typecheck` sin errores.
- [x] `npm run build` compila.
- [x] Verificación visual en browser (390px) con una página de preview temporal (no incluida en el commit): confirmé los 4 casos — sin fotos/sin avatar (sin cambio), sin fotos/con avatar (reemplaza iniciales), con fotos/con avatar (círculo chico con anillo junto al nombre), con fotos/sin avatar (sin cambio respecto a hoy).

https://claude.ai/code/session_01B36NwwyTxP2JgUQL1m396k