### PR TITLE
docs: cerrar la misión 06 (búsqueda y resultados)

### DIFF
--- a/docs/missions/06-busqueda-resultados/README.md
+++ b/docs/missions/06-busqueda-resultados/README.md
@@ -2,9 +2,9 @@
 
 **Tipo:** producto. **Abierta el** 2026-08-13. **Nace de:** ninguna.
 
-**Estado de la misión:** exploración
+**Estado de la misión:** cerrada 2026-08-31
 
-**Última actualización:** 2026-08-13
+**Última actualización:** 2026-08-31
 
 Quinta de seis misiones hacia el MVP (registrarse, mostrarse, buscar, reseñar). Depende de
 [misión 03](../03-taxonomia-categorias-y-comunas/) (contra qué categorías/comunas se filtra) y de
@@ -14,7 +14,24 @@ perfiles reales que buscar — sin datos, no hay resultados que mostrar ni relev
 **Documentos:** [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-**Próximo hito:** ninguno todavía — esta misión no se ha empezado a trabajar.
+**Próximo hito:** ninguno — los 5 issues del plan de construcción
+([#94](https://github.com/PatricioTabilo/datealo/issues/94)–[#98](https://github.com/PatricioTabilo/datealo/issues/98))
+están cerrados y mergeados.
+
+`producto.md` vigente — aprobado por Patricio el 2026-08-28. D-001 a D-004 aceptadas; D-001 (orden por
+completitud del perfil) queda marcada explícitamente como interina, y D-002 (comuna vecina = comparte
+límite real) llevó a activar Frutillar, Puerto Montt y Llanquihue en el catálogo de comunas junto con
+Puerto Varas.
+
+`experiencia.md` vigente — aprobado por Patricio el 2026-08-29. Una sola vista reactiva (V-001, UXF-001),
+comuna exacta y comunas vecinas en la misma lista (UX-002), sin pestañas ni mapa. Mockup validado en
+`design-mockups/resultados-busqueda.html` (9 frames, móvil y desktop).
+
+`ingenieria.md` vigente — aprobado por Patricio el 2026-08-29, tras auditoría en contexto separado
+(`clean-architecture`, `domain-driven-design`, `supabase-postgres-best-practices`). Endpoint único `GET
+/api/search` (F-001+F-002 a la vez), tabla nueva `comuna_vecinas` con adyacencia geográfica precalculada
+una sola vez (riesgo abierto no bloqueante: TR-001, qué tan confiable es el dataset elegido), y extracción
+del composable compartido `useSlowLoad()` desde la misión 05.
 
 ## Brief
 

--- a/docs/missions/06-busqueda-resultados/design-mockups/resultados-busqueda.html
+++ b/docs/missions/06-busqueda-resultados/design-mockups/resultados-busqueda.html
@@ -1,0 +1,517 @@
+<!doctype html>
+<html lang="es-CL">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>V-001 Resultados de búsqueda — misión 06</title>
+
+    <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+    <link
+      href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&family=Plus+Jakarta+Sans:wght@600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../../design/datealo-mockup-kit.css" />
+    <style type="text/tailwindcss">
+      @theme {
+        --color-primary: var(--ui-primary);
+        --color-secondary: var(--ui-secondary);
+        --color-success: var(--ui-success);
+        --color-error: var(--ui-error);
+      }
+    </style>
+    <style>
+      .search-bar {
+        display: flex;
+        gap: 0.5rem;
+        padding: 0.875rem 1.25rem;
+        background: var(--ui-bg);
+        border-bottom: 1px solid var(--ui-border);
+        /* sticky durante el scroll de la lista — ver "Decisiones que no deben quedar implícitas" de
+           UXF-001 en experiencia.md: por esto la card no repite la categoría, ya está siempre a la vista */
+        position: sticky;
+        top: 0;
+        z-index: 10;
+      }
+      .select-field {
+        flex: 1;
+        min-width: 0;
+        border: 1.5px solid var(--ui-border-accented);
+        border-radius: var(--ui-radius, 0.5rem);
+        padding: 0.625rem 0.75rem;
+        font-size: 0.8125rem;
+        color: var(--ui-text-highlighted);
+      }
+      .select-field.is-focused {
+        border-color: var(--ui-primary);
+        box-shadow: 0 0 0 3px color-mix(in oklab, var(--ui-primary) 15%, transparent);
+      }
+      .select-field .field-label {
+        display: block;
+        font-size: 0.625rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: var(--ui-text-muted);
+        margin-bottom: 0.125rem;
+      }
+      .select-field.is-empty .field-value {
+        color: var(--ui-text-dimmed);
+      }
+      .result-count {
+        font-size: 0.75rem;
+        color: var(--ui-text-muted);
+        padding: 0 0.125rem;
+      }
+      .result-card {
+        display: flex;
+        gap: 0.75rem;
+        padding: 0.875rem;
+        background: var(--ui-bg);
+        border: 1px solid var(--ui-border);
+        border-radius: 0.875rem;
+        min-width: 0;
+      }
+      .avatar-initials {
+        flex-shrink: 0;
+        width: 3rem;
+        height: 3rem;
+        border-radius: 999px;
+        background: var(--ui-primary);
+        color: #fff;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-weight: 800;
+        font-size: 0.9375rem;
+      }
+      .comuna-line {
+        color: var(--ui-text-muted);
+      }
+      /* modo comunas vecinas: mismo tamaño, más peso — el guardrail de M-002 (producto.md) exige que el
+         fallback nunca se vea igual de "normal" que un resultado de la comuna exacta */
+      .comuna-line.is-vecina {
+        color: var(--ui-text-highlighted);
+        font-weight: 700;
+      }
+      .since-pill {
+        display: inline-block;
+        color: var(--ui-text-muted);
+      }
+      .section-label {
+        font-family: var(--font-heading);
+        font-size: 0.6875rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: var(--ui-text-muted);
+        padding: 0 0.125rem;
+      }
+      .empty-banner {
+        background: var(--ui-bg-muted);
+        border-radius: 0.75rem;
+        padding: 0.875rem 1rem;
+        font-size: 0.8125rem;
+        color: var(--ui-text-toned);
+      }
+      .skeleton-card {
+        display: flex;
+        gap: 0.75rem;
+        padding: 0.875rem;
+        border: 1px solid var(--ui-border);
+        border-radius: 0.875rem;
+      }
+      .skeleton-block {
+        background: var(--ui-bg-accented);
+        border-radius: 0.375rem;
+        position: relative;
+        overflow: hidden;
+      }
+      .skeleton-block::after {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(
+          100deg,
+          transparent 30%,
+          var(--ui-bg-muted) 50%,
+          transparent 70%
+        );
+        animation: shimmer 1.4s infinite;
+      }
+      @keyframes shimmer {
+        from {
+          transform: translateX(-100%);
+        }
+        to {
+          transform: translateX(100%);
+        }
+      }
+      .btn-primary {
+        background: var(--ui-primary);
+        color: #fff;
+        font-weight: 700;
+        border-radius: var(--ui-radius, 0.5rem);
+      }
+      .icon-muted {
+        color: var(--ui-text-dimmed);
+      }
+    </style>
+  </head>
+
+  <body>
+    <div class="frames">
+      <!-- 1. eligiendo -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-001 · modo eligiendo
+          <small>llega directo a "Buscar", sin categoría pre-elegida — los dos campos vacíos</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="search-bar">
+            <div class="select-field is-empty">
+              <span class="field-label">Categoría</span>
+              <span class="field-value">Elige una categoría</span>
+            </div>
+            <div class="select-field is-empty">
+              <span class="field-label">Comuna</span>
+              <span class="field-value">Elige tu comuna</span>
+            </div>
+          </div>
+          <div class="flex h-full flex-col items-center justify-center p-8 text-center" style="height: calc(100% - 76px)">
+            <svg class="icon-muted" width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+            <h1 class="mt-4 text-base font-extrabold" style="color: var(--ui-text-highlighted)">
+              Elige una categoría y tu comuna
+            </h1>
+            <p class="mt-2 text-sm" style="color: var(--ui-text-muted)">
+              para ver profesionales disponibles
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- 2. cargando -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-001 · modo cargando
+          <small>categoría y comuna ya elegidas — esperando la respuesta del servidor; 4 skeletons, no 3</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="search-bar">
+            <div class="select-field">
+              <span class="field-label">Categoría</span>
+              <span class="field-value">Gasfitería</span>
+            </div>
+            <div class="select-field">
+              <span class="field-label">Comuna</span>
+              <span class="field-value">Puente Alto</span>
+            </div>
+          </div>
+          <div class="flex flex-col gap-3 p-4">
+            <div class="skeleton-card">
+              <div class="skeleton-block" style="width: 3rem; height: 3rem; border-radius: 999px; flex-shrink: 0"></div>
+              <div class="flex-1">
+                <div class="skeleton-block h-4 w-32"></div>
+                <div class="skeleton-block mt-2 h-3 w-20"></div>
+                <div class="skeleton-block mt-2 h-3 w-24"></div>
+              </div>
+            </div>
+            <div class="skeleton-card">
+              <div class="skeleton-block" style="width: 3rem; height: 3rem; border-radius: 999px; flex-shrink: 0"></div>
+              <div class="flex-1">
+                <div class="skeleton-block h-4 w-32"></div>
+                <div class="skeleton-block mt-2 h-3 w-20"></div>
+                <div class="skeleton-block mt-2 h-3 w-24"></div>
+              </div>
+            </div>
+            <div class="skeleton-card">
+              <div class="skeleton-block" style="width: 3rem; height: 3rem; border-radius: 999px; flex-shrink: 0"></div>
+              <div class="flex-1">
+                <div class="skeleton-block h-4 w-32"></div>
+                <div class="skeleton-block mt-2 h-3 w-20"></div>
+                <div class="skeleton-block mt-2 h-3 w-24"></div>
+              </div>
+            </div>
+            <div class="skeleton-card">
+              <div class="skeleton-block" style="width: 3rem; height: 3rem; border-radius: 999px; flex-shrink: 0"></div>
+              <div class="flex-1">
+                <div class="skeleton-block h-4 w-32"></div>
+                <div class="skeleton-block mt-2 h-3 w-20"></div>
+                <div class="skeleton-block mt-2 h-3 w-24"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- 3. con resultados -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-001 · modo con resultados
+          <small>orden por completitud + antigüedad (D-001): Marcelo y Jorge (perfil completo) antes que Héctor (sin precio) — nunca al revés</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="search-bar">
+            <div class="select-field">
+              <span class="field-label">Categoría</span>
+              <span class="field-value">Electricidad</span>
+            </div>
+            <div class="select-field">
+              <span class="field-label">Comuna</span>
+              <span class="field-value">Ñuñoa</span>
+            </div>
+          </div>
+          <div class="flex flex-col gap-3 p-4">
+            <p class="result-count">3 resultados</p>
+            <div class="result-card">
+              <div class="avatar-initials">MR</div>
+              <div class="flex-1 min-w-0">
+                <p class="truncate text-sm font-bold" style="color: var(--ui-text-highlighted)">Marcelo Rojas</p>
+                <p class="comuna-line truncate text-xs">Ñuñoa</p>
+                <p class="mt-1 text-xs font-bold" style="color: var(--ui-text-highlighted)">Desde $15.000</p>
+                <p class="since-pill mt-0.5 text-[0.6875rem]">En Datealo desde julio de 2026</p>
+              </div>
+            </div>
+            <div class="result-card">
+              <div class="avatar-initials">JP</div>
+              <div class="flex-1 min-w-0">
+                <p class="truncate text-sm font-bold" style="color: var(--ui-text-highlighted)">Jorge Pizarro</p>
+                <p class="comuna-line truncate text-xs">Ñuñoa</p>
+                <p class="mt-1 text-xs font-bold" style="color: var(--ui-text-highlighted)">Desde $12.000</p>
+                <p class="since-pill mt-0.5 text-[0.6875rem]">En Datealo desde agosto de 2026</p>
+              </div>
+            </div>
+            <div class="result-card">
+              <div class="avatar-initials">HS</div>
+              <div class="flex-1 min-w-0">
+                <p class="truncate text-sm font-bold" style="color: var(--ui-text-highlighted)">Héctor Silva</p>
+                <p class="comuna-line truncate text-xs">Ñuñoa</p>
+                <p class="since-pill mt-1 text-[0.6875rem]">En Datealo desde agosto de 2026</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- 4. un solo resultado -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-001 · modo con resultados — un solo profesional (CL-003)
+          <small>"1 resultado" da contexto real al espacio — nunca un elemento fabricado tipo "más opciones cerca"</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="search-bar">
+            <div class="select-field">
+              <span class="field-label">Categoría</span>
+              <span class="field-value">Jardinería</span>
+            </div>
+            <div class="select-field">
+              <span class="field-label">Comuna</span>
+              <span class="field-value">Providencia</span>
+            </div>
+          </div>
+          <div class="flex flex-col gap-3 p-4">
+            <p class="result-count">1 resultado</p>
+            <div class="result-card">
+              <div class="avatar-initials">CV</div>
+              <div class="flex-1 min-w-0">
+                <p class="truncate text-sm font-bold" style="color: var(--ui-text-highlighted)">Carlos Vera</p>
+                <p class="comuna-line truncate text-xs">Providencia</p>
+                <p class="mt-1 text-xs font-bold" style="color: var(--ui-text-highlighted)">Desde $20.000</p>
+                <p class="since-pill mt-0.5 text-[0.6875rem]">En Datealo desde agosto de 2026</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- 5. comunas vecinas -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-001 · modo comunas vecinas
+          <small>Puente Alto no tiene gasfiteres activos — La Florida y San Bernardo comparten límite real (D-002 de producto.md); comuna en negrita, nunca con el mismo peso que un resultado de la comuna exacta (M-002)</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="search-bar">
+            <div class="select-field">
+              <span class="field-label">Categoría</span>
+              <span class="field-value">Gasfitería</span>
+            </div>
+            <div class="select-field">
+              <span class="field-label">Comuna</span>
+              <span class="field-value">Puente Alto</span>
+            </div>
+          </div>
+          <div class="flex flex-col gap-3 p-4">
+            <div class="empty-banner">
+              Todavía no hay profesionales de Gasfitería en Puente Alto.
+            </div>
+            <p class="section-label">Cerca de Puente Alto</p>
+            <div class="result-card">
+              <div class="avatar-initials">RM</div>
+              <div class="flex-1 min-w-0">
+                <p class="truncate text-sm font-bold" style="color: var(--ui-text-highlighted)">Raúl Muñoz</p>
+                <p class="comuna-line is-vecina truncate text-xs">La Florida</p>
+                <p class="mt-1 text-xs font-bold" style="color: var(--ui-text-highlighted)">Desde $10.000</p>
+                <p class="since-pill mt-0.5 text-[0.6875rem]">En Datealo desde agosto de 2026</p>
+              </div>
+            </div>
+            <div class="result-card">
+              <div class="avatar-initials">PA</div>
+              <div class="flex-1 min-w-0">
+                <p class="truncate text-sm font-bold" style="color: var(--ui-text-highlighted)">Patricia Aros</p>
+                <p class="comuna-line is-vecina truncate text-xs">San Bernardo</p>
+                <p class="since-pill mt-1 text-[0.6875rem]">En Datealo desde agosto de 2026</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- 6. sin resultados — CL-001, la comuna y sus vecinas no tienen nada -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-001 · modo sin resultados — comuna sin oferta (CL-001)
+          <small>ni Puente Alto ni sus comunas vecinas tienen jardineros activos, pero Jardinería sí existe en otras comunas — el texto enmarca el problema como geográfico, porque lo es</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="search-bar">
+            <div class="select-field">
+              <span class="field-label">Categoría</span>
+              <span class="field-value">Jardinería</span>
+            </div>
+            <div class="select-field">
+              <span class="field-label">Comuna</span>
+              <span class="field-value">Puente Alto</span>
+            </div>
+          </div>
+          <div class="flex flex-col items-center justify-center p-8 text-center" style="height: calc(100% - 76px)">
+            <svg class="icon-muted" width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+            <h1 class="mt-4 text-base font-extrabold" style="color: var(--ui-text-highlighted)">
+              Todavía no hay profesionales de Jardinería cerca de Puente Alto
+            </h1>
+            <p class="mt-2 text-sm" style="color: var(--ui-text-muted)">
+              Prueba con otra comuna.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- 7. sin resultados — CL-002, la categoría no existe en ninguna comuna activa -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-001 · modo sin resultados — categoría sin oferta en todo el país (CL-002)
+          <small>Jardinería no tiene ningún profesional en ninguna comuna activa — el texto nunca dice "cerca de", porque cambiar de comuna acá no ayudaría (distinto de CL-001)</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="search-bar">
+            <div class="select-field">
+              <span class="field-label">Categoría</span>
+              <span class="field-value">Jardinería</span>
+            </div>
+            <div class="select-field">
+              <span class="field-label">Comuna</span>
+              <span class="field-value">Vitacura</span>
+            </div>
+          </div>
+          <div class="flex flex-col items-center justify-center p-8 text-center" style="height: calc(100% - 76px)">
+            <svg class="icon-muted" width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+            <h1 class="mt-4 text-base font-extrabold" style="color: var(--ui-text-highlighted)">
+              Todavía no hay profesionales de Jardinería en Datealo
+            </h1>
+            <p class="mt-2 text-sm" style="color: var(--ui-text-muted)">
+              Prueba con otra categoría.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- 8. tardando -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-001 · modo tardando (&gt;10s)
+          <small>la búsqueda superó los 10s — deja de mostrarse como skeleton y pasa a un mensaje explícito, mismo patrón que el perfil (misión 05)</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="search-bar">
+            <div class="select-field">
+              <span class="field-label">Categoría</span>
+              <span class="field-value">Gasfitería</span>
+            </div>
+            <div class="select-field">
+              <span class="field-label">Comuna</span>
+              <span class="field-value">Puente Alto</span>
+            </div>
+          </div>
+          <div class="flex flex-col items-center justify-center p-8 text-center" style="height: calc(100% - 76px)">
+            <svg class="icon-muted" width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14.5"/></svg>
+            <h1 class="mt-4 text-base font-extrabold" style="color: var(--ui-text-highlighted)">
+              Esto está tardando más de lo normal
+            </h1>
+            <button class="btn-primary mt-6 px-6 py-3 text-[0.9375rem]">Reintentar</button>
+          </div>
+        </div>
+      </section>
+
+      <!-- 9. con resultados — desktop -->
+      <section class="frame frame-desktop">
+        <div class="frame-label">
+          V-001 · modo con resultados — desktop
+          <small>selectores en la misma barra horizontal; cards en grilla de 3 columnas. Los demás modos
+            (eligiendo, comunas vecinas, sin resultados) reusan el mismo layout centrado de móvil, solo más
+            ancho — no llevan frame propio (ver "Decisiones que no deben quedar implícitas" en experiencia.md)</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="flex h-full flex-col">
+            <div class="search-bar" style="max-width: 480px">
+              <div class="select-field">
+                <span class="field-label">Categoría</span>
+                <span class="field-value">Electricidad</span>
+              </div>
+              <div class="select-field">
+                <span class="field-label">Comuna</span>
+                <span class="field-value">Ñuñoa</span>
+              </div>
+            </div>
+            <p class="result-count px-8 pt-4">3 resultados</p>
+            <div class="grid flex-1 grid-cols-3 gap-4 p-8 pt-3" style="align-content: start">
+              <div class="result-card">
+                <div class="avatar-initials">MR</div>
+                <div class="flex-1 min-w-0">
+                  <p class="truncate text-sm font-bold" style="color: var(--ui-text-highlighted)">Marcelo Rojas</p>
+                  <p class="comuna-line truncate text-xs">Ñuñoa</p>
+                  <p class="mt-1 text-xs font-bold" style="color: var(--ui-text-highlighted)">Desde $15.000</p>
+                  <p class="since-pill mt-0.5 text-[0.6875rem]">En Datealo desde julio de 2026</p>
+                </div>
+              </div>
+              <div class="result-card">
+                <div class="avatar-initials">JP</div>
+                <div class="flex-1 min-w-0">
+                  <p class="truncate text-sm font-bold" style="color: var(--ui-text-highlighted)">Jorge Pizarro</p>
+                  <p class="comuna-line truncate text-xs">Ñuñoa</p>
+                  <p class="mt-1 text-xs font-bold" style="color: var(--ui-text-highlighted)">Desde $12.000</p>
+                  <p class="since-pill mt-0.5 text-[0.6875rem]">En Datealo desde agosto de 2026</p>
+                </div>
+              </div>
+              <div class="result-card">
+                <div class="avatar-initials">HS</div>
+                <div class="flex-1 min-w-0">
+                  <p class="truncate text-sm font-bold" style="color: var(--ui-text-highlighted)">Héctor Silva</p>
+                  <p class="comuna-line truncate text-xs">Ñuñoa</p>
+                  <p class="since-pill mt-1 text-[0.6875rem]">En Datealo desde agosto de 2026</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  </body>
+</html>

--- a/docs/missions/06-busqueda-resultados/experiencia.md
+++ b/docs/missions/06-busqueda-resultados/experiencia.md
@@ -1,183 +1,232 @@
-# Misión: <nombre> — Experiencia
+# Misión: búsqueda y resultados — Experiencia
 
-**Estado:** borrador
+**Estado:** vigente — aprobado por Patricio el 2026-08-29
 
-**Última actualización:** AAAA-MM-DD
+**Última actualización:** 2026-08-29
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-<!--
-Fuente de verdad para flujos, estados, contenido e interacción. No redefine reglas de producto: si el
-diseño descubre una regla nueva o invalida una, abre o actualiza una decisión en producto.md.
+## Decisión de experiencia: una sola pantalla reactiva, sin pasos ni mapa
 
-Núcleo obligatorio: vistas, mapa de estados, flujos críticos y estados por superficie. Las secciones bajo
-demanda (modelo mental, jerarquía de información, validación) se agregan solo cuando una decisión las
-necesita.
+El buscador es una sola vista (V-001) con los selectores de categoría y comuna siempre visibles arriba —
+nunca un asistente de pasos, nunca un mapa. Apenas los dos campos tienen un valor, Datealo pide los
+resultados: si hay profesionales en la comuna exacta, esos se ven primero; si no hay ninguno, la misma
+pantalla se completa con los de sus comunas vecinas reales, marcados con su comuna, sin que el buscador
+tenga que hacer nada más que mirar hacia abajo. Tocar una card lleva al perfil del profesional (misión 05);
+esta vista no tiene ningún paso de contacto propio.
 
-Gate de salida — experiencia.md está lista para ingenieria.md cuando:
-- cada flujo crítico tiene secuencia, variantes, recuperación y criterio de término
-- cada estado tiene contenido concreto (texto real, información visible, acción disponible)
-- cada vista lista sus modos, y el mapa de estados cubre todas las transiciones entre ellos
-- cada modo tiene su indicador permanente de estado, y cada flujo tiene todas sus salidas documentadas
-- los casos límite de producto.md tienen flujo o estado mapeado
-- cada flujo crítico está mockeado en móvil (390px), y en desktop si también vive ahí
-- ninguna pantalla queda descrita como "similar a X" sin especificar qué cambia
--->
-
-## Decisión de experiencia: <qué cambia para quien usa el producto>
-
-<Modelo de interacción elegido, flujo más importante y la incertidumbre que sigue abierta.>
-
-- **Funcionalidades cubiertas:** F-001, <otras>.
-- **Pendiente bloqueante:** <pregunta o "ninguna">.
+- **Funcionalidades cubiertas:** F-001, F-002.
+- **Pendiente bloqueante:** ninguna.
 
 ## Vistas
 
-<!--
-El listado de pantallas que define la experiencia — el mapa que se entrega antes de los flujos. Una línea
-por vista, sin tabla, con sus modos anidados debajo. Una vista es un destino: se llega a ella. Un modo es
-un estado de esa vista que cambia qué se puede hacer y qué se ve — se anida, nunca se lista como vista
-hermana.
-
-El porqué de cada vista, su trade-off o su justificación no van aquí: viven en su flujo (UXF) o en una
-decisión (UX-xxx). Regla de formato para todo el documento: las tablas se reservan para índices de celdas
-cortas; lo que lleva justificación extensa va en secciones con header + bullets, nunca en una celda.
--->
-
-- **V-001 — <vista>** · móvil / desktop · resuelve F-001 · flujos UXF-001 · pendiente
-  - modo **<nombre>** — <qué lo distingue y qué se puede hacer en él>
-  - modo **<nombre>** — <ídem>
+- **V-001 — Resultados de búsqueda** · móvil / desktop · resuelve [F-001](./producto.md#f-001),
+  [F-002](./producto.md#f-002) · flujo UXF-001
+  - modo **eligiendo** — falta categoría y/o comuna; los selectores están visibles, no hay ninguna lista
+    abajo
+  - modo **cargando** — categoría y comuna completas, esperando la respuesta del servidor
+  - modo **con resultados** — al menos un profesional activo en la comuna exacta
+  - modo **comunas vecinas** — la comuna exacta no tiene a nadie de esa categoría; se muestran las comunas
+    vecinas reales (F-002)
+  - modo **sin resultados** — ni la comuna exacta ni sus vecinas tienen a nadie de esa categoría
+    ([CL-001](./producto.md#cl-001), [CL-002](./producto.md#cl-002) de producto.md)
 
 ## Mapa de estados
 
-<!--
-Vistas y flujos son listas, y una lista no muestra un camino. Esta tabla conecta los modos: qué acción
-lleva de uno a otro y qué pasa con el trabajo del usuario en cada salto. Cada fila que falte es una
-pregunta que ingeniería resuelve inventando.
--->
+| Desde                                              | Acción                                             | Queda en          | Qué pasa con el trabajo |
+| --------------------------------------------------- | --------------------------------------------------- | ------------------- | ----------------------------- |
+| eligiendo                                          | completa categoría y comuna (en cualquier orden)   | cargando           | ninguno — recién se arma la búsqueda |
+| eligiendo                                          | llega desde el carrusel de categorías de la landing | eligiendo          | la categoría queda pre-elegida, solo falta comuna |
+| cargando                                           | el servidor responde con resultados en la comuna exacta | con resultados | ninguno |
+| cargando                                           | el servidor no encuentra nada en la comuna exacta pero sí en vecinas | comunas vecinas | ninguno |
+| cargando                                           | el servidor no encuentra nada en ningún lado        | sin resultados      | ninguno |
+| con resultados / comunas vecinas / sin resultados  | cambia categoría o comuna                           | cargando            | los selectores quedan con el valor nuevo; la lista anterior desaparece |
+| con resultados / comunas vecinas                   | toca una card                                       | fuera de V-001, al perfil del profesional | ninguno — al volver con "atrás", V-001 se ve igual que la dejó |
 
-| Desde  | Acción             | Queda en | Qué pasa con el trabajo              |
-| ------ | ------------------ | -------- | ------------------------------------ |
-| <modo> | <acción concreta>  | <modo>   | <qué se aplicó, qué quedó pendiente> |
-| <modo> | <salir sin cerrar> | <modo>   | <qué se pierde o se conserva>        |
+## UXF-001 — Buscar y ver resultados de una categoría en una comuna
 
-## UXF-001 — <flujo principal en verbo>
+**Objetivo:** encontrar rápido a quién contactar, con o sin oferta en la comuna exacta. **Contrato:**
+[F-001](./producto.md#f-001), [F-002](./producto.md#f-002).
 
-<!--
-Duplica por flujo crítico. Cada paso describe acción → respuesta al nivel de "el usuario toca X → Datealo
-muestra Y". Un mockup no reemplaza la secuencia porque no explica estados ni recuperación.
--->
+**Punto de entrada:** dos caminos. (a) toca una categoría del carrusel de la landing
+(`LandingCategories.vue`, hoy decorativo) — llega con la categoría ya elegida, solo falta comuna. (b) entra
+directo a "Buscar" — llega con los dos campos vacíos. Ninguno de los dos exige sesión ni cuenta.
 
-**Objetivo:** <qué se completa o comprende>. **Contrato:** [F-001](./producto.md#f-001).
+**Criterio de término:** no es una acción que "se completa" de una vez — el buscador puede ajustar
+categoría y comuna varias veces antes de decidirse. Termina cuando toca una card y sigue al perfil, o
+cuando se va.
 
-**Punto de entrada:** <estado y superficie inicial, y qué acción trae al usuario hasta acá>.
+**Cómo sabe el usuario dónde está:** los dos campos de categoría y comuna, siempre visibles arriba de
+cualquier lista, muestran exactamente lo que se está buscando en este momento — nunca hay una lista en
+pantalla sin sus filtros a la vista al mismo tiempo.
 
-**Criterio de término:** <estado observable que confirma que el flujo terminó bien>.
+### Divergencia antes de converger
 
-**Cómo sabe el usuario dónde está:** <el elemento concreto y permanente en pantalla que se lo dice, por
-cada modo que toca este flujo>.
+Para resolver el mismo JTBD (encontrar a quién contactar, cerca, hoy) se generaron tres enfoques
+genuinamente distintos:
+
+- **Enfoque A — pantalla única reactiva:** los selectores de categoría y comuna quedan arriba, siempre
+  visibles y editables; la lista de abajo se actualiza sola apenas ambos tienen un valor. Es el patrón de
+  un portal inmobiliario chileno (Yapo.cl, Portalinmobiliario) — tipo de propiedad + comuna en la misma
+  barra, sin pasos — que el brief de esta misión ya usa como referencia.
+- **Enfoque B — asistente de dos pantallas:** paso 1 elegir categoría en una grilla de tarjetas grandes
+  (pantalla completa), paso 2 elegir comuna (otra pantalla completa), paso 3 resultados. Una decisión a la
+  vez, más simple de entender la primera vez, pero agrega dos transiciones de pantalla completa a algo que
+  hoy se resuelve con dos campos chicos.
+- **Enfoque C — mapa como vista principal:** pines por profesional, lista como panel secundario. Ya
+  descartado por `producto.md` ("Mapa visual de resultados", Fuera de alcance) — sin coordenadas que
+  mostrarle al buscador ni presupuesto de UI para esta entrega, no se desarrolla más acá.
+
+**Elegido: A.** El contexto real de uso de este skill (buscador de pie, apurado, con una mano) pesa contra
+el Enfoque B: dos pantallas completas y dos "Siguiente" para llegar al mismo lugar que A resuelve tocando
+dos campos que ya están a la vista. Ninguna conclusión de investigación pide una ceremonia de pasos, y C ya
+quedó fuera del alcance de producto antes de llegar a esta misión. A además es el único que cumple "cómo
+sabe el usuario dónde está" de este flujo sin depender de memoria: en B, el buscador nunca ve los dos
+filtros juntos en la misma pantalla, así que no hay ningún punto del flujo en el que confirme de un
+vistazo qué está pidiendo.
+
+### Jerarquía de información
+
+Con foto/iniciales, nombre, categoría, comuna, precio y antigüedad compitiendo por la misma card, el orden
+es:
+
+1. **Foto o iniciales** — primera señal, igual que en el perfil (misión 05); nunca un ícono genérico.
+2. **Nombre** — quién es.
+3. **Comuna** — confirma dónde trabaja. La categoría no se repite acá: los selectores de arriba quedan
+   `position: sticky` durante todo el scroll de la lista (ver "Decisiones que no deben quedar implícitas"),
+   así que ya está a la vista todo el tiempo y repetirla en cada card sería la misma información dos veces
+   sin agregar nada. En modo comunas vecinas, esta línea es la que avisa que no es la comuna exacta — va en
+   negrita en ese modo, para que el peso visual, no solo el texto, marque la diferencia (ver
+   "Decisiones que no deben quedar implícitas").
+4. **Precio** ("Desde $X", si existe) — filtro rápido de presupuesto.
+5. **"En Datealo desde..."** — mismo dato que el perfil, la única señal de actividad que no se inventa.
+
+Arriba de la lista, un texto corto y siempre verdadero indica cuántos resultados hay ("3 resultados", "1
+resultado") — nunca un espacio vacío sin explicar qué se está viendo, ni un número fabricado.
+
+Nunca aparece un número de distancia, un rating ni un contador de reseñas — ninguno de esos datos existe
+hoy ([C-002](./investigacion.md#c-002) de investigación, [D-001](./producto.md#d-001) de producto).
 
 ### Salidas
 
-<!--
-Todas las formas de irse, no solo terminar bien. El criterio de término cubre la salida buena; las otras
-son las que el usuario encuentra primero. Un modo del que no se sabe salir es un modo donde el usuario se
-pierde.
--->
-
-| Salida                | Cómo se ejecuta       | Qué queda del trabajo           |
-| --------------------- | --------------------- | ------------------------------- |
-| <termina bien>        | <acción>              | <qué se aplicó y dónde>         |
-| <descarta>            | <acción, Esc, cerrar> | <nada, ni a medias>             |
-| <abandona sin cerrar> | <navega a otra parte> | <se conserva, se pierde, avisa> |
+| Salida                                    | Cómo se ejecuta                  | Qué queda del trabajo |
+| -------------------------------------------- | ----------------------------------- | -------------------------- |
+| Encuentra a alguien y sigue al perfil        | toca una card                       | los filtros quedan guardados en V-001; si vuelve con "atrás", la ve igual |
+| Cambia de búsqueda                           | edita categoría o comuna            | la lista anterior se reemplaza, sin transición de pantalla |
+| Se va sin encontrar nada                     | cierra la pestaña o navega a otra parte | nada que perder — no hay ningún dato sin guardar |
 
 ### Secuencia principal
 
-| Paso | Acción            | Respuesta del sistema         | Información visible |
-| ---- | ----------------- | ----------------------------- | ------------------- |
-| 1    | <acción concreta> | <feedback o cambio de estado> | <dato y jerarquía>  |
+| Paso | Acción                                                          | Respuesta del sistema                                                                                       | Información visible |
+| ---- | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------ | ------------------------ |
+| 1    | Llega a V-001 (desde la landing con categoría pre-elegida, o directo) | Ve los dos selectores arriba; si falta alguno, ve el modo eligiendo                                                 | "Elige tu comuna para ver profesionales de Gasfitería cerca de ti" (si ya eligió categoría) o "Elige una categoría y tu comuna para ver profesionales disponibles" (si ninguna) |
+| 2    | Elige o confirma categoría y comuna (`CategoriaSelect`, `ComunaSelect`) | Apenas ambos tienen valor, Datealo pide los resultados; si tarda más de 300ms, ve un skeleton con la forma de 4 cards | Ninguna dato real todavía, solo la forma |
+| 3    | El servidor responde con resultados en la comuna exacta            | Ve un texto corto con el total ("3 resultados") y la lista: cada card con nombre, comuna, "Desde $X" si existe, "En Datealo desde..."                  | Nombre, foto o iniciales, comuna, precio si existe, antigüedad |
+| 3b   | (alternativa) No hay nada en la comuna exacta, sí en comunas vecinas | Ve un aviso corto arriba de la lista y debajo la sección de comunas vecinas, cada card con su comuna real visible   | Mismo contenido de card; la comuna de cada una nunca es la que se pidió |
+| 3c   | (alternativa) No hay nada ni en la comuna ni en sus vecinas         | Ve el estado vacío: título, texto y los mismos selectores arriba, listos para cambiar                               | Ningún dato — solo el mensaje y el camino de vuelta a los selectores |
+| 4    | Toca una card                                                       | Navega al perfil del profesional (misión 05)                                                                        | — |
 
 ### Variantes y recuperación
 
-| Condición          | Qué cambia              | Cómo se entiende    | Cómo se recupera             |
-| ------------------ | ----------------------- | ------------------- | ---------------------------- |
-| <sin resultados>   | <estado>                | <mensaje concreto>  | <acción disponible>          |
-| <sin permiso de ubicación> | <comportamiento> | <indicador visible> | <alternativa manual>         |
-| <conexión lenta>   | <skeleton, no spinner>  | <qué se ve mientras>| <qué pasa si falla>          |
+| Condición                                                            | Qué cambia                                                                       | Cómo se entiende                                                     | Cómo se recupera |
+| ------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | --------------------- |
+| Comuna exacta sin resultados, vecinas sí ([F-002](./producto.md#f-002))    | Aviso corto + sección de comunas vecinas, cada card marcada con su comuna real           | El texto dice explícitamente que no son de la comuna pedida                  | Cambia de comuna, o contacta a uno de comuna vecina |
+| Ni la comuna ni sus vecinas tienen nada, pero la categoría sí existe en otro lado activo ([CL-001](./producto.md#cl-001)) | Estado vacío enmarcado por zona: "cerca de \<comuna\>"                                  | Título que sugiere que el problema es geográfico — cambiar de comuna sí puede ayudar | Cambia comuna, ya visible arriba |
+| La categoría no tiene ningún profesional en ninguna comuna activa del país ([CL-002](./producto.md#cl-002)) | Estado vacío sin enmarcar por zona — nunca dice "cerca de \<comuna\>", porque cambiar de comuna acá no ayudaría | Título que deja claro que el problema es de categoría, no de ubicación        | Cambia categoría, ya visible arriba |
+| Un solo profesional en toda la comuna y categoría ([CL-003](./producto.md#cl-003)) | La lista muestra una sola card, sin ningún elemento fabricado tipo "más opciones cerca" | No hay ninguna insinuación de que falte algo                                 | Ninguna — es el resultado real |
+| Conexión lenta (>300ms)                                                    | Skeleton con forma de 4 cards, mismo patrón que el perfil (misión 05)                    | Igual al resto de Datealo                                                    | Si pasa de 10s, mensaje "Esto está tardando más de lo normal" + "Reintentar" |
+| Cambia categoría o comuna mientras una lista ya está visible               | La lista anterior desaparece y vuelve el modo cargando, sin transición de pantalla       | Los dos campos de arriba siempre reflejan lo que se está pidiendo ahora mismo | No aplica — no hay error que recuperar |
 
 ### Decisiones que no deben quedar implícitas
 
-- <qué ocurre al cancelar, volver atrás, reintentar o confirmar>.
-- <qué cambio se guarda inmediato y cuál necesita confirmación>.
+- Ninguna card muestra un número de distancia en km ni un ícono de mapa — la única señal de cercanía es en
+  qué sección aparece la card ("en tu comuna" o la sección de comunas vecinas), ver
+  [D-002](./producto.md#d-002).
+- El orden dentro de cada sección nunca se explica en pantalla — no hay badge de "recomendado" ni "perfil
+  completo": el criterio es interno ([D-001](./producto.md#d-001)).
+- Los selectores de categoría y comuna quedan `position: sticky` en la parte superior durante todo el
+  scroll de la lista — nunca se pierden de vista. Por eso la card no repite la categoría (ya visible
+  arriba); si no fueran sticky, esta decisión se revisa, porque ahí sí haría falta repetirla.
+- En modo comunas vecinas, el nombre de la comuna en cada card va en negrita (mismo tamaño, más peso) en
+  vez del gris muted que usa en modo "con resultados" — el guardrail de
+  [M-002 de producto.md](./producto.md#m-002) exige que el fallback "nunca se presente como si fuera un
+  resultado real de la comuna exacta", y un texto con el mismo peso visual en los dos modos no cumple eso
+  con suficiente fuerza por sí solo.
+- Cambiar categoría o comuna no navega a otra URL ni recarga la pantalla completa — solo la lista se
+  reemplaza; los selectores de arriba quedan fijos en su lugar.
+- El botón "Buscar profesionales" que ya existe en el modo "no encontrado" del perfil (misión 05) navega
+  exactamente a esta vista, en modo eligiendo.
+- Ningún ícono de esta vista es un emoji — mismo criterio que el resto del producto (`@lucide/vue`,
+  `CLAUDE.md`); el mockup los representa como SVG.
+- En desktop, los modos eligiendo, comunas vecinas y sin resultados reusan el mismo layout centrado que en
+  móvil, solo más ancho — no cambian de composición, así que no llevan su propio frame de mockup; el modo
+  con resultados sí, porque pasa de lista vertical a grilla.
 
 ## Estados por superficie
 
-<!--
-El contenido es concreto: texto real, no "mensaje apropiado". El estado vacío de un marketplace
-pre-lanzamiento no es un detalle: para muchas búsquedas será el estado principal durante meses.
--->
-
-| Estado  | Qué se muestra (texto e información real) | Acción disponible                   |
-| ------- | ----------------------------------------- | ----------------------------------- |
-| inicial | <contenido>                               | <acción>                            |
-| vacío   | <por qué está vacío, con texto concreto>  | <cómo avanzar, o ninguna y por qué> |
-| carga   | <skeleton de qué forma>                   | <ninguna>                           |
-| error   | <causa útil y alcance>                    | <recuperación>                      |
+| Estado                                       | Qué se muestra (texto e información real)                                                                          | Acción disponible |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ---------------------- |
+| eligiendo, sin categoría ni comuna              | "Elige una categoría y tu comuna para ver profesionales disponibles." + los dos selectores vacíos                        | Elegir categoría o comuna |
+| eligiendo, con categoría (llegó de la landing)  | "Elige tu comuna para ver profesionales de Gasfitería cerca de ti." + selector de comuna con foco                        | Elegir comuna |
+| cargando                                        | 4 skeletons con forma de card                                                                                             | Ninguna |
+| con resultados                                  | "3 resultados" + cards: "Marcelo Rojas", "Ñuñoa", "Desde $15.000", "En Datealo desde julio de 2026" (y más cards igual, ordenadas por completitud — la más completa primero) | Tocar una card |
+| con resultados, un solo profesional (CL-003)    | "1 resultado" + una sola card, mismo formato — nunca un elemento fabricado tipo "más opciones cerca"                      | Tocar la card |
+| comunas vecinas                                 | "Todavía no hay profesionales de Gasfitería en Puente Alto" + sección "Cerca de Puente Alto" con cards marcadas, en negrita, "La Florida", "San Bernardo" | Tocar una card, o cambiar comuna |
+| sin resultados, comuna sin oferta (CL-001)      | "Todavía no hay profesionales de Gasfitería cerca de Puente Alto." + "Prueba con otra comuna."                            | Cambiar comuna (selector arriba) |
+| sin resultados, categoría sin oferta (CL-002)   | "Todavía no hay profesionales de Jardinería en Datealo." + "Prueba con otra categoría."                                   | Cambiar categoría (selector arriba) |
+| tardando (>10s)                                 | "Esto está tardando más de lo normal."                                                                                    | "Reintentar" |
 
 ## Mockups
 
-<!--
-Los mockups viven en design-mockups/ como HTML (ver el skill discovery-ux y docs/design/README.md).
-Exploran o materializan una decisión; no son fuente de verdad de reglas de producto.
--->
-
-| Mockup   | Cubre   | Estado                 | Ruta                              |
-| -------- | ------- | ---------------------- | --------------------------------- |
-| <nombre> | UXF-001 | exploración o validado | `./design-mockups/<archivo>.html` |
+| Mockup               | Cubre           | Estado       | Ruta |
+| ---------------------- | ------------------ | -------------- | ------ |
+| resultados-busqueda   | UXF-001 (V-001)   | validado — 9 frames, evaluación heurística aplicada (contradicciones documento↔mockup corregidas, emoji reemplazados, overflow protegido) | `./design-mockups/resultados-busqueda.html` |
 
 ## Cobertura
 
-<!-- Detecta huecos antes de construir. Una funcionalidad sin pantalla nueva igual tiene estados. -->
-
-| Funcionalidad | Flujo   | Estados cubiertos       | Estado    |
-| ------------- | ------- | ----------------------- | --------- |
-| F-001         | UXF-001 | principal, vacío, error | pendiente |
-
-## Secciones bajo demanda
-
-<!--
-Agregar solo cuando una decisión las necesite, con estos títulos:
-
-- "Modelo mental y lenguaje": cuando un concepto de producto pueda confundirse en la interfaz.
-- "Jerarquía de información": cuando una superficie densa exija decidir qué se ve primero (una card de
-  resultado con foto, rating, distancia, precio y disponibilidad es exactamente ese caso).
-- "Validación (UXV-xxx)": cuando una incertidumbre de diseño necesite prueba con usuarios.
-- "Accesibilidad y adaptación": cuando el contexto de uso cambie el flujo o la representación.
--->
+| Funcionalidad | Flujo   | Estados cubiertos                                                            | Estado    |
+| ------------- | ------- | -------------------------------------------------------------------------------- | --------- |
+| F-001         | UXF-001 | eligiendo, cargando, con resultados, un solo resultado (CL-003), tardando        | en revisión |
+| F-002         | UXF-001 | comunas vecinas, sin resultados en comuna (CL-001), sin resultados en categoría (CL-002) | en revisión |
 
 ## Decisiones de experiencia
 
 <a id="ux-001"></a>
 
-### UX-001 — <decisión en una frase>
+### UX-001 — Pantalla única reactiva, sin asistente de pasos ni mapa
 
-- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
-- **Sustento:** F-001 o <hallazgo>.
-- **Alternativas descartadas:** <opciones relevantes y trade-off, con el porqué del rechazo>.
-- **Decisión y consecuencia:** <qué flujo o superficie cambia>.
-- **Impacto en producto:** <ninguno o enlace a D-xxx/F-xxx actualizado>.
+- **Estado:** aceptada. **Fecha:** 2026-08-28.
+- **Sustento:** contexto real de uso de `discovery-ux` (buscador apurado, con una mano); "Mapa visual de
+  resultados" y "Búsqueda por texto libre de categoría" ya en Fuera de alcance de `producto.md`.
+- **Alternativas descartadas:** ver "Divergencia antes de converger" de UXF-001 — asistente de dos
+  pantallas (agrega transiciones completas sin necesidad) y mapa como vista principal (fuera de alcance de
+  producto desde antes de esta misión).
+- **Decisión y consecuencia:** layout definido en la Secuencia principal de UXF-001 — selectores fijos
+  arriba, lista reactiva abajo, sin pantallas intermedias entre elegir y ver resultados.
+- **Impacto en producto:** ninguno.
+
+<a id="ux-002"></a>
+
+### UX-002 — Comuna exacta y comunas vecinas van en la misma lista con un aviso separador, nunca en pestañas distintas
+
+- **Estado:** aceptada. **Fecha:** 2026-08-28.
+- **Sustento:** [C-001](./investigacion.md#c-001) de investigación (pocos o cero resultados es el caso
+  típico, no la excepción).
+- **Alternativas descartadas:** pestañas "En tu comuna" / "Cerca" — separan con claridad las dos fuentes,
+  pero exigen un toque extra para ver la alternativa; con el volumen esperado, la pestaña "En tu comuna" va
+  a estar vacía la mayoría de las veces (C-001), así que obligar a cambiar de pestaña para ver lo único que
+  sí existe es fricción sin ningún beneficio.
+- **Decisión y consecuencia:** una sola lista continua. Si hay resultados en la comuna exacta, se ven
+  directo, sin ningún aviso adicional. Si no los hay, un aviso corto ("Todavía no hay profesionales de
+  Gasfitería en Puente Alto") antecede a la sección de comunas vecinas — nunca aparecen mezcladas sin ese
+  aviso.
+- **Impacto en producto:** ninguno.
 
 ## Preguntas
 
-<!--
-Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
-Estado: abierta | resuelta AAAA-MM-DD | disuelta AAAA-MM-DD. Solo las abiertas llevan bloque de detalle.
--->
+Ninguna bloquea UXF-001 tal como queda definido acá.
 
-<Una frase que responde "¿qué falta?": la pregunta que bloquea construcción y qué bloquea.>
-
-| ID      | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
-| ------- | ---------------------- | ------------------- | --------------------------------------------------------------- |
-| UXQ-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
-| UXQ-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |
+| ID | La duda | Estado | Respuesta, o quién la resuelve |
+| -- | ------- | ------ | ------------------------------- |
+| —  | —       | —      | sin preguntas abiertas propias de experiencia |

--- a/docs/missions/06-busqueda-resultados/ingenieria.md
+++ b/docs/missions/06-busqueda-resultados/ingenieria.md
@@ -1,162 +1,369 @@
-# Misión: <nombre> — Ingeniería
+# Misión: búsqueda y resultados — Ingeniería
 
-**Estado:** borrador
+**Estado:** vigente — aprobado por Patricio el 2026-08-29
 
-**Última actualización:** AAAA-MM-DD
+**Última actualización:** 2026-08-29
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-<!--
-Fuente de verdad para arquitectura, datos, contratos, factibilidad y pruebas. Consume el comportamiento
-definido en producto. Una limitación técnica cambia el alcance solo mediante una decisión explícita en
-producto.md.
+## Decisión técnica: un endpoint de solo lectura sobre lo que ya existe, más una tabla nueva de adyacencia entre comunas
 
-Núcleo obligatorio: contratos, modelo de datos, RLS y riesgos de factibilidad. Las secciones bajo demanda
-(migración, rendimiento, entrega por etapas) se agregan solo cuando el riesgo lo justifica.
+`professionals` (misión 04) ya tiene todo el dato para ordenar por completitud (`photoPaths`, `description`,
+`priceFrom`) y por antigüedad (`createdAt`) — esta misión no le agrega ninguna columna. Lo único nuevo es
+`comuna_vecinas`, una tabla de solo lectura que responde "qué comunas comparten límite real con esta",
+calculada una sola vez desde un dataset público de límites geográficos ([D-002](./producto.md#d-002)) y
+cargada como seed estático — mismo patrón que `categorias`/`comunas` de misión 03, no una llamada en
+runtime a ningún servicio externo.
 
-Gate de salida — ingenieria.md está lista para construir cuando:
-- los contratos definen qué entra, qué sale y qué invariantes se mantienen, sin ambigüedad
-- el modelo de datos soporta los casos límite de producto.md sin workarounds
-- el impacto en RLS está resuelto: qué policy se crea o cambia, o por qué ninguna
-- la migración de datos existentes tiene estrategia o está explícitamente fuera del alcance
-- los escenarios verificables de producto están mapeados a pruebas
-- el plan de construcción corta el diseño en slices atómicos ordenados (un slice = un Issue = un PR)
--->
+Un solo endpoint nuevo, `GET /api/search`, cubre F-001 y F-002 a la vez: primero busca en la comuna exacta,
+y solo si no hay nada, en sus comunas vecinas activas — nunca las dos búsquedas a la vez ni mezcladas en la
+misma respuesta.
 
-## Decisión técnica: <arquitectura y riesgo principal>
+- **Contratos de producto cubiertos:** F-001, F-002, D-001, D-002, D-003, D-004.
+- **Riesgo bloqueante:** ninguno — ver [TR-001](#tr-001) para el único riesgo no bloqueante (qué tan
+  confiable es el dataset de límites elegido).
 
-<Dirección técnica, trade-off principal y el riesgo que todavía podría invalidarla.>
+## Vocabulario: producto ↔ código
 
-- **Contratos de producto cubiertos:** F-001, <otros>.
-- **Riesgo bloqueante:** <incertidumbre o "ninguna">.
+| Término de producto           | Entidad/campo en código                                                         |
+| -------------------------------- | -------------------------------------------------------------------------------------- |
+| buscar                           | `GET /api/search`                                                                      |
+| comuna vecina                    | fila de `comuna_vecinas` cuya `comuna_codigo` coincide con la comuna elegida            |
+| completitud del perfil            | `rankByCompleteness()` en `server/utils/search.ts` — cuenta fotos, descripción y precio cargados |
+| resultado de búsqueda             | `SearchResultProfessional` (`server/utils/search.ts`)                                  |
 
-## Arquitectura: <cómo se divide la responsabilidad>
+## Arquitectura: una query orquestadora nueva, sobre datos que ya existen
 
-<!--
-La lógica de negocio se separa de la infraestructura: funciones puras en utils/ y server/utils/,
-reactividad en composables, acceso a datos en server/api/ con Drizzle. Incluye diagrama solo cuando tres o
-más partes interactúan.
--->
+```
+Browser (sin sesión)
+  ──GET /api/search?categoria=&comuna=──> server/api/search.get.ts
+       ──> server/utils/search.ts (findSearchResults)
+              ├─ exacta: professionals WHERE categoriaSlug, comunaCodigo, active=true
+              ├─ vecina (solo si exacta = []): server/utils/comunas.ts (findVecinasActivas)
+              │     ──> professionals WHERE categoriaSlug, comunaCodigo IN (vecinas), active=true
+              └─ ninguna (solo si vecina también = []): existe algún professionals activo de esa
+                 categoría en cualquier comuna activa → distingue CL-001 de CL-002
+```
 
-<Descripción del enfoque y por qué satisface los contratos con menor riesgo.>
+`server/utils/search.ts` es un dominio nuevo, no una extensión de `professionals.ts` — mismo criterio que
+ya aplicó T-004 de misión 05 para `professional-contact-events.ts` (A-006: cada archivo de
+`server/utils/` es de un dominio). `rankByCompleteness()` vive ahí como función pura, sin Drizzle ni
+`event` (ver [T-002](#t-002)): es exactamente la pieza que [D-001 de producto.md](./producto.md#d-001) ya
+anticipa reemplazar apenas exista una señal real de calidad, y una función pura se reemplaza sin tocar la
+query.
 
-| Componente | Responsabilidad       | No debe decidir | Contratos |
-| ---------- | --------------------- | --------------- | --------- |
-| <nombre>   | <una responsabilidad> | <frontera>      | F-001     |
+| Componente                                                | Responsabilidad                                                                    | No debe decidir                                    | Contratos      |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | -------------------------------------------------------- | ---------------- |
+| `server/db/schema/comuna-vecinas.ts`                            | Forma de la tabla nueva                                                                    | Qué pares existen (eso es el seed)                       | TC-001           |
+| `server/db/seed/comuna-vecinas.ts`                               | Datos precalculados de adyacencia — estático, generado una vez, no runtime                | Nada — solo datos                                        | TR-001           |
+| `server/utils/comunas.ts` (extendido)                            | `findVecinasActivas(comunaCodigo)` — una query más, mismo archivo que ya tiene `comunas`   | Ranking, presentación                                     | TC-001           |
+| `server/utils/search.ts` (nuevo)                                 | Orquesta exacta → vecina → ninguna; `rankByCompleteness()` pura                            | Acceso a `professionals` fuera de este flujo (eso es `professionals.ts`), HTTP | TC-001 |
+| `server/api/search.get.ts`                                       | I/O: valida `categoria`/`comuna`, llama a `search.ts`, arma la respuesta                    | Reglas de negocio (ya resueltas en `search.ts`)          | TC-001           |
+| `app/composables/useSlowLoad.ts` (nuevo, extraído)               | Timer compartido de "tardando >10s" desde un `pending` reactivo                            | De dónde viene ese `pending`                             | TC-002           |
+| `app/composables/useSearchResults.ts` (nuevo)                    | Fetch reactivo de `/api/search` según categoría/comuna elegidas, expone los 5 modos de V-001 | Presentación, routing                                     | TC-002, UXF-001  |
+| `app/pages/buscar/index.vue`                                     | Renderiza los modos de V-001, lee/escribe `categoria`/`comuna` como query params            | Cómo se calcula el orden o la adyacencia (ya lo hizo el servidor) | UXF-001 |
+| `app/components/landing/LandingCategories.vue` (editado)          | Cada card navega a `/buscar?categoria=<slug>` en vez de anclar a `#hero-form`               | Nada nuevo — sigue siendo decorativo salvo el link        | UXF-001          |
+| `app/pages/profesionales/[id].vue` (editado)                     | El botón "Buscar profesionales" del modo no-encontrado navega a `/buscar`, no a `/`         | Nada nuevo                                                | UXF-001          |
+
+No hay dominio nuevo de "ranking" separado de `search.ts`: con una sola función pura y un solo consumidor,
+un archivo aparte sería una capa sin nadie más que la use todavía (YAGNI) — si el criterio de orden crece
+lo suficiente como para tener sus propias pruebas de propiedad extensas, se separa entonces, no antes.
 
 ## Contratos
 
-<!--
-Cada contrato especifica entrada, salida e invariantes al nivel en que se puede implementar sin reuniones
-de aclaración. Incluye los errores observables y el código HTTP cuando es un endpoint.
--->
+### TC-001 — `GET /api/search` — buscar profesionales por categoría y comuna
 
-### TC-001 — <contrato en una frase>
+- **Entrada:** query params `categoria` (`categoriaSlug`, string) y `comuna` (`comunaCodigo`, string).
+  Ambos obligatorios ([D-004](./producto.md#d-004)) — no hay valor por default para ninguno. Sin sesión.
+- **Salida:** `200 { results: SearchResultProfessional[], matchType: 'exacta' | 'vecina' | 'ninguna',
+  categoryHasResultsInChile: boolean }`.
+  `SearchResultProfessional = { id: string, displayName: string, comunaNombre: string, priceFrom: number |
+  null, createdAt: string }` — `createdAt` en ISO 8601, para "En Datealo desde..." (mismo dato que misión
+  05). **Nunca incluye ningún campo de foto**: el avatar de V-001 se arma en el cliente con las iniciales de
+  `displayName` — ninguna foto de trabajo (`photoPaths`) se reusa como avatar (ver [T-006](#t-006)).
+- **Invariantes:**
+  - `results` viene ordenado por completitud desc, empate por `createdAt` asc, empate final por `id` asc
+    ([D-001](./producto.md#d-001), [CL-004](./producto.md#cl-004)) — ver [T-002](#t-002) para el cálculo.
+  - `matchType` nunca mezcla resultados de la comuna exacta con los de una comuna vecina en la misma
+    respuesta ([F-002](./producto.md#f-002)): es `'exacta'` cuando `results` viene de `comunaCodigo` tal
+    cual se pidió; `'vecina'` cuando viene de `comuna_vecinas` activas de esa comuna (la búsqueda en
+    comuna exacta ya dio cero); `'ninguna'` cuando ambas búsquedas dieron cero y `results` es `[]`.
+  - `categoryHasResultsInChile` solo es información que el cliente necesita cuando `matchType === 'ninguna'`
+    — distingue [CL-001](./producto.md#cl-001) (`true`: existe en otra comuna activa, el estado vacío se
+    enmarca "cerca de \<comuna\>") de [CL-002](./producto.md#cl-002) (`false`: la categoría no tiene ningún
+    profesional activo en ninguna comuna activa del país, el estado vacío no se enmarca por zona). En
+    cualquier otro `matchType` el campo es trivialmente `true`, pero el cliente no necesita leerlo ahí.
+- **Errores:** `400 { error: 'categoria_required' }` si falta `categoria`; `400 { error: 'comuna_required'
+  }` si falta `comuna`; `400 { error: 'invalid_categoria' }` si no es una categoría activa (reusa
+  `existsActiveCategoria`); `400 { error: 'invalid_comuna' }` si no es una comuna activa (reusa
+  `existsActiveComuna`).
+- **Contrato de producto:** [F-001](./producto.md#f-001), [F-002](./producto.md#f-002),
+  [D-001](./producto.md#d-001), [D-002](./producto.md#d-002), [D-003](./producto.md#d-003),
+  [D-004](./producto.md#d-004), [CL-001](./producto.md#cl-001), [CL-002](./producto.md#cl-002),
+  [CL-003](./producto.md#cl-003), [CL-004](./producto.md#cl-004).
 
-- **Entrada:** <datos y precondiciones, con tipos y forma concreta>.
-- **Salida:** <resultado y su forma concreta>.
-- **Invariantes:** <qué se cumple siempre: atomicidad, consistencia, idempotencia>.
-- **Errores:** <condición → código HTTP y cuerpo `{ error, code? }`, y qué puede hacer el llamador>.
-- **Contrato de producto:** [F-001](./producto.md#f-001).
+**Ejemplo verificable:** dado que Puente Alto no tiene gasfiteres activos pero La Florida sí tiene dos,
+`GET /api/search?categoria=gasfiteria&comuna=13201` (Puente Alto) devuelve `matchType: 'vecina'` con los
+dos profesionales de La Florida, cada uno con `comunaNombre: 'La Florida'` — nunca `'Puente Alto'`.
+
+### TC-002 — `useSlowLoad(pending)` — el timer de "tardando" compartido
+
+- **Entrada:** `pending: Ref<boolean>`, `ms?: number` (default `10_000`).
+- **Salida:** `slow: Ref<boolean>` — pasa a `true` si `pending` sigue en `true` después de `ms`
+  milisegundos; vuelve a `false` en cuanto `pending` cambia a `false`.
+- **Invariantes:** el timer se limpia en cada cambio de `pending` y al desmontar el componente que lo usa
+  (`onUnmounted`) — nunca deja un `setTimeout` corriendo después de que el fetch ya resolvió o el componente
+  ya no existe. Solo corre en cliente (`import.meta.client`) — no tiene sentido en SSR, donde no hay
+  "esperar" real.
+- **Errores:** no aplica — es un timer, no una llamada que pueda fallar.
+- **Contrato de producto:** soporte de [F-001](./producto.md#f-001), [F-002](./producto.md#f-002) — el modo
+  "tardando" de V-001 (`experiencia.md`).
 
 ## Modelo de datos
 
-<!-- Entidades con significado, escritura y ciclo de vida. El schema completo vive en server/db/. -->
-
-| Entidad o campo | Significado             | Escritura          | Retención o historial |
-| --------------- | ----------------------- | ------------------ | --------------------- |
-| <dato>          | <semántica de producto> | <endpoint o acción>| <política>            |
+| Entidad o campo                    | Significado                                                                | Escritura                             | Retención o historial |
+| -------------------------------------- | --------------------------------------------------------------------------------- | ----------------------------------------- | ------------------------ |
+| `professionals.*`                      | Sin cambio de schema — esta misión solo lee `categoriaSlug`, `comunaCodigo`, `photoPaths`, `description`, `priceFrom`, `createdAt`, `active` | (misión 04)             | (misión 04)              |
+| `comuna_vecinas.comuna_codigo`         | Una comuna (FK a `comunas.codigo`)                                                 | Seed, una sola vez ([TR-001](#tr-001))    | Permanente, no se borra  |
+| `comuna_vecinas.vecina_codigo`         | Otra comuna que comparte límite real con la primera (FK a `comunas.codigo`)        | Seed, una sola vez                        | Permanente               |
 
 ### Invariantes de datos
 
-- <unicidad, pertenencia, orden o consistencia temporal>.
-- <qué operación es atómica o qué dato tiene una única fuente de verdad>.
+- `comuna_vecinas` guarda **ambos sentidos** de cada par (si Puente Alto es vecina de La Florida, existe la
+  fila `(Puente Alto, La Florida)` y también `(La Florida, Puente Alto)`) — así `findVecinasActivas(codigo)`
+  es un `select` simple por `comuna_codigo`, sin necesitar una unión de dos columnas en cada consulta. **La
+  simetría no está reforzada por ningún `CHECK` ni trigger** — depende de que el script de TR-001 siempre
+  inserte los dos sentidos, y de que una corrección manual futura en la base (mismo criterio sin panel de
+  administración que `categorias`/`comunas`) toque los dos sentidos, no uno. Es un riesgo aceptado
+  explícitamente, no una garantía de la base — el spot check de TR-001 solo cubre Gran Santiago y la zona
+  del lago Llanquihue, no las 346 comunas, así que una asimetría fuera de esa zona podría no notarse hasta
+  que alguien active esa comuna y su fallback de F-002 se vea incompleto en una sola dirección.
+- `comuna_vecinas` se calcula para **las 346 comunas**, no solo las activas — la adyacencia es un hecho
+  geográfico, no depende de qué comuna esté activa hoy. Esto es lo que hace que activar una comuna nueva
+  ([D-002 de producto.md](./producto.md#d-002)) no exija ningún trabajo de ingeniería adicional: sus vecinas
+  ya están en la tabla desde el seed inicial, la consulta solo filtra por `comunas.activa = true` al
+  momento de buscar.
+- Ninguna fila de `comuna_vecinas` se borra ni se recalcula en runtime — es un hecho geográfico que no
+  cambia; si el dataset de origen resultara tener un error puntual, se corrige a mano en la base, igual
+  criterio que `categorias`/`comunas` (sin panel de administración todavía).
+- `professionals` no gana ninguna columna ni índice nuevo — `professionals_categoria_slug_idx` y
+  `professionals_comuna_codigo_idx` (misión 04) ya cubren el filtro de TC-001.
+
+**Migración:** `comuna_vecinas` es una tabla nueva, sin dato previo que adaptar. `professionals` no cambia
+de schema — no hay migración de datos existentes.
 
 ### Impacto en RLS
 
-<!--
-Obligatorio. Fuente de verdad: server/db/sql/rls.sql. Si el cambio no toca ownership ni relaciones usadas
-en policies, decirlo explícitamente con esa razón — no dejar la sección vacía.
--->
+**`professionals` no cambia de policy ni de camino de acceso.** TC-001 lee vía Drizzle (rol dueño, A-002),
+el mismo camino que ya usan TC-001/TC-002 de misión 05 — nunca PostgREST directo. Ninguna policy nueva ni
+modificada para esta tabla.
 
-| Tabla    | Cambio                 | Policy afectada | Acción                    |
-| -------- | ---------------------- | --------------- | ------------------------- |
-| <tabla>  | <nueva, ownership, FK> | <nombre>        | <crear, actualizar, nada> |
+`comuna_vecinas` es catálogo de referencia público, mismo criterio que `categorias`/`comunas` (misión 03):
+lectura sin restricción, sin policy de escritura (nada la escribe vía `server/api/`, el seed va directo a
+la base), y cerrada a PostgREST por el mismo `revoke` que ya protege a esas dos tablas (A-007) — sin este
+`revoke`, el default de Supabase deja `comuna_vecinas` alcanzable directo con la publishable key del
+cliente, aunque nadie la consuma por ahí.
+
+| Tabla             | Cambio  | Policy o grant                                                          | Acción                                                                                                     |
+| --------------------- | ------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `professionals`       | ninguno | (sin cambio — todas las policies de misión 04)                             | nada — TC-001 usa Drizzle (rol dueño), que ya bypassea RLS por completo, igual que TC-001 de misión 05        |
+| `comuna_vecinas`      | nueva   | `comuna_vecinas_select_public` (`using (true)`)                            | crear — lectura pública sin restricción, mismo criterio que `categorias_select_public`/`comunas_select_public` |
+| `comuna_vecinas`      | nueva   | `revoke all on public.comuna_vecinas from anon, authenticated`             | crear — cierra PostgREST por completo (A-007); `findVecinasActivas()` usa Drizzle, que no le afecta            |
+
+No hay bucket de Storage nuevo ni cliente de Supabase nuevo en el browser — `/buscar` solo habla con
+`/api/search` y con `/api/categorias`/`/api/comunas` (ya existentes, para los selectores).
 
 ## Riesgos y experimentos de factibilidad
 
-<!--
-Un riesgo que podría cambiar el producto se enlaza como pregunta o decisión en producto.md. Un experimento
-tiene pregunta, límite de tiempo y resultado capaz de cerrar la incertidumbre.
--->
+<a id="tr-001"></a>
 
-| ID     | Riesgo o pregunta | Qué invalida        | Experimento o mitigación  | Criterio de salida      | Estado  |
-| ------ | ----------------- | ------------------- | ------------------------- | ----------------------- | ------- |
-| TR-001 | <incertidumbre>   | <alcance en riesgo> | <spike, prueba o recorte> | <resultado concluyente> | abierto |
+| ID     | Riesgo o pregunta                                                                      | Qué invalida                                          | Experimento o mitigación                                                                                                                                          | Criterio de salida                                                                                          | Estado  |
+| ------ | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ------- |
+| TR-001 | Ninguno de los tres datasets candidatos ([E-012](./investigacion.md#e-012)) tiene cobertura completa o licencia usable para las 346 comunas | El fallback de comunas vecinas (F-002) queda sin datos confiables para calcular, o expuesto a un problema de licencia | Probar los tres en orden (`niclabs/maps` primero, por venir de un grupo de investigación con mantenimiento más visible que los otros dos) con un script offline (`scripts/compute-comuna-vecinas.ts`, no forma parte del runtime): calcular adyacencia con una librería de geometría (`@turf/boolean-intersects` o equivalente) sobre los polígonos, cruzar cada feature contra `comunas.nombre` normalizado (sin tildes, minúsculas) y marcar cualquier comuna sin match para revisión manual — mismo criterio de "fuente única, no reescribir a mano" que TR-001 de misión 03 usó para el seed de comunas | Un dataset con las 346 comunas identificadas sin ambigüedad (o los huecos documentados y aceptados a mano) y licencia compatible con uso comercial (MIT, CC-BY o dominio público) — documentado como comentario en `server/db/seed/comuna-vecinas.ts` | abierto |
+
+Si ninguno de los tres alcanza cobertura completa, el criterio de salida no exige 100%: comunas sin match
+quedan sin fila en `comuna_vecinas` (su F-002 simplemente no tiene vecinas — cae directo a
+[CL-001](./producto.md#cl-001)/[CL-002](./producto.md#cl-002), un estado que el diseño ya cubre), no bloquea
+el resto de la entrega.
 
 ## Estrategia de pruebas
 
-<!-- Mapea los ejemplos verificables de producto.md a niveles de prueba. Qué demuestra cada una. -->
+Mismo criterio que misión 05: sin infraestructura de test de integración contra Postgres, se verifica a
+mano contra la base de desarrollo — salvo `rankByCompleteness()`, que al ser una función pura sí se prueba
+con Vitest sin ninguna infraestructura.
 
-| Contrato o riesgo | Nivel                          | Caso principal | Límite o falla |
-| ----------------- | ------------------------------ | -------------- | -------------- |
-| F-001, CL-001     | <unidad, contrato, integración>| <caso>         | <caso>         |
+| Contrato o riesgo                                                        | Nivel     | Caso principal                                                                                                                     | Límite o falla |
+| ----------------------------------------------------------------------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| `rankByCompleteness()` (D-001)                                               | unitario (Vitest) | Un perfil con 3 fotos, descripción y precio queda antes que uno solo con nombre y contacto                                                | Dos perfiles con la misma completitud y distinta `createdAt`: gana el más antiguo; con la misma `createdAt` también, gana el `id` menor (orden estable, CL-004) |
+| TC-001 — comuna exacta con resultados (F-001)                                | manual    | `categoria=electricidad&comuna=<Ñuñoa>` con 2 profesionales activos devuelve `matchType: 'exacta'`, ordenados por completitud       | Un profesional `active = false` en esa comuna/categoría nunca aparece |
+| TC-001 — fallback a comuna vecina (F-002)                                    | manual    | `categoria=gasfiteria&comuna=<Puente Alto>` sin resultados exactos pero con 2 en La Florida devuelve `matchType: 'vecina'`, cada `comunaNombre` es la comuna real del profesional, nunca "Puente Alto" | Un profesional activo en una comuna que NO es vecina de la elegida nunca aparece |
+| TC-001 — comuna sin oferta cercana (CL-001)                                   | manual    | Categoría existente en otra comuna activa, sin resultados en la exacta ni en sus vecinas: `matchType: 'ninguna'`, `categoryHasResultsInChile: true` | — |
+| TC-001 — categoría sin oferta en ningún lado (CL-002)                         | manual    | Categoría sin ningún profesional activo en ninguna comuna activa: `matchType: 'ninguna'`, `categoryHasResultsInChile: false`        | — |
+| TC-001 — validación de query params                                           | manual    | Sin `categoria` o sin `comuna` → `400` con el `error` correspondiente; con un slug/código inexistente o inactivo → `400 invalid_*`   | — |
+| TC-002 (`useSlowLoad`)                                                        | unitario (Vitest) | `pending = true` sostenido más de `ms` pone `slow = true`; `pending = false` antes de `ms` nunca lo activa                          | Desmontar el componente mientras el timer corre no deja ningún `setTimeout` pendiente (verificable con `vi.useFakeTimers()` y contando timers activos) |
+| Impacto en RLS — PostgREST directo, `comuna_vecinas`                          | manual, **desde la consola del navegador**, con o sin sesión | `$supabase.from('comuna_vecinas').select('*')` devuelve `permission denied`                                                        | — |
+| TR-001 (cobertura del dataset elegido)                                        | manual, una vez | Cada una de las 34 comunas del Gran Santiago + las 4 de la zona del lago Llanquihue tiene al menos una fila en `comuna_vecinas` (spot check, no las 346) | Puente Alto incluye a La Florida y San Bernardo como vecinas reales, verificado contra un mapa |
 
 ### Propiedades que deben probarse
 
-- <invariante bajo reintentos, concurrencia o distintas entradas>.
-- <ausencia de efectos parciales en falla>.
+- `rankByCompleteness()` nunca cambia de orden entre dos llamadas con el mismo input — es una función pura,
+  sin `Math.random()` ni dependencia de reloj salvo `createdAt`, que ya viene en el input.
+- TC-001 nunca devuelve una mezcla de `matchType: 'exacta'` y resultados de otra comuna en el mismo array —
+  verificable revisando que todo `comunaNombre` del array coincida con la comuna pedida cuando
+  `matchType === 'exacta'`, y con ninguno de ellos cuando es `'vecina'`.
+- Un profesional `active = false` nunca aparece en ningún `matchType`, ni siquiera cuando es el único que
+  existiría para esa categoría/comuna (ese caso cae en `'ninguna'`, no en un array con una fila inactiva).
 
 ## Plan de construcción
 
-<!--
-Se completa al final, cuando el gate de salida se cumple y ninguna pregunta bloqueante sigue abierta —
-cortar sobre decisiones abiertas produce issues que mueren. Cada slice es un cambio funcional atómico: un
-Issue, un PR, ejecutable sin haber leído la misión (el issue lleva su contrato inline) y con criterios
-pass/fail enumerables como tests. Guía completa en el skill discovery-engineering.
--->
+| ID    | Slice (una frase, sin "y")                                                                    | Sustento                                              | Criterio de aceptación principal                                                                                                                                                                                        | Depende de | Issue |
+| ----- | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | ----- |
+| S-001 | Tabla `comuna_vecinas` con RLS y seed calculado desde el dataset elegido en TR-001                   | D-002, TR-001                                          | `select count(*) from comuna_vecinas` > 0; Puente Alto tiene a La Florida y San Bernardo como vecinas (verificado a mano); vía PostgREST, `select`/`insert` devuelven `permission denied`                                | —          | [#94](https://github.com/PatricioTabilo/datealo/issues/94) |
+| S-002 | Endpoint `GET /api/search` con orden por completitud y fallback a comunas vecinas                    | F-001, F-002, D-001, D-003, D-004, TC-001, CL-001 a CL-004 | Cubre los 5 casos de la tabla de Estrategia de pruebas para TC-001 (exacta, vecina, CL-001, CL-002, validación); `rankByCompleteness()` tiene sus tests unitarios en verde                                                | S-001      | [#95](https://github.com/PatricioTabilo/datealo/issues/95) |
+| S-003 | Composable compartido `useSlowLoad()`, extraído de `usePublicProfessionalProfile` sin cambiar su comportamiento | TC-002                                                 | `usePublicProfessionalProfile` sigue pasando sus propios casos de uso (misión 05) usando el composable nuevo; test unitario de `useSlowLoad()` en verde                                                                  | —          | [#96](https://github.com/PatricioTabilo/datealo/issues/96) |
+| S-004 | Página `/buscar` con los 8 modos del mockup, consumiendo `/api/search` y `useSlowLoad()`              | F-001, F-002, UXF-001, todos los CL de producto.md      | Abrir `/buscar?categoria=&comuna=` reproduce cada modo del mockup validado (`design-mockups/resultados-busqueda.html`) con datos reales; tocar una card navega al perfil (misión 05)                                    | S-002, S-003 | [#97](https://github.com/PatricioTabilo/datealo/issues/97) |
+| S-005 | Conectar el carrusel de la landing y el botón "Buscar profesionales" del perfil a `/buscar`           | UXF-001                                                | Tocar una card de `LandingCategories` navega a `/buscar?categoria=<slug>` con esa categoría pre-elegida (modo eligiendo, solo falta comuna); el botón "Buscar profesionales" de `/profesionales/[id].vue` navega a `/buscar` en vez de `/`; el `SearchAction` de `index.vue` apunta a `/buscar?categoria={search_term_string}` en vez de `?q=` | S-004      | [#98](https://github.com/PatricioTabilo/datealo/issues/98) |
 
-| ID    | Slice (una frase, sin "y") | Sustento      | Criterio de aceptación principal          | Depende de |
-| ----- | -------------------------- | ------------- | ----------------------------------------- | ---------- |
-| S-001 | <cambio atómico>           | TC-001, D-001 | <entrada concreta → resultado observable> | —          |
-
-## Secciones bajo demanda
-
-<!--
-Agregar solo cuando el riesgo lo justifique, con estos títulos:
-
-- "Migración y compatibilidad": cuando existan datos o consumidores que deben llegar al nuevo contrato.
-  Incluye rollback lógico si la migración física no puede revertirse.
-- "Rendimiento y observabilidad": cuando haya presupuesto de latencia o volumen que defender (búsqueda
-  geográfica y listados paginados son los candidatos naturales).
-- "SEO e indexación": cuando la superficie deba ser indexable (páginas por categoría + comuna, datos
-  estructurados).
-- "Entrega por etapas": cuando el cambio necesite despliegue incremental o feature flags.
--->
+S-001 y S-003 no dependen entre sí — pueden ir en paralelo. S-002 depende solo de la tabla (S-001), no del
+composable de tardando. S-004 es el walking skeleton: la vista real consumiendo los dos contratos ya
+probados por separado. S-005 queda último porque toca archivos que ya existen y funcionan (aunque de forma
+decorativa o apuntando a `/`) — cambiarlos antes de que `/buscar` exista dejaría un link roto en producción
+si los slices se mergean por separado.
 
 ## Decisiones técnicas
 
 <a id="t-001"></a>
 
-### T-001 — <decisión en una frase>
+### T-001 — `search.ts` es un dominio propio, no una extensión de `professionals.ts`
 
-- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
-- **Contratos:** F-001 y <regla relevante>.
-- **Alternativas descartadas:** <opciones y trade-offs, con el porqué del rechazo>.
-- **Decisión y consecuencias:** <enfoque elegido, beneficio, costo y trabajo futuro aceptado>.
-- **Reapertura:** <medición o cambio que justificaría revisar>.
+- **Estado:** aceptada. **Fecha:** 2026-08-29.
+- **Contratos:** TC-001.
+- **Alternativas descartadas:** agregar `findSearchResults()` a `server/utils/professionals.ts` — más corto
+  de escribir porque ya importa `professionals`, pero mezcla dos razones de cambio (editar/leer un perfil
+  propio vs. orquestar una búsqueda multi-comuna con su propio criterio de orden) en el mismo archivo,
+  contradiciendo A-006 sin nombrarlo — mismo error que T-004 de misión 05 ya corrigió para
+  `professional-contact-events.ts`.
+- **Decisión y consecuencia:** `server/utils/search.ts` importa `professionals` y `comunas`, pero
+  `professionals.ts` y `comunas.ts` no saben que `search.ts` existe. `findVecinasActivas()` sí vive en
+  `comunas.ts` (no en `search.ts`), porque es una query más sobre `comunas`, mismo criterio que
+  `existsActiveComuna()`.
+- **Reapertura:** ninguna prevista.
+
+<a id="t-002"></a>
+
+### T-002 — El orden por completitud es una función pura, separada de la query a la base
+
+- **Estado:** aceptada. **Fecha:** 2026-08-29.
+- **Contratos:** TC-001, [D-001](./producto.md#d-001).
+- **Alternativas descartadas:** `ORDER BY` calculado en SQL (ej. una expresión que sume columnas booleanas)
+  — más rápido de escribir hoy y evita traer filas a memoria para ordenarlas, pero D-001 ya declara este
+  criterio explícitamente interino ("se espera reemplazar apenas exista una señal real de calidad"); cuando
+  eso pase (reseñas de misión 07, o una tasa de respuesta), el cambio sería una migración de query en vez de
+  un cambio de función, y no se podría probar sin levantar Postgres. Con el volumen esperado por
+  [C-001 de investigación](./investigacion.md#c-001) (pocos resultados por búsqueda), traer todas las filas
+  que ya matchearon categoría+comuna a memoria para ordenarlas no es el antipatrón de "traer todo el
+  catálogo a filtrar en el cliente" — el filtro ya ocurrió en SQL, solo el orden de un puñado de filas se
+  mueve a JS.
+- **Decisión y consecuencia:** `rankByCompleteness()` recibe y devuelve `ProfessionalCompletenessInput[]`,
+  un tipo propio de `search.ts` — **no** el `ProfessionalRow` privado de `professionals.ts` (8 columnas,
+  pensado para el CRUD del dueño del perfil, con `contact`/`categoriaSlug`/`comunaCodigo`/`active` que la
+  regla de orden no usa). `ProfessionalCompletenessInput = { id: string, createdAt: Date, hasPhotos:
+  boolean, hasDescription: boolean, hasPrice: boolean }` — `findSearchResults()` mapea la fila que trae
+  Drizzle a esta forma mínima antes de llamar a `rankByCompleteness()`, y recién después arma
+  `SearchResultProfessional` con los campos que sí necesita el cliente (`displayName`, `comunaNombre`,
+  `priceFrom`). Sin este mapeo explícito, la función "pura" terminaría acoplada a la forma de persistencia
+  de `professionals` — exactamente lo que la Dependency Rule prohíbe cruzar hacia el círculo interno, y lo
+  que impediría reemplazar este criterio (D-001, cuando exista una señal real de calidad) sin tocar cómo se
+  lee la tabla.
+- **Reapertura:** cuando [D-001 de producto.md](./producto.md#d-001) se reabra (misión 07, reseñas), este
+  es el único lugar que cambia — `ProfessionalCompletenessInput` gana un campo (`rating`, `reviewCount`) sin
+  que `professionals.ts` ni el endpoint necesiten saberlo.
+
+<a id="t-003"></a>
+
+### T-003 — La adyacencia de comunas se precalcula una sola vez y se guarda como seed estático, no se calcula en runtime
+
+- **Estado:** aceptada. **Fecha:** 2026-08-29.
+- **Contratos:** [D-002 de producto.md](./producto.md#d-002).
+- **Alternativas descartadas:** guardar solo coordenadas por comuna y calcular distancia Haversine en cada
+  consulta — ya descartada en D-002 de producto (la distancia recta no es fiel a "comparte límite", puede
+  cruzar la cordillera). Llamar a un servicio externo de geometría (ej. una API GIS) en cada `GET
+  /api/search` — agrega latencia y una dependencia externa a un dato que no cambia nunca (la geografía de
+  Chile no se mueve), sin ningún beneficio sobre precalcularlo una vez.
+- **Decisión y consecuencia:** un script offline (`scripts/compute-comuna-vecinas.ts`, no se despliega ni
+  corre en producción) calcula adyacencia real para las 346 comunas desde el dataset elegido en
+  [TR-001](#tr-001), cruza cada feature contra `comunas.nombre` y genera el array estático de
+  `server/db/seed/comuna-vecinas.ts` — mismo patrón que `server/db/seed/taxonomia.ts`. Activar una comuna
+  nueva ([D-002 de producto.md](./producto.md#d-002)) nunca requiere volver a correr este script: sus
+  vecinas ya están en la tabla desde el seed inicial, calculadas para las 346 comunas, no solo las activas.
+- **Reapertura:** si el dataset elegido resulta tener huecos de cobertura serios (ver TR-001), o si Chile
+  activa/crea una comuna nueva de verdad (raro, pero ha pasado históricamente) — ahí sí habría que
+  recorrer el script una vez más.
+
+<a id="t-004"></a>
+
+### T-004 — `useSlowLoad()` se extrae como composable compartido, en vez de duplicar el timer de misión 05
+
+- **Estado:** aceptada. **Fecha:** 2026-08-29.
+- **Contratos:** TC-002.
+- **Alternativas descartadas:** copiar el mismo `ref` + `setTimeout` + `watch` dentro de
+  `useSearchResults.ts`, como ya existe en `usePublicProfessionalProfile.ts` — es literalmente la misma
+  regla (10s desde que empieza a cargar, sin depender de qué se está cargando), no dos reglas parecidas; el
+  criterio del skill de ingeniería para decidir esto es exactamente "si esta regla cambia, ¿cambia para las
+  dos entidades a la vez, por el mismo motivo?" — sí: si el umbral de "tardando" cambiara mañana (ej. a 8s),
+  tendría que cambiar en los dos lugares a la vez, y duplicado eso solo pasa si alguien se acuerda de tocar
+  los dos archivos.
+- **Decisión y consecuencia:** `app/composables/useSlowLoad.ts` nuevo, con la firma de TC-002.
+  `usePublicProfessionalProfile.ts` (misión 05) se refactoriza para consumirlo, sin cambiar su
+  comportamiento observable — mismo timer, ahora compartido. `useSearchResults.ts` lo consume igual.
+- **Reapertura:** si alguna vez el umbral o el criterio de "tardando" necesitara ser distinto entre el
+  perfil y la búsqueda — ahí deja de ser la misma regla y esta decisión se revisa.
+
+<a id="t-005"></a>
+
+### T-005 — `/buscar` usa query params para categoría y comuna, y corrige el `SearchAction` de la landing que ya apuntaba ahí
+
+- **Estado:** aceptada. **Fecha:** 2026-08-29.
+- **Contratos:** UXF-001, [D-003](./producto.md#d-003), [D-004](./producto.md#d-004).
+- **Alternativas descartadas:** estado solo en el cliente (sin reflejar categoría/comuna en la URL) — más
+  simple de escribir, pero no permite compartir ni recargar un link de búsqueda ya armado, y rompe el caso
+  de uso de `LandingCategories` (llegar con la categoría pre-elegida, [UXF-001](./experiencia.md#uxf-001)
+  exige exactamente eso).
+- **Decisión y consecuencia:** `/buscar?categoria=<slug>&comuna=<codigo>`, ambos opcionales en la URL (el
+  modo "eligiendo" de V-001 cubre el caso de que falte uno o los dos). `app/pages/index.vue` ya tiene un
+  `SearchAction` de schema.org apuntando a `https://datealo.cl/buscar?q={search_term_string}` — un patrón de
+  texto libre que [D-003 de producto.md](./producto.md#d-003) ya descartó para categoría; se corrige en el
+  mismo slice (S-005) a `https://datealo.cl/buscar?categoria={search_term_string}`, coherente con que la
+  categoría sí viene de un catálogo fijo pero el nombre del parámetro puede recibirse como texto desde un
+  buscador externo sin que Datealo tenga que validarlo ahí (la validación real ocurre en TC-001, que
+  devuelve `400 invalid_categoria` si no matchea el catálogo).
+- **Reapertura:** ninguna prevista.
+
+<a id="t-006"></a>
+
+### T-006 — El endpoint de búsqueda nunca devuelve una foto para el avatar
+
+- **Estado:** aceptada. **Fecha:** 2026-08-29.
+- **Contratos:** TC-001.
+- **Alternativas descartadas:** devolver la primera foto de `photoPaths` como avatar de la card — es lo que
+  una lectura superficial de "Foto o iniciales" en `experiencia.md` podría sugerir, pero el propio mockup
+  validado de esta misión (`design-mockups/resultados-busqueda.html`) nunca muestra una foto en el círculo
+  de avatar, solo iniciales, en los 9 frames — y hay una razón de fondo: ninguna foto de trabajo garantiza
+  mostrar la cara del profesional (ver la investigación de la misión 08, aún sin aprobar, que documenta
+  exactamente este problema). Devolver una foto que el mockup nunca muestra sería construir un campo que la
+  experiencia aprobada no usa.
+- **Decisión y consecuencia:** `SearchResultProfessional` no incluye ningún campo de foto — el cliente
+  arma las iniciales de `displayName` (mismo criterio que el perfil público, misión 05, cuando no hay
+  fotos). Si la misión 08 se aprueba y agrega un campo de foto de perfil dedicado, este contrato se
+  extiende ahí, no antes.
+- **Reapertura:** cuando la misión 08 (foto de perfil de profesional) se apruebe y quede `vigente`.
 
 ## Preguntas
 
-<!--
-Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
-Estado: abierta | resuelta AAAA-MM-DD | disuelta AAAA-MM-DD. Solo las abiertas llevan bloque de detalle.
--->
+Ninguna bloquea construcción — el único punto abierto es TR-001, que es un riesgo con mitigación en curso,
+no una pregunta de producto o de diseño.
 
-<Una frase que responde "¿qué falta?": la pregunta que bloquea construcción y qué bloquea.>
-
-| ID     | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
-| ------ | ---------------------- | ------------------- | --------------------------------------------------------------- |
-| TQ-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
-| TQ-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |
+| ID     | La duda | Estado | Respuesta, o quién la resuelve |
+| ------ | ------- | ------ | ------------------------------- |
+| —      | —       | —      | sin preguntas abiertas todavía |

--- a/docs/missions/06-busqueda-resultados/investigacion.md
+++ b/docs/missions/06-busqueda-resultados/investigacion.md
@@ -1,118 +1,252 @@
-# Misión: <nombre> — Investigación
+# Misión: búsqueda y resultados — Investigación
 
 **Estado:** activo
 
-**Última actualización:** AAAA-MM-DD
+**Última actualización:** 2026-08-28
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-<!--
-Este documento se acumula: la evidencia y las conclusiones no se borran cuando el alcance cambia, porque
-explican por qué el producto es como es. Lo que sí se actualiza es el ideal, que resume la dirección que
-la investigación sostiene hoy.
+## El problema aparece cuando don Sergio busca un gasfiter en Puente Alto un domingo y no hay ninguno ahí
 
-Gate de salida — la investigación sostiene un producto.md cuando:
-- el problema tiene situación y consecuencia concretas, no una categoría abstracta
-- al menos una conclusión con confianza alta o media respalda la dirección
-- el ideal describe capacidades observables, no intenciones
--->
+**Situación:** a don Sergio se le tapa el lavaplatos un domingo en la tarde, en Puente Alto. Abre Datealo,
+elige "Gasfitería" y su comuna, y la lista sale vacía — los dos gasfiteres que ya se registraron en Datealo
+están en Ñuñoa y Providencia, al otro lado de la ciudad. Es exactamente el escenario que anticipa el
+catálogo de comunas de misión 03: 34 comunas activas de Gran Santiago más la zona del lago Llanquihue
+(Puerto Varas, Frutillar, Puerto Montt y Llanquihue), y el registro de profesionales (misión 04) recién se
+cerró hoy mismo, así que casi ninguna combinación de categoría y comuna tiene todavía más de uno o dos
+profesionales.
 
-## El problema aparece cuando <historia concreta>
+**Acción o necesidad:** encontrar a alguien que resuelva el problema hoy, sin tener que adivinar si ampliar
+la búsqueda a otra comuna sirve de algo o si Datealo simplemente no tiene nada para él.
 
-<!--
-Una situación real o reconstruida con precisión. No abras con una categoría como "falta de confianza" —
-abre con quién estaba haciendo qué y qué salió mal. Nombra a la persona y el servicio concreto.
--->
+**Respuesta actual:** hoy pregunta en el grupo de WhatsApp del edificio o busca en Facebook Marketplace —
+ahí la búsqueda no está acotada a su comuna exacta, así que igual le puede responder alguien de más lejos
+([E-008](#e-008)).
 
-**Situación:** <qué está ocurriendo antes del problema>.
-
-**Acción o necesidad:** <qué se intenta resolver o decidir>.
-
-**Respuesta actual:** <qué hace hoy la persona: grupo de WhatsApp, Google, recomendación de un vecino,
-Datealo si ya existe la superficie>.
-
-**Consecuencia:** <error, demora, riesgo o decisión que no puede tomarse>.
+**Consecuencia:** si la pantalla de resultados se ve simplemente vacía, sin ninguna alternativa, don Sergio
+cierra Datealo y vuelve al grupo de WhatsApp — y esto no es un caso raro: con el catálogo y el volumen
+actuales, "pocos o cero resultados" es el resultado más probable de cualquier búsqueda al lanzamiento, no
+la excepción ([E-003](#e-003)).
 
 ## Preguntas que la investigación debe resolver
 
-<!--
-Solo preguntas capaces de cambiar el ideal o una decisión. Al resolver una, moverla a evidencia o
-conclusión. No es un backlog.
--->
-
-- ¿<pregunta y decisión que depende de ella>?
+- ¿Qué reemplaza a "ordenar por relevancia" cuando Datealo no tiene reseñas, tasa de respuesta ni ningún
+  historial de un profesional? Afecta el criterio de orden que el ideal puede prometer.
+- ~~¿Qué significa concretamente "comuna cercana" sin coordenadas ni un mapa de adyacencia entre comunas ya
+  cargado en la base?~~ Resuelta: existen datasets públicos de coordenadas y límites reales que permiten
+  calcular adyacencia real sin geocodificar a mano ([C-007](#c-007)) — la pregunta que queda abierta es cuál
+  fuente usar y cómo cruzarla contra los códigos SUBDERE de Datealo, una decisión de `producto.md`.
+- ¿Hace falta búsqueda por texto libre de categoría, o alcanza con elegir de una lista fija como ya hace el
+  carrusel de la landing? Afecta si esta misión reabre el problema de vocabulario que misión 03 ya cerró
+  para el registro.
 
 ## Evidencia
 
-<!--
-Un hecho verificable con fuente y límite. Prioriza observación directa, entrevistas y comportamiento
-comprobado. Los benchmarks de otros productos también son evidencia: qué hacen, qué trade-off eligieron y
-qué no aplica a Datealo.
+| ID    | Tipo             | Fuente                                                                                          | Hecho verificable | Límite de la evidencia |
+| ----- | ----------------- | ------------------------------------------------------------------------------------------------- | ------------------ | ----------------------- |
+| E-001 | código             | `server/db/schema/professionals.ts`                                                              | El perfil de un profesional no tiene ninguna columna de rating, reseña, tasa de respuesta ni contador de contactos o vistas — solo `displayName`, `categoriaSlug` (uno solo), `comunaCodigo` (uno solo), `contact`, `description`, `priceFrom`, `photoPaths` y `active` | Dice qué datos existen hoy para ordenar resultados, no cómo debería verse ni ordenarse la búsqueda |
+| E-002 | decisión interna   | [D-001](../03-taxonomia-categorias-y-comunas/producto.md#d-001), [D-004](../03-taxonomia-categorias-y-comunas/producto.md#d-004) de misión 03 | Categoría y comuna siempre se eligen de un catálogo fijo (`CategoriaSelect`, `ComunaSelect`), nunca texto libre; y D-001 deja explícito que "cómo un buscador la elige en pantalla... es una decisión de la misión 06, no de esta" | Fija una restricción de catálogo, no dice cómo ordenar los resultados ni qué mostrar cuando no hay ninguno |
+| E-003 | código             | `server/db/seed/taxonomia.ts`, `docs/missions/04-registro-perfil-profesional/README.md`          | Hay 8 categorías activas × 38 comunas activas (34 de Gran Santiago + 4 de la zona del lago Llanquihue) = 304 combinaciones posibles de búsqueda, y el registro de profesionales (misión 04) recién se cerró el 2026-08-28, el mismo día en que se abre esta investigación | No mide cuántos profesionales reales existen hoy (no se consultó la base directamente), pero confirma que el volumen es necesariamente bajo por lo reciente del registro |
+| E-004 | benchmark          | [Recommending Search Filters To Improve Conversions At Airbnb (arXiv)](https://arxiv.org/html/2602.23717v1) | Airbnb define "low inventory" como un resultado con menos de 18 listados (el tamaño de una página) y su sistema evita activamente sugerir filtros que dejen el conteo bajo ese umbral | Mide inventario de arriendos turísticos a escala global — Datealo no tiene ese volumen ni cerca, pero confirma que hasta un marketplace con millones de listados protege contra sobre-filtrar cuando el resultado ya es escaso |
+| E-005 | benchmark          | [Evolution of Search Ranking at Thumbtack (Thumbtack Engineering)](https://medium.com/thumbtack-engineering/evolution-of-search-ranking-at-thumbtack-f7a69fd0da13) | El ranking de Thumbtack pondera historial del profesional, tasa de respuesta y reseñas junto con la solicitud del cliente; etiquetas como "Responds Quickly" o "In High Demand" solo aparecen en profesionales con historial acumulado | Describe un sistema de machine learning entrenado con años de datos de miles de transacciones — ninguna de esas señales (reseñas, tasa de respuesta) existe en Datealo hoy ([E-001](#e-001)) |
+| E-006 | benchmark          | [How does Yelp determine its search results? (Yelp Support Center)](https://www.yelp-support.com/article/How-does-Yelp-determine-its-search-results) | El sort "Recommended" (default) combina término de búsqueda, distancia, rating y datos de uso; "Distance" es un sort alternativo que reordena solo por proximidad — un negocio a una cuadra puede ganarle a uno con mejor rating a varios kilómetros | Yelp tiene millones de reseñas para alimentar "Recommended" — Datealo no tiene ninguna, así que ese modo no es replicable hoy; pero confirma que ordenar solo por proximidad ("Distance") es un modo válido que un producto maduro ya ofrece cuando no hay otra señal |
+| E-007 | benchmark          | [Understand & manage your location when you search on Google (Google Search Help)](https://support.google.com/websearch/answer/179386) | Sin permiso de ubicación precisa, Google estima un "área general" (más de 3 km²) desde IP o wifi y sigue mostrando resultados locales, aunque pueden estar "más lejos de lo que en verdad estás" | Es búsqueda web general, no un marketplace de servicios, pero confirma que degradar sin geolocalización de precisión no es una limitación inventada por falta de presupuesto — es el patrón estándar cuando no se pide GPS |
+| E-008 | benchmark general de UX | [Search UX Best Practices (Pencil & Paper)](https://www.pencilandpaper.io/articles/search-ux), [Empty state UX examples and design rules that actually work (Eleken)](https://www.eleken.co/blog-posts/empty-state-ux) | La práctica estándar ante cero resultados es nunca dejar una pantalla vacía sin salida: reconocer la falta de resultados y ofrecer un siguiente paso concreto (ampliar el filtro, ver alternativas relacionadas) | Son guías generales de UX de búsqueda, no específicas de marketplaces de servicios locales ni validadas con usuarios reales de Datealo |
+| E-009 | decisión interna   | Brief de esta misión (ver [README](./README.md)), conversación de roadmap del 2026-08-13         | La dirección propuesta es ordenar por relevancia y cercanía por comuna "como un portal inmobiliario", sin geolocalización de precisión; el debounce de 300ms sin resultados mientras se escribe y los estados vacíos que inviten a probar otra categoría o comuna ya son estándar del producto (`CLAUDE.md`) | Es una recomendación a confirmar en `producto.md`, no una decisión ratificada — y "como un portal inmobiliario" describe la sensación deseada, no un mecanismo verificado: no se encontró documentación técnica pública de cómo Yapo.cl o Portalinmobiliario calculan esa cercanía entre comunas |
+| E-010 | código             | `server/db/schema/comunas.ts`                                                                    | La tabla de comunas solo tiene `codigo`, `nombre` y `activa` — no tiene coordenadas ni ninguna relación de comunas vecinas o adyacentes | Dice qué falta, no cómo debería resolverse (coordenadas y cálculo real, o una lista fija de adyacencia mantenida a mano) |
+| E-011 | dataset externo    | [Todas las comunas de Chile con sus coordenadas geográficas (gist de rafafdz)](https://gist.github.com/rafafdz/a67d3f6ac058c45cfad8176bf583b632) | Existe un dataset público y gratuito en CSV con latitud/longitud por comuna chilena, cubriendo casi todas las comunas del país | No está atado a los códigos oficiales SUBDERE que ya usa la tabla `comunas` de Datealo — cruzarlo exige hacerlo por nombre, con riesgo de comunas homónimas o tildes distintas, no es un join automático sin revisión |
+| E-012 | dataset externo    | [caracena/chile-geojson](https://github.com/caracena/chile-geojson), [fcortes/Chile-GeoJSON](https://github.com/fcortes/Chile-GeoJSON), [niclabs/maps](https://github.com/niclabs/maps) | Existen al menos tres fuentes públicas independientes con los límites geográficos reales (polígonos) de las comunas chilenas, de los que se puede calcular qué comunas comparten frontera — adyacencia real, no solo distancia en línea recta | Son proyectos de la comunidad, no una fuente oficial única — ninguno declara licencia explícita ni mantenimiento activo (ej. `caracena/chile-geojson` tiene solo 2 commits), hay que validar cobertura y licencia antes de depender de uno |
 
-Datealo no tiene datos de uso propios todavía. Cuando la única evidencia disponible sea un benchmark o
-una entrevista, la columna "límite" es lo que impide que se lea como dato duro.
--->
+<a id="e-004"></a>
 
-| ID    | Tipo                                              | Fuente                | Hecho verificable | Límite de la evidencia |
-| ----- | ------------------------------------------------- | --------------------- | ----------------- | ---------------------- |
-| E-001 | <entrevista, benchmark, uso, código, observación> | <enlace o referencia> | <hecho>           | <qué no demuestra>     |
+### E-004 — Hasta Airbnb evita activamente que un filtro deje pocos resultados
 
-<a id="e-001"></a>
+Airbnb mide "low inventory" en 18 listados — el tamaño de una página de resultados — y su módulo de
+recomendación de filtros descarta cualquier filtro que dejaría el conteo por debajo de eso, aunque el
+filtro sea relevante para la búsqueda. Lo hacen con millones de propiedades disponibles globalmente.
 
-### E-001 — <fuente o hecho en una frase>
+Esto permite afirmar que "no dejar que un filtro vacíe la lista" es un principio de diseño válido incluso a
+gran escala, pero no demuestra qué debería hacer Datealo en concreto — a la escala de Datealo el problema no
+es qué filtro sacar, es que la lista ya nace corta antes de aplicar ningún filtro.
 
-<!--
-Desarrollar solo cuando la tabla no alcanza para evaluar la calidad de la evidencia. Cierra con la
-consecuencia para la investigación.
--->
+<a id="e-009"></a>
 
-<Observación precisa y contexto necesario.>
+### E-009 — La analogía "como un portal inmobiliario" no tiene un mecanismo verificado detrás
 
-Esto permite afirmar <alcance>, pero no demuestra <límite>.
+La búsqueda de propiedades en Yapo.cl y Portalinmobiliario permite filtrar por comuna, pero no se encontró
+documentación pública de cómo esos portales calculan o muestran "comunas cercanas" cuando la elegida no
+tiene resultados. La analogía del brief describe la sensación que se busca (una lista ordenada por zona, no
+una búsqueda exacta que falla en seco), no un algoritmo que copiar.
+
+Esto permite afirmar que la dirección del brief es una hipótesis de producto razonable, respaldada por el
+patrón general de degradar sin geolocalización de precisión ([E-007](#e-007)), pero no demuestra que exista
+un mecanismo listo para reusar — el cómo todavía hay que diseñarlo, empezando por resolver [E-010](#e-010).
 
 ## Conclusiones
 
-<!--
-Una conclusión interpreta evidencia; no es una preferencia ni una funcionalidad. El título expresa el
-hallazgo, no el tema.
--->
-
 <a id="c-001"></a>
 
-### C-001 — <conclusión en una frase>
+### C-001 — Pocos o cero resultados va a ser el caso típico de una búsqueda al lanzamiento, no el caso raro
 
-- **Sustento:** [E-001](#e-001).
-- **Razonamiento:** <por qué la evidencia conduce a esta lectura y no a otra>.
-- **Implicación:** <qué deberá ser cierto en el producto o qué alternativa queda debilitada>.
-- **Confianza:** <alta, media o baja> porque <razón o validación pendiente>.
+- **Sustento:** [E-003](#e-003), [E-004](#e-004).
+- **Razonamiento:** con 304 combinaciones posibles de categoría y comuna y un registro de profesionales que
+  recién se cerró hoy, la mayoría de esas combinaciones va a tener cero o uno o dos profesionales durante
+  meses. Si Airbnb, con millones de propiedades, ya trata "menos de 18 resultados" como un estado a evitar
+  activamente, en Datealo ese mismo estado no es una rareza a manejar con un mensaje de cortesía — es el
+  resultado más probable de cualquier búsqueda real.
+- **Implicación:** el buscador no puede diseñarse asumiendo que va a haber suficiente oferta para que
+  filtros u orden avanzados tengan sentido. Tiene que funcionar bien con 0, 1 o 2 resultados como el caso
+  principal a resolver primero, igual que misión 05 tuvo que diseñar el perfil asumiendo cero reseñas como
+  el estado normal, no la excepción.
+- **Confianza:** alta — combina un hecho interno verificable (E-003) con un patrón consistente de un
+  benchmark a escala mucho mayor (E-004).
 
-## El ideal: <resultado completo, sin recortar>
+<a id="c-002"></a>
 
-<!--
-El ideal es el producto de la investigación: la dirección que la evidencia sostiene, sin restricciones de
-implementación. El recorte a la primera entrega no vive aquí — vive en producto.md como decisión de
-alcance. Esta sección sí se reescribe cuando nueva evidencia cambia la dirección.
--->
+### C-002 — Sin reseñas, tasa de respuesta ni historial, Datealo no tiene ninguna señal propia de "relevancia" — solo cercanía y qué tan completo está el perfil
+
+- **Sustento:** [E-001](#e-001), [E-005](#e-005), [E-006](#e-006).
+- **Razonamiento:** Thumbtack y el modo "Recommended" de Yelp ponderan reseñas, tasa de respuesta y datos de
+  uso — ninguno de esos datos existe en la base de Datealo hoy (E-001), porque misión 07 (reseñas) todavía
+  no se construye y el contacto pasa por WhatsApp, fuera del control de Datealo. El modo "Distance" de Yelp,
+  en cambio, no depende de ninguno de esos datos y coincide con lo único que Datealo sí tiene: la comuna del
+  profesional.
+- **Implicación:** el orden inicial del buscador no puede llamarse "relevancia" en el sentido en que
+  Thumbtack o Yelp lo usan — tiene que ser honesto sobre qué está ordenando (cercanía y completitud del
+  perfil: fotos, descripción, precio), no simular un ranking de calidad que no tiene datos detrás.
+- **Confianza:** alta — es una restricción verificable de lo que existe hoy (E-001), reforzada por dos
+  benchmarks consistentes.
+
+<a id="c-003"></a>
+
+### C-003 — "Cercanía por comuna" hoy es una idea sin mecanismo: la base no tiene cómo calcular qué tan cerca está una comuna de otra
+
+- **Sustento:** [E-010](#e-010).
+- **Razonamiento:** el schema actual de comunas (`codigo`, `nombre`, `activa`) no guarda coordenadas ni una
+  relación de comunas vecinas. Ordenar "por cercanía" o mostrar "comunas vecinas cuando la exacta no tiene
+  nadie" (la dirección del brief, [E-009](#e-009)) requiere agregar ese dato — no es algo que ya exista y
+  solo falte usar.
+- **Implicación:** antes de que `producto.md` pueda prometer comunas vecinas marcadas con su distancia,
+  tiene que decidir de dónde sale ese dato: coordenadas con cálculo real, o una lista fija de adyacencia por
+  zona (ej. agrupar Gran Santiago en sectores) mantenida a mano, con el mismo criterio manual que ya se usa
+  para activar categorías y comunas (D-002 de misión 03).
+- **Confianza:** alta — es una restricción verificable del schema actual, no una inferencia externa.
+
+<a id="c-004"></a>
+
+### C-004 — Degradar sin geolocalización de precisión ya es el patrón que usan productos con muchos más recursos que Datealo
+
+- **Sustento:** [E-007](#e-007), [E-009](#e-009).
+- **Razonamiento:** Google, con toda su infraestructura de geolocalización, igual degrada a un "área
+  general" en vez de un punto exacto cuando no tiene permiso preciso, y sigue entregando resultados locales
+  útiles. La dirección que ya trae el brief de esta misión (comuna elegida a mano, no GPS) va en la misma
+  línea.
+- **Implicación:** no vale la pena invertir en geolocalización de precisión para el lanzamiento — elegir la
+  comuna a mano, reusando `ComunaSelect` de misión 03, es consistente con cómo degrada la búsqueda local un
+  producto con muchos más recursos que Datealo.
+- **Confianza:** media — el benchmark es de búsqueda web general, no de un marketplace de servicios, así que
+  confirma el patrón general pero no lo prueba para este caso específico.
+
+<a id="c-005"></a>
+
+### C-005 — Un resultado vacío o casi vacío necesita una salida concreta, y en Datealo esto va a pasar seguido, no ocasionalmente
+
+- **Sustento:** [E-008](#e-008), [C-001](#c-001).
+- **Razonamiento:** la práctica de UX ya dice que un cero-resultados sin salida frustra y hace abandonar —
+  eso es justo lo que `CLAUDE.md` anticipa (estados vacíos que inviten a probar otra categoría o comuna).
+  Pero deja de ser un detalle cosmético cuando el caso vacío es el resultado más probable de cualquier
+  búsqueda al lanzamiento (C-001), no una rareza.
+- **Implicación:** el estado vacío no es algo a resolver después en `experiencia.md` con solo un mensaje —
+  necesita una salida concreta definida en `producto.md` (ej. comunas vecinas, u otras categorías con oferta
+  en la misma comuna), consistente con lo que este mismo estado vacío va a exigir en la mayoría de las
+  búsquedas, no en un caso límite aislado.
+- **Confianza:** alta.
+
+<a id="c-006"></a>
+
+### C-006 — Elegir la categoría de una lista fija, no escribirla, ya es la dirección que la decisión previa de misión 03 sostiene
+
+- **Sustento:** [E-002](#e-002).
+- **Razonamiento:** D-004 de misión 03 exige que categoría y comuna sean siempre una referencia al catálogo,
+  nunca texto libre, y el mismo componente (`CategoriaSelect`, `ComunaSelect`) que usa el registro (misión
+  04) ya existe para reutilizar en el buscador. D-001 de misión 03 deja abierto cómo se elige en pantalla,
+  pero no obliga a texto libre — la restricción de "siempre catálogo" sí es vinculante.
+- **Implicación:** el buscador parte de una lista de categorías para tocar (como ya hace el carrusel de la
+  landing), no de una caja de texto libre con matching de sinónimos — eso solo se reconsidera si aparece
+  evidencia real de que la gente prefiere escribir en vez de tocar, y en ese caso reabre el problema de
+  vocabulario que misión 03 ya cerró para el registro (CL-003, retirado en esa misión por la misma razón).
+- **Confianza:** alta — es una restricción de una decisión de producto ya aprobada, no una inferencia
+  externa.
+
+<a id="c-007"></a>
+
+### C-007 — Calcular cercanía real entre comunas es más barato de lo que parecía: no hay que geocodificar a mano, hay que cruzar un dataset público una sola vez
+
+- **Sustento:** [E-011](#e-011), [E-012](#e-012).
+- **Razonamiento:** el supuesto de que agregar coordenadas exige geocodificar 346 comunas a mano no es
+  cierto — ya existen varios datasets públicos y gratuitos con coordenadas o límites reales de las comunas
+  chilenas. El trabajo real no es generar el dato desde cero, es cruzarlo una vez contra los códigos SUBDERE
+  que ya usa la tabla `comunas` ([E-010](#e-010)) y validar que la cobertura y la licencia sirvan — un
+  trabajo de ingeniería acotado y de una sola vez, no mantenimiento manual continuo.
+- **Implicación:** una "zona fija mantenida a mano" deja de ser claramente la opción más barata frente a
+  calcular adyacencia real (qué comunas comparten frontera) a partir de un dataset de límites — es
+  probablemente más preciso, más fácil de explicar ("comuna vecina" es la que comparte límite, no un número
+  de zona inventado) y no exige que alguien la actualice a mano cada vez que se active una comuna nueva.
+- **Confianza:** media — confirma que el dato existe y es accesible, pero no valida todavía la calidad,
+  cobertura exacta ni licencia de ningún dataset específico; eso es trabajo de ingeniería antes de
+  comprometerse a una fuente.
+
+## El ideal: cualquier persona encuentra en segundos a los profesionales más cerca de su categoría y comuna, y nunca se topa con una pantalla vacía sin salida
 
 ### El resultado ideal se ve así
 
-<Narra de principio a fin una situación futura con datos concretos: nombres, comunas, oficios, horarios.
-Qué acción ocurre, qué responde Datealo, qué decisión puede tomar la persona. Evita "una experiencia
-simple" sin comportamiento observable.>
+Don Sergio abre Datealo desde su celular en Puente Alto un domingo porque se le tapó el lavaplatos. Toca
+"Gasfitería" de una lista de categorías y elige "Puente Alto" de la lista de comunas, sin escribir ninguna
+de las dos a mano. Como todavía no hay ningún gasfiter registrado en Puente Alto, no ve una pantalla vacía:
+ve a los tres gasfiteres más cercanos —dos en La Florida, uno en San Bernardo— cada uno
+marcado con su comuna, sus fotos, su precio "desde $X" y hace cuánto está en Datealo, sin ningún número de
+reseñas inventado porque todavía no existen. Elige al primero y le escribe directo por WhatsApp desde su
+perfil. Semanas después, cuando alguien busca "Jardinería" en Providencia y ya hay seis jardineros
+registrados ahí, Datealo los ordena por cercanía real dentro de la comuna, sin fingir que sabe cuál es
+"mejor" porque ninguno tiene reseñas todavía.
 
 ### Capacidades del ideal
 
-| Capacidad | Acción habilitada    | Respuesta esperada              | Conclusión que la justifica |
-| --------- | -------------------- | ------------------------------- | --------------------------- |
-| <nombre>  | <qué se puede hacer> | <qué produce o explica Datealo> | [C-001](#c-001)             |
+| Capacidad                                                    | Acción habilitada                                                | Respuesta esperada                                                                                     | Conclusión que la justifica |
+| -------------------------------------------------------------- | -------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ---------------------------- |
+| Elegir categoría de una lista fija                           | Tocar una categoría, como ya hace el carrusel de la landing          | Ve solo profesionales activos de esa categoría, sin escribir ni adivinar sinónimos                          | [C-006](#c-006)              |
+| Elegir su comuna a mano, sin GPS                              | Seleccionar una comuna activa del catálogo (`ComunaSelect`)          | Ve profesionales de esa comuna, sin que Datealo le pida permiso de ubicación precisa                        | [C-004](#c-004)              |
+| Ver resultados ordenados sin una relevancia inventada         | Abre la lista de resultados de su categoría y comuna                 | Los ve ordenados por cercanía y por qué tan completo está el perfil, nunca por un rating o reseña que no existe | [C-002](#c-002)              |
+| Ver alternativas cuando su comuna no tiene nadie              | Busca en una comuna sin profesionales activos de esa categoría       | Ve profesionales de comunas vecinas marcados con su distancia, en vez de una pantalla vacía                 | [C-001](#c-001), [C-003](#c-003), [C-005](#c-005) |
+| Nunca perder resultados por un filtro que los vacía           | Aplica cualquier filtro futuro (precio, disponibilidad)              | Datealo no deja que un filtro reduzca la lista a un puñado o a cero sin ofrecer una alternativa            | [C-001](#c-001)              |
 
-### El ideal no significa <confusión probable>
+### El ideal no significa que Datealo sepa más de lo que en verdad sabe
 
-- <límite conceptual que evita una interpretación incorrecta>.
+- No significa que ya exista un mecanismo real de cercanía entre comunas — el ideal lo asume, pero hoy no
+  existe ese dato en la base ([C-003](#c-003)); construirlo es parte de lo que `producto.md` tiene que
+  decidir, no algo que ya esté resuelto.
+- No significa ranking por calidad o reputación — sin reseñas, "ordenado" no quiere decir "el mejor
+  primero", quiere decir "el más cerca y el más completo primero" ([C-002](#c-002)).
+- No significa geolocalización GPS de precisión — la comuna se elige a mano, Datealo no detecta la ubicación
+  exacta de nadie automáticamente ([C-004](#c-004)).
+- No significa que el buscador tenga que escribir para encontrar su categoría — elige de una lista fija,
+  igual que ya elige de una lista al registrarse ([C-006](#c-006)).
 
 ## Referencias
 
-<!-- Fuentes primarias citadas por las evidencias. El enlace no sustituye el hecho y el límite en E-xxx. -->
-
-- [<título descriptivo>](URL): usado en E-001 para <afirmación concreta>.
+- [Recommending Search Filters To Improve Conversions At Airbnb (arXiv)](https://arxiv.org/html/2602.23717v1):
+  usado en E-004 para el umbral de "low inventory" y cómo Airbnb evita activamente generarlo.
+- [Evolution of Search Ranking at Thumbtack (Thumbtack Engineering)](https://medium.com/thumbtack-engineering/evolution-of-search-ranking-at-thumbtack-f7a69fd0da13):
+  usado en E-005 para qué señales alimentan un ranking de "relevancia" con historial acumulado.
+- [How does Yelp determine its search results? (Yelp Support Center)](https://www.yelp-support.com/article/How-does-Yelp-determine-its-search-results):
+  usado en E-006 para la diferencia entre ordenar por "Recommended" y por "Distance".
+- [Understand & manage your location when you search on Google (Google Search Help)](https://support.google.com/websearch/answer/179386):
+  usado en E-007 para cómo degrada la búsqueda local sin permiso de ubicación precisa.
+- [Search UX Best Practices (Pencil & Paper)](https://www.pencilandpaper.io/articles/search-ux) y
+  [Empty state UX examples and design rules that actually work (Eleken)](https://www.eleken.co/blog-posts/empty-state-ux):
+  usados en E-008 para la práctica estándar ante cero resultados de búsqueda.
+- [Todas las comunas de Chile con sus coordenadas geográficas (gist de rafafdz)](https://gist.github.com/rafafdz/a67d3f6ac058c45cfad8176bf583b632):
+  usado en E-011 para confirmar que existe un dataset público de coordenadas por comuna.
+- [caracena/chile-geojson](https://github.com/caracena/chile-geojson), [fcortes/Chile-GeoJSON](https://github.com/fcortes/Chile-GeoJSON):
+  usados en E-012 para confirmar que existen límites geográficos reales por comuna, públicos y gratuitos.

--- a/docs/missions/06-busqueda-resultados/producto.md
+++ b/docs/missions/06-busqueda-resultados/producto.md
@@ -1,149 +1,277 @@
-# Misión: <nombre> — Producto
+# Misión: búsqueda y resultados — Producto
 
-**Estado:** borrador
+**Estado:** vigente — aprobado por Patricio el 2026-08-28
 
-**Última actualización:** AAAA-MM-DD
+**Última actualización:** 2026-08-28
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-<!--
-Este documento es la spec viva del resultado: qué construimos ahora y bajo qué reglas. El porqué vive en
-investigacion.md — aquí solo se enlaza. Se reescribe cuando el alcance cambia; no acumula historia.
+## Qué construimos: elegir categoría y comuna y ver a los profesionales más cerca, sin una pantalla vacía cuando la comuna exacta no tiene a nadie
 
-Gate de salida — producto.md está listo para experiencia.md cuando:
-- cada funcionalidad tiene formato JTBD, reglas y al menos un caso límite con comportamiento definido
-- cada funcionalidad enlaza una conclusión de investigacion.md y una señal de éxito
-- cada funcionalidad declara a qué lado del marketplace sirve, y qué necesita del otro lado para funcionar
-- no hay decisiones de producto delegadas a diseño o ingeniería
-- las decisiones propuestas tienen fecha límite en el README
--->
+**Resultado:** cualquier persona toca una categoría y una comuna de dos listas fijas y ve, en segundos, a
+los profesionales activos de esa categoría y comuna — ordenados por qué tan completo está su perfil, nunca
+por una reseña o un rating que no existe. Si su comuna exacta todavía no tiene a nadie de esa categoría, ve
+en su lugar a los de las comunas vecinas, marcados con su nombre, en vez de una lista vacía.
 
-## Qué construimos: <resultado en una frase>
+**Recorte respecto del ideal:** el ideal ([investigacion.md](./investigacion.md)) incluye, más adelante, un
+orden que sí incorpore reseñas cuando existan. Acá se recorta a lo que hay datos para sostener hoy: sin
+reseñas ([C-002](./investigacion.md#c-002)), el orden usa completitud del perfil y antigüedad, no calidad —
+es un criterio interino que se espera reemplazar apenas exista una señal real (ver [D-001](#d-001)). La
+cercanía sí usa adyacencia geográfica real (comunas que comparten límite), calculada una sola vez desde un
+dataset público ([C-007](./investigacion.md#c-007)) — no muestra una distancia en kilómetros esta entrega.
 
-<!--
-El recorte vigente del ideal y por qué sigue entregando el resultado central. Máximo cuatro párrafos
-cortos. El ideal completo vive en investigacion.md.
--->
-
-**Resultado:** <qué podrá lograr una persona al finalizar esta entrega>.
-
-**Recorte respecto del ideal:** <qué dimensión se reduce y por qué sigue siendo suficiente>
-(ver [el ideal](./investigacion.md)).
-
-**Restricciones aceptadas:** <plataforma, cobertura geográfica, categorías, volumen inicial de
-profesionales>.
+**Restricciones aceptadas:** solo categoría y comuna como filtros — sin precio, disponibilidad ni rating
+todavía; sin mapa visual de resultados, solo lista; sin geolocalización automática — la comuna siempre se
+elige a mano; comuna y categoría son obligatorias para ver resultados, no hay una vista de "todo el
+catálogo" sin filtrar.
 
 ## Funcionalidades
 
-| ID    | Funcionalidad                  | Lado         | Sustento     | Éxito |
-| ----- | ------------------------------ | ------------ | ------------ | ----- |
-| F-001 | <verbo + resultado observable> | buscador     | C-001, D-001 | M-001 |
+| ID    | Funcionalidad                                                                 | Lado     | Sustento                     | Éxito |
+| ----- | -------------------------------------------------------------------------------- | -------- | ------------------------------- | ----- |
+| F-001 | Buscar profesionales de una categoría en una comuna y verlos ordenados sin datos inventados | buscador | C-001, C-002, C-006, D-001, D-003, D-004 | M-001 |
+| F-002 | Ver profesionales de comunas vecinas cuando la comuna elegida no tiene a nadie   | buscador | C-001, C-003, C-005, D-002      | M-002 |
 
 <a id="f-001"></a>
 
-### F-001 — <verbo + resultado observable>
+### F-001 — Buscar profesionales de una categoría en una comuna y verlos ordenados sin datos inventados
 
-<!--
-Duplica este bloque por funcionalidad. Se escribe desde el resultado del usuario (working backwards):
-primero el JTBD, después las reglas. Si la respuesta de Datealo no se puede describir sin hablar de tablas
-o componentes, falta cerrar la decisión de producto.
--->
+Cuando a don Sergio se le tapa el lavaplatos un domingo y no conoce a ningún gasfiter de confianza,
+quiero elegir "Gasfitería" y mi comuna y ver quién puede ayudarme,
+para decidir a quién contactar sin tener que preguntarle a nadie primero.
 
-Cuando <usuario en contexto concreto>,
-quiero <acción>,
-para <resultado observable>.
+**Lado del marketplace:** buscador. **Qué necesita del otro lado:** al menos un perfil activo (misión 04)
+en esa categoría y comuna exactas — funciona igual con 1 o con 50 profesionales, el orden es el mismo
+mecanismo.
 
-**Lado del marketplace:** buscador, profesional o ambos. **Qué necesita del otro lado:** <volumen mínimo
-de perfiles, reseñas o cobertura sin el cual esta funcionalidad no entrega su resultado>.
-
-**Sustento:** [C-001](./investigacion.md#c-001) y [D-001](#d-001). **Éxito:** [M-001](#m-001).
+**Sustento:** [C-001](./investigacion.md#c-001), [C-002](./investigacion.md#c-002),
+[C-006](./investigacion.md#c-006), [D-001](#d-001), [D-003](#d-003), [D-004](#d-004). **Éxito:**
+[M-001](#m-001).
 
 **Reglas:**
 
-- Si <condición>, Datealo <comportamiento esperado>.
-- Si <caso límite>, Datealo <comportamiento seguro y qué información muestra>.
-- Datealo nunca <comportamiento que rompería el significado o la confianza>.
+- Don Sergio elige la categoría tocando una opción de una lista fija (`CategoriaSelect`, [D-003](#d-003)) y
+  la comuna tocando una opción de la lista de comunas activas (`ComunaSelect`, misión 03) — ambas son
+  obligatorias antes de ver ningún resultado ([D-004](#d-004)).
+- Solo aparecen profesionales con `active = true` de esa categoría y esa comuna exacta.
+- Dentro de la misma comuna, se ordenan por completitud del perfil (fotos, descripción y precio cargados) y,
+  en empate, por antigüedad del perfil — nunca por un puntaje de "relevancia" simulado ni al azar
+  ([D-001](#d-001)).
+- Si no hay ningún profesional activo en esa categoría y comuna, Datealo no muestra una lista vacía —
+  entrega el resultado de [F-002](#f-002) en su lugar.
+- Datealo nunca muestra un contador de reseñas, un rating ni ningún indicador de calidad que no exista
+  todavía — mismo criterio que el perfil público (misión 05).
 
-**Ejemplo verificable:** dado <estado con datos concretos>, cuando <acción>, entonces <resultado
-observable>.
+**Ejemplo verificable:** dado que hay dos gasfiteres activos en Ñuñoa —uno con 3 fotos, descripción y
+precio; otro solo con nombre y contacto—, cuando alguien busca "Gasfitería" en "Ñuñoa", entonces ve a ambos,
+el primero (perfil completo) antes que el segundo.
 
-**No incluye:** <variante del ideal excluida de esta funcionalidad>.
+**No incluye:** filtros de precio, disponibilidad o rating (ver Fuera de alcance), geolocalización
+automática de la comuna (ver [C-004](./investigacion.md#c-004)), búsqueda por texto libre de categoría
+([D-003](#d-003)).
 
-**Experiencia:** <enlace a UXF-xxx cuando exista>. **Ingeniería:** <enlace a T-xxx cuando exista>.
+**Experiencia:** pendiente. **Ingeniería:** pendiente.
+
+<a id="f-002"></a>
+
+### F-002 — Ver profesionales de comunas vecinas cuando la comuna elegida no tiene a nadie
+
+Cuando don Sergio busca "Gasfitería" en Puente Alto y todavía no hay ningún gasfiter registrado ahí,
+quiero ver igual a alguien cercano en vez de una pantalla vacía,
+para no tener que adivinar si ampliar la búsqueda a otra comuna sirve de algo.
+
+**Lado del marketplace:** buscador. **Qué necesita del otro lado:** al menos un perfil activo de esa
+categoría en alguna comuna vecina real (comparte límite con la elegida, ver [D-002](#d-002)) — si tampoco
+hay ninguno ahí, entra [CL-001](#cl-001).
+
+**Sustento:** [C-001](./investigacion.md#c-001), [C-003](./investigacion.md#c-003),
+[C-005](./investigacion.md#c-005), [D-002](#d-002). **Éxito:** [M-002](#m-002).
+
+**Reglas:**
+
+- Si la comuna elegida no tiene ningún profesional activo de esa categoría, Datealo muestra los de sus
+  comunas vecinas reales — las que comparten límite geográfico con ella ([D-002](#d-002)) —, cada uno
+  marcado con el nombre de su propia comuna — nunca mezclados sin decir que no son de la comuna exacta que
+  se buscó.
+- Un resultado de la comuna exacta, si existe, siempre aparece antes que cualquier resultado de una comuna
+  vecina — el fallback solo se activa cuando la comuna exacta está en cero.
+- Si tampoco hay ningún profesional activo en ninguna comuna vecina, Datealo no expande más lejos — entra el
+  estado vacío honesto de [CL-001](#cl-001).
+
+**Ejemplo verificable:** dado que Puente Alto no tiene gasfiteres activos pero La Florida (comuna vecina,
+comparte límite) tiene dos, cuando alguien busca "Gasfitería" en "Puente Alto", entonces ve a los dos de La
+Florida, cada uno marcado "La Florida", no una pantalla vacía.
+
+**No incluye:** mostrar una distancia en kilómetros (esta entrega no la calcula ni la muestra, ver
+[D-002](#d-002)), expandir la búsqueda más allá de las comunas vecinas directas de la comuna elegida.
+
+**Experiencia:** pendiente. **Ingeniería:** pendiente.
 
 ## Casos límite que cruzan funcionalidades
 
-<!--
-Solo condiciones que afectan varias funcionalidades. Las propias de una viven en su bloque. Un caso
-retirado no se borra ni se reutiliza: conserva su fila, o se nombra con su motivo en una línea debajo.
+<a id="cl-001"></a>
 
-Los casos límite propios de un marketplace pre-lanzamiento aparecen acá: cero resultados en una comuna,
-un profesional sin reseñas, una categoría con un solo perfil, un perfil sin verificar.
--->
-
-| ID     | Condición concreta     | Comportamiento esperado | Funcionalidades |
-| ------ | ---------------------- | ----------------------- | --------------- |
-| CL-001 | <estado o combinación> | <qué hace Datealo>      | F-001           |
+| ID     | Condición concreta                                                                 | Comportamiento esperado                                                                                            | Funcionalidades |
+| ------ | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ---------------- |
+| CL-001 | Ni la comuna elegida ni ninguna de sus comunas vecinas reales tienen un profesional activo de esa categoría | Datealo muestra un estado vacío honesto —sin inventar resultados de más lejos— con una invitación a probar otra categoría o comuna | F-001, F-002     |
+| CL-002 | La categoría elegida no tiene ningún profesional activo en ninguna comuna activa del país | Mismo comportamiento que CL-001, a nivel de toda la categoría, no solo de una comuna                                    | F-001, F-002     |
+| CL-003 | Solo hay un profesional activo en toda la comuna y categoría buscada                    | Se muestra igual, sin ningún elemento de "otras opciones" fabricado para simular una lista más larga                     | F-001            |
+| CL-004 | Dos profesionales de la misma comuna y categoría empatan en completitud de perfil y en fecha de registro | El orden es estable entre recargas de la misma búsqueda (ej. por `id`) — nunca cambia solo porque se refrescó la página | F-001            |
 
 ## Fuera de alcance
 
-<!-- Distingue postergado de descartado y qué condición justificaría reabrirlo. -->
-
-| Capacidad o caso      | Estado                  | Razón del recorte | Condición para reconsiderar |
-| --------------------- | ----------------------- | ----------------- | --------------------------- |
-| <capacidad del ideal> | postergada o descartada | <trade-off>       | <evidencia o hito>          |
+| Capacidad o caso                                            | Estado     | Razón del recorte                                                                                     | Condición para reconsiderar |
+| ----------------------------------------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------ | -------------------------------- |
+| Filtros de precio, rating o disponibilidad                        | postergada | Con la oferta esperada al lanzamiento, cada filtro combinado reduce la lista a cero con más facilidad que ayuda ([C-001](./investigacion.md#c-001)) | Una categoría-comuna promedia 15+ profesionales activos (mismo umbral que misión 03 usa para subcategorías) |
+| Mapa visual de resultados                                         | postergada | El ideal no lo exige, y aunque ahora sí hay coordenadas disponibles (D-002), mostrar un mapa es trabajo de UI que esta entrega no necesita para resolver el fallback | Si se decide mostrar resultados en un mapa, no solo en lista |
+| Geolocalización GPS automática de la comuna                       | postergada | Cada profesional está atado a una comuna, no a una dirección exacta — GPS exigiría el permiso del navegador y traducir coordenadas a comuna sin ganar ninguna precisión real, porque no hay ningún dato más fino contra el cual ordenar | Cuando el perfil de un profesional guarde una dirección o ubicación exacta, no solo su comuna |
+| Búsqueda por texto libre de categoría                              | postergada | Reabriría el problema de sinónimos que misión 03 ya cerró para el registro, sin catálogo que lo justifique ([D-003](#d-003)) | El catálogo de categorías crece mucho, o aparece evidencia real de que la gente prefiere escribir en vez de tocar |
+| Distancia real en kilómetros entre una comuna y sus vecinas       | postergada | D-002 calcula adyacencia (comparte límite o no), no una distancia — mostrar "a 8 km" exige un cálculo adicional que esta entrega no hace | Si aparece evidencia de que la sola etiqueta "comuna vecina" no alcanza para decidir |
 
 ## Señales de éxito
 
 <a id="m-001"></a>
 
-### M-001 — <señal que demuestra el resultado>
+### M-001 — El orden por completitud ayuda a decidir, no da lo mismo que cualquier otro orden
 
-- **Pregunta:** ¿<qué queremos comprobar>?
-- **Señal:** <comportamiento o resultado observable>.
-- **Método y umbral:** <instrumentación o revisión, qué resultado, en qué población y ventana>.
-- **Guardrail:** <daño que no debe aumentar para conseguir la señal>.
+- **Pregunta:** ¿de los que buscan y sí encuentran resultados en su comuna exacta, una parte real abre un
+  perfil, o el orden no influye en nada?
+- **Señal (qué observaríamos si funciona):** de cada 10 búsquedas con al menos un resultado en la comuna
+  exacta, al menos 4 abren un perfil.
+- **Método y umbral:** sin analítica instrumentada todavía — se resuelve cuando exista (fuera del alcance
+  técnico de esta misión, mismo criterio que misión 04 y 05). Mientras tanto, revisión cualitativa de
+  Patricio sobre las primeras búsquedas reales.
+- **Guardrail:** ningún perfil queda oculto por tener el perfil vacío — CL-003 y las reglas de F-001
+  garantizan que se ordena después, nunca se esconde.
+
+<a id="m-002"></a>
+
+### M-002 — El fallback a comunas vecinas rescata la búsqueda en vez de que la gente abandone
+
+- **Pregunta:** ¿cuando la comuna exacta no tiene a nadie, ver profesionales de una comuna vecina de verdad
+  convierte, o la gente igual se va al ver que no son de su comuna?
+- **Señal:** de cada 10 búsquedas que caen en el fallback de F-002, al menos 3 abren un perfil de esa lista.
+- **Método y umbral:** revisión cualitativa de Patricio sobre las primeras búsquedas reales — sin
+  instrumentación todavía.
+- **Guardrail:** el fallback nunca se presenta como si fuera un resultado real de la comuna exacta — siempre
+  marcado con el nombre de su propia comuna, para que quien busca sepa que no es lo que pidió.
 
 ## Decisiones de producto
 
-<!--
-Solo decisiones con alternativas reales. No borres decisiones reemplazadas: explican por qué el producto
-es como es. Toda decisión propuesta se refleja en el README con fecha límite.
--->
-
 <a id="d-001"></a>
 
-### D-001 — <decisión en una frase que se entiende sola>
+### D-001 — Dentro de una comuna, los resultados se ordenan por completitud del perfil y antigüedad — nunca por un ranking de "relevancia" simulado ni al azar
 
-- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
-- **Sustento:** [C-001](./investigacion.md#c-001).
-- **Tensión:** <criterios que no podían maximizarse al mismo tiempo>.
-- **Alternativas descartadas:** <opciones y razón concreta del rechazo, en la misma línea>.
-- **Decisión y consecuencia:** <qué se hará y qué habilita, limita o exige revisar en UX e ingeniería>.
-- **Reapertura:** <evidencia o cambio que justificaría revisarla>.
+- **Estado:** aceptada, y explícitamente interina — no la versión final del criterio de orden. **Fecha:**
+  2026-08-28.
+- **Sustento:** [C-002](./investigacion.md#c-002).
+- **Tensión:** un orden aleatorio en cada carga le da a cada profesional la misma oportunidad de aparecer
+  primero sin importar cuándo se registró, pero puede poner un perfil vacío (sin fotos ni descripción) por
+  delante de uno completo — contradice directamente lo que la investigación concluye que sí puede prometerse
+  hoy (C-002). Ordenar solo por antigüedad (el que se registró primero, siempre arriba) es predecible, pero
+  no recompensa a quien sí completó su perfil, y no hay ninguna razón real para que "más antiguo" signifique
+  "mejor".
+- **Alternativas descartadas:** orden aleatorio en cada carga — descartado porque puede mostrar un perfil
+  vacío por delante de uno completo, y el ideal de investigación exige que el orden refleje qué tan completo
+  está el perfil, no azar. Orden por antigüedad simple — descartado porque no incentiva a nadie a completar
+  su perfil (misión 04, F-002) y no distingue entre dos profesionales igual de nuevos si uno subió fotos y
+  el otro no.
+- **Decisión y consecuencia:** dentro de la misma comuna, los resultados se ordenan por completitud del
+  perfil (cuántos de fotos, descripción y precio tiene cargados, de más a menos) y, en empate, por
+  antigüedad del perfil (el más antiguo primero, ver [CL-004](#cl-004) para el empate total). Ningún
+  resultado se presenta como "recomendado" ni "mejor calificado" — el orden es honesto sobre lo que mide.
+  Es el mejor criterio disponible con los datos que existen hoy (C-002), no uno que se espere que dure: el
+  día en que exista una señal real de calidad, este criterio deja de ser suficiente casi de inmediato.
+- **Reapertura:** cuando exista alguna señal real de calidad (reseñas de misión 07, o una tasa de respuesta
+  medible), se reabre para decidir si reemplaza o se combina con este criterio — se espera que esto ocurra,
+  no es una posibilidad remota; "completitud + antigüedad" es un punto de partida, no el diseño final del
+  orden de resultados.
+
+<a id="d-002"></a>
+
+### D-002 — Una "comuna vecina" es la que comparte límite real con la elegida, calculado una sola vez desde un dataset público — no una zona inventada a mano
+
+- **Estado:** aceptada. **Fecha:** 2026-08-28 (revisada 2026-08-28).
+- **Sustento:** [C-003](./investigacion.md#c-003), [C-007](./investigacion.md#c-007).
+- **Qué decía antes, en corto:** la primera versión de esta decisión (mismo día) proponía un mapa fijo de
+  zonas por sector, mantenido a mano igual que el campo `activa`, asumiendo que agregar coordenadas exigía
+  geocodificar 346 comunas desde cero. Murió apenas se investigó un poco más: ya existen datasets públicos
+  con coordenadas y límites reales de las comunas chilenas ([E-011](./investigacion.md#e-011),
+  [E-012](./investigacion.md#e-012)), así que ese costo no es real. Lo que sobrevive de la versión anterior
+  es que sigue sin haber presupuesto para un mapa visual ni para mostrar una distancia en kilómetros esta
+  entrega (ver Fuera de alcance) — cambia el *cómo* se calcula "cerca", no el alcance visible para quien
+  busca.
+- **Tensión:** un mapa de zonas a mano es más rápido de escribir hoy mismo, pero es un número de zona
+  inventado por Datealo, no algo que un chileno reconozca ("¿por qué La Cisterna está en mi misma zona y
+  San Bernardo no?"), y hay que rehacerlo a mano cada vez que se active una comuna nueva. Calcular adyacencia
+  real (qué comunas comparten frontera) desde un dataset de límites geográficos es más intuitivo — "vecina"
+  significa lo mismo que en la vida real — y se recalcula solo cuando se activa una comuna nueva, sin que
+  nadie tenga que redibujar zonas; el costo es un trabajo de ingeniería de una sola vez para elegir la
+  fuente, cruzarla contra los códigos SUBDERE de la tabla `comunas` y validar que la cobertura y la licencia
+  sirvan.
+- **Alternativas descartadas:** mapa fijo de zonas por sector mantenido a mano — descartada por ser la
+  versión anterior de esta misma decisión (ver arriba). Agregar coordenadas y ordenar por distancia en línea
+  recta (Haversine) en vez de por adyacencia — descartada porque la distancia recta puede engañar en un país
+  tan alargado y con cordillera de por medio (dos comunas pueden estar cerca en línea recta y separadas por
+  un cerro sin conexión directa); "comparte límite" es más fiel a cómo la gente entiende "comuna vecina".
+  Mostrar todo el Gran Santiago como "vecino" sin ninguna agrupación — descartada porque mezclaría comunas
+  realmente lejanas entre sí (ej. Puente Alto y Lampa) como si fueran cercanas, rompiendo la promesa de
+  "cerca" del ideal.
+- **Decisión y consecuencia:** Datealo calcula, una sola vez, qué comunas comparten límite real con cada
+  comuna activa, cruzando los códigos SUBDERE de la tabla `comunas` contra un dataset público de límites
+  geográficos (a elegir y validar en `ingenieria.md` — ver [E-012](./investigacion.md#e-012)), y guarda ese
+  resultado en la base. Cuando la comuna elegida no tiene resultados, Datealo muestra los de sus comunas
+  vecinas reales, marcadas con su nombre de comuna — nunca con una distancia en kilómetros, porque esta
+  entrega no calcula ni muestra esa cifra (ver Fuera de alcance).
+- **Reapertura:** si el dataset elegido en `ingenieria.md` resulta tener huecos de cobertura o problemas de
+  licencia, se revisa esta decisión — el mapa fijo de zonas queda como respaldo de emergencia, no como plan
+  B silencioso.
+
+<a id="d-003"></a>
+
+### D-003 — La categoría se elige tocando una opción de una lista fija, nunca escribiendo texto libre
+
+- **Estado:** aceptada. **Fecha:** 2026-08-28.
+- **Sustento:** [C-006](./investigacion.md#c-006).
+- **Tensión:** un campo de texto libre con autocompletado se siente más natural para quien ya sabe
+  exactamente qué palabra usar, pero reabre el problema de vocabulario que misión 03 ya cerró para el
+  registro (D-004 de esa misión) — "electricista" y "instalaciones eléctricas" tendrían que reconocerse como
+  la misma categoría, y ese diccionario de sinónimos no existe hoy. Tocar de una lista fija es más lento de
+  escanear si el catálogo creciera mucho, pero con 8 categorías eso no es un problema real todavía.
+- **Alternativas descartadas:** campo de texto libre con autocompletado y matching de sinónimos —
+  descartado porque exige construir y mantener un diccionario de sinónimos que no existe, solo para resolver
+  un catálogo de 8 categorías donde tocar una opción de una lista corta ya cumple lo mismo sin ese costo.
+- **Decisión y consecuencia:** el buscador elige la categoría tocando una opción de una lista fija (mismo
+  componente `CategoriaSelect` de misión 03), igual que ya hace el carrusel de categorías de la landing — no
+  hay campo de texto libre para categoría en esta entrega.
+- **Reapertura:** si el catálogo de categorías crece mucho, o aparece evidencia real de que la gente
+  prefiere escribir en vez de tocar, se reconsidera agregar texto libre con matching.
+
+<a id="d-004"></a>
+
+### D-004 — Categoría y comuna son obligatorias para ver resultados; no existe una vista de "todo el catálogo" sin filtrar
+
+- **Estado:** aceptada. **Fecha:** 2026-08-28.
+- **Sustento:** guardrail de `CLAUDE.md` ("encuentra al profesional que necesitas, cerca de ti").
+- **Tensión:** mostrar todos los profesionales activos de una categoría en todo Chile sin exigir comuna es
+  más simple de construir y nunca cae en cero resultados si existe al menos un profesional en cualquier
+  lado, pero mezclaría a alguien de Puerto Varas con alguien de Ñuñoa en la misma lista sin ningún criterio
+  de cercanía — contradice el mensaje core del producto y deja al buscador sin poder decidir a quién llamar
+  hoy.
+- **Alternativas descartadas:** comuna opcional, con fallback a "todo el catálogo activo" sin ordenar por
+  cercanía cuando no se elige — descartado porque el mensaje core de Datealo es "cerca de ti", y una lista
+  nacional sin cercanía deja de cumplir esa promesa, además de duplicar en la práctica lo que ya hace
+  [F-002](#f-002) pero sin limitarse a comunas vecinas reales.
+- **Decisión y consecuencia:** el flujo de búsqueda exige elegir categoría y comuna antes de ver cualquier
+  resultado — no existe una vista de "todos los profesionales de Chile" sin filtrar por comuna.
+- **Reapertura:** si aparece una razón real de explorar sin comuna (ej. alguien que se está por mudar y
+  quiere comparar zonas antes de elegir dónde vivir), se reconsidera un modo de exploración separado.
 
 ## Preguntas
 
-<!--
-Solo preguntas que pueden cambiar una decisión o funcionalidad. Lo demás va a un issue.
-Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
-Estado: abierta | resuelta AAAA-MM-DD (alguien la respondió) | disuelta AAAA-MM-DD (el producto cambió y la
-pregunta dejó de tener sentido). Solo las abiertas llevan bloque de detalle debajo de la tabla.
--->
+Ninguna pregunta bloquea este `producto.md` hoy — Q-001 quedó disuelta el mismo día en que se abrió.
 
-<Una frase que responde "¿qué falta?": la pregunta que bloquea y qué bloquea.>
-
-| ID    | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
-| ----- | ---------------------- | ------------------- | --------------------------------------------------------------- |
-| Q-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
-| Q-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |
-
-<a id="q-001"></a>
-
-### Q-001 — <la pregunta en una frase que se entiende sola>
-
-- **La duda, con un ejemplo:** <el caso concreto que muestra por qué hay dos respuestas posibles>.
-- **Afecta a:** D-001 o F-001.
-- **Cómo se resolverá:** <quién y con qué método>.
-- **¿Bloquea algo?:** <qué bloquea y su fecha límite, o no>.
+| ID    | La duda                                                                        | Estado  | Respuesta, o quién la resuelve |
+| ----- | ----------------------------------------------------------------------------------- | ------- | ------------------------------------ |
+| Q-001 | ¿Qué comunas exactas componen cada zona del mapa fijo que usaba la primera versión de D-002? | disuelta 2026-08-28 | Dejó de tener sentido: D-002 se revisó el mismo día para calcular adyacencia geográfica real desde un dataset público en vez de un mapa de zonas a mano — no hay zonas que definir. Qué dataset usar y cómo cruzarlo contra los códigos SUBDERE de la tabla `comunas` queda como trabajo de `ingenieria.md`, no una decisión de producto pendiente. Al resolver esta pregunta salió a la luz que Puerto Varas no operaba sola en la práctica — Patricio confirmó que un profesional que vive ahí normalmente ya atiende Frutillar, Puerto Montt y Llanquihue también, así que esas tres se activaron el mismo día en el catálogo de comunas (ver revisión en `docs/missions/03-taxonomia-categorias-y-comunas/producto.md` D-002). F-002 ya tiene con qué operar en esa zona; solo Cochamó, otra vecina real, queda fuera del catálogo activo por ahora. |

--- a/docs/missions/README.md
+++ b/docs/missions/README.md
@@ -14,7 +14,7 @@ abrieron y de dónde salió cada una.
 | 03  | [taxonomía: categorías y comunas](./03-taxonomia-categorias-y-comunas/) | producto | 2026-08-13 | cerrada 2026-08-20 | — | — |
 | 04  | [registro y perfil de profesional](./04-registro-perfil-profesional/) | producto | 2026-08-13 | cerrada 2026-08-28 | — | — |
 | 05  | [perfil público de profesional](./05-perfil-publico-profesional/) | producto | 2026-08-13 | cerrada 2026-08-29 | — | — |
-| 06  | [búsqueda y resultados](./06-busqueda-resultados/) | producto | 2026-08-13 | exploración | — | — |
+| 06  | [búsqueda y resultados](./06-busqueda-resultados/) | producto | 2026-08-13 | cerrada 2026-08-31 | — | — |
 | 07  | [reseñas verificadas por contacto](./07-resenas-verificadas-por-contacto/) | producto | 2026-08-13 | cerrada 2026-08-31 | — | — |
 | 08  | [foto de perfil de profesional](./08-foto-perfil-profesional/) | producto | 2026-08-29 | lista para construir | — | — |
 


### PR DESCRIPTION
## Resumen

- Trae al repo el discovery completo de la misión 06 (búsqueda y resultados), que quedó `vigente` el 28 y 29 de agosto pero nunca se commiteó — quedó viviendo sin commitear en un checkout local hasta ahora. No encontré ninguna copia en otra rama local o remota.
- Mientras tanto, los 5 slices de su plan de construcción ya se construyeron y mergearon con sus propios PRs (#99 cierra #94, #100 cierra #95, #101 cierra #96, #102 cierra #97, #103 cierra #98) — el código ya está en `main` desde el 2026-08-31. Verifiqué que cada fila del Plan de construcción de `ingenieria.md` corresponde exactamente al PR que la cerró.
- `producto.md`, `experiencia.md`, `ingenieria.md`: los tres quedan `vigente`, sin preguntas bloqueantes abiertas. Corregí una fecha inconsistente en `experiencia.md` (última actualización decía 08-28, la aprobación es del 08-29).
- Actualiza el registro de `docs/missions/README.md` y el README de la misión: estado `cerrada 2026-08-31`, próximo hito ninguno (los 5 issues ya están cerrados — el texto anterior decía "ejecutar el plan de construcción", desactualizado).
- Agrega `design-mockups/resultados-busqueda.html` (9 frames, móvil y desktop), referenciado por `experiencia.md`.

## Contexto

Esto lo encontré revisando el estado de la raíz antes de seguir con la misión 08 — la carpeta tenía cambios sin commitear de varias misiones distintas. Los cambios de la misión 03 (activación de 3 comunas más el 2026-08-28) y una extracción del skill `write-code` desde `CLAUDE.md` quedan para PRs separados.

https://claude.ai/code/session_01B36NwwyTxP2JgUQL1m396k