### PR TITLE
docs(docs): corregir estado de las decisiones D-xxx y T-xxx de la misión 09

### DIFF
--- a/docs/missions/09-layout-general/ingenieria.md
+++ b/docs/missions/09-layout-general/ingenieria.md
@@ -174,7 +174,7 @@ hace falta tocar `server/db/sql/rls.sql` en esta misión.
 
 ### T-001 — Un layout de Nuxt nuevo (`general.vue`) en vez de repetir `AppHeader`+`AppFooter` en cada página
 
-- **Estado:** propuesta. **Fecha:** 2026-09-02.
+- **Estado:** aceptada. **Fecha:** 2026-09-02.
 - **Contratos:** F-001, F-003.
 - **Alternativas descartadas:** poner `AppHeader`+`AppFooter` directo en el template de cada una de las
   cinco páginas afectadas — funciona, pero duplica el mismo wrapper cinco veces y diverge la primera vez
@@ -188,7 +188,7 @@ hace falta tocar `server/db/sql/rls.sql` en esta misión.
 
 ### T-002 — `LandingFooter` es un wrapper delgado sobre `AppFooter`, no un componente con el mismo contenido copiado
 
-- **Estado:** propuesta. **Fecha:** 2026-09-02.
+- **Estado:** aceptada. **Fecha:** 2026-09-02.
 - **Contratos:** F-003, D-002.
 - **Alternativas descartadas:** copiar el markup de los cinco grupos en los dos archivos (lo que existía
   hasta ahora entre `LandingFooter` y la ausencia de un footer general) — diverge en el primer cambio de
@@ -206,7 +206,7 @@ hace falta tocar `server/db/sql/rls.sql` en esta misión.
 
 ### T-003 — `useProfessionalSession()` comparte el `useState` de `useProfessionalProfile` en vez de duplicar el fetch
 
-- **Estado:** propuesta. **Fecha:** 2026-09-02.
+- **Estado:** aceptada. **Fecha:** 2026-09-02.
 - **Contratos:** TC-001, D-005.
 - **Alternativas descartadas:** un composable totalmente independiente con su propio `useState` — en
   `/profesional/perfil`, donde `AppHeader` y la página de edición conviven, esto dispararía dos fetches del
@@ -224,7 +224,7 @@ hace falta tocar `server/db/sql/rls.sql` en esta misión.
 
 ### T-004 — El botón de volver nunca usa `router.back()`, calcula el destino por ruta
 
-- **Estado:** propuesta. **Fecha:** 2026-09-02.
+- **Estado:** aceptada. **Fecha:** 2026-09-02.
 - **Contratos:** TC-004, UXF-002.
 - **Alternativas descartadas:** `router.back()` — se rompe exactamente en el caso que
   [F-001](./producto.md#f-001) nombra como ejemplo verificable: alguien que entra directo a un perfil desde
@@ -241,7 +241,7 @@ hace falta tocar `server/db/sql/rls.sql` en esta misión.
 
 ### T-005 — Términos y Privacidad usan un header propio y chico, no el layout `general` ni `AppHeader`
 
-- **Estado:** propuesta. **Fecha:** 2026-09-02.
+- **Estado:** aceptada. **Fecha:** 2026-09-02.
 - **Contratos:** F-004.
 - **Alternativas descartadas:** meterlas en el layout `general.vue` junto con `/buscar` y el perfil — le
   agregaría un buscador y una zona de avatar irrelevantes a dos páginas de puro texto legal; los mockups ya

--- a/docs/missions/09-layout-general/producto.md
+++ b/docs/missions/09-layout-general/producto.md
@@ -306,7 +306,7 @@ usa cookies de tracking de terceros hoy; si eso cambia, se revisita.
 
 ### D-001 — El header sigue un patrón de profundidad, no una estructura fija idéntica en toda página
 
-- **Estado:** propuesta. **Fecha:** 2026-09-08.
+- **Estado:** aceptada. **Fecha:** 2026-09-02.
 - **Sustento:** [C-001](./investigacion.md#c-001), [C-002](./investigacion.md#c-002),
   [C-005](./investigacion.md#c-005), [C-011](./investigacion.md#c-011).
 - **Tensión:** consistencia y simplicidad de un solo diseño fijo vs. utilidad contextual real, respaldada
@@ -330,7 +330,7 @@ usa cookies de tracking de terceros hoy; si eso cambia, se revisita.
 
 ### D-002 — La landing mantiene su propio header, separado del header general de la app; el footer usa el mismo diseño en ambos
 
-- **Estado:** propuesta. **Fecha:** 2026-09-08.
+- **Estado:** aceptada. **Fecha:** 2026-09-02.
 - **Sustento:** [C-001](./investigacion.md#c-001), [C-006](./investigacion.md#c-006).
 - **Tensión:** reducir duplicación de componentes vs. la landing tiene necesidades propias en el header
   (buscador grande en el hero, nav con anclas a secciones propias) que el footer no tiene.
@@ -358,7 +358,7 @@ usa cookies de tracking de terceros hoy; si eso cambia, se revisita.
 
 ### D-003 — Las referencias de benchmark se adoptan solo para pulido visual y estructura de header/footer; sus secciones y funcionalidades adicionales quedan fuera de alcance
 
-- **Estado:** propuesta. **Fecha:** 2026-09-08.
+- **Estado:** aceptada. **Fecha:** 2026-09-02.
 - **Sustento:** [C-003](./investigacion.md#c-003), [C-004](./investigacion.md#c-004).
 - **Tensión:** la "robustez" que pidió el dueño de producto vs. los guardrails de no agregar pasos al
   flujo core ni features/contenido antes de tener tracción.
@@ -373,7 +373,7 @@ usa cookies de tracking de terceros hoy; si eso cambia, se revisita.
 
 ### D-004 — El contenido de cada footer se organiza en cuatro columnas: lado buscador, lado profesional, contacto y legal — la legal apunta a las páginas simples que esta misión construye
 
-- **Estado:** propuesta. **Fecha:** 2026-09-08.
+- **Estado:** aceptada. **Fecha:** 2026-09-02.
 - **Sustento:** [C-004](./investigacion.md#c-004), [C-006](./investigacion.md#c-006),
   [E-010](./investigacion.md#e-010), [E-018](./investigacion.md#e-018).
 - **Tensión:** el footer de referencia (benchmark) incluye legal, pero Datealo no tenía páginas de destino
@@ -392,7 +392,7 @@ usa cookies de tracking de terceros hoy; si eso cambia, se revisita.
 
 ### D-005 — El header general muestra el avatar del profesional (link a "Mi perfil") cuando hay sesión activa; sin sesión, no muestra ningún acceso al lado profesional fuera de la landing
 
-- **Estado:** propuesta. **Fecha:** 2026-09-08.
+- **Estado:** aceptada. **Fecha:** 2026-09-02.
 - **Sustento:** [C-008](./investigacion.md#c-008).
 - **Tensión:** mostrar siempre el mismo CTA de registro a alguien que ya tiene perfil es lo más simple de
   implementar, pero le habla mal justo al lado más caro de conseguir y retener — y en mobile, agregar un
@@ -416,7 +416,7 @@ usa cookies de tracking de terceros hoy; si eso cambia, se revisita.
 
 ### D-006 — El buscador es un patrón "expandible" en mobile (botón/resumen que abre una vista completa), no los mismos campos inline achicados
 
-- **Estado:** propuesta. **Fecha:** 2026-09-08.
+- **Estado:** aceptada. **Fecha:** 2026-09-02.
 - **Sustento:** [C-009](./investigacion.md#c-009).
 - **Tensión:** reusar el mismo componente de campos en mobile y desktop (menos código) vs. la evidencia de
   que en mobile esos campos se sienten apretados y compiten con el teclado.
@@ -432,7 +432,7 @@ usa cookies de tracking de terceros hoy; si eso cambia, se revisita.
 
 ### D-007 — Datealo no implementa un bottom nav en esta misión
 
-- **Estado:** propuesta. **Fecha:** 2026-09-08.
+- **Estado:** aceptada. **Fecha:** 2026-09-02.
 - **Sustento:** [C-010](./investigacion.md#c-010).
 - **Tensión:** las guías de UX mobile recomiendan bottom nav para apps donde buscar es la acción principal
   vs. Datealo no tiene suficientes destinos reales y distintos para llenarlo con sentido.


### PR DESCRIPTION
## Resumen

- Corrige un artefacto de plantilla: las 7 decisiones `D-xxx` de `producto.md` y las 5 `T-xxx` de
  `ingenieria.md` quedaron con `Estado: propuesta` y (las `D-xxx`) una fecha futura sin sentido
  (2026-09-08), aunque ambos documentos ya están `vigente — aprobado por Patricio el 2026-09-02`.
- Se detectó al validar las citas de sustento antes de crear los issues del plan de construcción — ninguna
  apuntaba a algo `descartada`/`reemplazada`, pero el estado real no coincidía con el del documento.
- Sin cambios de contenido ni de decisiones — solo el campo `Estado`/`Fecha`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JixGH7VgBVVMokmzwHG3pu