### PR TITLE
chore(docs): extraer principios de código al skill write-code

### DIFF
--- a/.claude/rules/comentarios.global.md
+++ b/.claude/rules/comentarios.global.md
@@ -1,0 +1,17 @@
+---
+paths:
+  - "app/**/*.ts"
+  - "app/**/*.vue"
+  - "server/**/*.ts"
+---
+# Comentarios
+
+- Antes de escribir un comentario nuevo, o de guardar un archivo donde se tocó uno ya existente, invocar
+  el skill `comentarios` y aplicar su test y sus reglas antes de cerrar el edit.
+- Si al pasar por un comentario existente (aunque no sea el que estás tocando) no pasa el test del skill,
+  corregirlo ahí mismo — ya es la instrucción del skill, se repite acá porque es la condición que dispara
+  la invocación.
+- Antes de cerrar el edit, si agregaste o tocaste algún comentario, correr
+  `grep -nE "T-[0-9]|D-[0-9]|A-[0-9]|TC-[0-9]|UXF-[0-9]|UX-[0-9]|F-[0-9]|TR-[0-9]|CL-[0-9]|V-[0-9]"` sobre
+  los archivos modificados. Haber leído el skill al principio no garantiza que el comentario final lo
+  cumpla — este grep es lo que lo verifica de verdad.

--- a/.claude/rules/write-code.global.md
+++ b/.claude/rules/write-code.global.md
@@ -1,0 +1,12 @@
+---
+paths:
+  - "app/**/*.ts"
+  - "app/**/*.vue"
+  - "server/**/*.ts"
+---
+# Escribir código
+
+- Antes de escribir o editar cualquier archivo en estos paths, invocar el skill `write-code` (YAGNI,
+  TypeScript strict, errores, naming) — no asumir estas reglas de memoria.
+- Si el archivo es un `.vue` o un composable, invocar también `vue-composition` para la auditoría de salud
+  y la arquitectura de extracción antes de agregar código.

--- a/.claude/skills/write-code/SKILL.md
+++ b/.claude/skills/write-code/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: write-code
+description: Convenciones base para escribir código en Datealo — YAGNI, TypeScript strict, manejo de errores y naming. Usar antes de escribir o editar cualquier `.ts` o `.vue` en `app/` o `server/`, sin importar la capa. No cubre arquitectura de componentes/composables (ver `vue-composition`), comentarios (ver `comentarios`), endpoints (ver `nuxt-server-endpoints`) ni dónde vive cada pieza del sistema (ver `arquitectura`) — este skill es la base que aplica encima de todos esos.
+---
+
+# Escribir código en Datealo
+
+Reglas base para cualquier archivo de código del proyecto. No reemplazan a los skills más específicos —
+son la capa debajo de `vue-composition`, `nuxt-server-endpoints`, `comentarios` y `arquitectura`.
+
+## YAGNI
+
+Cada línea de código es deuda técnica. Antes de escribir código custom: (1) buscar si ya existe en el
+proyecto, (2) evaluar si una librería establecida lo resuelve, (3) recién entonces escribir lo mínimo.
+
+Esto no aplica a la estructura de lo que sí se va a construir: aislar un dominio, definir un contrato
+entre capas o separar lógica pura de reactividad no son abstracciones especulativas, son la forma de que
+lo pedido quede bien hecho. La pregunta no es "¿sería más simple sin esto?" sino "¿esto existe por algo
+que ya nos pidieron?".
+
+## TypeScript strict
+
+- `type` sobre `interface` para modelos de dominio.
+- `as const` para enums; derivar tipos de las constantes (`(typeof X)[keyof typeof X]`).
+- Sin `any` — usar `unknown` + narrowing.
+- Sin `@ts-ignore`.
+
+## Errores
+
+- Ningún `catch` vacío.
+- Fallo de red → feedback visible al usuario. Fallo de servidor → mensaje legible, no el error crudo.
+- Sin `console.log` de debug en código que se mergea.
+
+## Naming
+
+- Archivos: kebab-case.
+- Componentes: PascalCase.
+- Composables: `useAlgo`.
+- Constantes: `SCREAMING_SNAKE_CASE`.
+- Tipos: PascalCase.
+- Funciones: camelCase.
+- Named exports sobre default exports.
+
+## Componentes Vue, mínimo
+
+- Siempre `<script setup lang="ts">`.
+- `computed()` sobre métodos para estado derivado.
+- Presentacionales — la lógica de negocio vive en composables, no en el componente.
+
+Para extracción, umbrales de tamaño y arquitectura de composables (incluyendo estado local vs.
+compartido, cuándo usar `useState()` vs. `ref()`), ver `vue-composition` — ahí vive la auditoría de salud
+de archivos que aplica antes de tocar cualquier `.vue` o composable.
+
+## Al terminar
+
+Correr `npx nuxi typecheck` — cero errores es el mínimo, no una aspiración.

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ logs
 .DS_Store
 .fleet
 .idea
+__pycache__
+*.pyc
 
 # Local env files
 .env

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,50 +115,11 @@ npm run build           # Compila
 **Verificación visual**: para cambios de UI, levantar `npm run dev` (puerto 3001) y probar en el browser
 antes de dar el cambio por hecho. Móvil primero: 390px de ancho es el caso principal, no una variante.
 
-## Principios de código
+## Escribir código
 
-**YAGNI**: cada línea de código es deuda técnica. Antes de escribir código custom: (1) buscar si ya existe
-en el proyecto, (2) evaluar si una librería establecida lo resuelve, (3) recién entonces escribir lo mínimo.
-Esto **no aplica a la estructura de lo que sí se va a construir**: aislar un dominio, definir un contrato
-entre capas o separar lógica pura de reactividad no son abstracciones especulativas, son la forma de que lo
-pedido quede bien hecho. La pregunta no es "¿sería más simple sin esto?" sino "¿esto existe por algo que ya
-nos pidieron?".
-
-**TypeScript strict**: `type` sobre `interface` para modelos de dominio. `as const` para enums. Derivar
-tipos de las constantes. Sin `any` — usar `unknown` + narrowing. Sin `@ts-ignore`.
-
-**Composables**: `useState()` en vez de `ref()` para compatibilidad SSR. Un composable, un dominio. Return
-como objeto plano de refs, agrupado (estado, computeds, acciones). Cleanup con `onUnmounted` para
-intervals, listeners y subscriptions.
-
-**Componentes**: siempre `<script setup lang="ts">`. `computed()` sobre métodos para estado derivado.
-Presentacionales — la lógica vive en composables. Ver el skill `vue-composition` para umbrales, triggers
-de extracción y patrones.
-
-**Errores**: ningún `catch` vacío. Fallo de red → feedback visible. Fallo de servidor → mensaje legible.
-Sin `console.log` de debug en el código que se mergea.
-
-**Naming**: archivos en kebab-case, componentes en PascalCase, composables `useAlgo`, constantes en
-SCREAMING_SNAKE_CASE, tipos en PascalCase, funciones en camelCase. Named exports sobre default exports.
-
-**Comentarios**: ver el skill `comentarios` — cuándo escribir uno, cómo evitar que se pudra, ejemplos
-reales de este repo. Es la fuente de verdad, no se repite acá.
-
-## Umbrales de salud de archivos
-
-| Recurso                        | Verde     | Amarilla  | Roja      |
-| ------------------------------ | --------- | --------- | --------- |
-| Componente `.vue`              | ≤ 200 LOC | 200–400   | > 400 LOC |
-| Composable `.ts`               | ≤ 150 LOC | 150–300   | > 300 LOC |
-| Función/método                 | ≤ 30 LOC  | 30–60     | > 60 LOC  |
-| Props por componente           | ≤ 5       | 6–8       | > 8       |
-| Funciones en `<script setup>`  | ≤ 5       | 6–10      | > 10      |
-| Miembros en el return          | ≤ 15      | —         | > 15      |
-| Entidades por composable       | 1         | —         | > 1       |
-
-Verde: editar. Amarilla: evaluar extracción si vas a agregar código. Roja: extraer **antes** de agregar
-código — un archivo de 500 LOC con "solo 5 líneas más" sigue siendo un archivo en zona roja. La extracción
-es parte de implementar, no un refactor extra.
+Las convenciones de código (YAGNI, TypeScript strict, errores, naming) viven en el skill `write-code` —
+es la fuente de verdad, no se repite acá. Arquitectura de componentes/composables y sus umbrales de salud
+de archivos viven en `vue-composition`. Comentarios viven en `comentarios`.
 
 ## Seguridad RLS
 
@@ -219,6 +180,7 @@ Skills propios del repo, escritos para las convenciones de Datealo:
 | Skill                       | Cuándo                                                              |
 | ---------------------------- | -------------------------------------------------------------------- |
 | `arquitectura`               | Endpoints, base de datos, RLS, secretos, despliegue, librería de UI |
+| `write-code`                 | Antes de escribir o editar cualquier `.ts`/`.vue` — YAGNI, TS strict, errores, naming |
 | `discovery-product`          | Iterar `investigacion.md` o `producto.md` de una misión              |
 | `discovery-ux`               | Iterar `experiencia.md`: vistas, flujos, estados, mockups            |
 | `discovery-engineering`      | Iterar `ingenieria.md`: contratos, datos, slicing en issues          |


### PR DESCRIPTION
## Resumen

- Extrae la sección "Principios de código" de `CLAUDE.md` (YAGNI, TypeScript strict, errores, naming) al skill `write-code` — mismo patrón que ya usan `vue-composition` (umbrales de salud de archivos) y `comentarios`. Verifiqué que nada se pierde: la tabla de umbrales que se borra de `CLAUDE.md` ya vive completa en `vue-composition/SKILL.md`, y cada punto de "Composables"/"Componentes" del `CLAUDE.md` viejo tiene su equivalente ahí.
- Agrega dos reglas (`.claude/rules/comentarios.global.md`, `write-code.global.md`) que disparan la invocación de esos skills antes de tocar código — ya estaban en el filesystem pero sin commitear.
- Agrega `__pycache__`/`*.pyc` a `.gitignore` y borra el bytecode de Python que había quedado sin trackear en `ui-ux-pro-max/scripts/`.
- No incluye `git.global.md` ni `skills.global.md` de `.claude/rules/` — quedan excluidos a propósito en `.git/info/exclude` (local, no compartido), probablemente porque referencian un plugin (`claude-toolkit`) que no está instalado para todo el equipo.

## Test plan

- [x] `npx nuxi typecheck` sin errores (sin cambios de código, solo docs/skills/config).

https://claude.ai/code/session_01B36NwwyTxP2JgUQL1m396k