### PR TITLE
feat(app): reescribir AppFooter con los cinco grupos reales

### DIFF
--- a/app/components/AppFooter.vue
+++ b/app/components/AppFooter.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+const { professional } = useProfessionalSession()
+
+const professionalLink = computed(() => professional.value ? '/profesional/perfil' : '/profesional/registro')
+const professionalLabel = computed(() => professional.value ? 'Mi perfil' : 'Publícate en Datealo')
+</script>
+
+<template>
+  <footer class="bg-primary px-5 py-6 lg:px-16 lg:py-12">
+    <div class="lg:grid lg:grid-cols-5 lg:gap-8">
+      <div class="mb-6 lg:mb-0">
+        <p class="mb-1 font-heading text-xl font-extrabold lg:mb-2 lg:text-2xl">
+          <span class="text-white">datea</span><span class="text-secondary">lo</span>
+        </p>
+        <p class="text-sm text-white/78">Encuentra al profesional que necesitas, cerca de ti.</p>
+      </div>
+
+      <div class="mb-5 border-t border-white/15 pt-5 lg:mb-0 lg:border-t-0 lg:pt-0">
+        <p class="mb-2.5 font-heading text-[0.6875rem] font-bold uppercase tracking-wide text-white/80">Buscador</p>
+        <NuxtLink
+          to="/buscar"
+          class="block rounded py-1.5 text-sm font-semibold text-white/95 hover:text-secondary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-secondary"
+        >
+          Buscar profesionales
+        </NuxtLink>
+      </div>
+
+      <div class="mb-5 border-t border-white/15 pt-5 lg:mb-0 lg:border-t-0 lg:pt-0">
+        <p class="mb-2.5 font-heading text-[0.6875rem] font-bold uppercase tracking-wide text-white/80">Profesionales</p>
+        <NuxtLink
+          :to="professionalLink"
+          class="block rounded py-1.5 text-sm font-semibold text-white/95 hover:text-secondary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-secondary"
+        >
+          {{ professionalLabel }}
+        </NuxtLink>
+      </div>
+
+      <div class="mb-5 border-t border-white/15 pt-5 lg:mb-0 lg:border-t-0 lg:pt-0">
+        <p class="mb-2.5 font-heading text-[0.6875rem] font-bold uppercase tracking-wide text-white/80">Contacto</p>
+        <p class="text-sm text-white/85">hola@datealo.cl</p>
+        <p class="text-sm text-white/85">Santiago, Chile</p>
+      </div>
+
+      <div class="border-t border-white/15 pt-5 lg:border-t-0 lg:pt-0">
+        <p class="mb-2.5 font-heading text-[0.6875rem] font-bold uppercase tracking-wide text-white/80">Legal</p>
+        <NuxtLink
+          to="/legal/terminos"
+          class="block rounded py-1.5 text-sm font-semibold text-white/95 hover:text-secondary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-secondary"
+        >
+          Términos y Condiciones
+        </NuxtLink>
+        <NuxtLink
+          to="/legal/privacidad"
+          class="block rounded py-1.5 text-sm font-semibold text-white/95 hover:text-secondary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-secondary"
+        >
+          Política de Privacidad
+        </NuxtLink>
+      </div>
+    </div>
+
+    <div class="mt-6 border-t border-white/15 pt-5 text-center text-xs text-white/75 lg:mt-10 lg:pt-6">
+      &copy; {{ new Date().getFullYear() }} datealo. Todos los derechos reservados.
+    </div>
+  </footer>
+</template>

--- a/app/components/AppFooter.vue
+++ b/app/components/AppFooter.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-const { professional, pending } = useProfessionalSession()
+const { professional } = await useProfessionalSession()
 
 const professionalLink = computed(() => professional.value ? '/profesional/perfil' : '/profesional/registro')
 const professionalLabel = computed(() => professional.value ? 'Mi perfil' : 'Publícate en Datealo')
@@ -27,9 +27,7 @@ const professionalLabel = computed(() => professional.value ? 'Mi perfil' : 'Pub
 
       <div class="mb-5 border-t border-white/15 pt-5 lg:mb-0 lg:border-t-0 lg:pt-0">
         <p class="mb-2.5 font-heading text-[0.6875rem] font-bold uppercase tracking-wide text-white/80">Profesionales</p>
-        <div v-if="pending" class="h-[1.375rem] w-32 animate-pulse rounded bg-white/15" />
         <NuxtLink
-          v-else
           :to="professionalLink"
           class="block rounded py-1.5 text-sm font-semibold text-white/95 hover:text-secondary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-secondary"
         >

--- a/app/components/AppFooter.vue
+++ b/app/components/AppFooter.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-const { professional } = useProfessionalSession()
+const { professional, pending } = useProfessionalSession()
 
 const professionalLink = computed(() => professional.value ? '/profesional/perfil' : '/profesional/registro')
 const professionalLabel = computed(() => professional.value ? 'Mi perfil' : 'Publícate en Datealo')
@@ -27,7 +27,9 @@ const professionalLabel = computed(() => professional.value ? 'Mi perfil' : 'Pub
 
       <div class="mb-5 border-t border-white/15 pt-5 lg:mb-0 lg:border-t-0 lg:pt-0">
         <p class="mb-2.5 font-heading text-[0.6875rem] font-bold uppercase tracking-wide text-white/80">Profesionales</p>
+        <div v-if="pending" class="h-[1.375rem] w-32 animate-pulse rounded bg-white/15" />
         <NuxtLink
+          v-else
           :to="professionalLink"
           class="block rounded py-1.5 text-sm font-semibold text-white/95 hover:text-secondary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-secondary"
         >

--- a/app/components/landing/LandingFooter.vue
+++ b/app/components/landing/LandingFooter.vue
@@ -1,27 +1,3 @@
 <template>
-  <footer class="bg-datealo-text py-10 sm:py-14">
-    <div class="container mx-auto px-5 sm:px-8">
-      <div class="flex flex-col sm:flex-row items-center justify-between gap-6">
-        <!-- Brand -->
-        <div class="text-center sm:text-left">
-          <p class="text-2xl font-extrabold font-heading mb-1">
-            <span class="text-datealo-bg">datea</span><span class="text-secondary">lo</span>
-          </p>
-          <p class="text-sm text-datealo-bg/40">
-            Encuentra al profesional que necesitas, cerca de ti.
-          </p>
-        </div>
-
-        <!-- Contact -->
-        <div class="text-center sm:text-right text-sm text-datealo-bg/40">
-          <p>hola@datealo.cl</p>
-          <p>Santiago, Chile</p>
-        </div>
-      </div>
-
-      <div class="border-t border-datealo-bg/10 mt-8 pt-6 text-center text-xs text-datealo-bg/30">
-        &copy; {{ new Date().getFullYear() }} datealo. Todos los derechos reservados.
-      </div>
-    </div>
-  </footer>
+  <AppFooter />
 </template>

--- a/app/composables/useProfessionalSession.ts
+++ b/app/composables/useProfessionalSession.ts
@@ -1,19 +1,24 @@
 import type { Professional } from '~/types/professional'
 
-export function useProfessionalSession() {
+export async function useProfessionalSession() {
   const professional = useState<Professional | null>('professional-profile', () => null)
   const pending = useState('professional-profile-pending', () => true)
   const started = useState('professional-profile-started', () => false)
 
-  onMounted(() => {
-    if (started.value) return
+  if (!started.value) {
     started.value = true
-
-    $fetch<{ professional: Professional }>('/api/professionals/me')
-      .then((response) => { professional.value = response.professional })
-      .catch(() => { professional.value = null })
-      .finally(() => { pending.value = false })
-  })
+    try {
+      // useRequestFetch(), no $fetch a secas: durante SSR reenvía las cookies de la request original,
+      // así la página ya llega al navegador con el estado de sesión correcto — sin esto, Nuxt no tiene
+      // forma de saber quién pide la página hasta que el cliente hace su propio fetch.
+      const { professional: data } = await useRequestFetch()<{ professional: Professional }>('/api/professionals/me')
+      professional.value = data
+    } catch {
+      professional.value = null
+    } finally {
+      pending.value = false
+    }
+  }
 
   return {
     professional: computed(() => professional.value


### PR DESCRIPTION
Cierra #151 (S-002 del plan de construcción de la misión 09).

## Sustento

F-003, D-002, TC-001

## Qué hace

`AppFooter.vue` (nuevo): cinco grupos — Marca, Buscador ("Buscar profesionales" → `/buscar`), Profesional
("Publícate en Datealo" → `/profesional/registro` sin sesión, o "Mi perfil" → `/profesional/perfil` con
sesión, vía `useProfessionalSession`), Contacto (texto), Legal (Términos/Privacidad, publicadas en #158).
Mobile: apilado sin acordeón. Desktop: grid de 5 columnas.

`LandingFooter.vue` pasa a ser un wrapper delgado (`<AppFooter />`) — mismo patrón que
`CategoriaSelect`/`ComunaSelect` sobre `CatalogSelect` (misión 03). Cero markup duplicado.

## Criterio de aceptación

- [x] En `/` y en cualquier página con `AppFooter`, se ven los cinco grupos con el contenido correcto.
- [x] Sin sesión, el grupo Profesional dice "Publícate en Datealo"; con sesión activa, dice "Mi perfil" —
  verificado en browser con una sesión real.
- [x] Los links de Legal navegan a `/legal/terminos` y `/legal/privacidad`, ya publicadas — verificado
  clickeando el link en browser.
- [x] `LandingFooter.vue` no duplica ningún markup del footer.
- [x] Mobile 390px: apilado en una columna, sin acordeón, sin scroll horizontal — verificado visualmente.
- [x] `npx nuxi typecheck`, `npm test` (57/57) y `npm run build` sin errores.

## Test plan

- Verificado en browser a 390px y 1440px (landing con footer real, sesión activa mostrando "Mi perfil").
- Clic en "Términos y Condiciones" navega correctamente a `/legal/terminos`.
- Sin errores de consola.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JixGH7VgBVVMokmzwHG3pu