### PR TITLE
docs(docs): cerrar discovery de la misión 10 (vista de resultados de búsqueda)

### DIFF
--- a/docs/missions/06-busqueda-resultados/experiencia.md
+++ b/docs/missions/06-busqueda-resultados/experiencia.md
@@ -107,6 +107,9 @@ resultado") — nunca un espacio vacío sin explicar qué se está viendo, ni un
 
 Nunca aparece un número de distancia, un rating ni un contador de reseñas — ninguno de esos datos existe
 hoy ([C-002](./investigacion.md#c-002) de investigación, [D-001](./producto.md#d-001) de producto).
+**Superado por la misión 10** ([F-001](../10-vista-resultados-busqueda/producto.md#f-001)): una vez que
+existen reseñas (misión 07), la card sí muestra rating y cantidad — la distancia en km sigue sin
+aparecer, eso no cambió.
 
 ### Salidas
 

--- a/docs/missions/10-vista-resultados-busqueda/README.md
+++ b/docs/missions/10-vista-resultados-busqueda/README.md
@@ -1,0 +1,40 @@
+# Misión 10 — Vista de resultados de búsqueda
+
+**Tipo:** producto. **Abierta el** 2026-09-01. **Nace de:** división de la misión 09 (ver su
+[README](../09-layout-general/README.md)).
+
+**Estado de la misión:** lista para construir
+
+**En foco:** —
+
+**Última actualización:** 2026-09-02
+
+**Documentos:** [Investigación](./investigacion.md) · [Producto](./producto.md) ·
+[Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
+
+**Próximo hito:** discovery cerrado — `producto.md`, `experiencia.md` e `ingenieria.md` vigentes, los tres
+aprobados por Patricio el 2026-09-02. Plan de construcción con 4 slices (S-001 a S-004) listo en
+`ingenieria.md`, sin issues abiertos todavía por pedido explícito — se crean cuando el dueño de producto lo
+pida.
+
+## Brief
+
+Nace de dividir la misión 09 ("mejoras de UI/UX") en problemas de diseño independientes — el header y el
+footer que envuelven `/buscar` ya quedaron resueltos en la 09, pero cómo se ven los resultados en sí (las
+cards, el grid, el espaciado, mobile y desktop) es un problema aparte, sin investigar todavía.
+
+Los `SearchResultCard` y el layout de `/buscar` hoy tienen un grid `lg:grid-cols-3` en desktop pero nunca
+recibieron una pasada de diseño dedicada — nacieron junto con la lógica de búsqueda (misión 06), priorizando
+que funcionara antes que cómo se ve.
+
+## Temas a explorar
+
+Notas sueltas, sin evidencia ni decisión todavía — punto de partida para `investigacion.md`, no su
+resultado.
+
+- **Cards de resultado (`SearchResultCard.vue`).** Qué información muestra cada una, jerarquía visual,
+  cómo se ve con y sin foto de perfil (ver [misión 08](../08-foto-perfil-profesional/)).
+- **Grid y layout de la lista.** Cómo se organiza en mobile (una columna) y en desktop (grid) — espaciado,
+  densidad, cuántos resultados por fila.
+- **Estados de la vista** (`SearchEmptyState`, cargando, comuna vecina) — si necesitan la misma pasada de
+  diseño que las cards con datos.

--- a/docs/missions/10-vista-resultados-busqueda/design-mockups/resultados-busqueda.html
+++ b/docs/missions/10-vista-resultados-busqueda/design-mockups/resultados-busqueda.html
@@ -1,0 +1,474 @@
+<!doctype html>
+<html lang="es-CL">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>V-001 Resultados de búsqueda (card enriquecida) — misión 10</title>
+
+    <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+    <link
+      href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&family=Plus+Jakarta+Sans:wght@600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../../design/datealo-mockup-kit.css" />
+    <style type="text/tailwindcss">
+      @theme {
+        --color-primary: var(--ui-primary);
+        --color-secondary: var(--ui-secondary);
+        --color-success: var(--ui-success);
+        --color-error: var(--ui-error);
+      }
+    </style>
+    <style>
+      .results-container {
+        /* max-w-6xl — subido desde max-w-5xl (el ancho del perfil) tras la evaluación heurística:
+           1024px es un ancho pensado para una columna de texto: en un grid de fotos de 3 columnas
+           dejaba ~47% de un monitor de 1920px en blanco sin agrandar ninguna foto (el tope de la card
+           no crecía con el contenedor). 1152px está dentro del rango de 1140-1440px que la práctica de
+           grids de listados usa, y acá sí se combina con un tope de card más grande (ver .results-grid). */
+        max-width: 72rem;
+        margin: 0 auto;
+        width: 100%;
+      }
+      .search-bar {
+        display: flex;
+        gap: 0.5rem;
+        padding: 0.875rem 1.25rem;
+        background: var(--ui-bg);
+        border-bottom: 1px solid var(--ui-border);
+        position: sticky;
+        top: 0;
+        z-index: 10;
+      }
+      .select-field {
+        flex: 1;
+        min-width: 0;
+        border: 1.5px solid var(--ui-border-accented);
+        border-radius: var(--ui-radius, 0.5rem);
+        padding: 0.625rem 0.75rem;
+        font-size: 0.8125rem;
+        color: var(--ui-text-highlighted);
+      }
+      .select-field .field-label {
+        display: block;
+        font-size: 0.625rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: var(--ui-text-muted);
+        margin-bottom: 0.125rem;
+      }
+      .result-count {
+        font-size: 0.75rem;
+        color: var(--ui-text-muted);
+        padding: 0 0.125rem;
+      }
+      /* card vertical foto-arriba — mismo slot aspect-4/3 que ProfessionalPublicPhotos.vue (misión 05).
+         Es un <a> real (no un div con click), con hover/focus visibles — hallazgo 6 de la evaluación
+         heurística: un div sin estos estados falla accesibilidad y no se distingue de contenido inerte. */
+      .result-card {
+        display: flex;
+        flex-direction: column;
+        background: var(--ui-bg);
+        border: 1px solid var(--ui-border);
+        border-radius: 1rem;
+        overflow: hidden;
+        min-width: 0;
+        text-decoration: none;
+        color: inherit;
+        transition: box-shadow 0.2s, border-color 0.2s;
+      }
+      .result-card:hover {
+        border-color: var(--ui-border-accented);
+        box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+      }
+      .result-card:focus-visible {
+        outline: 2px solid var(--ui-primary);
+        outline-offset: 2px;
+      }
+      .result-photo {
+        aspect-ratio: 4 / 3;
+        width: 100%;
+        object-fit: cover;
+        display: block;
+        background: var(--ui-bg-muted);
+      }
+      .result-photo-fallback {
+        /* tinte de --ui-primary en vez de var(--ui-bg-muted) plano — evaluación heurística: el gris
+           genérico se ve "menos terminado" junto a una foto real, justo en el caso más común (CL-001).
+           Un tinte de marca (mismo mecanismo que el ring de foco de .select-field) lee como una decisión
+           de diseño, no como un hueco de contenido faltante. */
+        aspect-ratio: 4 / 3;
+        width: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: color-mix(in oklab, var(--ui-primary) 10%, var(--ui-bg));
+      }
+      /* 5.5rem/1.5rem — igual a ProfessionalPublicPhotos.vue (h-22 w-22, text-2xl), no un valor
+         inventado. La segunda evaluación heurística encontró que el 5rem original no coincidía ni con
+         el baseline real de SearchResultCard.vue (3rem, h-12 w-12) ni con el del perfil que UX-001 decía
+         reusar — quedaba como un tercer número sin relación con el sistema. */
+      .avatar-initials-lg {
+        width: 5.5rem;
+        height: 5.5rem;
+        border-radius: 999px;
+        background: var(--ui-primary);
+        color: #fff;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-weight: 800;
+        font-size: 1.5rem;
+      }
+      .result-body {
+        /* flex: 1 es lo que hace que el align-items:stretch del grid llegue hasta acá — sin esto, el
+           borde de la card se estira parejo pero el contenido interno no, y el "En Datealo desde..."
+           de cada card queda a una altura distinta (hallazgo 1 de la evaluación heurística). */
+        flex: 1;
+        padding: 0.875rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.125rem;
+      }
+      .comuna-line {
+        color: var(--ui-text-muted);
+      }
+      .comuna-line.is-vecina {
+        color: var(--ui-text-highlighted);
+        font-weight: 700;
+      }
+      .rating-line {
+        display: flex;
+        align-items: center;
+        gap: 0.25rem;
+        font-size: 0.8125rem;
+        margin-top: 0.25rem;
+        color: var(--ui-text-highlighted);
+      }
+      .star-icon {
+        width: 0.8125rem;
+        height: 0.8125rem;
+        fill: #f59e0b;
+        color: #f59e0b;
+      }
+      .since-pill {
+        display: inline-block;
+        color: var(--ui-text-muted);
+        margin-top: auto;
+        padding-top: 0.375rem;
+      }
+      .section-label {
+        font-family: var(--font-heading);
+        font-size: 0.6875rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: var(--ui-text-muted);
+        padding: 0 0.125rem;
+      }
+      /* auto-fit + justify-content: center, en vez de grid-cols-3 fijo — con menos de 3 resultados,
+         grid-cols-3 deja columnas vacías a la derecha y la card queda pegada en la esquina (hallazgo 3
+         de la evaluación heurística: max-width sola no lo resuelve). auto-fit colapsa las columnas sin
+         contenido y justify-content centra la fila parcial, sin cambiar el ancho ni el diseño de la card. */
+      .results-grid {
+        display: grid;
+        /* tope subido de 21rem (336px) a 23.75rem (380px) junto con max-w-6xl — así el ancho extra del
+           contenedor se traduce en fotos más grandes, no en más margen en blanco. */
+        grid-template-columns: repeat(auto-fit, minmax(17.5rem, 23.75rem));
+        justify-content: center;
+        gap: 1rem;
+      }
+      .empty-banner {
+        background: var(--ui-bg-muted);
+        border-radius: 0.75rem;
+        padding: 0.875rem 1rem;
+        font-size: 0.8125rem;
+        color: var(--ui-text-toned);
+      }
+      .skeleton-card {
+        border: 1px solid var(--ui-border);
+        border-radius: 1rem;
+        overflow: hidden;
+      }
+      .skeleton-block {
+        background: var(--ui-bg-accented);
+        position: relative;
+        overflow: hidden;
+      }
+      .skeleton-block::after {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(100deg, transparent 30%, var(--ui-bg-muted) 50%, transparent 70%);
+        animation: shimmer 1.4s infinite;
+      }
+      @keyframes shimmer {
+        from {
+          transform: translateX(-100%);
+        }
+        to {
+          transform: translateX(100%);
+        }
+      }
+    </style>
+  </head>
+
+  <body>
+    <div class="frames">
+      <!-- 1. cargando -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-001 · modo cargando
+          <small>skeleton actualizado a la forma de la card vertical — bloque aspect-4/3 arriba, 3 líneas abajo</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="search-bar">
+            <div class="select-field">
+              <span class="field-label">Categoría</span>
+              <span class="field-value">Electricidad</span>
+            </div>
+            <div class="select-field">
+              <span class="field-label">Comuna</span>
+              <span class="field-value">Puerto Varas</span>
+            </div>
+          </div>
+          <div class="results-container flex flex-col gap-3 p-4" aria-busy="true">
+            <div class="skeleton-card">
+              <div class="skeleton-block" style="aspect-ratio: 4/3; width: 100%"></div>
+              <div class="flex flex-col gap-2 p-3.5">
+                <div class="skeleton-block h-4 w-32 rounded"></div>
+                <div class="skeleton-block h-3 w-20 rounded"></div>
+                <div class="skeleton-block h-3 w-24 rounded"></div>
+              </div>
+            </div>
+            <div class="skeleton-card">
+              <div class="skeleton-block" style="aspect-ratio: 4/3; width: 100%"></div>
+              <div class="flex flex-col gap-2 p-3.5">
+                <div class="skeleton-block h-4 w-32 rounded"></div>
+                <div class="skeleton-block h-3 w-20 rounded"></div>
+                <div class="skeleton-block h-3 w-24 rounded"></div>
+              </div>
+            </div>
+            <div class="skeleton-card">
+              <div class="skeleton-block" style="aspect-ratio: 4/3; width: 100%"></div>
+              <div class="flex flex-col gap-2 p-3.5">
+                <div class="skeleton-block h-4 w-32 rounded"></div>
+                <div class="skeleton-block h-3 w-20 rounded"></div>
+                <div class="skeleton-block h-3 w-24 rounded"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- 2. con resultados — con foto y sin foto (CL-001) -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-001 · modo con resultados
+          <small>Marcela con foto de trabajo y reseñas; Héctor sin ninguna de las dos (CL-001) — mismo alto, mismo slot</small>
+        </div>
+        <div class="frame-viewport is-auto">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="search-bar">
+            <div class="select-field">
+              <span class="field-label">Categoría</span>
+              <span class="field-value">Electricidad</span>
+            </div>
+            <div class="select-field">
+              <span class="field-label">Comuna</span>
+              <span class="field-value">Puerto Varas</span>
+            </div>
+          </div>
+          <div class="results-container flex flex-col gap-3 p-4">
+            <p class="result-count">2 resultados</p>
+            <a href="#" class="result-card">
+              <img
+                class="result-photo"
+                alt=""
+                loading="lazy"
+                src="https://images.unsplash.com/photo-1621905251189-08b45d6a269e?auto=format&fit=crop&w=600&q=60"
+              />
+              <div class="result-body">
+                <p class="truncate text-sm font-bold" style="color: var(--ui-text-highlighted)">Marcela Fuentes</p>
+                <p class="comuna-line truncate text-xs">Puerto Varas</p>
+                <div class="rating-line">
+                  <svg class="star-icon" viewBox="0 0 24 24"><path d="M12 2l2.9 6.6 7.1.6-5.4 4.7 1.7 7-6.3-3.8-6.3 3.8 1.7-7L2 9.2l7.1-.6z"/></svg>
+                  <span class="font-bold">4,8</span>
+                  <span style="color: var(--ui-text-muted)">· 12 reseñas</span>
+                </div>
+                <p class="mt-1 text-xs font-bold" style="color: var(--ui-text-highlighted)">Desde $15.000</p>
+                <p class="since-pill text-[0.6875rem]">En Datealo desde julio de 2026</p>
+              </div>
+            </a>
+            <a href="#" class="result-card">
+              <div class="result-photo-fallback">
+                <div class="avatar-initials-lg">HS</div>
+              </div>
+              <div class="result-body">
+                <p class="truncate text-sm font-bold" style="color: var(--ui-text-highlighted)">Héctor Silva</p>
+                <p class="comuna-line truncate text-xs">Puerto Varas</p>
+                <p class="mt-1 text-xs font-bold" style="color: var(--ui-text-highlighted)">Desde $12.000</p>
+                <p class="since-pill text-[0.6875rem]">En Datealo desde agosto de 2026</p>
+              </div>
+            </a>
+          </div>
+        </div>
+      </section>
+
+      <!-- 3. comunas vecinas -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-001 · modo comunas vecinas
+          <small>card enriquecida + comuna en negrita, mismo criterio que la misión 06</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="search-bar">
+            <div class="select-field">
+              <span class="field-label">Categoría</span>
+              <span class="field-value">Gasfitería</span>
+            </div>
+            <div class="select-field">
+              <span class="field-label">Comuna</span>
+              <span class="field-value">Puente Alto</span>
+            </div>
+          </div>
+          <div class="results-container flex flex-col gap-3 p-4">
+            <div class="empty-banner">Todavía no hay profesionales de Gasfitería en Puente Alto.</div>
+            <p class="section-label">Cerca de Puente Alto</p>
+            <a href="#" class="result-card">
+              <div class="result-photo-fallback">
+                <div class="avatar-initials-lg">RM</div>
+              </div>
+              <div class="result-body">
+                <p class="truncate text-sm font-bold" style="color: var(--ui-text-highlighted)">Raúl Muñoz</p>
+                <p class="comuna-line is-vecina truncate text-xs">La Florida</p>
+                <p class="mt-1 text-xs font-bold" style="color: var(--ui-text-highlighted)">Desde $10.000</p>
+                <p class="since-pill text-[0.6875rem]">En Datealo desde agosto de 2026</p>
+              </div>
+            </a>
+          </div>
+        </div>
+      </section>
+
+      <!-- 4. desktop, con resultados -->
+      <section class="frame frame-desktop">
+        <div class="frame-label">
+          V-001 · modo con resultados — desktop
+          <small>grid auto-fit centrado dentro de max-w-6xl, cards hasta 380px — ya no de borde a borde ni angosto como el perfil</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="flex h-full flex-col">
+            <div class="search-bar">
+              <div class="results-container flex gap-2">
+                <div class="select-field" style="max-width: 220px">
+                  <span class="field-label">Categoría</span>
+                  <span class="field-value">Electricidad</span>
+                </div>
+                <div class="select-field" style="max-width: 220px">
+                  <span class="field-label">Comuna</span>
+                  <span class="field-value">Ñuñoa</span>
+                </div>
+              </div>
+            </div>
+            <div class="results-container p-8 pt-3">
+              <p class="result-count mb-3">3 resultados</p>
+              <div class="results-grid">
+                <a href="#" class="result-card">
+                  <img
+                    class="result-photo"
+                    alt=""
+                    loading="lazy"
+                    src="https://images.unsplash.com/photo-1621905251189-08b45d6a269e?auto=format&fit=crop&w=600&q=60"
+                  />
+                  <div class="result-body">
+                    <p class="truncate text-sm font-bold" style="color: var(--ui-text-highlighted)">Marcelo Rojas</p>
+                    <p class="comuna-line truncate text-xs">Ñuñoa</p>
+                    <div class="rating-line">
+                      <svg class="star-icon" viewBox="0 0 24 24"><path d="M12 2l2.9 6.6 7.1.6-5.4 4.7 1.7 7-6.3-3.8-6.3 3.8 1.7-7L2 9.2l7.1-.6z"/></svg>
+                      <span class="font-bold">4,9</span>
+                      <span style="color: var(--ui-text-muted)">· 8 reseñas</span>
+                    </div>
+                    <p class="mt-1 text-xs font-bold" style="color: var(--ui-text-highlighted)">Desde $15.000</p>
+                    <p class="since-pill text-[0.6875rem]">En Datealo desde julio de 2026</p>
+                  </div>
+                </a>
+                <a href="#" class="result-card">
+                  <div class="result-photo-fallback">
+                    <div class="avatar-initials-lg">JP</div>
+                  </div>
+                  <div class="result-body">
+                    <p class="truncate text-sm font-bold" style="color: var(--ui-text-highlighted)">Jorge Pizarro</p>
+                    <p class="comuna-line truncate text-xs">Ñuñoa</p>
+                    <p class="mt-1 text-xs font-bold" style="color: var(--ui-text-highlighted)">Desde $12.000</p>
+                    <p class="since-pill text-[0.6875rem]">En Datealo desde agosto de 2026</p>
+                  </div>
+                </a>
+                <a href="#" class="result-card">
+                  <img
+                    class="result-photo"
+                    alt=""
+                    loading="lazy"
+                    src="https://images.unsplash.com/photo-1621905252507-b35492cc74b4?auto=format&fit=crop&w=600&q=60"
+                  />
+                  <div class="result-body">
+                    <p class="truncate text-sm font-bold" style="color: var(--ui-text-highlighted)">Héctor Silva</p>
+                    <p class="comuna-line truncate text-xs">Ñuñoa</p>
+                    <div class="rating-line">
+                      <svg class="star-icon" viewBox="0 0 24 24"><path d="M12 2l2.9 6.6 7.1.6-5.4 4.7 1.7 7-6.3-3.8-6.3 3.8 1.7-7L2 9.2l7.1-.6z"/></svg>
+                      <span class="font-bold">4,6</span>
+                      <span style="color: var(--ui-text-muted)">· 3 reseñas</span>
+                    </div>
+                    <p class="since-pill text-[0.6875rem]">En Datealo desde agosto de 2026</p>
+                  </div>
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- 5. desktop, un solo resultado (CL-002) -->
+      <section class="frame frame-desktop">
+        <div class="frame-label">
+          V-001 · modo con resultados — un solo profesional (CL-002) · desktop
+          <small>la captura original del dueño de producto: Electricidad en Puerto Varas, 1 resultado — ahora centrada dentro de max-w-6xl, sin quedar perdida en la esquina</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="flex h-full flex-col">
+            <div class="search-bar">
+              <div class="results-container flex gap-2">
+                <div class="select-field" style="max-width: 220px">
+                  <span class="field-label">Categoría</span>
+                  <span class="field-value">Electricidad</span>
+                </div>
+                <div class="select-field" style="max-width: 220px">
+                  <span class="field-label">Comuna</span>
+                  <span class="field-value">Puerto Varas</span>
+                </div>
+              </div>
+            </div>
+            <div class="results-container p-8 pt-3">
+              <p class="result-count mb-3">1 resultado</p>
+              <div class="results-grid">
+                <a href="#" class="result-card">
+                  <div class="result-photo-fallback">
+                    <div class="avatar-initials-lg">PT</div>
+                  </div>
+                  <div class="result-body">
+                    <p class="truncate text-sm font-bold" style="color: var(--ui-text-highlighted)">Patricio Tabilo</p>
+                    <p class="comuna-line truncate text-xs">Puerto Varas</p>
+                    <p class="mt-1 text-xs font-bold" style="color: var(--ui-text-highlighted)">Desde $15.000</p>
+                    <p class="since-pill text-[0.6875rem]">En Datealo desde agosto de 2026</p>
+                  </div>
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  </body>
+</html>

--- a/docs/missions/10-vista-resultados-busqueda/experiencia.md
+++ b/docs/missions/10-vista-resultados-busqueda/experiencia.md
@@ -1,0 +1,274 @@
+# Misión: vista de resultados de búsqueda — Experiencia
+
+**Estado:** vigente — aprobado por Patricio el 2026-09-02
+
+**Última actualización:** 2026-09-02
+
+[Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
+[Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
+
+## Decisión de experiencia: la card pasa de fila horizontal a card vertical foto-arriba, reusando el slot que ya existe en el perfil público
+
+V-001 (la misma vista de resultados de la misión 06, sin vista nueva) cambia su card de una fila
+horizontal (avatar chico + texto) a una card vertical: una foto arriba con el mismo slot `aspect-4/3` que
+`ProfessionalPublicPhotos.vue` ya usa en el perfil (misión 05), y debajo el nombre, la comuna, el rating
+(si existe), el precio y la antigüedad. Cuando el profesional no subió fotos de trabajo, ese mismo slot
+muestra su avatar centrado sobre un fondo con tinte de `--ui-primary` — mismo mecanismo que el ring de
+foco de los selectores, no el gris genérico que usa el perfil. La página gana un contenedor con ancho
+máximo `max-w-6xl` (más ancho que el perfil, porque acá es un grid de fotos, no una columna de texto) para
+que el filtro y el grid de resultados no se estiren vacíos ni se queden angostos en desktop.
+
+- **Funcionalidades cubiertas:** F-001, F-002.
+- **Pendiente bloqueante:** ninguna. La evaluación heurística en agente separado dejó 2 hallazgos de
+  enfoque (ancho de página, peso visual del fallback) — se investigaron prácticas de grids de listados y
+  de placeholders de imagen (ver UX-001 y UX-002) y se resolvieron ambos antes de este estado.
+
+## Vistas
+
+- **V-001 — Resultados de búsqueda** · móvil / desktop · resuelve [F-001](./producto.md#f-001),
+  [F-002](./producto.md#f-002) · flujo UXF-001 (mismos modos que en la misión 06 — esta misión no agrega
+  ni quita modos, cambia el contenido de la card dentro de "con resultados" y "comunas vecinas", y el
+  layout de la página completa)
+  - modo **eligiendo** — sin cambios respecto a la misión 06
+  - modo **cargando** — el skeleton se actualiza a la forma de la nueva card (ver "Decisiones que no deben
+    quedar implícitas")
+  - modo **con resultados** — la card ahora es vertical, con foto/avatar, rating si existe, precio y
+    antigüedad
+  - modo **comunas vecinas** — misma card enriquecida; conserva el tratamiento en negrita de la comuna
+  - modo **sin resultados** — sin cambios respecto a la misión 06
+
+## Mapa de estados
+
+Sin cambios respecto al de la misión 06 — esta misión no agrega transiciones nuevas, solo cambia qué se ve
+dentro de los modos "con resultados" y "comunas vecinas". Ver
+[el mapa de estados de la misión 06](../06-busqueda-resultados/experiencia.md#mapa-de-estados).
+
+## UXF-001 — Ver un resultado completo, con o sin foto de trabajo
+
+**Objetivo:** que cualquier resultado —tenga 1 o varios— se vea como un profesional real y no como un
+renglón vacío. **Contrato:** [F-001](./producto.md#f-001), [F-002](./producto.md#f-002).
+
+Este flujo extiende UXF-001 de la misión 06 (mismo punto de entrada, mismo criterio de término, mismo
+"cómo sabe el usuario dónde está" — los selectores sticky no cambiaron). Lo que sigue documenta solo lo
+que esta misión modifica: la forma de la card y el layout de la página.
+
+### Divergencia antes de converger
+
+Para la card enriquecida (JTBD de F-001: reconocer al profesional sin abrir su perfil) se generaron tres
+enfoques:
+
+- **Enfoque A — fila horizontal ampliada:** mantener el layout actual (avatar/foto a la izquierda, texto a
+  la derecha) pero agrandando la foto y agregando la línea de rating. Cambia poco código, pero la foto
+  queda chica (un círculo o cuadrado de ~64px) — exactamente el problema que motivó la misión: la
+  información sigue compitiendo por poco espacio y el resultado se sigue viendo austero.
+- **Enfoque B — card vertical foto-arriba, estilo Airbnb (referencia original del dueño de producto):**
+  foto en la parte superior con ancho completo de la card (`aspect-4/3`), contenido debajo. Foto y rating
+  tienen el protagonismo que la investigación pidió (C-002: la card individual debe cargar el peso
+  visual).
+- **Enfoque C — híbrido, foto cuadrada mediana a la izquierda:** una foto de ~112px (más grande que hoy,
+  más chica que B) con el texto a la derecha, sin pasar a vertical completo. Preserva más densidad por
+  pantalla en mobile, pero no reusa ningún patrón visual existente de Datealo — sería un tercer tratamiento
+  de foto distinto al de la landing (carrusel) y al del perfil (`aspect-4/3`).
+
+**Elegido: B.** Es literalmente la referencia que trajo el dueño de producto a esta misión, y es el único
+que reusa un patrón ya construido: `ProfessionalPublicPhotos.vue` (perfil público, misión 05) ya resuelve
+el slot `aspect-4/3` con su fallback a avatar sobre `bg-datealo-surface` — B copia ese mismo componente
+visual en vez de inventar un tercero, lo que además reduce el trabajo de ingeniería (mismo patrón, no una
+variante nueva). C se descarta por eso mismo: agregaría un tamaño de foto que no existe en ningún otro
+lugar del producto. A se descarta porque no resuelve el problema que originó la misión — dejaría la card
+"un poco más grande", no "sólida".
+
+**Costo aceptado de B:** en mobile, cada card ocupa más alto que hoy (una foto `aspect-4/3` a ancho
+completo empuja bastante el contenido hacia abajo). Con el volumen actual (1-3 resultados típicos, C-002 de
+investigación), el costo de scroll es bajo. Si Datealo escala a docenas de resultados por búsqueda, esto
+se reevalúa — es exactamente la restricción de arranque en frío del skill `cold-start-problem`, no una
+sorpresa que aparece después.
+
+### Jerarquía de información
+
+Con foto/avatar, nombre, comuna, rating, precio y antigüedad compitiendo por la misma card, el orden es:
+
+1. **Foto de trabajo, o avatar si no subió ninguna** — ocupa toda la parte superior de la card
+   (`aspect-4/3`), primera señal, igual criterio que el perfil (misión 05).
+2. **Nombre** — quién es.
+3. **Comuna** — confirma dónde trabaja. En modo comunas vecinas, va en negrita, mismo criterio que la
+   misión 06 (avisa que no es la comuna exacta).
+4. **Rating y cantidad de reseñas**, solo si `reviewCount > 0` — mismo formato que el perfil público:
+   ícono de estrella, promedio con coma decimal, "· N reseñas". Si no tiene reseñas todavía, esta línea no
+   existe — no hay "Sin reseñas" ni "0,0", eso leería como una carencia en vez de simplemente omitir un
+   dato que no existe.
+5. **Precio** ("Desde $X", si existe).
+6. **"En Datealo desde..."** — igual que hoy, la única señal de actividad que no se inventa.
+
+### Salidas
+
+Sin cambios respecto a la misión 06 — la card sigue siendo un solo link al perfil; no se agregan
+interacciones dentro de la card (nada de carrusel ni de swipe, eso queda para el perfil completo).
+
+### Secuencia principal
+
+| Paso | Acción                                                                | Respuesta del sistema                                                                                                              | Información visible |
+| ---- | ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| 1    | Llega a V-001 (sin cambios respecto a la misión 06)                      | Ve los selectores dentro de un contenedor con ancho máximo (`max-w-6xl`), ya no de borde a borde en desktop                                | — |
+| 2    | Elige o confirma categoría y comuna                                      | Si tarda más de 300ms, ve un skeleton con la forma de la nueva card vertical (bloque `aspect-4/3` + 3 líneas de texto)                     | Ninguna dato real todavía, solo la forma |
+| 3    | El servidor responde con resultados en la comuna exacta                  | Ve el contador de resultados y la lista/grid: cada card con foto o avatar arriba, nombre, comuna, rating si existe, precio, antigüedad     | Foto o avatar, nombre, comuna, rating (si existe), precio si existe, antigüedad |
+| 3b   | (alternativa) Solo hay resultados en comunas vecinas                     | Igual que la misión 06 (aviso + sección "Cerca de \<comuna\>"), con la misma card enriquecida y la comuna en negrita                        | Mismo contenido que 3, comuna nunca es la exacta |
+| 3c   | (alternativa) No hay nada en la comuna ni sus vecinas                    | Sin cambios respecto a la misión 06                                                                                                        | — |
+| 4    | Toca una card                                                             | Navega al perfil del profesional — sin cambios                                                                                             | — |
+
+### Variantes y recuperación
+
+| Condición                                                                 | Qué cambia                                                                        | Cómo se entiende                                                              | Cómo se recupera |
+| ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------ | --------------------- |
+| Profesional sin fotos de trabajo ni reseñas ([CL-001](./producto.md#cl-001))    | El slot de foto muestra su avatar centrado sobre un fondo con tinte de `--ui-primary`; no hay línea de rating | El slot tiene el mismo tamaño y posición que una card con foto, y el tinte de marca lo distingue de un hueco de contenido faltante | Ninguna — es el estado real de ese perfil |
+| Profesional con reseñas pero sin precio publicado ([CL-004](./producto.md#cl-004)) | La línea de precio se omite; el resto de la card (foto/avatar, nombre, comuna, rating, antigüedad) queda igual | `priceFrom` ya es opcional en F-001 — omitir la línea es el mismo criterio que ya usaba la card horizontal de la misión 06 | Ninguna — es el estado real de ese perfil |
+| 1 solo resultado en desktop ancho ([CL-002](./producto.md#cl-002))              | La card queda centrada dentro del contenedor `max-w-6xl` (ver "Decisiones que no deben quedar implícitas" — grid `auto-fit`), sin estirarse para ocupar el resto del ancho | No queda pegada en una esquina con espacio vacío al lado — el espacio sobrante se reparte como margen simétrico | Ninguna — es el resultado real |
+| Modo comunas vecinas ([CL-003](./producto.md#cl-003))                           | Mismo tratamiento en negrita de la comuna que la misión 06, ahora dentro de la card enriquecida | El peso visual de la comuna, no solo el texto, avisa que no es la comuna exacta        | Cambia de comuna, o contacta a uno de comuna vecina |
+| Conexión lenta (>300ms)                                                        | Skeleton con la forma de la nueva card (bloque `aspect-4/3` + 3 líneas)               | Igual al resto de Datealo                                                            | Si pasa de 10s, mensaje "Esto está tardando más de lo normal" + "Reintentar" |
+
+### Decisiones que no deben quedar implícitas
+
+- El skeleton de carga (`SearchResultCard` en estado `pending`) tiene que actualizarse a la forma nueva —
+  un bloque `aspect-4/3` animado arriba, 3 líneas de texto abajo — para que la carga no "salte" de un
+  layout viejo a uno nuevo cuando llegan los datos.
+- El contenedor `max-w-6xl` se aplica tanto al filtro sticky como al área de resultados — los dos
+  comparten el mismo ancho y los mismos márgenes, para que no se vean desalineados entre sí. Esto es una
+  medida de layout de página (F-002), no un cambio al comportamiento del buscador — los campos de
+  categoría y comuna siguen siendo los mismos componentes, sin tocar `CategoriaSelect` ni `ComunaSelect`.
+- El grid de desktop usa columnas `auto-fit` (`minmax(280px, 380px)`) con `justify-content: center`, no
+  `grid-cols-3` fijo. Con 3 resultados el efecto es el mismo (3 columnas llenando el ancho); con 1 o 2, las
+  columnas sin contenido colapsan y la fila parcial queda centrada en vez de pegada a la izquierda con
+  espacio vacío al lado — sin este cambio, un ancho máximo de página por sí solo no evita que una card
+  sola se vea perdida en una esquina (encontrado en la evaluación heurística de este documento).
+- `align-items: stretch` (default de CSS Grid) iguala el alto de todas las cards de una fila — pero el
+  contenedor de texto de la card (`result-body` en el mockup) necesita `flex: 1` para que ese alto extra
+  llegue hasta el `margin-top: auto` que empuja "En Datealo desde..." hacia abajo. Sin ese `flex: 1`, el
+  borde de la card se estira parejo pero el texto interno no, y las cards de una misma fila quedan con la
+  antigüedad a alturas distintas (encontrado en la evaluación heurística).
+- La card es un link real (`<NuxtLink>`, ya lo es hoy en `SearchResultCard.vue`), con estado de foco
+  visible (anillo de `--ui-primary`) y de hover (sombra + borde más marcado) — no solo un contenedor con
+  click. Esto ya lo cumple el componente actual; esta misión no lo cambia, solo lo hereda.
+- Cada foto de trabajo carga con `loading="lazy"` — es el guardrail de [M-001](./producto.md#m-001) de
+  producto.md (el tiempo de carga de `/buscar` no debe empeorar), y quedaba sin nombrar en este documento
+  hasta la evaluación heurística.
+- El `alt` de la foto de trabajo va vacío (`alt=""`, imagen decorativa) — el nombre del profesional ya es
+  visible como texto una línea más abajo; repetirlo en el `alt` hace que un lector de pantalla lo anuncie
+  dos veces seguidas al entrar a la card.
+- El breakpoint que separa mobile (1 columna) de desktop (grid) es `lg` (1024px) — el mismo que ya define
+  `app/pages/buscar/index.vue` desde la misión 06 (`lg:grid lg:grid-cols-3`). Esta misión no agrega un
+  breakpoint intermedio para tablet/laptop angosto: hereda el mismo corte binario de la misión 06.
+- Ningún ícono de esta vista es un emoji — el ícono de rating es `Star` de `@lucide/vue`
+  (`fill-amber-400 text-amber-400`), el mismo que ya usa el perfil público.
+- En mobile, la vista sigue siendo una columna (sin pasar a grid de 2 columnas) — mismo criterio que la
+  misión 06, sin abrir una decisión nueva de densidad mobile que nadie pidió.
+
+## Estados por superficie
+
+| Estado                                          | Qué se muestra (texto e información real)                                                                                                          | Acción disponible |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------- |
+| cargando                                             | Skeletons con forma de card vertical (bloque `aspect-4/3` + 3 líneas)                                                                                     | Ninguna |
+| con resultados, con foto y reseñas                   | "2 resultados" + card: foto de trabajo, "Marcela Fuentes", "Ñuñoa", ★ "4,8 · 12 reseñas", "Desde $15.000", "En Datealo desde julio de 2026"               | Tocar la card |
+| con resultados, sin foto ni reseñas (CL-001)         | Card con avatar de iniciales sobre fondo `bg-datealo-surface` en el mismo slot, sin línea de rating: "Héctor Silva", "Ñuñoa", "Desde $12.000", "En Datealo desde agosto de 2026" | Tocar la card |
+| con resultados, con reseñas y sin precio             | Card con foto/avatar y rating, sin línea de precio: "Héctor Silva", "Ñuñoa", ★ "4,6 · 3 reseñas", "En Datealo desde agosto de 2026"                       | Tocar la card |
+| con resultados, un solo resultado (CL-002)           | "1 resultado" + una sola card centrada dentro del contenedor `max-w-6xl`, sin estirarse                                                                   | Tocar la card |
+| comunas vecinas                                      | Mismo aviso y sección de la misión 06, con la card enriquecida y la comuna "La Florida" en negrita                                                        | Tocar una card, o cambiar comuna |
+
+## Mockups
+
+| Mockup                | Cubre           | Estado  | Ruta |
+| ------------------------ | ------------------ | --------- | ------ |
+| resultados-busqueda   | UXF-001 (V-001)    | validado — 5 frames, 2 rondas de evaluación heurística en agente separado (grid `auto-fit`/`justify-content`, `flex: 1` en el body de la card, card como link con foco/hover, `loading="lazy"`, `alt` sin redundancia, frame mobile sin recortar, avatar del fallback alineado a `ProfessionalPublicPhotos.vue`) | `./design-mockups/resultados-busqueda.html` |
+
+## Cobertura
+
+| Funcionalidad | Flujo   | Estados cubiertos                                                                 | Estado    |
+| ------------- | ------- | -------------------------------------------------------------------------------- | --------- |
+| F-001         | UXF-001 | con foto y reseñas, sin foto ni reseñas (CL-001), con reseñas sin precio (CL-004), cargando | en revisión |
+| F-002         | UXF-001 | un solo resultado (CL-002), comunas vecinas (CL-003)                              | en revisión |
+
+## Decisiones de experiencia
+
+<a id="ux-001"></a>
+
+### UX-001 — La card pasa de fila horizontal a card vertical foto-arriba, reusando el slot `aspect-4/3` del perfil
+
+- **Estado:** aceptada. **Fecha:** 2026-09-02.
+- **Sustento:** ver "Divergencia antes de converger" de UXF-001; [C-002](./investigacion.md#c-002) y
+  [C-003](./investigacion.md#c-003) de investigación.
+- **Alternativas descartadas:** fila horizontal ampliada (no resuelve el problema que originó la misión) e
+  híbrido con foto cuadrada mediana (agrega un tercer tratamiento visual de foto sin reusar nada existente)
+  — ver "Divergencia antes de converger" arriba.
+- **Decisión y consecuencia:** la card usa el mismo componente visual que `ProfessionalPublicPhotos.vue`
+  (perfil público) para su slot de imagen — foto real o avatar. Esto además simplifica ingeniería: no hay
+  un segundo tratamiento de "sin foto" que mantener.
+- **Impacto en producto:** ninguno — D-002 de `producto.md` ya definía el slot fijo con fallback a avatar;
+  esta decisión solo fija cuál es visualmente (el mismo del perfil).
+
+**Revisión (2026-09-02):** la evaluación heurística en agente separado cuestionó el fallback en sí — con
+foto y sin foto, las cards miden lo mismo, pero el gris plano de `bg-datealo-surface` (heredado tal cual
+del perfil) pierde peso visual junto a una foto real, justo en el caso que producto.md marca como "el más
+común hoy" (CL-001). Se investigaron patrones de placeholder de imagen en e-commerce
+([Shopify Placeholder Images Guide](https://ailee.ai/guides/shopify-placeholder-images)): la práctica es
+usar color de marca en vez de gris genérico ("match your brand with brand colors and style" en vez de un
+"gray box" que se lee como contenido faltante). El fallback cambia a un fondo con tinte de `--ui-primary`
+(`color-mix(in oklab, var(--ui-primary) 10%, var(--ui-bg))` — la misma técnica de `color-mix()` que el
+mockup ya usa para su propio ring de foco, aunque `.select-field` es una clase del mockup, no de
+`app/`; no hay ningún componente real con este tratamiento hoy, es una decisión nueva) y el avatar pasa de
+los 3rem (`h-12 w-12`) que usa hoy `SearchResultCard.vue` a 5.5rem
+(`h-22 w-22`, `text-2xl`) — el mismo tamaño que `ProfessionalPublicPhotos.vue` usa en el perfil, no un
+valor propio. Una segunda evaluación heurística (sobre el mockup ya corregido) verificó el contraste del
+tinte con la fórmula real de WCAG (11,5:1, muy por encima del mínimo AA de 4.5:1) y confirmó con un render
+real que se percibe como decisión de marca, no como gris apenas azulado; también corrigió que la primera
+versión usaba 5rem, un tercer número que no coincidía ni con el baseline real ni con el del perfil citado
+como fuente. Con esto la decisión queda cerrada.
+
+<a id="ux-002"></a>
+
+### UX-002 — El ancho máximo de la página es `max-w-6xl`
+
+- **Estado:** aceptada. **Fecha:** 2026-09-02.
+- **Sustento:** [C-001](./investigacion.md#c-001) de investigación (contenedor sin ancho máximo);
+  práctica de grids de listados tipo Airbnb: anchos de contenedor de 1140-1440px para desktop grande
+  ([Layout grid, USWDS](https://designsystem.digital.gov/utilities/layout-grid/);
+  [What's the best container width for websites?](https://qualityhive.com/blog/optimum-website-container-sizes))
+  — 1024px (el ancho del perfil) queda por debajo de ese rango.
+- **Alternativas descartadas:** `max-w-5xl` (1024px), copiado del perfil público — descartado tras la
+  evaluación heurística: el perfil es una columna de texto (ancho angosto por legibilidad), esta vista es
+  un grid de fotos en 3 columnas (el ancho define qué tan grande se ve cada foto, el objetivo de C-002);
+  en un monitor de 1920px dejaba ~47% de la pantalla en blanco sin agrandar ninguna foto. `max-w-7xl`
+  (1280px) — descartado por ahora: en `minmax(280px, 380px)` de UX-003, un contenedor más ancho que 6xl
+  solo agrega margen, no agranda más las cards (el tope de 380px ya lo limita), así que no aporta sobre
+  6xl con los valores actuales.
+- **Decisión y consecuencia:** el filtro sticky y el área de resultados comparten el mismo contenedor
+  `max-w-6xl` (1152px) centrado. Se combina con subir el tope de card de UX-003 a 380px, para que el
+  ancho extra se traduzca en fotos más grandes, no en más margen.
+- **Impacto en producto:** ninguno.
+
+<a id="ux-003"></a>
+
+### UX-003 — El grid de desktop usa columnas `auto-fit` con `justify-content: center`, no `grid-cols-3` fijo
+
+- **Estado:** aceptada. **Fecha:** 2026-09-02.
+- **Sustento:** hallazgo de la evaluación heurística en agente separado — con `grid-cols-3` fijo, una
+  búsqueda con 1 o 2 resultados deja columnas vacías a la derecha y la card queda pegada en la esquina
+  superior izquierda; el ancho máximo de página por sí solo (F-002, [CL-002](./producto.md#cl-002) de
+  producto.md) no lo evita, solo lo acota a un contenedor más chico.
+- **Alternativas descartadas:** mantener `grid-cols-3` fijo y centrar el contenido manualmente por conteo
+  de resultados en el componente Vue — descartado porque `auto-fit` + `justify-content: center` resuelve
+  lo mismo en CSS puro, sin lógica condicional que mantener; `grid-template-columns: repeat(auto-fill, ...)`
+  (sin colapsar columnas vacías) — descartado porque no centra una fila parcial, dejaría el mismo problema.
+- **Decisión y consecuencia:** `grid-template-columns: repeat(auto-fit, minmax(280px, 380px))` con
+  `justify-content: center`. Con 3 resultados el efecto es prácticamente el mismo de un grid fijo (llena
+  el ancho); con menos, la fila queda centrada. El tope de 380px (subido desde 336px junto con UX-002)
+  hace que el ancho extra del contenedor agrande las cards en vez de solo el margen.
+- **Impacto en producto:** ninguno — cumple lo que [CL-002](./producto.md#cl-002) de producto.md ya
+  prometía ("evita que la card quede perdida en una esquina"), que con solo el ancho máximo de página no
+  se cumplía.
+
+## Preguntas
+
+Ninguna bloquea UXF-001 tal como queda definido acá.
+
+| ID | La duda | Estado | Respuesta, o quién la resuelve |
+| -- | ------- | ------ | ------------------------------- |
+| —  | —       | —      | sin preguntas abiertas propias de experiencia |

--- a/docs/missions/10-vista-resultados-busqueda/ingenieria.md
+++ b/docs/missions/10-vista-resultados-busqueda/ingenieria.md
@@ -1,0 +1,226 @@
+# Misión: vista de resultados de búsqueda — Ingeniería
+
+**Estado:** vigente — aprobado por Patricio el 2026-09-02
+
+**Última actualización:** 2026-09-02
+
+[Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
+[Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
+
+## Decisión técnica: extender un contrato existente, sin tabla ni RLS nuevos
+
+`/api/search` ya devuelve profesionales activos con `avatarUrl`. Los tres datos que faltan —foto de
+trabajo, promedio de reseñas, cantidad de reseñas— ya existen en `professionals.photo_paths` y en la tabla
+`reviews`; ninguno de los dos necesita una columna ni una tabla nueva. El trabajo es: (a) agregar el rating
+con una sola consulta por búsqueda, no una por profesional, y (b) migrar `SearchResultCard.vue` y
+`app/pages/buscar/index.vue` al layout de `experiencia.md`. No hay riesgo de arquitectura — es extender un
+`select` y reescribir dos componentes ya existentes.
+
+- **Contratos de producto cubiertos:** F-001, F-002.
+- **Riesgo bloqueante:** ninguno.
+
+## Arquitectura: mismas capas de A-001, sin una nueva
+
+| Componente                                                          | Responsabilidad                                                                 | No debe decidir                              | Contratos |
+| ------------------------------------------------------------------- | --------------------------------------------------------------------------------- | --------------------------------------------- | --------- |
+| `server/utils/reviews.ts` (`findRatingSummaries`)                   | Agregar rating y cantidad de reseñas por profesional, para un conjunto de ids     | Cómo se muestra el rating en la card           | TC-001    |
+| `server/utils/professionals.ts` (`buildPhotoUrls`, ya existe)       | Construir la URL pública de una foto a partir de su path en Storage               | Cuál foto se usa (eso lo decide `search.ts`)   | TC-001    |
+| `server/utils/search.ts` (`toSearchResult`, `findSearchResults`)    | Componer la forma pública de un resultado, combinando `professionals` + rating    | El orden de los resultados (sin cambios, D-001 de misión 06) | TC-001 |
+| `server/api/search.get.ts`                                          | I/O: validar query params, delegar a `findSearchResults`                          | La forma de la respuesta (la define `search.ts`) | TC-001  |
+| `app/types/search.ts` (`SearchResultProfessional`, copia manual del tipo del servidor — no se comparte vía import, es el patrón ya existente en el repo) | Reflejar la forma pública que el cliente puede usar | Cómo se calcula cada campo (eso lo decide el servidor) | TC-001 |
+| `app/components/search/SearchResultCard.vue`                        | Renderizar un resultado: foto/avatar, rating, precio, antigüedad                  | Cómo se calculan esos datos                    | F-001, UX-001 |
+| `app/pages/buscar/index.vue`                                        | Layout de la página: ancho máximo, grid, skeleton de carga                        | El contenido de cada card                      | F-002, UX-002, UX-003 |
+
+## Contratos
+
+### TC-001 — `GET /api/search` expone foto, rating y reseñas de cada resultado
+
+- **Entrada:** sin cambios — `{ categoria: string, comuna: string }` por query string (ya validados por
+  `search.get.ts`).
+- **Salida:** `SearchResultProfessional` gana tres campos:
+
+  ```ts
+  export type SearchResultProfessional = {
+    id: string
+    displayName: string
+    comunaNombre: string
+    priceFrom: number | null
+    avatarUrl: string | null
+    photoUrl: string | null       // NUEVO — primera foto de trabajo, o null si no subió ninguna
+    ratingAverage: number | null  // NUEVO — null si reviewCount es 0
+    reviewCount: number           // NUEVO
+    createdAt: string
+  }
+  ```
+
+- **Invariantes:**
+  - `photoUrl` es siempre la primera posición de `photoPaths` transformada a URL pública (`buildPhotoUrls(...)[0] ?? null`)
+    — nunca una foto elegida por el cliente (F-001, "No incluye").
+  - `ratingAverage` es `null` si y solo si `reviewCount` es `0` — nunca `0` ni `NaN` cuando no hay reseñas.
+  - El redondeo de `ratingAverage` usa `computeRatingAverage` (ya existe en `reviews.ts`, testeado) — el
+    mismo camino que usa el perfil público, para que el mismo profesional nunca muestre un promedio
+    distinto en `/buscar` y en su perfil.
+  - Una sola consulta a `reviews` por llamada a `/api/search`, sin importar cuántos resultados devuelva
+    (evita N+1 — ver [T-001](#t-001)).
+- **Errores:** sin cambios respecto al contrato actual (`400 { error: 'categoria_required' }`, etc.).
+- **Contrato de producto:** [F-001](./producto.md#f-001).
+
+## Modelo de datos
+
+No hay entidades ni columnas nuevas. La tabla resume de dónde sale cada campo agregado:
+
+| Dato            | Significado                              | Fuente                                                        | Retención o historial |
+| ---------------- | ------------------------------------------ | ----------------------------------------------------------------- | ---------------------- |
+| `photoUrl`       | Primera foto de trabajo del profesional    | `professionals.photo_paths[0]`, ya existe (misión 04)              | Sigue la de `professionals` |
+| `ratingAverage`  | Promedio de las reseñas del profesional    | `computeRatingAverage` (ya existe, misión 07) aplicado a cada grupo de `reviews.rating` — el agrupamiento por varios profesionales a la vez (`groupRatingsByProfessional`) es nuevo de esta misión, ver [T-001](#t-001) | Sigue la de `reviews` |
+| `reviewCount`    | Cantidad de reseñas del profesional        | `COUNT` sobre `reviews`, mismo grupo                                | Sigue la de `reviews` |
+
+### Invariantes de datos
+
+- `photoUrl`, `ratingAverage` y `reviewCount` son derivados, calculados en cada request — ninguno se
+  guarda en `professionals` ni se cachea. Con el volumen actual (decenas de profesionales, no miles) el
+  costo de recalcular en cada búsqueda es despreciable; si eso cambia, es un problema de rendimiento a
+  resolver aparte, no de consistencia de datos.
+- La única fuente de verdad del rating sigue siendo la tabla `reviews` — `search.ts` no duplica el cálculo
+  de promedio, reusa `computeRatingAverage` (ver T-001).
+
+### Impacto en RLS
+
+**Ninguna policy nueva ni modificada.** Los dos caminos de acceso que este cambio agrega ya están cubiertos
+por lo que existe en `server/db/sql/rls.sql`, aunque por mecanismos distintos:
+
+- `professionals` tiene la policy `professionals_select_public` (`using (true)`, misión 04) como respaldo
+  explícito de lectura pública — así queda registrado incluso si algo llegara a consultarla por PostgREST.
+- `reviews` **no tiene ninguna policy** — solo `enable row level security` + `revoke all on public.reviews
+  from anon, authenticated` (líneas 138-140 de `rls.sql`). RLS habilitada sin policies es deny-all por
+  default: `reviews` queda cerrada del todo a PostgREST, más estricta que `professionals`, no igual de
+  abierta por una policy equivalente. La lectura real de ambas tablas ocurre por Drizzle con rol dueño
+  (A-002), que bypassa RLS por completo — por eso el cambio no necesita tocar ninguna policy en ningún
+  caso, aunque el mecanismo de cada tabla sea distinto.
+
+No se agrega ninguna columna, tabla ni bucket; este cambio no toca ownership ni agrega un camino de
+escritura.
+
+| Tabla           | Cambio | Policy afectada | Acción |
+| ---------------- | ------ | ---------------- | ------ |
+| `professionals`  | ninguno (se leen columnas ya seleccionadas o ya públicas) | `professionals_select_public` (misión 04) | nada |
+| `reviews`        | ninguno (se agrega una consulta de lectura, mismo criterio que ya usa `findReviewsForProfessional`) | ninguna — cerrada a PostgREST sin policy, se lee vía Drizzle | nada |
+
+## Riesgos y experimentos de factibilidad
+
+| ID     | Riesgo o pregunta                                              | Qué invalida                     | Experimento o mitigación                                                        | Criterio de salida                              | Estado |
+| ------ | ---------------------------------------------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------ | -------------------------------------------------- | ------ |
+| TR-001 | La agregación de rating en JS (no `GROUP BY` en SQL) no escala si un profesional acumula cientos de reseñas | El tiempo de respuesta de `/buscar` | Mitigado por diseño: `findRatingSummaries` trae `professional_id` + `rating` con un `IN`, filtrado por el mismo índice único de `reviews` (`reviews_professional_id_token_key`, `professional_id` como columna líder) — no es un table scan | Si el volumen de reseñas por profesional crece a cientos, mover el promedio a `AVG()/GROUP BY` en SQL, replicando el mismo redondeo de `computeRatingAverage` | cerrado — aceptado con el volumen actual (ver [C-002](./investigacion.md#c-002): pocos profesionales por búsqueda es la restricción de esta etapa, no una excepción) |
+
+## Estrategia de pruebas
+
+| Contrato o riesgo                          | Nivel        | Caso principal                                                                 | Límite o falla |
+| --------------------------------------------- | -------------- | ------------------------------------------------------------------------------ | ---------------- |
+| TC-001 (agrupar reseñas por profesional)      | unidad (`server/utils/reviews.test.ts`) | 3 reseñas de un profesional y 2 de otro, mezcladas en la misma lista, agrupan cada una en su profesional | lista vacía devuelve un `Map` vacío |
+| TC-001 (promedio y conteo por grupo)          | unidad (`server/utils/reviews.test.ts`) | un grupo de 3 ratings produce el mismo promedio que `computeRatingAverage` ya calcula hoy | — (ya cubierto, se reusa la función existente) |
+| TC-001 (forma pública del resultado)          | unidad (`server/utils/search.test.ts`)  | profesional con foto y 2 reseñas → `photoUrl` no nulo, `ratingAverage`/`reviewCount` reflejan las 2 reseñas | profesional sin fotos ni reseñas (CL-001) → `photoUrl: null`, `ratingAverage: null`, `reviewCount: 0` |
+| F-001 (`SearchResultCard.vue`, mismo patrón de `CatalogSelect.test.ts`) | componente (`@vue/test-utils`, jsdom) | con `photoUrl` y `ratingAverage` renderiza la foto y la línea de rating           | sin `photoUrl` renderiza el fallback con avatar; sin `ratingAverage` no renderiza la línea de rating (nunca "0,0" ni vacía) |
+| F-002 (`app/pages/buscar/index.vue`)          | manual (`npm run dev`, 390px y desktop ancho) | 1 resultado en desktop queda centrado, no en una esquina (CL-002)                | grid con 3 resultados mantiene el mismo alto entre una card con foto y una sin foto |
+
+### Propiedades que deben probarse
+
+- Ningún resultado de búsqueda expone más que `photoUrl` (string única) aunque el profesional tenga varias
+  fotos de trabajo — el resto del array nunca sale de `server/utils/search.ts` (A-005: la forma pública no
+  es la fila cruda).
+- `ratingAverage` y `reviewCount` son consistentes entre sí en cualquier combinación de entrada — nunca
+  `ratingAverage: null` con `reviewCount > 0` ni al revés.
+
+## Plan de construcción
+
+| ID    | Slice (una frase, sin "y")                                                    | Sustento             | Criterio de aceptación principal                                                                                          | Depende de |
+| ----- | ---------------------------------------------------------------------------------- | --------------------- | ---------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| S-001 | Exponer foto, rating y cantidad de reseñas en `/api/search`                        | TC-001, F-001, T-001  | un profesional con 2 fotos y 3 reseñas devuelve `photoUrl` (la primera) y `ratingAverage`/`reviewCount` correctos; uno sin ninguna de las dos devuelve `null`/`null`/`0`; `app/types/search.ts` refleja los tres campos nuevos; `SearchResultCard.vue` sigue renderizando igual que hoy (campos nuevos sin consumir todavía) | — |
+| S-002 | Migrar `SearchResultCard.vue` a la card vertical foto-arriba                       | F-001, UX-001, T-002, T-003 | con foto y rating, la card muestra ambos en el orden de "Jerarquía de información" de `experiencia.md`; sin foto cae al fallback con tinte de `--ui-primary` y avatar de `ProfessionalPublicPhotos.vue` (5.5rem); sin reseñas, la línea de rating no existe; la card es un `<a>` con foco y hover visibles | S-001 |
+| S-003 | Layout de `/buscar` con ancho máximo y grid centrado                               | F-002, UX-002, UX-003, T-004 | en desktop, el contenedor no excede `max-w-6xl`; con 1 resultado la card queda centrada, no pegada a una esquina (CL-002) | — |
+| S-004 | Actualizar el skeleton de carga a la forma de la card nueva                        | F-002, UX-003         | el skeleton usa la forma `aspect-4/3` + 3 líneas, no la fila horizontal actual — se mergea junto o después de S-002, nunca antes, para que la carga no "salte" de un skeleton vertical a una card vieja horizontal | S-002 |
+
+S-002 depende de S-001 porque consume sus campos nuevos. S-003 (ancho máximo + grid) es independiente de
+los otros tres y puede ir en paralelo — toca el contenedor de la página, no el contenido de la card. S-004
+se separó de S-003 en la auditoría de este documento: el skeleton vive en el mismo archivo que S-003
+(`app/pages/buscar/index.vue`), pero su forma correcta depende de que `SearchResultCard.vue` (S-002) ya
+tenga el layout vertical — mergear el skeleton nuevo sin la card nueva produce exactamente el salto visual
+que `experiencia.md` ("Decisiones que no deben quedar implícitas") dice que no debe pasar.
+
+## Decisiones técnicas
+
+<a id="t-001"></a>
+
+### T-001 — El rating se agrupa en JS con una sola consulta `IN`, reusando `computeRatingAverage`
+
+- **Estado:** aceptada. **Fecha:** 2026-09-02.
+- **Contratos:** TC-001.
+- **Alternativas descartadas:** (a) `AVG()/GROUP BY` en SQL — transfiere menos bytes, pero reimplementa el
+  redondeo que `computeRatingAverage` ya define y testea; el riesgo real es que el perfil público y los
+  resultados de búsqueda terminen mostrando un promedio distinto para el mismo profesional por dos
+  redondeos que divergen. Con el volumen actual (docenas de reseñas, no miles) esa diferencia de bytes no
+  compensa el riesgo. (b) Llamar `findReviewsForProfessional` una vez por resultado — descartada, es
+  exactamente el N+1 que el skill `discovery-engineering` marca como antipatrón.
+- **Decisión y consecuencias:** `findRatingSummaries(professionalIds)` trae `{ professionalId, rating }`
+  de `reviews` con un solo `WHERE professional_id = ANY(...)`, agrupa con la función pura
+  `groupRatingsByProfessional` (testeable sin base de datos), y aplica `computeRatingAverage` por grupo.
+  Consecuencia aceptada: si el volumen de reseñas por profesional crece mucho, esta consulta trae más
+  filas de las que un `GROUP BY` traería — ver [TR-001](#riesgos-y-experimentos-de-factibilidad).
+- **Reapertura:** si TR-001 se cierra por volumen real, no por vencimiento de fecha.
+
+<a id="t-002"></a>
+
+### T-002 — `SearchResultProfessional.photoUrl` es una sola URL, no el array completo
+
+- **Estado:** aceptada. **Fecha:** 2026-09-02.
+- **Contratos:** [F-001](./producto.md#f-001) ("No incluye": la card nunca deja elegir qué foto ver).
+- **Alternativas descartadas:** exponer `photoUrls: string[]` completo, igual que el perfil público —
+  descartada porque la card nunca muestra más de una foto; el resto del array serían bytes que el cliente
+  descarga y nunca usa.
+- **Decisión y consecuencias:** se exporta `buildPhotoUrls` desde `professionals.ts` (ya existe, privada) y
+  `search.ts` la reusa, tomando `[0] ?? null`. Cero lógica de construcción de URL duplicada.
+- **Reapertura:** si F-001 cambia para mostrar más de una foto en la card (fuera del alcance de esta
+  misión), se reevalúa exponer el array completo.
+
+<a id="t-003"></a>
+
+### T-003 — `SearchResultCard.vue` no reusa `ProfessionalPublicPhotos.vue` para su slot de imagen
+
+- **Estado:** aceptada. **Fecha:** 2026-09-02.
+- **Contratos:** [UX-001](./experiencia.md#ux-001) (mismo lenguaje visual — `aspect-4/3`, avatar como
+  fallback — que el perfil público).
+- **Tensión:** mismo criterio visual (aspect-4/3, fallback con avatar) frente a necesidades de interacción
+  distintas (`ProfessionalPublicPhotos.vue` es un carrusel con miniaturas para varias fotos; la card
+  siempre muestra una sola, sin interacción — F-001 lo excluye explícitamente).
+- **Alternativas descartadas:** reusar `ProfessionalPublicPhotos.vue` directo — traería `UCarousel` y la
+  tira de miniaturas que la card nunca necesita, agregando peso y comportamiento sin uso. Forzar un prop
+  "modo simple" en `ProfessionalPublicPhotos.vue` — el componente terminaría con condicionales para dos
+  casos de uso genuinamente distintos, exactamente el caso que `discovery-engineering` marca como
+  abstracción equivocada ("¿es la misma regla, o dos reglas que hoy se ven parecidas?" — acá son dos).
+- **Decisión y consecuencias:** `SearchResultCard.vue` implementa su propio slot de imagen (mismas clases
+  `aspect-4/3`, mismo criterio de fallback con avatar sobre `bg-primary/10`) — es duplicación deliberada de
+  markup chico, no una regla compartida forzada.
+- **Reapertura:** si en el futuro la card necesita mostrar más de una foto, se reevalúa si a esa altura sí
+  conviene una interfaz común entre ambos componentes.
+
+<a id="t-004"></a>
+
+### T-004 — El grid de `/buscar` en desktop usa columnas `auto-fit` vía valor arbitrario de Tailwind
+
+- **Estado:** aceptada. **Fecha:** 2026-09-02.
+- **Contratos:** [UX-003](./experiencia.md#ux-003).
+- **Alternativas descartadas:** mantener `lg:grid-cols-3` y centrar manualmente según la cantidad de
+  resultados en el componente — descartada, `auto-fit` + `justify-center` resuelve lo mismo en CSS puro,
+  sin lógica condicional en `buscar/index.vue`.
+- **Decisión y consecuencias:** `class="grid lg:[grid-template-columns:repeat(auto-fit,minmax(17.5rem,23.75rem))] lg:justify-center gap-4"`
+  en el contenedor de resultados de `buscar/index.vue`, reemplazando `lg:grid-cols-3`. Mismo criterio que
+  ya usa el mockup (`docs/missions/10-vista-resultados-busqueda/design-mockups/resultados-busqueda.html`).
+- **Reapertura:** si Tailwind v4 agrega soporte nativo a `auto-fit` sin valor arbitrario, se simplifica la
+  clase sin cambiar el comportamiento.
+
+## Preguntas
+
+Ninguna abierta — el diseño no dejó ninguna decisión pendiente para el momento de cortar en slices.
+
+| ID | La duda | Estado | Respuesta, o quién la resuelve |
+| -- | ------- | ------ | ------------------------------- |
+| —  | —       | —      | sin preguntas abiertas propias de ingeniería |

--- a/docs/missions/10-vista-resultados-busqueda/investigacion.md
+++ b/docs/missions/10-vista-resultados-busqueda/investigacion.md
@@ -1,0 +1,152 @@
+# Misión: Vista de resultados de búsqueda — Investigación
+
+**Estado:** activo
+
+**Última actualización:** 2026-09-02
+
+[Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
+[Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
+
+<!--
+Este documento se acumula: la evidencia y las conclusiones no se borran cuando el alcance cambia, porque
+explican por qué el producto es como es. Lo que sí se actualiza es el ideal, que resume la dirección que
+la investigación sostiene hoy.
+
+Gate de salida — la investigación sostiene un producto.md cuando:
+- el problema tiene situación y consecuencia concretas, no una categoría abstracta
+- al menos una conclusión con confianza alta o media respalda la dirección
+- el ideal describe capacidades observables, no intenciones
+-->
+
+## El problema aparece cuando Patricio busca electricidad en Puerto Varas
+
+**Situación:** el dueño de producto abre `/buscar`, elige la categoría Electricidad y la comuna Puerto
+Varas en un monitor de escritorio ancho.
+
+**Acción o necesidad:** evaluar si la vista de resultados, tal como está hoy, comunica que Datealo tiene
+algo sólido que ofrecer.
+
+**Respuesta actual:** la búsqueda encuentra 1 profesional. La card aparece arriba a la izquierda —
+pequeña, sin foto, solo un círculo con iniciales, nombre, comuna, precio y "en Datealo desde" — y el resto
+de la pantalla queda en blanco. `/buscar` nació en la misión 06 priorizando que el matching funcionara;
+nunca recibió una pasada de diseño dedicada, y el grid (`lg:grid-cols-3`) se agregó sin ningún contenedor
+con ancho máximo.
+
+**Consecuencia:** un resultado que en el fondo es exitoso — Datealo encontró exactamente al profesional
+que se buscaba — se lee como si la plataforma no tuviera nada. La vista no transmite la confianza que el
+resto del producto ya construyó (foto de perfil, reseñas verificadas, precio orientativo).
+
+## Evidencia
+
+| ID    | Tipo         | Fuente                                                                 | Hecho verificable | Límite de la evidencia |
+| ----- | ------------ | ----------------------------------------------------------------------- | ------------------ | ----------------------- |
+| E-001 | código        | `app/types/search.ts` vs. `app/types/professional.ts`                  | `SearchResultProfessional` (lo que llega a la card) trae `displayName`, `comunaNombre`, `priceFrom`, `avatarUrl`, `createdAt`. `PublicProfessionalProfile` (el perfil completo) ya trae además `photoUrls`, `ratingAverage` y `reviewCount`, cargados por el propio profesional en `ProfessionalPhotos.vue`. | Explica por qué la card no puede mostrar foto de trabajo ni rating hoy — no explica si mostrarlos mejora la percepción. |
+| E-002 | código + observación | `app/pages/buscar/index.vue:41,89,102`                          | Ni el filtro sticky ni el contenedor de resultados (`flex flex-col gap-3 lg:grid lg:grid-cols-3`) tienen `max-width`. En desktop ancho, con 1-3 resultados, la mayor parte de la pantalla queda vacía. | Es lectura de código + una captura real del dueño de producto (Electricidad, Puerto Varas), no un test con usuarios. |
+| E-003 | benchmark     | patrones de grid de cards ([Card Grid Layout](https://coddy.tech/learn/html/practical_frontend/card_grid_layout), [What is Card Grid Layout](https://www.hashbuilds.com/patterns/what-is-card-grid-layout), [CSS Card Grid Layout](https://www.fixtools.io/css-tool/css-card-grid-layout)) | CSS Grid con `align-items: stretch` iguala automáticamente el alto de todas las cards de una misma fila; un slot de imagen con aspect-ratio fijo evita que la presencia o ausencia de foto cambie el alto de la card. | Son guías generales de layout web, no específicas de marketplaces de servicios ni validadas con tráfico real de Datealo. |
+| E-004 | benchmark     | [TaskRabbit Identity Policy](https://support.taskrabbit.com/hc/en-us/articles/46260420987675-Identity-Policy) | TaskRabbit exige a sus Taskers una foto de perfil real y reconocible; el patrón de industria para "sin foto" es un avatar con iniciales o silueta, nunca una foto de stock genérica. Datealo ya implementa ese fallback (avatar con iniciales) en `SearchResultCard.vue`. | No encontramos el detalle específico de cómo Thumbtack o TaskRabbit tratan la ausencia de foto dentro de su propio grid de resultados — la búsqueda no fue concluyente en ese punto. |
+| E-005 | uso (dato de la oferta actual) | captura del dueño de producto, categoría Electricidad en Puerto Varas | Con la oferta de profesionales que Datealo tiene hoy, una búsqueda típica devuelve 1-3 resultados, no decenas. Las referencias visuales que motivaron esta misión (Airbnb: "Más de 1000 alojamientos"; grid genérico de servicios: "51 Results") asumen un volumen que Datealo no tiene en esta etapa. | Es la oferta actual, pre-lanzamiento — no una proyección de cuándo cambiará. |
+
+<a id="e-002"></a>
+
+### E-002 — `/buscar` hereda un layout mobile sin adaptar a desktop
+
+El contenedor raíz de la vista es `flex min-h-screen flex-col` (línea 40), el filtro sticky es
+`flex gap-2 ... p-3.5` (línea 41) y el bloque de resultados es `flex flex-col gap-3 p-4 lg:p-8` con
+`flex flex-col gap-3 lg:grid lg:grid-cols-3 lg:gap-4` (líneas 89 y 102). Ninguno fija un ancho máximo: en
+mobile el `flex-col` ocupa el ancho completo (correcto, es una sola columna), pero en desktop el mismo
+`flex-col` sigue ocupando el 100% del viewport y el `grid-cols-3` reparte ese ancho completo entre como
+máximo 3 cards por fila — con 1 resultado, esa card queda angosta y sola en una esquina.
+
+Esto confirma que el "se ve pelado" no es solo falta de contenido en la card: es también la ausencia de un
+contenedor que le dé un ancho razonable a la vista en desktop, independiente de cuántos resultados haya.
+
+## Conclusiones
+
+<a id="c-001"></a>
+
+### C-001 — La card se ve pelada por dos causas independientes, no una
+
+- **Sustento:** [E-001](#e-001), [E-002](#e-002).
+- **Razonamiento:** el contenido de la card es pobre (falta foto y rating que el profesional ya cargó,
+  porque el tipo de búsqueda no los expone) y, por separado, el contenedor de la vista no tiene ancho
+  máximo, así que en desktop una card angosta queda perdida en una pantalla en blanco. Resolver solo una
+  de las dos deja la otra visible.
+- **Implicación:** la solución de esta misión necesita tocar tanto la card (qué muestra) como el layout de
+  la página (`/buscar`, sin tocar el buscador/filtro en sí — territorio de la misión 09).
+- **Confianza:** alta, porque está sustentada en lectura directa de código y una captura real del dueño de
+  producto, no en una hipótesis.
+
+<a id="c-002"></a>
+
+### C-002 — Diseñar para un grid denso no es la referencia correcta en esta etapa
+
+- **Sustento:** [E-005](#e-005).
+- **Razonamiento:** Airbnb y los grids de servicios genéricos que motivaron esta misión asumen decenas o
+  cientos de resultados por búsqueda; Datealo, con la oferta actual, resuelve la mayoría de las búsquedas
+  con 1-3 profesionales. Copiar un grid pensado para volumen sin ese volumen agrava el problema — más
+  columnas vacías, no menos.
+- **Implicación:** la card individual tiene que cargar el peso visual (verse completa y sólida por sí
+  sola), en vez de depender de que haya muchas cards juntas para que la vista se sienta llena.
+- **Confianza:** alta, porque es el dato de oferta actual de Datealo, no una proyección — y es
+  exactamente la restricción de arranque en frío que aplica a cualquier funcionalidad del lado buscador.
+
+<a id="c-003"></a>
+
+### C-003 — Un slot de imagen de aspect-ratio fijo, con el avatar existente como fallback, resuelve la
+tensión entre "compacto" y "grid consistente"
+
+- **Sustento:** [E-003](#e-003), [E-004](#e-004).
+- **Razonamiento:** si cada card reserva el mismo espacio de imagen (con o sin foto real adentro), el
+  grid se mantiene con el alto uniforme sin necesidad de que todos los profesionales tengan fotos de
+  trabajo subidas — algo que hoy no se puede garantizar. El fallback no necesita inventarse: el avatar con
+  iniciales que `SearchResultCard.vue` ya usa cuando no hay `avatarUrl` es exactamente el patrón que la
+  industria usa para este caso.
+- **Implicación:** ninguna card queda obligada a tener foto para verse terminada, y el grid no se vuelve
+  irregular cuando unas la tienen y otras no.
+- **Confianza:** media, porque es un patrón de layout general de industria — no está validado con el
+  volumen real de fotos que los profesionales de Datealo terminen subiendo.
+
+## El ideal: cada resultado se ve completo, exista o no una foto de trabajo
+
+### El resultado ideal se ve así
+
+Patricio abre `/buscar` en un monitor ancho, elige Electricidad y Puerto Varas, y ve un resultado — no
+perdido en una pantalla en blanco, sino una card sustancial dentro de un contenedor centrado y con ancho
+razonable. La card muestra la primera foto de trabajo que el profesional subió (o su avatar con iniciales
+si todavía no subió ninguna), su nombre, comuna, precio desde, y — cuando ya tenga reseñas — su promedio y
+cantidad (toda reseña en Datealo es "verificada por contacto" por construcción, así que no hace falta un
+badge aparte para eso). Nada de eso es información nueva: todo ya lo cargó el profesional en su perfil o
+ya lo calculó Datealo, la vista de resultados simplemente deja de esconderlo. Si la búsqueda trae dos o tres
+resultados, todos comparten el mismo alto y la misma jerarquía visual, sin que la ausencia de foto en uno
+de ellos rompa la fila. En mobile, la vista sigue siendo una columna legible de arriba a abajo, sin
+competir por espacio horizontal.
+
+### Capacidades del ideal
+
+| Capacidad                         | Acción habilitada                                                          | Respuesta esperada                                                                                  | Conclusión que la justifica |
+| ---------------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | ---------------------------- |
+| Card con foto/rating                | El buscador ve la card con foto de trabajo (o avatar) y rating sin salir de `/buscar`              | Datealo muestra todo dato que el profesional ya cargó a su perfil, sin pedirle nada nuevo             | [C-001](#c-001)              |
+| Contenedor con ancho máximo        | El buscador en desktop ve resultados centrados, con espacio proporcional     | El layout respeta un ancho máximo; el espacio sobrante se reparte como margen, no como vacío en la card | [C-001](#c-001), [C-002](#c-002) |
+| Grid con alto uniforme, con o sin foto | El buscador compara en una misma búsqueda profesionales con y sin fotos de trabajo | Todas las cards de una fila comparten el mismo alto; sin foto, el slot cae al avatar con iniciales existente | [C-003](#c-003)              |
+
+### El ideal no significa agregar features nuevas ni tocar el buscador
+
+- No significa sumar badges pagados, contador de vistas o favoritos — el dueño de producto fue explícito:
+  esta misión mejora cómo se ve lo que ya existe, no agrega funcionalidad nueva. No existe un campo
+  "verificado" en el modelo de profesional; solo las reseñas son verificadas por contacto, por
+  construcción del token que las habilita — no hay nada nuevo que inventar ahí.
+- No significa rediseñar el selector de categoría/comuna ni el buscador del header — eso es alcance de la
+  misión 09 (layout general), en curso por separado.
+- No significa que una card sin foto se vea inferior o "a medio construir" — el fallback con avatar tiene
+  que sentirse tan resuelto como la versión con foto, no como un estado de carga pendiente.
+
+## Referencias
+
+- [Card Grid Layout](https://coddy.tech/learn/html/practical_frontend/card_grid_layout): usado en E-003
+  para el patrón de `align-items: stretch` y alto uniforme entre cards.
+- [What is Card Grid Layout? Uniform Card-Based Grid System](https://www.hashbuilds.com/patterns/what-is-card-grid-layout):
+  usado en E-003 para el patrón de slot de imagen con aspect-ratio fijo.
+- [CSS Card Grid Layout, Responsive Equal-Height Cards](https://www.fixtools.io/css-tool/css-card-grid-layout):
+  usado en E-003 para la implementación de grids con alto equalizado en CSS.
+- [TaskRabbit Identity Policy](https://support.taskrabbit.com/hc/en-us/articles/46260420987675-Identity-Policy):
+  usado en E-004 para el estándar de foto de perfil real y avatar como fallback.

--- a/docs/missions/10-vista-resultados-busqueda/producto.md
+++ b/docs/missions/10-vista-resultados-busqueda/producto.md
@@ -1,0 +1,182 @@
+# Misión: vista de resultados de búsqueda — Producto
+
+**Estado:** vigente — aprobado por Patricio el 2026-09-02
+
+**Última actualización:** 2026-09-02
+
+[Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
+[Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
+
+## Qué construimos: cada resultado de /buscar se ve como una tarjeta completa, no un renglón pelado
+
+**Resultado:** cualquier búsqueda en `/buscar` —tenga 1 resultado o varios— muestra cards con foto de
+trabajo (o avatar) y reseñas cuando existen, dentro de una página con ancho máximo que no se estira vacía
+en desktop.
+
+**Recorte respecto del ideal:** ninguno de fondo — esta entrega cubre el ideal completo de
+[investigación](./investigacion.md#el-ideal-cada-resultado-se-ve-completo-exista-o-no-una-foto-de-trabajo),
+salvo lo que el ideal mismo excluye explícitamente.
+
+**Restricciones aceptadas:** no se agrega ningún campo nuevo al modelo de profesional (sin "verificado",
+sin favoritos, sin contador de vistas); la card solo expone datos que ya existen (`photoUrls`,
+`avatarUrl`, `ratingAverage`, `reviewCount`, `priceFrom`, `comunaNombre`). No se toca el selector de
+categoría/comuna ni el resto del header — eso es alcance de la misión 09, en curso en paralelo.
+
+## Funcionalidades
+
+| ID    | Funcionalidad                                                     | Lado     | Sustento     | Éxito |
+| ----- | -------------------------------------------------------------------- | -------- | ------------ | ----- |
+| F-001 | La card muestra la foto de trabajo (o avatar) y las reseñas del profesional | buscador | C-001, D-001 | M-001 |
+| F-002 | La página de resultados tiene un ancho máximo y un grid de alto uniforme | buscador | C-002, C-003, D-002 | M-001 |
+
+<a id="f-001"></a>
+
+### F-001 — La card muestra la foto de trabajo (o avatar) y las reseñas del profesional
+
+Cuando el buscador ve un resultado en `/buscar`,
+quiero reconocer al profesional con la misma sustancia que vería en su perfil,
+para decidir si contactarlo sin tener que abrirlo primero.
+
+**Lado del marketplace:** buscador. **Qué necesita del otro lado:** que el profesional haya completado su
+perfil (misión 04) — la foto de trabajo y el rating son opcionales y la card funciona sin ellos, pero
+cuantos más profesionales los tengan cargados, más resultados se ven completos.
+
+**Sustento:** [C-001](./investigacion.md#c-001) y [D-001](#d-001). **Éxito:** [M-001](#m-001).
+
+**Reglas:**
+
+- Si el profesional subió al menos una foto de trabajo (`photoUrls`), Datealo la muestra en el slot de
+  imagen de la card.
+- Si no subió ninguna, Datealo muestra su avatar (`avatarUrl` o iniciales) en ese mismo slot — nunca lo
+  deja vacío ni usa una imagen de stock genérica.
+- Si el profesional tiene reseñas (`reviewCount > 0`), Datealo muestra el promedio (`ratingAverage`) y la
+  cantidad junto al nombre.
+- Si todavía no tiene reseñas, Datealo no muestra un rating vacío ni "0.0" — omite esa línea por completo.
+- Datealo nunca muestra un badge de "destacado" pagado, un contador de vistas ni un ícono de favoritos —
+  no son features de esta entrega.
+
+**Ejemplo verificable:** dado un profesional de Electricidad en Puerto Varas con 2 fotos de trabajo
+subidas y 3 reseñas (promedio 4,7), cuando el buscador filtra por esa categoría y comuna, entonces su card
+muestra la primera foto, "4,7 · 3 reseñas" junto al nombre, la comuna y el precio desde — sin abrir el
+perfil. El formato exacto (coma decimal, separador "·", palabra "reseñas") es el mismo que ya usa el
+perfil público (`app/pages/profesionales/[id].vue`) — se especifica en `experiencia.md`.
+
+**No incluye:** ningún control para que el buscador elija qué foto ver (carrusel, swipe) — se muestra
+siempre la primera de `photoUrls`; eso es del perfil completo (misión 05), no de la card de resultado.
+
+**Experiencia:** por definir en `experiencia.md`. **Ingeniería:** por definir en `ingenieria.md`.
+
+<a id="f-002"></a>
+
+### F-002 — La página de resultados tiene un ancho máximo y un grid de alto uniforme
+
+Cuando el buscador ve resultados en un monitor ancho,
+quiero que la vista ocupe un espacio proporcional a lo que realmente encontró,
+para no sentir que Datealo "no tiene nada" cuando en realidad encontró justo lo que buscaba.
+
+**Lado del marketplace:** buscador. **Qué necesita del otro lado:** nada — es un cambio de layout, no
+depende de cuántos profesionales existan.
+
+**Sustento:** [C-002](./investigacion.md#c-002) y [C-003](./investigacion.md#c-003), [D-002](#d-002).
+**Éxito:** [M-001](#m-001).
+
+**Reglas:**
+
+- El contenedor de `/buscar` (filtro y resultados) tiene un ancho máximo en desktop; el espacio sobrante
+  se reparte como márgenes, no como vacío dentro del área de resultados.
+- Todas las cards de una misma fila del grid comparten el mismo alto, tenga o no foto cada profesional
+  (ver [CL-001](#cl-001)).
+- Con 1 solo resultado, la card conserva su proporción normal — no se estira para "llenar" el ancho
+  disponible (ver [CL-002](#cl-002)).
+- En mobile, la vista sigue siendo una sola columna de arriba a abajo — esta funcionalidad no cambia nada
+  ahí.
+
+**Ejemplo verificable:** dado que una búsqueda en un monitor de 1920px de ancho devuelve 1 resultado,
+cuando se carga `/buscar`, entonces la card aparece dentro de un contenedor centrado con ancho máximo, sin
+que el resto de la pantalla quede en blanco de borde a borde.
+
+**No incluye:** cambios al filtro de categoría/comuna en sí (posición, tamaño, comportamiento) — eso es
+alcance de la misión 09.
+
+**Experiencia:** por definir en `experiencia.md`. **Ingeniería:** por definir en `ingenieria.md`.
+
+## Casos límite que cruzan funcionalidades
+
+| ID     | Condición concreta                                                         | Comportamiento esperado                                                                                 | Funcionalidades |
+| ------ | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ---------------- |
+| CL-001 | Profesional sin fotos de trabajo y sin reseñas (el caso más común hoy)     | La card cae a avatar + nombre + comuna + precio, sin rating — pero mantiene el mismo alto que las cards con foto/rating de su misma fila | F-001, F-002     |
+| CL-002 | 1 solo resultado en un monitor ancho                                       | El ancho máximo del contenedor y el grid centrado evitan que la card quede perdida en una esquina; la card no se distorsiona para ocupar más espacio (ver [UX-003](./experiencia.md#ux-003)) | F-002            |
+| CL-003 | Resultado en modo "vecina" (comuna vecina, ver misión 06)                  | Conserva el tratamiento en negrita ya existente para avisar que no es la comuna exacta, ahora dentro de la card enriquecida — sin competir visualmente con la foto o el rating | F-001            |
+| CL-004 | Profesional con reseñas pero sin precio publicado                         | La línea de precio se omite; el resto de la card (foto/avatar, nombre, comuna, rating, antigüedad) queda igual — `priceFrom` ya es opcional en F-001 | F-001            |
+
+## Fuera de alcance
+
+| Capacidad o caso                                        | Estado     | Razón del recorte                                                                                          | Condición para reconsiderar |
+| ---------------------------------------------------------- | ---------- | ---------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| Favoritos o guardar un profesional                          | descartada | El dueño de producto fue explícito: esta misión mejora la vista existente, no agrega funcionalidad nueva    | Si se decide explorar retención vía favoritos, abre su propio discovery |
+| Contador de vistas o de contactos                           | descartada | Mismo motivo, y Datealo no instrumenta ese dato hoy                                                          | Igual que arriba |
+| Badge de "destacado" pagado                                 | descartada | Choca directo con el guardrail de no-bidding entre profesionales                                            | No se reconsidera salvo cambio explícito de ese guardrail |
+| Rediseño del selector de categoría/comuna (el buscador)     | postergada | Es alcance de la misión 09, en curso en paralelo                                                             | Se retoma si la 09 identifica algo que dependa de esta vista |
+| Carrusel o editor de fotos dentro de la card de resultado    | descartada | Ninguna otra superficie de Datealo lo tiene todavía; no es una regresión específica de esta funcionalidad    | Si se agrega en el perfil completo, se evalúa acá también |
+
+## Señales de éxito
+
+<a id="m-001"></a>
+
+### M-001 — La card más completa cambia cómo se comporta el buscador, no solo cómo se ve
+
+- **Pregunta:** ¿mostrar foto y reseñas en la card mueve al buscador a hacer clic (abrir perfil o
+  WhatsApp), o solo mejora la percepción sin cambiar el comportamiento?
+- **Señal:** de los buscadores que abren `/buscar` y ven al menos un resultado, qué proporción hace clic
+  en una card, comparando el período antes y después de este cambio.
+- **Método y umbral:** revisión manual de los primeros resultados de búsqueda tras el lanzamiento, sin
+  umbral numérico todavía — no hay tráfico para un umbral serio en esta etapa.
+- **Guardrail:** el tiempo de carga de `/buscar` no debe empeorar por cargar fotos adicionales — se
+  mantiene el mismo estándar de lazy loading que ya usa el resto del producto.
+
+## Decisiones de producto
+
+<a id="d-001"></a>
+
+### D-001 — La card de resultado solo expone datos que el profesional ya cargó, sin campos ni features nuevas
+
+- **Estado:** aceptada. **Fecha:** 2026-09-02.
+- **Sustento:** [C-001](./investigacion.md#c-001).
+- **Tensión:** hacer la card más rica y atractiva (como las referencias de Airbnb y de marketplaces de
+  servicios) frente a mantener el guardrail de no agregar funcionalidad antes de tener tracción.
+- **Alternativas descartadas:** (a) badge "destacado" pagado — descartada, choca directo con el guardrail
+  de no-bidding entre profesionales; (b) contador de vistas o contactos — descartada, es una feature
+  nueva sin decidir y Datealo no instrumenta ese dato hoy; (c) ícono de favoritos/guardar — descartada,
+  mismo motivo, y el dueño de producto fue explícito en que esta misión mejora la vista, no agrega
+  funcionalidad.
+- **Decisión y consecuencia:** la card enriquecida se construye solo con datos que ya existen en el modelo
+  (`photoUrls`, `avatarUrl`, `ratingAverage`, `reviewCount`). Esto acota el trabajo de ingeniería a
+  exponer esos campos en `SearchResultProfessional`, sin tocar schema ni agregar tablas.
+- **Reapertura:** si más adelante el dueño de producto decide explorar favoritos o algún tipo de
+  destacado, es su propia misión de discovery, no una extensión de esta.
+
+<a id="d-002"></a>
+
+### D-002 — Toda card reserva el mismo slot de imagen; sin foto, cae al avatar existente en vez de una card compacta distinta
+
+- **Estado:** aceptada. **Fecha:** 2026-09-02.
+- **Sustento:** [C-003](./investigacion.md#c-003).
+- **Tensión:** la preferencia del dueño de producto por una card compacta cuando no hay foto (sin dejar
+  un hueco de imagen vacío) frente a mantener el grid con el mismo alto de card en toda la fila cuando
+  conviven profesionales con foto y sin foto.
+- **Alternativas descartadas:** (a) card compacta real (sin slot de imagen) cuando falta la foto —
+  descartada porque en una fila con cards de distinto alto el grid se ve irregular, exactamente lo que se
+  quería evitar; (b) layout tipo masonry/Pinterest que tolera alturas libres — descartada porque en un
+  listado donde el orden importa (cercanía/relevancia), las alturas libres dificultan escanearlo en
+  orden — le sirve a un feed de descubrimiento, no a un listado de resultados.
+- **Decisión y consecuencia:** toda card reserva el mismo slot de imagen con aspect-ratio fijo; sin foto,
+  ese slot muestra el avatar que `SearchResultCard.vue` ya usa (`avatarUrl` o iniciales) en vez de dejarlo
+  vacío o angosto. El grid mantiene alto uniforme sin depender de que todos los profesionales suban fotos.
+- **Reapertura:** si en producción la mayoría de los profesionales termina subiendo fotos de trabajo, se
+  reevalúa si vale la pena una card sin slot fijo para los pocos casos sin foto.
+
+## Preguntas
+
+Ninguna abierta — las dos dudas que motivaron esta misión (qué elementos de las referencias traer, y cómo
+resolver "compacta sin foto" sin romper el grid) se resolvieron en conversación con el dueño de producto y
+quedaron registradas como D-001 y D-002.

--- a/docs/missions/README.md
+++ b/docs/missions/README.md
@@ -17,6 +17,7 @@ abrieron y de dónde salió cada una.
 | 06  | [búsqueda y resultados](./06-busqueda-resultados/) | producto | 2026-08-13 | cerrada 2026-08-31 | — | — |
 | 07  | [reseñas verificadas por contacto](./07-resenas-verificadas-por-contacto/) | producto | 2026-08-13 | cerrada 2026-08-31 | — | — |
 | 08  | [foto de perfil de profesional](./08-foto-perfil-profesional/) | producto | 2026-08-29 | cerrada 2026-09-02 | — | — |
+| 10  | [vista de resultados de búsqueda](./10-vista-resultados-busqueda/) | producto | 2026-09-01 | lista para construir | — | — |
 
 Misiones 02 a 07 son las seis que llevan al MVP (registrarse, mostrarse, buscar, reseñar), en el orden de
 dependencia definido en la conversación de roadmap del 2026-08-13 — el número no es prioridad, pero acá sí


### PR DESCRIPTION
## Resumen

- Rediseña la card de resultados de `/buscar`: de fila horizontal a card vertical foto-arriba, reusando el slot `aspect-4/3` que ya usa el perfil público (`ProfessionalPublicPhotos.vue`), con fallback con tinte de marca en vez de gris genérico cuando el profesional no subió fotos.
- Layout de `/buscar` con ancho máximo (`max-w-6xl`) y grid `auto-fit` centrado, para que 1-2 resultados no queden perdidos en una esquina en desktop.
- `producto.md`, `experiencia.md` e `ingenieria.md` quedan **vigentes** (aprobados por Patricio el 2026-09-02). `investigacion.md` documenta el problema y la evidencia.
- Mockup con 5 frames evaluado en 2 rondas de evaluación heurística en agente separado (`ui-ux-pro-max`, `web-design-guidelines`, `frontend-design`, `ux-writing`), y `ingenieria.md` auditado (`clean-architecture`, `domain-driven-design`, `supabase-postgres-best-practices`).
- Sin tabla ni cambio de RLS: el endpoint de búsqueda se extiende con datos que ya son públicos (fotos, rating) vía otros endpoints existentes.
- Plan de construcción con 4 slices (S-001 a S-004) en `ingenieria.md`, sin issues abiertos todavía.

## Test plan

- [ ] Revisar el mockup: `docs/missions/10-vista-resultados-busqueda/design-mockups/resultados-busqueda.html`
- [ ] Confirmar que `producto.md`/`experiencia.md`/`ingenieria.md` reflejan lo acordado antes de abrir los issues de S-001 a S-004

🤖 Generated with [Claude Code](https://claude.com/claude-code)