### PR TITLE
feat(app): mostrar la foto de perfil en resultados de búsqueda

### DIFF
--- a/app/components/search/SearchResultCard.vue
+++ b/app/components/search/SearchResultCard.vue
@@ -14,7 +14,14 @@ const memberSince = computed(() => formatMemberSince(props.professional.createdA
     :to="`/profesionales/${professional.id}`"
     class="flex gap-3 rounded-2xl border border-datealo-surface bg-white p-3.5"
   >
+    <img
+      v-if="professional.avatarUrl"
+      :src="professional.avatarUrl"
+      :alt="professional.displayName"
+      class="h-12 w-12 shrink-0 rounded-full object-cover"
+    >
     <div
+      v-else
       class="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-primary text-[0.9375rem] font-extrabold text-white"
     >
       {{ initials(professional.displayName) }}

--- a/app/types/search.ts
+++ b/app/types/search.ts
@@ -5,6 +5,7 @@ export type SearchResultProfessional = {
   displayName: string
   comunaNombre: string
   priceFrom: number | null
+  avatarUrl: string | null
   createdAt: string
 }
 


### PR DESCRIPTION
## Resumen

- S-007 del [Plan de construcción](https://github.com/PatricioTabilo/datealo/blob/main/docs/missions/08-foto-perfil-profesional/ingenieria.md#plan-de-construcción) de la [misión 08](https://github.com/PatricioTabilo/datealo/blob/main/docs/missions/08-foto-perfil-profesional/README.md) — último slice del plan.
- `SearchResultCard.vue` muestra el avatar real en vez de las iniciales cuando existe, mismo lugar y tamaño (3rem) que el círculo de hoy.
- Extiende `SearchResultProfessional` (cliente) con `avatarUrl`.
- Cierra #131.

## Test plan

- [x] `npx nuxi typecheck` sin errores.
- [x] `npm run build` compila.
- [x] Verificación visual en browser con una página de preview temporal (no incluida en el commit): una card con avatar (foto real) y otra sin avatar (iniciales), mismo lugar y tamaño — coincide con el mockup validado.

https://claude.ai/code/session_01B36NwwyTxP2JgUQL1m396k