### PR TITLE
docs: cerrar la misión 08 (foto de perfil de profesional)

### DIFF
--- a/docs/missions/08-foto-perfil-profesional/README.md
+++ b/docs/missions/08-foto-perfil-profesional/README.md
@@ -2,9 +2,9 @@
 
 **Tipo:** producto. **Abierta el** 2026-08-29. **Nace de:** ninguna.
 
-**Estado de la misión:** lista para construir
+**Estado de la misión:** cerrada 2026-09-02
 
-**Última actualización:** 2026-09-01
+**Última actualización:** 2026-09-02
 
 No es una de las seis misiones originales hacia el MVP (esas son la 02 a la 07, ver el registro de
 misiones) — nace después, al descubrir que [misión 05](../05-perfil-publico-profesional/) y
@@ -16,7 +16,9 @@ consume en la 05 (perfil público) y la 06 (búsqueda y resultados).
 **Documentos:** [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-**Próximo hito:** crear los issues del Plan de construcción (S-001 a S-007) y empezar a construir.
+**Próximo hito:** ninguno — los 7 issues del plan de construcción
+([#125](https://github.com/PatricioTabilo/datealo/issues/125)–[#131](https://github.com/PatricioTabilo/datealo/issues/131))
+están cerrados y mergeados. F-001 y F-002 funcionando de punta a punta.
 
 `investigacion.md` sostiene dos conclusiones: una foto de trabajo no sirve como avatar de confianza
 (C-001), y mostrar siempre iniciales sin excepción deja la lista de resultados sin señal diferenciadora

--- a/docs/missions/README.md
+++ b/docs/missions/README.md
@@ -16,7 +16,7 @@ abrieron y de dónde salió cada una.
 | 05  | [perfil público de profesional](./05-perfil-publico-profesional/) | producto | 2026-08-13 | cerrada 2026-08-29 | — | — |
 | 06  | [búsqueda y resultados](./06-busqueda-resultados/) | producto | 2026-08-13 | cerrada 2026-08-31 | — | — |
 | 07  | [reseñas verificadas por contacto](./07-resenas-verificadas-por-contacto/) | producto | 2026-08-13 | cerrada 2026-08-31 | — | — |
-| 08  | [foto de perfil de profesional](./08-foto-perfil-profesional/) | producto | 2026-08-29 | lista para construir | — | — |
+| 08  | [foto de perfil de profesional](./08-foto-perfil-profesional/) | producto | 2026-08-29 | cerrada 2026-09-02 | — | — |
 
 Misiones 02 a 07 son las seis que llevan al MVP (registrarse, mostrarse, buscar, reseñar), en el orden de
 dependencia definido en la conversación de roadmap del 2026-08-13 — el número no es prioridad, pero acá sí


### PR DESCRIPTION
## Resumen

- Los 7 issues del plan de construcción (#125-#131) están cerrados y mergeados (#132-#136, #141) — F-001 (el profesional sube su foto) y F-002 (se ve en perfil público y búsqueda) funcionando de punta a punta.
- Actualiza el registro de `docs/missions/README.md` y el README de la misión: estado `cerrada 2026-09-02`, próximo hito ninguno.

https://claude.ai/code/session_01B36NwwyTxP2JgUQL1m396k