### PR TITLE
feat(server): exponer GET /api/comunas/frecuentes

### DIFF
--- a/server/api/comunas/frecuentes.get.ts
+++ b/server/api/comunas/frecuentes.get.ts
@@ -1,0 +1,4 @@
+export default defineEventHandler(async (event) => {
+  setResponseHeader(event, 'cache-control', 'public, s-maxage=3600, stale-while-revalidate=86400')
+  return { comunas: await findComunasFrecuentes() }
+})

--- a/server/utils/comunas.ts
+++ b/server/utils/comunas.ts
@@ -1,6 +1,7 @@
-import { and, asc, eq } from 'drizzle-orm'
-import { comunas } from '../db/schema/comunas'
+import { and, asc, count, desc, eq } from 'drizzle-orm'
 import { comunaVecinas } from '../db/schema/comuna-vecinas'
+import { comunas } from '../db/schema/comunas'
+import { professionals } from '../db/schema/professionals'
 
 export async function findActiveComunas() {
   return useDb()
@@ -32,4 +33,18 @@ export async function findVecinasActivas(comunaCodigo: string): Promise<{ codigo
     .innerJoin(comunas, eq(comunaVecinas.vecinaCodigo, comunas.codigo))
     .where(and(eq(comunaVecinas.comunaCodigo, comunaCodigo), eq(comunas.activa, true)))
     .orderBy(asc(comunas.nombre))
+}
+
+export async function findComunasFrecuentes(limit = 3): Promise<{ codigo: string, nombre: string }[]> {
+  return useDb()
+    .select({ codigo: comunas.codigo, nombre: comunas.nombre })
+    .from(comunas)
+    .innerJoin(
+      professionals,
+      and(eq(professionals.comunaCodigo, comunas.codigo), eq(professionals.active, true)),
+    )
+    .where(eq(comunas.activa, true))
+    .groupBy(comunas.codigo, comunas.nombre)
+    .orderBy(desc(count(professionals.id)))
+    .limit(limit)
 }


### PR DESCRIPTION
Cierra #150 (S-004 del plan de construcción de la misión 09).

## Sustento

TC-003, F-002

## Contrato (TC-003)

- **Entrada:** sin parámetros.
- **Salida:** `{ comunas: { codigo: string, nombre: string }[] }`, máximo 3 filas, ordenadas por cantidad
  de profesionales con `active = true` en esa comuna, descendente.
- **Invariantes:** nunca incluye una comuna con `activa = false` — mismo filtro que `findActiveComunas`.
  Si ninguna comuna tiene profesionales activos todavía, devuelve `{ comunas: [] }`, no un error.
- **Errores:** ninguno específico — mismo manejo que `GET /api/comunas` (catálogo público, sin auth).

## Impacto en RLS

Ninguno — `findComunasFrecuentes` es una query de solo lectura nueva, mismo patrón de acceso (Drizzle con
rol dueño) que `findActiveComunas`. Sin policy nueva.

## Criterio de aceptación

- [x] Probado contra la base real de desarrollo: responde `{ comunas: [...] }` con los datos correctos.
- [x] Cache-control igual que `GET /api/comunas` (`s-maxage=3600`).
- [x] `npx nuxi typecheck`, `npm test` (57/57) y `npm run build` sin errores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JixGH7VgBVVMokmzwHG3pu