### PR TITLE
feat(app): crear useProfessionalSession, compartiendo estado con useProfessionalProfile

### DIFF
--- a/app/composables/useProfessionalProfile.ts
+++ b/app/composables/useProfessionalProfile.ts
@@ -4,6 +4,10 @@ export function useProfessionalProfile() {
   const professional = useState<Professional | null>('professional-profile', () => null)
   const pending = useState('professional-profile-pending', () => true)
   const loadError = useState<string | null>('professional-profile-load-error', () => null)
+  // useProfessionalSession también lee/escribe estos tres useState (mismas claves) para mostrar el avatar
+  // del header sin sesión propia de edición — este flag evita que dispare su propio fetch si esta página
+  // ya está cargando el perfil.
+  const started = useState('professional-profile-started', () => false)
 
   const editingField = useState<ProfessionalField | null>('professional-profile-editing', () => null)
   const savingField = useState<ProfessionalField | null>('professional-profile-saving', () => null)
@@ -14,6 +18,7 @@ export function useProfessionalProfile() {
   const saveErrorField = useState<ProfessionalField | null>('professional-profile-save-error', () => null)
 
   async function load() {
+    started.value = true
     pending.value = true
     loadError.value = null
     try {

--- a/app/composables/useProfessionalSession.ts
+++ b/app/composables/useProfessionalSession.ts
@@ -1,0 +1,24 @@
+import type { Professional } from '~/types/professional'
+
+export function useProfessionalSession() {
+  const professional = useState<Professional | null>('professional-profile', () => null)
+  const pending = useState('professional-profile-pending', () => true)
+  const started = useState('professional-profile-started', () => false)
+
+  onMounted(() => {
+    if (started.value) return
+    started.value = true
+
+    $fetch<{ professional: Professional }>('/api/professionals/me')
+      .then((response) => { professional.value = response.professional })
+      .catch(() => { professional.value = null })
+      .finally(() => { pending.value = false })
+  })
+
+  return {
+    professional: computed(() => professional.value
+      ? { displayName: professional.value.displayName, avatarUrl: professional.value.avatarUrl }
+      : null),
+    pending,
+  }
+}


### PR DESCRIPTION
Cierra #149 (S-003 del plan de construcción de la misión 09).

## Sustento

TC-001, D-005

## Contrato (TC-001)

- **Entrada:** ninguna — se ejecuta en el cliente, lee la sesión ya presente.
- **Salida:** `{ professional: ComputedRef<{ displayName, avatarUrl } | null>, pending: Ref<boolean> }`.
- **Invariantes:** `professional.value` es `null` tanto sin sesión (401) como con sesión sin perfil
  todavía (404) — nunca un error. Comparte el `useState('professional-profile', ...)` de
  `useProfessionalProfile` (mismo patrón para `pending` y un nuevo `started`) para no duplicar el fetch en
  `/profesional/perfil`, la única página donde los dos composables conviven.
- **Errores:** cualquier falla (401, 404, 500) resuelve a `professional.value = null` — nunca un estado de
  error propio, solo "sin sesión".

## Por qué no duplica el fetch (T-003)

`useProfessionalProfile.load()` ahora también marca el nuevo `started` compartido. En
`/profesional/perfil`, `load()` corre primero (está `await`eado en el `<script setup>` de la página, antes
de que monte el header); cuando `useProfessionalSession` intenta disparar su propio fetch en `onMounted`,
ve `started === true` y no hace nada — solo lee el resultado que ya llegó.

## Criterio de aceptación

- [x] Con sesión y perfil existente → `professional` con `displayName`/`avatarUrl`.
- [x] Sin sesión (401) → `professional: null`, sin lanzar error.
- [x] Con sesión pero sin perfil todavía (404) → `professional: null`, sin lanzar error.
- [x] En `/profesional/perfil`, con ambos composables montados, solo se dispara un fetch (por diseño: el
  guard `started` compartido).
- [x] `pending` nunca queda en `true` indefinidamente si el fetch falla.
- [x] `npx nuxi typecheck`, `npm test` (57/57) y `npm run build` sin errores.

Sin UI propia todavía — se consume en los slices de `AppHeader`/`AppFooter`/`LandingNavbar` que siguen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JixGH7VgBVVMokmzwHG3pu