### PR TITLE
chore(db): activar Frutillar, Puerto Montt y Llanquihue en comunas

### DIFF
--- a/docs/missions/03-taxonomia-categorias-y-comunas/README.md
+++ b/docs/missions/03-taxonomia-categorias-y-comunas/README.md
@@ -22,11 +22,14 @@ Issues cerrados: [#45](https://github.com/PatricioTabilo/datealo/issues/45) (S-0
 [#48](https://github.com/PatricioTabilo/datealo/issues/48) (S-004, `CatalogSelect`),
 [#49](https://github.com/PatricioTabilo/datealo/issues/49) (S-005, `CategoriaSelect`/`ComunaSelect`).
 También corregido en el camino: [#55](https://github.com/PatricioTabilo/datealo/issues/55) (Puente Alto y
-San Bernardo activados en el catálogo de comunas).
+San Bernardo activados en el catálogo de comunas); y el 2026-08-28, durante el discovery de misión 06,
+Frutillar, Puerto Montt y Llanquihue activadas junto a Puerto Varas (los profesionales de esa zona ya
+atienden cruzando esas comunas) — pendiente de su propio issue/PR, hecho directo en la base por pedido de
+Patricio.
 
 Plan de construcción completo — las 346 comunas y 8 categorías existen desde el día uno (D-002), Gran
-Santiago y Puerto Varas activos, y el componente de selección (`CategoriaSelect`, `ComunaSelect`) listo
-para que lo importen las misiones 04 y 06.
+Santiago y la zona del lago Llanquihue activas, y el componente de selección (`CategoriaSelect`,
+`ComunaSelect`) listo para que lo importen las misiones 04 y 06.
 
 ## Brief
 

--- a/docs/missions/03-taxonomia-categorias-y-comunas/producto.md
+++ b/docs/missions/03-taxonomia-categorias-y-comunas/producto.md
@@ -98,16 +98,19 @@ qué se ofrece en registro y búsqueda, sin tocar código
   ([E-006](./investigacion.md#e-006) de investigación) desde el día uno, cada una con un campo booleano
   `activa`. Solo las comunas `activa = true` aparecen como opción en el selector de registro y de búsqueda
   — una comuna inactiva no se ofrece, no se muestra como "sin resultados". Al lanzamiento parten activas
-  las comunas de Gran Santiago y Puerto Varas (los dos mercados donde Patricio puede reclutar y verificar
-  profesionales directamente); el resto existe en la tabla pero apagado. "Gran Santiago" acá son 34
-  comunas, no las 32 de la Provincia de Santiago a secas: esa provincia más Puente Alto y San Bernardo,
+  las comunas de Gran Santiago y la zona del lago Llanquihue (los mercados donde Patricio puede reclutar y
+  verificar profesionales directamente); el resto existe en la tabla pero apagado. "Gran Santiago" acá son
+  34 comunas, no las 32 de la Provincia de Santiago a secas: esa provincia más Puente Alto y San Bernardo,
   los dos conurbados que administrativamente caen en otra provincia (Cordillera y Maipo) pero son parte
   del área urbana continua — es la definición que usa el Área Metropolitana de Santiago para "Gran
   Santiago" (32 + Puente Alto + San Bernardo = 34). La primera versión de esta fila activó solo las 32,
   dejando Puente Alto y San Bernardo apagados por una lectura demasiado literal del nombre de la
-  provincia — corregido el 2026-08-19. Activar una comuna nueva es cambiar ese campo, sin deploy — hoy a
-  mano en la base de datos, más adelante quizás desde un panel de administración (fuera de alcance de esta
-  misión).
+  provincia — corregido el 2026-08-19. La zona del lago Llanquihue partió como Puerto Varas sola; el
+  2026-08-28 se sumaron Frutillar, Puerto Montt y Llanquihue, porque un profesional que vive en Puerto
+  Varas normalmente ya atiende esas comunas también, no solo la suya — activarlas solo a ella dejaba a
+  esos profesionales invisibles para quien buscara en la comuna donde de hecho trabajan. Activar una
+  comuna nueva es cambiar ese campo, sin deploy — hoy a mano en la base de datos, más adelante quizás
+  desde un panel de administración (fuera de alcance de esta misión).
 - **Reapertura:** ninguna — el catálogo ya está completo. Lo que se revisa con el tiempo es qué comunas
   están activas, y eso no necesita reabrir esta decisión (ver [M-002](#m-002)).
 
@@ -189,7 +192,7 @@ la misión 06 más adelante define texto libre y necesita un caso límite equiva
 
 <a id="m-002"></a>
 
-### M-002 — Gran Santiago y Puerto Varas tienen tracción antes de activar más comunas
+### M-002 — Gran Santiago y la zona del lago Llanquihue tienen tracción antes de activar más comunas
 
 - **Pregunta:** ¿ya vale la pena activar comunas nuevas fuera de las que se están trabajando hoy?
 - **Señal:** profesionales registrados y verificados en al menos la mitad de las comunas activas, con al
@@ -198,7 +201,8 @@ la misión 06 más adelante define texto libre y necesita un caso límite equiva
   04); sin fecha objetivo todavía. Activar una comuna nueva no requiere esperar esta señal — es solo la
   referencia para decidir cuándo conviene, dado que el campo `activa` no tiene costo de revertir.
 - **Guardrail:** activar comunas nuevas no debe diluir el esfuerzo de reclutamiento en las que ya están
-  activas — no se suma una comuna a costa de dejar de reclutar en Gran Santiago o Puerto Varas.
+  activas — no se suma una comuna a costa de dejar de reclutar en Gran Santiago o la zona del lago
+  Llanquihue.
 
 ## Preguntas
 

--- a/server/db/seed/taxonomia.ts
+++ b/server/db/seed/taxonomia.ts
@@ -15,9 +15,11 @@
 // Activas al sembrar: las 8 categorías, más el Gran Santiago (34 comunas: las 32 de la Provincia de
 // Santiago más Puente Alto y San Bernardo, los dos conurbados que quedan fuera de esa provincia pero
 // son parte del área urbana continua — la definición administrativa "Provincia de Santiago" no
-// alcanza sola) y Puerto Varas — los mercados donde Patricio puede reclutar y verificar profesionales
-// directamente al lanzamiento. El resto de las comunas queda en la tabla pero inactivo, listo para
-// activarse cambiando el campo sin necesitar otro deploy.
+// alcanza sola) y la zona del lago Llanquihue (Puerto Varas, Frutillar, Puerto Montt y Llanquihue) —
+// las tres últimas se sumaron el 2026-08-28 porque un profesional que vive en Puerto Varas
+// normalmente ya atiende ahí también, no solo su propia comuna — los mercados donde Patricio puede
+// reclutar y verificar profesionales directamente al lanzamiento. El resto de las comunas queda en la
+// tabla pero inactivo, listo para activarse cambiando el campo sin necesitar otro deploy.
 
 import { drizzle } from 'drizzle-orm/postgres-js'
 import postgres from 'postgres'
@@ -271,13 +273,13 @@ const comunasSeed = [
   { codigo: '9209', nombre: 'Renaico', activa: false },
   { codigo: '9210', nombre: 'Traiguén', activa: false },
   { codigo: '9211', nombre: 'Victoria', activa: false },
-  { codigo: '10101', nombre: 'Puerto Montt', activa: false },
+  { codigo: '10101', nombre: 'Puerto Montt', activa: true },
   { codigo: '10102', nombre: 'Calbuco', activa: false },
   { codigo: '10103', nombre: 'Cochamó', activa: false },
   { codigo: '10104', nombre: 'Fresia', activa: false },
-  { codigo: '10105', nombre: 'Frutillar', activa: false },
+  { codigo: '10105', nombre: 'Frutillar', activa: true },
   { codigo: '10106', nombre: 'Los Muermos', activa: false },
-  { codigo: '10107', nombre: 'Llanquihue', activa: false },
+  { codigo: '10107', nombre: 'Llanquihue', activa: true },
   { codigo: '10108', nombre: 'Maullín', activa: false },
   { codigo: '10109', nombre: 'Puerto Varas', activa: true },
   { codigo: '10201', nombre: 'Castro', activa: false },


### PR DESCRIPTION
## Resumen

- Refleja en `server/db/seed/taxonomia.ts` una activación que ya se hizo a mano en la base el 2026-08-28, a pedido de Patricio durante el discovery de la misión 06: un profesional que vive en Puerto Varas normalmente ya atiende Frutillar, Puerto Montt y Llanquihue también, no solo su propia comuna — dejarlas apagadas invisibilizaba a esos profesionales para quien buscara en la comuna donde de hecho trabajan.
- Actualiza `README.md` y `producto.md` de la misión 03 (cerrada) para que quede documentado — sin esto, el seed y la base real ya no coincidían y nadie podía reconstruir por qué.
- Sin PR ni issue propio en su momento (se hizo directo en la base) — este PR lo cierra retroactivamente.

## Test plan

- [x] `npx nuxi typecheck` sin errores.

https://claude.ai/code/session_01B36NwwyTxP2JgUQL1m396k