### PR TITLE
docs(docs): documentar que el discovery corre en worktree y el delivery en la raíz

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,21 @@ El discovery de una feature vive en `docs/missions/`. El tracking de ejecución 
 los skills `discovery-product`, `discovery-ux` y `discovery-engineering`. El registro de misiones y la
 convención de carpetas están en [`docs/missions/README.md`](docs/missions/README.md).
 
+### Discovery: siempre en worktree
+
+El discovery de una misión se trabaja siempre en un git worktree, nunca en la raíz: usar `EnterWorktree`
+(nombrado como la carpeta de la misión, `NN-slug`) al abrir o retomar una misión en esta fase.
+`investigacion.md` no se aprueba y no dispara PR por sí solo — es registro acumulativo. Cuando
+`producto.md`, `experiencia.md` e `ingenieria.md` (los tres documentos que sí requieren aprobación del
+dueño de producto) están completos y a punto de pasar a `vigente`, abrir el PR con los documentos de la
+misión. Una vez aprobado y mergeado, cerrar el worktree con `ExitWorktree action: "remove"`.
+
+### Delivery: siempre en la raíz, una misión a la vez
+
+La ejecución (issues y PRs de código de una misión ya aprobada) se trabaja siempre en la raíz del repo,
+nunca en un worktree. Por foco, solo una misión puede estar en delivery (estado `en construcción`) a la
+vez — no arrancar la ejecución de una misión nueva mientras otra sigue `en construcción`.
+
 **Una tarea = un Issue = un PR chico y revisable.** No una feature completa punta a punta — un cambio
 funcional atómico. Los issues salen del "Plan de construcción" de `ingenieria.md`, ya cortado en slices.
 

--- a/docs/missions/README.md
+++ b/docs/missions/README.md
@@ -27,6 +27,11 @@ Estados: `exploración`, `definición`, `lista para construir`, `en construcció
 `cerrada`, `pausada`. Al cerrar, el estado lleva su fecha (`cerrada 2026-09-30`). **En foco** es el único
 documento que se está trabajando; el detalle de por qué vive en el README de la misión, no acá.
 
+Solo una misión puede estar `en construcción` (delivery) a la vez, por foco — ver "Discovery: siempre en
+worktree" y "Delivery: siempre en la raíz" en el `CLAUDE.md` raíz. El discovery previo (hasta `lista para
+construir`) se trabaja en un git worktree y no cuenta para ese límite: varias misiones pueden estar en
+discovery en paralelo, cada una en su propio worktree.
+
 Los cuatro documentos de una misión (`investigacion.md`, `producto.md`, `experiencia.md`, `ingenieria.md`)
 tienen su propio estado, independiente del de la misión: `pendiente`, `activo`, `en revisión`, `vigente`.
 Vive en el encabezado de cada documento, no se repite en ningún README. Claude puede proponer contenido y


### PR DESCRIPTION
## Resumen

- Agrega dos secciones a `CLAUDE.md`: "Discovery: siempre en worktree" y "Delivery: siempre en la raíz,
  una misión a la vez" — fija por escrito la convención que ya se venía siguiendo en la práctica (incluida
  en el discovery de la misión 09 recién cerrado).
- Agrega el mismo criterio a `docs/missions/README.md`: solo una misión puede estar `en construcción` a la
  vez; el discovery previo no cuenta para ese límite porque corre en worktrees paralelos.
- Sin cambios de código.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JixGH7VgBVVMokmzwHG3pu