### PR TITLE
docs(docs): marcar la misión 09 en construcción, con sus 8 issues abiertos

### DIFF
--- a/docs/missions/09-layout-general/README.md
+++ b/docs/missions/09-layout-general/README.md
@@ -2,15 +2,18 @@
 
 **Tipo:** producto. **Abierta el** 2026-08-31. **Nace de:** ninguna.
 
-**Estado de la misión:** discovery completo — lista para delivery
+**Estado de la misión:** en construcción
 
 **Última actualización:** 2026-09-02
 
 **Documentos:** [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-**Próximo hito:** abrir los issues del plan de construcción (S-001 a S-008 de `ingenieria.md`) y arrancar
-delivery en la raíz del repo, una tarea a la vez. Sin fecha límite todavía.
+**Próximo hito:** los 8 issues del plan de construcción ya están abiertos
+([#148](https://github.com/PatricioTabilo/datealo/issues/148) a
+[#155](https://github.com/PatricioTabilo/datealo/issues/155), ver tabla en
+[`ingenieria.md`](./ingenieria.md#plan-de-construcción)) — arrancar por S-001, S-003 y S-004 (sin
+dependencias entre sí), en la raíz del repo, un PR chico por issue. Sin fecha límite todavía.
 
 `ingenieria.md` **vigente — aprobado por Patricio el 2026-09-02**: sin tablas nuevas (reutiliza
 `GET /api/professionals/me` y agrega una sola query de solo lectura, comunas frecuentes); layout de Nuxt

--- a/docs/missions/README.md
+++ b/docs/missions/README.md
@@ -17,7 +17,7 @@ abrieron y de dónde salió cada una.
 | 06  | [búsqueda y resultados](./06-busqueda-resultados/) | producto | 2026-08-13 | cerrada 2026-08-31 | — | — |
 | 07  | [reseñas verificadas por contacto](./07-resenas-verificadas-por-contacto/) | producto | 2026-08-13 | cerrada 2026-08-31 | — | — |
 | 08  | [foto de perfil de profesional](./08-foto-perfil-profesional/) | producto | 2026-08-29 | cerrada 2026-09-02 | — | — |
-| 09  | [layout general (navbar, footer, TOS)](./09-layout-general/) | producto | 2026-08-31 | lista para construir | — | — |
+| 09  | [layout general (navbar, footer, TOS)](./09-layout-general/) | producto | 2026-08-31 | en construcción | — | — |
 | 10  | [vista de resultados de búsqueda](./10-vista-resultados-busqueda/) | producto | 2026-09-01 | lista para construir | — | — |
 | 11  | [vista de detalle de perfil](./11-perfil-profesional/) | producto | 2026-09-01 | exploración | — | — |
 | 12  | [hero y copy de la landing](./12-hero-y-copy-landing/) | producto | 2026-09-01 | definición | Producto | — |


### PR DESCRIPTION
## Resumen

- `docs/missions/README.md`: misión 09 pasa de "lista para construir" a "en construcción" — ninguna otra
  misión está en ese estado, cumple el límite de una a la vez.
- `docs/missions/09-layout-general/README.md`: próximo hito actualizado con los 8 issues ya abiertos
  (#148 a #155) y por dónde arrancar (S-001, S-003, S-004, sin dependencias entre sí).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JixGH7VgBVVMokmzwHG3pu