### PR TITLE
feat(app): construir AppHeader — volver por ruta, buscador solo en /buscar, avatar

### DIFF
--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -1,0 +1,70 @@
+<script setup lang="ts">
+import { ChevronLeft } from '@lucide/vue'
+
+const route = useRoute()
+const isBuscar = computed(() => route.path === '/buscar')
+const lastSearchQuery = useLastSearchQuery()
+
+// En /buscar, volver es un nivel más arriba (la landing). En el perfil, vuelve a /buscar con la
+// categoría/comuna que trajo hasta acá — nunca router.back(), no hay historial si se entró por un link
+// externo (ej. WhatsApp).
+const backTo = computed(() => {
+  if (isBuscar.value) return '/'
+  const query: Record<string, string> = {}
+  if (lastSearchQuery.value.categoria) query.categoria = lastSearchQuery.value.categoria
+  if (lastSearchQuery.value.comuna) query.comuna = lastSearchQuery.value.comuna
+  return { path: '/buscar', query }
+})
+const backLabel = computed(() => (isBuscar.value ? 'Volver al inicio' : 'Volver a la búsqueda'))
+
+const { professional } = await useProfessionalSession()
+</script>
+
+<template>
+  <header class="border-b border-datealo-surface">
+    <div class="flex items-center gap-3 px-5 py-3.5 lg:hidden">
+      <NuxtLink
+        :to="backTo"
+        :aria-label="backLabel"
+        class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-datealo-text"
+      >
+        <ChevronLeft class="h-5 w-5" />
+      </NuxtLink>
+      <CompactSearchBar v-if="isBuscar" class="min-w-0 flex-1" />
+      <NuxtLink
+        v-if="professional"
+        to="/profesional/perfil"
+        aria-label="Mi perfil"
+        class="ml-auto flex h-9 w-9 shrink-0 items-center justify-center overflow-hidden rounded-full bg-primary text-xs font-extrabold text-white"
+      >
+        <img v-if="professional.avatarUrl" :src="professional.avatarUrl" alt="" class="h-full w-full object-cover">
+        <span v-else>{{ initials(professional.displayName) }}</span>
+      </NuxtLink>
+    </div>
+
+    <div class="hidden grid-cols-[1fr_auto_1fr] items-center gap-6 px-12 py-4 lg:grid">
+      <NuxtLink
+        :to="backTo"
+        :aria-label="backLabel"
+        class="flex w-fit items-center gap-2 justify-self-start rounded-full px-3.5 py-2 text-sm font-bold text-datealo-text hover:bg-datealo-surface"
+      >
+        <ChevronLeft class="h-5 w-5" />
+        Volver
+      </NuxtLink>
+
+      <CompactSearchBar v-if="isBuscar" />
+      <span v-else />
+
+      <NuxtLink
+        v-if="professional"
+        to="/profesional/perfil"
+        aria-label="Mi perfil"
+        class="flex h-10 w-10 shrink-0 items-center justify-center justify-self-end overflow-hidden rounded-full bg-primary text-sm font-extrabold text-white"
+      >
+        <img v-if="professional.avatarUrl" :src="professional.avatarUrl" alt="" class="h-full w-full object-cover">
+        <span v-else>{{ initials(professional.displayName) }}</span>
+      </NuxtLink>
+      <span v-else />
+    </div>
+  </header>
+</template>

--- a/app/composables/useLastSearchQuery.ts
+++ b/app/composables/useLastSearchQuery.ts
@@ -1,0 +1,8 @@
+export type LastSearchQuery = { categoria: string | null, comuna: string | null }
+
+// El botón de volver del perfil necesita la categoría/comuna que trajo al usuario hasta ahí, pero esa
+// ruta no lleva query propia — /buscar la escribe acá cada vez que cambia, para que el perfil la lea sin
+// depender del historial del navegador, que no existe si se entró por un link externo.
+export function useLastSearchQuery() {
+  return useState<LastSearchQuery>('last-search-query', () => ({ categoria: null, comuna: null }))
+}

--- a/app/pages/buscar/index.vue
+++ b/app/pages/buscar/index.vue
@@ -7,6 +7,8 @@ const router = useRouter()
 const categoriaSlug = ref(typeof route.query.categoria === 'string' ? route.query.categoria : null)
 const comunaCodigo = ref(typeof route.query.comuna === 'string' ? route.query.comuna : null)
 
+const lastSearchQuery = useLastSearchQuery()
+
 // Refleja la elección en la URL para que un link de búsqueda ya armado se pueda compartir — replace, no
 // push, así cada cambio de selector no le agrega una entrada nueva al historial.
 watch([categoriaSlug, comunaCodigo], ([categoria, comuna]) => {
@@ -14,7 +16,9 @@ watch([categoriaSlug, comunaCodigo], ([categoria, comuna]) => {
   if (categoria) query.categoria = categoria
   if (comuna) query.comuna = comuna
   router.replace({ query })
+  lastSearchQuery.value = { categoria, comuna }
 })
+lastSearchQuery.value = { categoria: categoriaSlug.value, comuna: comunaCodigo.value }
 
 const { items: categorias } = useCategoriasCatalog()
 const { items: comunas } = useComunasCatalog()


### PR DESCRIPTION
Cierra #153 (S-006 del plan de construcción de la misión 09).

## Sustento

TC-004, F-001, D-005, UX-003, UX-005

## Contrato (TC-004)

- En `/buscar` → `navigateTo('/')`.
- En `/profesionales/[id]` y `/profesional/*` → `navigateTo('/buscar')`, conservando `categoria`/`comuna`
  de la búsqueda que trajo al usuario al perfil.
- Nunca usa `router.back()` — el caso canónico de F-001 es alguien que entra directo a un perfil desde un
  link de WhatsApp, sin historial de la app en el navegador.

## Qué construye

- `useLastSearchQuery()` (nuevo, chico): `/buscar` escribe ahí su categoría/comuna cada vez que cambian
  (la misma ruta no lleva query propia una vez que se navega al perfil). `AppHeader` lo lee para construir
  el destino de "volver" desde el perfil.
- `AppHeader.vue`: mobile, volver es solo ícono en toda superficie sin excepción. Desktop, ícono + texto,
  grid de 3 zonas (`1fr auto 1fr`) para que `CompactSearchBar` (#163) quede centrado respecto al ancho
  total, no pegado al botón de volver. El avatar (o nada, fuera de la landing) usa `useProfessionalSession`
  (#159).

## Criterio de aceptación

- [x] Mobile: volver es solo ícono en `/buscar` y en el perfil — verificado visualmente.
- [x] Desktop: volver lleva ícono+texto; el buscador queda centrado respecto al ancho total del header —
  verificado visualmente.
- [x] En `/buscar`, volver navega a `/`. En el perfil, vuelve a `/buscar` con los mismos filtros que tenía
  antes de entrar — probado en browser con el flujo completo: buscar → entrar a un perfil → volver, filtros
  intactos en la URL y en los resultados.
- [x] Con sesión, aparece el avatar a la derecha (mobile y desktop) → `/profesional/perfil`. Sin sesión,
  esa zona queda vacía fuera de la landing.
- [x] `CompactSearchBar` solo se muestra en `/buscar`; en el perfil, esa zona queda vacía.
- [x] `npx nuxi typecheck`, `npm test` (57/57) y `npm run build` sin errores.

Se probó montándolo temporalmente en `/buscar` y en `/profesionales/[id]` (revertido antes de este commit
— ningún diff en esas plantillas más allá de `useLastSearchQuery`); la integración real via el layout
`general.vue` llega en #154 (S-007).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JixGH7VgBVVMokmzwHG3pu