### PR TITLE
feat(app): publicar Términos y Condiciones y Política de Privacidad

### DIFF
--- a/app/components/LegalHeader.vue
+++ b/app/components/LegalHeader.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { ChevronLeft } from '@lucide/vue'
+
+defineProps<{
+  title: string
+}>()
+
+const router = useRouter()
+</script>
+
+<template>
+  <div class="flex items-center gap-3 border-b border-datealo-surface px-5 py-4 lg:gap-4 lg:px-12 lg:py-6">
+    <button
+      type="button"
+      aria-label="Volver"
+      class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-datealo-text lg:hidden"
+      @click="router.back()"
+    >
+      <ChevronLeft class="h-5 w-5" />
+    </button>
+    <NuxtLink to="/" class="hidden font-heading text-lg font-extrabold text-primary lg:inline">
+      datea<span class="text-secondary">lo</span>
+    </NuxtLink>
+    <span class="hidden text-datealo-muted lg:inline">/</span>
+    <p class="font-heading font-extrabold text-datealo-text">{{ title }}</p>
+  </div>
+</template>

--- a/app/pages/legal/privacidad.vue
+++ b/app/pages/legal/privacidad.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+useSeoMeta({ title: 'Política de Privacidad' })
+</script>
+
+<template>
+  <div>
+    <LegalHeader title="Política de Privacidad" />
+
+    <div class="mx-auto max-w-2xl px-5 py-4 lg:px-12 lg:py-10">
+      <p class="text-sm leading-relaxed text-datealo-text">
+        En Datealo nos tomamos en serio tu privacidad. Esta página explica qué datos recolectamos, para qué
+        los usamos y cómo puedes ejercer tus derechos.
+      </p>
+
+      <h2 class="mb-2 mt-6 font-heading text-base font-bold text-datealo-text">¿Quién es responsable de tus datos?</h2>
+      <p class="text-sm leading-relaxed text-datealo-text">
+        Datealo (datealo.cl) es responsable del tratamiento de los datos que se describen acá. Puedes
+        contactarnos en hola@datealo.cl para cualquier consulta.
+      </p>
+
+      <h2 class="mb-2 mt-6 font-heading text-base font-bold text-datealo-text">¿Qué datos recolectamos?</h2>
+      <p class="text-sm leading-relaxed text-datealo-text">
+        Si eres profesional y creas un perfil, recolectamos tu email (para iniciar sesión y avisarte cuando
+        alguien te deja una reseña), el nombre que quieres mostrar, tu categoría y comuna, tu contacto
+        (WhatsApp o teléfono), una descripción de tu trabajo, un precio referencial si lo indicas, y las
+        fotos que subas.
+      </p>
+      <p class="mt-2 text-sm leading-relaxed text-datealo-text">
+        Si buscas un profesional o dejas una reseña, no te pedimos ningún dato personal: guardamos en tu
+        navegador un identificador anónimo que solo sirve para evitar reseñas duplicadas al mismo
+        profesional.
+      </p>
+
+      <h2 class="mb-2 mt-6 font-heading text-base font-bold text-datealo-text">¿Para qué los usamos?</h2>
+      <p class="text-sm leading-relaxed text-datealo-text">
+        Para mostrar tu perfil público, avisarte por correo cuando recibes una reseña nueva, y evitar
+        reseñas duplicadas o falsas.
+      </p>
+
+      <h2 class="mb-2 mt-6 font-heading text-base font-bold text-datealo-text">¿Con quién los compartimos?</h2>
+      <p class="text-sm leading-relaxed text-datealo-text">
+        Con Supabase (base de datos e inicio de sesión) y Resend (envío de correos), como proveedores de
+        infraestructura. Nunca los vendemos ni los usamos para otro fin.
+      </p>
+
+      <h2 class="mb-2 mt-6 font-heading text-base font-bold text-datealo-text">¿Qué puedes pedirnos?</h2>
+      <p class="text-sm leading-relaxed text-datealo-text">
+        Que te mostremos qué datos tenemos tuyos, que los corrijamos, o que los eliminemos. Escríbenos a
+        hola@datealo.cl.
+      </p>
+
+      <h2 class="mb-2 mt-6 font-heading text-base font-bold text-datealo-text">Cookies</h2>
+      <p class="text-sm leading-relaxed text-datealo-text">
+        Solo la necesaria para mantener tu sesión si eres profesional. Nada de publicidad ni seguimiento.
+      </p>
+    </div>
+  </div>
+</template>

--- a/app/pages/legal/terminos.vue
+++ b/app/pages/legal/terminos.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+useSeoMeta({ title: 'Términos y Condiciones' })
+</script>
+
+<template>
+  <div>
+    <LegalHeader title="Términos y Condiciones" />
+
+    <div class="mx-auto max-w-2xl px-5 py-4 lg:px-12 lg:py-10">
+      <h2 class="mb-2 font-heading text-base font-bold text-datealo-text">¿Qué es Datealo?</h2>
+      <p class="text-sm leading-relaxed text-datealo-text">
+        Un buscador de profesionales de servicios para el hogar y la vida diaria. Conectamos a personas con
+        profesionales de su zona. No somos el empleador de ningún profesional, ni parte del servicio que
+        contratas.
+      </p>
+
+      <h2 class="mb-2 mt-6 font-heading text-base font-bold text-datealo-text">Qué no garantizamos</h2>
+      <p class="text-sm leading-relaxed text-datealo-text">
+        La calidad del trabajo de ningún profesional, ni que su perfil sea exacto más allá de lo que él
+        mismo declara. No mediamos en conflictos: el trato es directo entre ambos.
+      </p>
+
+      <h2 class="mb-2 mt-6 font-heading text-base font-bold text-datealo-text">Reglas básicas</h2>
+      <p class="text-sm leading-relaxed text-datealo-text">
+        Si creas un perfil, la información debe ser real. Las reseñas solo se publican cuando quedan atadas
+        a un contacto real con el profesional.
+      </p>
+
+      <h2 class="mb-2 mt-6 font-heading text-base font-bold text-datealo-text">Tu contenido</h2>
+      <p class="text-sm leading-relaxed text-datealo-text">
+        Las fotos y la descripción que subas siguen siendo tuyas. Nos das permiso para mostrarlas en tu
+        perfil público.
+      </p>
+
+      <h2 class="mb-2 mt-6 font-heading text-base font-bold text-datealo-text">Cuándo damos de baja un perfil</h2>
+      <p class="text-sm leading-relaxed text-datealo-text">
+        Si tiene información falsa, fotos que no correspondan, o uso indebido de la plataforma.
+      </p>
+
+      <h2 class="mb-2 mt-6 font-heading text-base font-bold text-datealo-text">Ley aplicable</h2>
+      <p class="text-sm leading-relaxed text-datealo-text">Chile.</p>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
Cierra #148 (S-001 del plan de construcción de la misión 09).

## Sustento

F-004

## Qué hace

- `app/pages/legal/terminos.vue` y `app/pages/legal/privacidad.vue`: renderizan el copy ya aprobado en
  `docs/missions/09-layout-general/contenido/*.md`, tal cual.
- `app/components/LegalHeader.vue` (nuevo): chrome mínimo propio de estas dos páginas — en mobile, ícono de
  volver (`router.back()`) + título; en desktop, logo + "/" + título. Sin buscador ni avatar — es
  intencionalmente distinto del header general (`AppHeader`), que llega en otro slice (#153).

## Criterio de aceptación

- [x] `/legal/terminos` renderiza el copy completo de `terminos-y-condiciones.md`, sin truncar.
- [x] `/legal/privacidad` renderiza el copy completo de `politica-privacidad.md`, sin truncar.
- [x] Mobile (390px): header = ícono de volver + título, nada más — verificado visualmente.
- [x] Desktop (1280px+): header = logo + breadcrumb con el título, nada más — verificado visualmente.
- [x] `npx nuxi typecheck` sin errores.
- [x] `npm run build` sin errores.

## Test plan

- Verificado en browser a 390px y ~1568px: ambos breakpoints muestran el chrome correcto, sin errores de
  consola.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JixGH7VgBVVMokmzwHG3pu