### PR TITLE
feat(server): GET /api/search expone avatarUrl por resultado

### DIFF
--- a/server/utils/professionals.ts
+++ b/server/utils/professionals.ts
@@ -108,7 +108,7 @@ function buildPhotoUrls(photoPaths: string[]): string[] {
 }
 
 // Mismo patrón que buildPhotoUrls, para el único path de la foto de perfil en vez de un array.
-function buildAvatarUrl(avatarPath: string | null): string | null {
+export function buildAvatarUrl(avatarPath: string | null): string | null {
   if (!avatarPath) return null
   const { public: pub } = useRuntimeConfig()
   return `${pub.supabaseUrl}/storage/v1/object/public/professional-photos/${avatarPath}`

--- a/server/utils/search.ts
+++ b/server/utils/search.ts
@@ -10,6 +10,7 @@ export type SearchResultProfessional = {
   displayName: string
   comunaNombre: string
   priceFrom: number | null
+  avatarUrl: string | null
   createdAt: string
 }
 
@@ -34,6 +35,7 @@ type ProfessionalSearchRow = {
   displayName: string
   comunaNombre: string
   priceFrom: number | null
+  avatarPath: string | null
   createdAt: Date
   photoPaths: string[]
   description: string | null
@@ -71,6 +73,7 @@ function toSearchResult(row: ProfessionalSearchRow): SearchResultProfessional {
     displayName: row.displayName,
     comunaNombre: row.comunaNombre,
     priceFrom: row.priceFrom,
+    avatarUrl: buildAvatarUrl(row.avatarPath),
     createdAt: row.createdAt.toISOString(),
   }
 }
@@ -91,6 +94,7 @@ async function findActiveProfessionals(
       displayName: professionals.displayName,
       comunaNombre: comunas.nombre,
       priceFrom: professionals.priceFrom,
+      avatarPath: professionals.avatarPath,
       createdAt: professionals.createdAt,
       photoPaths: professionals.photoPaths,
       description: professionals.description,


### PR DESCRIPTION
## Resumen

- S-006 del [Plan de construcción](https://github.com/PatricioTabilo/datealo/blob/main/docs/missions/08-foto-perfil-profesional/ingenieria.md#plan-de-construcción) de la [misión 08](https://github.com/PatricioTabilo/datealo/blob/main/docs/missions/08-foto-perfil-profesional/README.md).
- `SearchResultProfessional` (`server/utils/search.ts`) se extiende con `avatarUrl: string | null` — extensión aditiva, misma regla que TC-003.
- Exporta `buildAvatarUrl` desde `server/utils/professionals.ts` para reutilizarla acá en vez de duplicar la construcción de la URL.
- Cierra #130.

## Test plan

- [x] `npx nuxi typecheck` sin errores.
- [x] `npm run build` compila.

https://claude.ai/code/session_01B36NwwyTxP2JgUQL1m396k