### PR TITLE
docs(docs): reabrir header desktop y buscador chico con evidencia de Airbnb

### DIFF
--- a/docs/missions/09-layout-general/experiencia.md
+++ b/docs/missions/09-layout-general/experiencia.md
@@ -132,8 +132,10 @@ como parte de la página — nunca conviven los dos ([F-002](./producto.md#f-002
 **Objetivo:** volver a donde estaba (resultados o landing) sin perder lo que ya había elegido.
 **Contrato:** [F-001](./producto.md#f-001).
 
-**Punto de entrada:** cualquier página que muestre flecha atrás en vez de logo (`/buscar`,
-`/profesionales/[id]`, `/profesional/*`).
+**Punto de entrada:** en mobile, cualquier página que muestre flecha atrás en vez de logo (`/buscar`,
+`/profesionales/[id]`, `/profesional/*`). En desktop, solo `/profesional/*` — `/buscar` y
+`/profesionales/[id]` muestran el logo en su lugar ([D-009 en producto.md](./producto.md#d-009)); ahí este
+flujo no aplica, el logo lleva directo a la landing sin conservar filtros, igual que en la landing misma.
 
 **Criterio de término:** llega a la pantalla anterior con el estado (filtros) conservado cuando
 corresponde.
@@ -147,8 +149,8 @@ En `/buscar`, el resumen de búsqueda junto al botón confirma qué está viendo
 
 | Salida                                          | Cómo se ejecuta                          | Qué queda del trabajo |
 | --------------------------------------------------- | -------------------------------------------- | ------------------------ |
-| Vuelve desde el perfil a resultados             | toca el botón de volver en `/profesionales/[id]` | `/buscar` con los mismos filtros que tenía antes de entrar al perfil |
-| Vuelve desde `/buscar` a la landing             | toca el botón de volver en `/buscar`      | landing en su estado inicial (arriba) — los filtros no se conservan, es un nivel más arriba |
+| Vuelve desde el perfil a resultados             | toca el botón de volver en `/profesionales/[id]` (mobile en toda superficie; desktop no tiene este botón ahí, ver punto de entrada) | `/buscar` con los mismos filtros que tenía antes de entrar al perfil |
+| Vuelve desde `/buscar` a la landing             | mobile: toca el botón de volver. Desktop: toca el logo — mismo destino, otro elemento | landing en su estado inicial (arriba) — los filtros no se conservan, es un nivel más arriba |
 | Usa el botón atrás del navegador en vez del botón de volver | gesto del navegador, no de la app | mismo resultado — la URL ya refleja los filtros (misión 06) |
 
 ### Secuencia principal
@@ -310,7 +312,11 @@ o ausencia del avatar — no hay otro estado visual permanente para esto.
   como caso principal a alguien que entra en frío por WhatsApp, sin contexto previo para interpretar un
   ícono suelto); texto "Volver" en todo tamaño, incluido mobile (versión original de esta decisión) — se
   descarta en la revisión de abajo; volver a mostrar el isotipo junto al botón en `/buscar` y el perfil —
-  se descarta porque reabriría [C-011](./investigacion.md#c-011) (el logo se reserva para la landing).
+  se descartó en su momento porque reabriría [C-011](./investigacion.md#c-011) (el logo se reserva para la
+  landing). Esa razón ya no aplica en desktop: C-011 se revisó con evidencia propia de escritorio, y
+  `/buscar`/`/profesionales/[id]` en desktop sí muestran el logo en vez de "volver" —
+  [D-009 en producto.md](./producto.md#d-009). Esta decisión (UX-003) sigue vigente para cuándo el botón
+  de volver, cuando existe, lleva texto o no — no para dónde existe.
 - **Decisión y consecuencia:** en desktop, el botón lleva ícono + la palabra "Volver" — hay espacio y
   resuelve la orientación visual y el nombre accesible al mismo tiempo. En mobile, solo el ícono, con
   `aria-label` — 390px con el buscador y, cuando hay sesión, el avatar, no deja espacio para texto también

--- a/docs/missions/09-layout-general/experiencia.md
+++ b/docs/missions/09-layout-general/experiencia.md
@@ -2,7 +2,7 @@
 
 **Estado:** vigente — aprobado por Patricio el 2026-09-02
 
-**Última actualización:** 2026-09-02
+**Última actualización:** 2026-09-03
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
@@ -82,6 +82,13 @@ como resumen; dentro del panel abierto, el campo activo aparece expandido y resa
 de opciones (categorías, o comunas frecuentes) inmediatamente debajo — nunca con el otro campo interpuesto
 entre el campo activo y su lista. El campo ya resuelto queda colapsado arriba, como resumen; el que todavía
 no corresponde llenar queda colapsado más abajo, después de la lista.
+
+**Dos densidades en desktop, mismo componente ([UX-006](#ux-006)):** el header general (`/buscar`, perfil,
+`/profesional/*`) usa la densidad chica — solo el valor elegido ("Electricidad · Puerto Varas"), sin el
+nombre del campo encima — porque ahí el buscador está fijo en pantalla todo el tiempo. El navbar de la
+landing tras hacer scroll (misión 08) usa la densidad completa, con el nombre del campo sobre el valor. En
+`/buscar`, este buscador es el único: reemplaza la barra de filtros de categoría/comuna que existe hoy
+como parte de la página — nunca conviven los dos ([F-002](./producto.md#f-002)).
 
 ### Salidas
 
@@ -360,6 +367,29 @@ o ausencia del avatar — no hay otro estado visual permanente para esto.
   [D-002 en producto.md](./producto.md#d-002).
 - **Impacto en producto:** sí — [D-002](./producto.md#d-002) se revisó para reflejar que header y footer
   ya no comparten el mismo criterio de "diseño propio por superficie".
+
+<a id="ux-006"></a>
+
+### UX-006 — El buscador compacto de desktop tiene una densidad chica (sin nombre de campo) para el header general, y una completa (con nombre de campo) para la landing tras scroll
+
+- **Estado:** aceptada. **Fecha:** 2026-09-03.
+- **Sustento:** hallazgo del dueño de producto probando el header general en vivo — con la barra de
+  filtros vieja de `/buscar` todavía sin sacar ([E-002](./investigacion.md#e-002)), el header se sentía
+  con demasiado alto fijo en pantalla. Ver [D-008 en producto.md](./producto.md#d-008).
+- **Alternativas descartadas:** achicar el header entero al hacer scroll (mismo componente cambia de
+  tamaño según la posición del scroll) — se descartó porque no hay evidencia de que Airbnb lo haga en
+  ningún header que no sea el hero de una landing sin sesión ([E-023](./investigacion.md#e-023)); dejar
+  una sola densidad en todos lados — pierde la ocasión de que la landing tras scroll (una entrada más
+  prominente al producto) siga viéndose completa sin pagar ese mismo alto en el header general, que está
+  fijo todo el tiempo.
+- **Decisión y consecuencia:** en desktop, `CompactSearchBar` recibe qué densidad mostrar según dónde
+  vive — no cambia sola con el scroll. Densidad **chica**: cada campo muestra solo su valor ("Electricidad
+  · Puerto Varas"), sin el nombre del campo encima; la usa el header general (`/buscar`, perfil,
+  `/profesional/*`). Densidad **completa** (la que ya existía): el nombre del campo ("Categoría"/"Comuna")
+  sobre su valor; la usa el navbar de la landing tras hacer scroll (misión 08, todavía sin construir). El
+  panel que se abre al hacer click (categorías o comunas) es igual en ambas densidades — lo que cambia es
+  solo el resumen cerrado. Mobile no tiene esta distinción, su resumen ya es una sola línea.
+- **Impacto en producto:** sí — [D-008](./producto.md#d-008), nueva.
 
 ## Preguntas
 

--- a/docs/missions/09-layout-general/investigacion.md
+++ b/docs/missions/09-layout-general/investigacion.md
@@ -2,7 +2,7 @@
 
 **Estado:** activo
 
-**Última actualización:** 2026-09-02
+**Última actualización:** 2026-09-03
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
@@ -86,6 +86,8 @@ una entrevista, la columna "límite" es lo que impide que se lea como dato duro.
 | E-019 | investigación | búsqueda sobre diseño de footer, mobile vs. desktop | En desktop, 4-6 columnas es el máximo recomendado — Datealo ya está en 4. En mobile, la práctica estándar es apilar todo en una sola columna, o usar acordeón cuando hay muchos links (algunos footers de referencia manejan 50-75). | Guía general — no dice qué hacer cuando, como Datealo, el footer es intencionalmente chico (~5 links reales); esa lectura es propia (ver [C-014](#c-014)). |
 | E-020 | código      | búsqueda de `geolocation`/`getCurrentPosition` en todo `app/` y `server/` | No existe ningún uso de la API de geolocalización del navegador en el código hoy — cero resultados. | Confirma que "Cerca de ti" (tomado literal de la referencia de Airbnb, [E-017](#e-017)) describía una funcionalidad nueva que nadie pidió, colada por copiar el detalle visual de la referencia sin auditarlo — el dueño de producto lo detectó y pidió sacarlo (ver [C-015](#c-015)). |
 | E-021 | código      | `server/api/search.get.ts`, `app/pages/buscar/index.vue` (misión 06, ya construido) | `/api/search` exige `categoria` **y** `comuna` — responde `400 comuna_required` si falta la comuna. `/buscar` refleja lo mismo: sin comuna elegida muestra el estado "Elige tu comuna" y nunca dispara la búsqueda (`ready` en `useSearchResults` requiere ambos valores). El fallback "vecina" que sí existe busca en comunas cercanas **a la comuna elegida**, no reemplaza el requisito de elegir una. | Al escribir esta misión se documentó un camino "buscar solo con categoría" que ninguna parte del código soportaba — se detectó auditando el código antes de armar `ingenieria.md` (ver [C-016](#c-016)). |
+| E-022 | benchmark   | `airbnb.cl` (sitio desktop, sesión real del dueño de producto) navegado en vivo el 2026-09-03 | En resultados de búsqueda (`/s/Providencia--Chile/homes`) y en el detalle de una propiedad, el header muestra el logo completo ("airbnb", texto + isotipo) junto al buscador compacto y el avatar — nunca una flecha "volver", ni siquiera en el detalle de una propiedad específica. En "Configuración de la cuenta" (equivalente más cercano a `/profesional/perfil`: fila por campo con su link "Edita"/"Agregar"), el header cambia a un patrón distinto — solo el isotipo (sin el texto "airbnb") y un botón "Listo" arriba a la derecha; "Listo" no vuelve a la página anterior, navega directo a la home (`/`). | Es el sitio desktop, no la app mobile de [E-013](#e-013) — son productos con comportamiento distinto. La cuenta de prueba tenía sesión activa y contenido personalizado ("Vistos recientemente"), no se probó el estado sin sesión. |
+| E-023 | benchmark   | mismas páginas de `airbnb.cl`, scrolleadas hasta el final de los resultados y del home con sesión | El header no cambia de alto ni de contenido al hacer scroll, en ninguna de las dos superficies — se mantiene fijo (sticky) con el mismo tamaño de principio a fin. No se pudo probar el hero de la landing de primera visita (marketing, sin sesión) porque la cuenta usada ya tenía sesión activa y no muestra ese estado. | No confirma ni descarta comportamiento de scroll en el hero sin sesión — solo cubre resultados y home-con-sesión, las dos superficies con equivalente directo hoy en Datealo (`/buscar` y el perfil, no la landing). |
 
 ## Conclusiones
 
@@ -222,7 +224,9 @@ una entrevista, la columna "límite" es lo que impide que se lea como dato duro.
 
 ### C-011 — El header debe seguir un patrón de profundidad: mientras más adentro del flujo está la pantalla, menos elementos de navegación superior y más foco en volver atrás
 
-- **Sustento:** [E-013](#e-013), [E-016](#e-016).
+- **Estado:** revisada 2026-09-03 — la flecha "volver" en vez de logo aplica en mobile; en desktop, la
+  evidencia real dice lo contrario. Ver revisión abajo.
+- **Sustento:** [E-013](#e-013), [E-016](#e-016), [E-022](#e-022), [E-023](#e-023).
 - **Razonamiento:** en el caso real de Airbnb, ni el logo ni el buscador editable aparecen en toda
   pantalla — el logo se reemplaza por una flecha atrás en resultados y detalle, y el buscador se reemplaza
   primero por su resumen compacto (resultados) y después desaparece del todo (detalle), porque ya no hace
@@ -233,7 +237,20 @@ una entrevista, la columna "límite" es lo que impide que se lea como dato duro.
   en el hero), `/buscar` (flecha atrás + resumen compacto de la búsqueda), perfil (solo flecha atrás) —
   sin que esto contradiga la intención original de "un componente, sin variantes ad-hoc" ([D-001](./producto.md#d-001)):
   es un patrón deliberado y respaldado por evidencia, no una variante inventada por conveniencia.
-- **Confianza:** alta — patrón consistente en un caso real bien documentado, más la guía de branding.
+- **Confianza:** alta para mobile (patrón consistente en la app de Airbnb, más la guía de branding); baja
+  para desktop tras la revisión de abajo — el propio caso real la contradice ahí.
+- **Revisión (2026-09-03):** el sustento original ([E-013](#e-013)) son capturas de la **app mobile** de
+  Airbnb — la conclusión se aplicó por igual a mobile y desktop sin evidencia propia de desktop. Navegando
+  el sitio desktop real ([E-022](#e-022)), el patrón es el opuesto: ni en resultados ni en el detalle de
+  una propiedad aparece una flecha "volver" — el logo completo está siempre presente, incluso en el
+  detalle de una propiedad específica (el caso que más se parece a `/profesionales/[id]`). El patrón de
+  profundidad de C-011 es real, pero es un patrón de **app mobile con bottom nav**, no de sitio web
+  desktop — en desktop, Airbnb no tiene el mismo problema de espacio que resuelve la flecha en mobile, así
+  que mantiene el logo (que además funciona como "ir a inicio", algo que un bottom nav ya resuelve en la
+  app y que un sitio desktop sin bottom nav no tiene por otro lado). El caso de `/profesional/perfil` no
+  tiene un equivalente limpio: la página de cuenta de Airbnb usa un tercer patrón (solo isotipo + "Listo"
+  que va a home, no "volver" a la página anterior) — queda para resolver en `producto.md`, no lo resuelve
+  esta conclusión por sí sola.
 
 <a id="c-012"></a>
 
@@ -339,11 +356,19 @@ en una fila angosta. Si busca y llega a resultados, la fila de arriba cambia: fl
 de lo que está buscando, tocable para ajustarlo — ya no hace falta el buscador completo ni el logo, hace
 falta volver o refinar.
 
+En desktop el mismo recorrido no repite la flecha: la restricción de espacio que la justifica en mobile
+(volver + buscador + avatar compitiendo en 390px) no existe con el ancho completo de una pantalla grande,
+y el caso real de Airbnb en desktop lo confirma — el logo (que lleva a la landing) está siempre presente
+en resultados y en el detalle de un profesional, nunca una flecha. Qué le pasa al header de
+`/profesional/perfil` en desktop queda abierto — el caso real más parecido (la cuenta de Airbnb) usa un
+tercer patrón, ni logo-a-home ni flecha-atrás, que todavía no se tradujo a una decisión de Datealo.
+
 ### Capacidades del ideal
 
 | Capacidad                       | Acción habilitada                                                    | Respuesta esperada                                                                          | Conclusión que la justifica |
 | -------------------------------- | ---------------------------------------------------------------------| --------------------------------------------------------------------------------------------- | ---------------------------- |
-| Header con profundidad           | cualquier página de la app                                           | landing: logo + nav + buscador grande. `/buscar`: flecha atrás + resumen compacto de búsqueda. Perfil: solo flecha atrás. | [C-002](#c-002), [C-005](#c-005), [C-011](#c-011) |
+| Header con profundidad, mobile   | cualquier página de la app, en mobile                                | landing: logo + nav + buscador grande. `/buscar`: flecha atrás + resumen compacto de búsqueda. Perfil: solo flecha atrás. | [C-002](#c-002), [C-005](#c-005), [C-011](#c-011) |
+| Header con logo persistente, desktop | `/buscar` y `/profesionales/[id]` en desktop                    | el logo reemplaza a la flecha atrás — lleva a la landing. `/profesional/perfil` en desktop queda sin resolver (ver revisión de [C-011](#c-011)). | [C-011](#c-011) |
 | Buscador adaptado a mobile/desktop | cualquiera que busque desde cualquier pantalla                     | mobile: botón/resumen compacto que expande a vista completa. Desktop: inline compacto, siempre visible. Al tocar cada campo, un panel con las categorías completas o comunas frecuentes — sin búsquedas recientes, sin geolocalización. | [C-009](#c-009), [C-012](#c-012), [C-013](#c-013), [C-015](#c-015) |
 | Footer con navegación real, en la landing y fuera de ella | cualquier página de la app, landing incluida | footer que cubre los tres pilares: lado buscador (categorías), lado profesional (registro), contacto/legal | [C-001](#c-001), [C-004](#c-004), [C-006](#c-006) |
 | Sesión de profesional reconocida en el header | un profesional con sesión activa                              | "Mi perfil" en vez del CTA de registro | [C-008](#c-008) |

--- a/docs/missions/09-layout-general/producto.md
+++ b/docs/missions/09-layout-general/producto.md
@@ -2,7 +2,7 @@
 
 **Estado:** vigente — aprobado por Patricio el 2026-09-02
 
-**Última actualización:** 2026-09-02
+**Última actualización:** 2026-09-03
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
@@ -113,8 +113,8 @@ para no pelear con campos apretados en mobile ni ver un componente desaprovechan
 existen en la comuna buscada — no depende de volumen adicional.
 
 **Sustento:** [C-009](./investigacion.md#c-009), [C-012](./investigacion.md#c-012),
-[C-013](./investigacion.md#c-013), [C-015](./investigacion.md#c-015), [C-016](./investigacion.md#c-016) y
-[D-006](#d-006). **Éxito:** [M-001](#m-001).
+[C-013](./investigacion.md#c-013), [C-015](./investigacion.md#c-015), [C-016](./investigacion.md#c-016),
+[D-006](#d-006) y [D-008](#d-008). **Éxito:** [M-001](#m-001).
 
 **Reglas:**
 
@@ -128,6 +128,11 @@ existen en la comuna buscada — no depende de volumen adicional.
 - En desktop, el buscador se muestra inline, compacto, siempre visible en el header. Al hacer click en un
   campo, se abre un panel flotante debajo (no a pantalla completa) con el mismo contenido que en mobile —
   el resto de la página queda visible atrás.
+- En desktop, el buscador tiene dos densidades — ver [D-008](#d-008): **completa**, con el nombre del
+  campo ("Categoría"/"Comuna") sobre su valor, para el navbar de la landing tras hacer scroll ([F-001](#f-001));
+  y **chica**, solo el valor elegido, sin el nombre del campo encima, para el header general fijo
+  (`/buscar`, perfil, `/profesional/*`) — ahí el buscador está siempre a la vista, así que no necesita
+  ocupar el alto de la versión completa.
 - Al expandirse el campo de categoría (mobile o desktop), Datealo muestra las 8 categorías como filas
   tocables — no hace falta distinguir "sugeridas" de "todas", son pocas.
 - Al expandirse el campo de comuna, Datealo muestra un buscador de texto más una lista corta de comunas
@@ -443,6 +448,31 @@ usa cookies de tracking de terceros hoy; si eso cambia, se revisita.
   [F-001](#f-001). No hay trabajo de bottom nav en esta misión.
 - **Reapertura:** cuando aparezcan secciones reales (ej. favoritos, historial) que un bottom nav resolvería
   mejor que el header actual.
+
+<a id="d-008"></a>
+
+### D-008 — El buscador compacto de desktop tiene una variante chica sin el nombre del campo, para cuando vive fijo en el header general
+
+- **Estado:** aceptada. **Fecha:** 2026-09-03.
+- **Sustento:** [E-022](./investigacion.md#e-022), [E-023](./investigacion.md#e-023).
+- **Tensión:** una sola presentación del buscador de desktop es menos código y más simple de mantener, vs.
+  el header general (`/buscar`, perfil, `/profesional/*`) queda fijo en pantalla todo el tiempo — el
+  dueño de producto lo sintió pesado, con dos filas de texto por campo (nombre + valor) ocupando alto de
+  forma permanente, justo donde antes convivía con la barra de filtros vieja de `/buscar` que
+  [F-002](#f-002) ya decía que había que sacar y nunca se ejecutó.
+- **Alternativas descartadas:** achicar el buscador con scroll (el mismo componente cambia de tamaño según
+  la posición de scroll) — se descartó porque no hay evidencia de que Airbnb lo haga en ningún header que
+  no sea el hero de una landing sin sesión ([E-023](./investigacion.md#e-023)); una sola densidad chica en
+  todos lados, incluida la landing tras scroll — se descartó porque el navbar de la landing es una entrada
+  más prominente al producto (misión 08, [F-001](#f-001)) y no compite por espacio fijo todo el tiempo
+  como el header general.
+- **Decisión y consecuencia:** el mismo componente (`CompactSearchBar`) soporta dos densidades en desktop
+  — completa (nombre del campo sobre el valor) y chica (solo el valor) — elegidas por dónde vive, no por
+  scroll. El header general (`/buscar`, perfil, `/profesional/*`) usa la chica, fija, siempre visible. El
+  navbar de la landing tras hacer scroll (misión 08, todavía sin construir) usa la completa. Mobile no
+  tiene esta distinción — su resumen ya es de una sola línea.
+- **Reapertura:** si al construir la misión 08 el navbar de la landing tras scroll se siente igual de
+  apretado con la versión completa, evaluar la misma variante chica ahí también.
 
 ## Preguntas
 

--- a/docs/missions/09-layout-general/producto.md
+++ b/docs/missions/09-layout-general/producto.md
@@ -60,22 +60,31 @@ de navegación, no depende de volumen de perfiles ni de reseñas.
 
 **Sustento:** [C-001](./investigacion.md#c-001), [C-002](./investigacion.md#c-002),
 [C-005](./investigacion.md#c-005), [C-008](./investigacion.md#c-008), [C-011](./investigacion.md#c-011) y
-[D-001](#d-001), [D-002](#d-002), [D-005](#d-005). **Éxito:** [M-001](#m-001).
+[D-001](#d-001), [D-002](#d-002), [D-005](#d-005), [D-009](#d-009). **Éxito:** [M-001](#m-001).
 
 **Reglas:**
 
 - En la landing (`/`), Datealo muestra `LandingNavbar`: logo, un link a categorías (ancla a la sección),
   un link al lado profesional — "Publícate" si no hay sesión, "Mi perfil" si la hay — y el buscador grande
   vive en el hero, no en el nav.
-- En `/buscar`, Datealo reemplaza el logo por un botón de volver (vuelve a la landing) y muestra el
-  [buscador compacto](#f-002) en modo resumen — nunca ambos (logo y buscador completo) a la vez.
-- En `/profesionales/[id]` y `/profesional/*`, Datealo muestra solo el botón de volver — a `/buscar`
-  conservando los filtros elegidos, o a donde corresponda — sin logo, sin buscador.
-- **Layout en desktop:** tres zonas — botón de volver (con ícono y el texto "Volver") a la izquierda, el
-  buscador compacto centrado en medio (cuando la página lo tiene), y el acceso al lado profesional a la
-  derecha. El buscador se centra respecto al ancho completo del header, no pegado al botón de volver.
-- **Layout en mobile:** el botón de volver es solo el ícono, sin texto "Volver" — 390px no alcanza para
-  dos íconos, texto y el buscador a la vez. El buscador ocupa el espacio restante.
+- En `/buscar`, Datealo muestra el [buscador compacto](#f-002) en modo resumen — nunca junto al buscador
+  completo. En mobile, el logo se reemplaza por un botón de volver (vuelve a la landing); en desktop, el
+  logo se mantiene (lleva a la landing) — ver [C-011 revisada](./investigacion.md#c-011).
+- En `/profesionales/[id]`, en mobile Datealo muestra solo el botón de volver — a `/buscar` conservando
+  los filtros elegidos, o a donde corresponda — sin logo, sin buscador; en desktop muestra el logo (lleva
+  a la landing) en su lugar — ver [C-011 revisada](./investigacion.md#c-011).
+- En `/profesional/*`, Datealo muestra solo el botón de volver, en mobile y en desktop — a `/buscar`
+  conservando los filtros elegidos, o a donde corresponda — sin logo, sin buscador. La página de cuenta de
+  Airbnb (el caso real más parecido) tampoco usa "volver" ahí, pero su patrón — solo el isotipo más un
+  botón "Listo" que sale a home, no una acción de volver — no tiene un equivalente limpio en Datealo hoy;
+  se mantiene "volver" hasta que haya evidencia propia de qué lo reemplazaría.
+- **Layout en desktop:** tres zonas — logo o botón de volver, lo que corresponda a la página (con ícono y
+  el texto "Volver" cuando es volver) a la izquierda, el buscador compacto centrado en medio (cuando la
+  página lo tiene), y el acceso al lado profesional a la derecha. El buscador se centra respecto al ancho
+  completo del header, no pegado a la zona izquierda.
+- **Layout en mobile:** siempre el botón de volver (nunca el logo, en ninguna página fuera de la landing),
+  solo el ícono, sin texto "Volver" — 390px no alcanza para dos íconos, texto y el buscador a la vez. El
+  buscador ocupa el espacio restante.
 - Si hay una sesión de profesional activa, el acceso al lado profesional se muestra como el avatar del
   profesional (a la derecha), que lleva a `/profesional/perfil` — ver [D-005](#d-005). Usa el mismo campo
   y el mismo fallback a iniciales que ya definió la misión 08 (`avatarPath`) — nada nuevo, mismo patrón
@@ -89,10 +98,12 @@ de navegación, no depende de volumen de perfiles ni de reseñas.
   encontrado) — no solo en el estado con datos.
 
 **Ejemplo verificable:** dado que alguien abre `/profesionales/casa-del-gasfiter-nunoa` directo desde un
-link de WhatsApp, cuando la página carga, entonces ve solo el ícono de volver arriba a la izquierda — sin
-logo, sin buscador, sin nada a la derecha — que lo devuelve a `/buscar` con los filtros que hubiera
-elegido antes, o vacíos si no venía de ahí. Dado que quien abre ese mismo link es un profesional con
-sesión activa, ve además su avatar arriba a la derecha.
+link de WhatsApp **en su celular**, cuando la página carga, entonces ve solo el ícono de volver arriba a
+la izquierda — sin logo, sin buscador, sin nada a la derecha — que lo devuelve a `/buscar` con los filtros
+que hubiera elegido antes, o vacíos si no venía de ahí. Dado que quien abre ese mismo link es un
+profesional con sesión activa, ve además su avatar arriba a la derecha. Dado que alguien abre ese mismo
+link **en desktop**, ve el logo de Datealo en su lugar — clickeable, lleva a la landing — en vez del ícono
+de volver.
 
 **No incluye:** un menú de cuenta completo (nombre, cerrar sesión, configuración) — el avatar es un solo
 link directo a "Mi perfil", sin desplegable, para esta misión. Tampoco incluye el footer — ver
@@ -473,6 +484,32 @@ usa cookies de tracking de terceros hoy; si eso cambia, se revisita.
   tiene esta distinción — su resumen ya es de una sola línea.
 - **Reapertura:** si al construir la misión 08 el navbar de la landing tras scroll se siente igual de
   apretado con la versión completa, evaluar la misma variante chica ahí también.
+
+<a id="d-009"></a>
+
+### D-009 — En desktop, el logo reemplaza a "volver" en `/buscar` y `/profesionales/[id]`; `/profesional/*` mantiene "volver" en todo tamaño
+
+- **Estado:** aceptada. **Fecha:** 2026-09-03.
+- **Sustento:** [C-011 revisada](./investigacion.md#c-011), [E-022](./investigacion.md#e-022).
+- **Tensión:** la versión original de esta misión aplicó "flecha en vez de logo" por igual a mobile y
+  desktop, apoyada en capturas de la app **mobile** de Airbnb ([E-013](./investigacion.md#e-013)) — nunca
+  se verificó si el sitio **desktop** de Airbnb hace lo mismo. Cambiar el patrón en desktop toca una
+  decisión ya aprobada ([F-001](#f-001)), no un detalle suelto.
+- **Alternativas descartadas:** mantener "volver" en desktop por consistencia con mobile — se descarta
+  porque la restricción de espacio que justifica la flecha en mobile (volver + buscador + avatar
+  compitiendo en 390px) no existe en desktop, y el caso real de Airbnb desktop la contradice directamente:
+  ni en resultados ni en el detalle de una propiedad usa flecha, siempre logo ([E-022](./investigacion.md#e-022));
+  aplicar el mismo cambio a `/profesional/*` — se descarta porque esa página es más parecida a la cuenta
+  de Airbnb (edición de datos propios) que a contenido público, y la cuenta de Airbnb no usa ni logo
+  simple ni "volver" — usa un tercer patrón (isotipo + "Listo" que sale a home) sin equivalente limpio en
+  Datealo hoy; cambiarla ahora sería una decisión sin evidencia propia.
+- **Decisión y consecuencia:** en desktop, `/buscar` y `/profesionales/[id]` muestran el logo de Datealo
+  (clickeable, lleva a la landing) donde antes mostraban el botón de volver. `/profesional/*` (ingresar,
+  perfil, registro) mantiene "volver" en desktop y en mobile — sin cambios ahí. Mobile no cambia en
+  ninguna página — sigue siendo siempre "volver", nunca el logo, fuera de la landing.
+- **Reapertura:** si aparece evidencia propia (no de Airbnb) de qué patrón le sirve a
+  `/profesional/perfil` en desktop — hoy es la única superficie de la misión sin resolver con este mismo
+  nivel de confianza.
 
 ## Preguntas
 


### PR DESCRIPTION
Revisión de la misión 09, en discovery — no cierra ningún issue.

## Qué cambia

- **`investigacion.md`**: E-022/E-023, evidencia real de `airbnb.cl` desktop (resultados, detalle de
  propiedad, cuenta) navegado en vivo. C-011 revisada: su sustento original (E-013) eran capturas de la
  app mobile, no del sitio desktop — se aplicó a ambos sin evidencia propia de desktop. En desktop, el
  caso real dice lo contrario (logo siempre presente, nunca "volver").
- **`producto.md`**: D-008 nueva — el buscador compacto de desktop tiene una densidad chica (solo el
  valor, sin nombre de campo) para el header general fijo, y mantiene la completa para el navbar de la
  landing tras scroll (misión 08). F-002 actualizada con la regla.
- **`experiencia.md`**: UX-006 nueva, con el detalle de interacción de las dos densidades.

## Qué queda abierto (no se resuelve acá)

- Logo vs. "volver" en desktop para `/buscar` y `/profesionales/[id]` — la evidencia lo apoya bastante
  fuerte, pero no hay decisión en `producto.md` todavía (F-001 sigue diciendo "flecha, no logo" sin
  distinguir mobile de desktop).
- `/profesional/perfil` en desktop no tiene un mapeo limpio a ningún patrón de Airbnb — su página de
  cuenta usa un tercer patrón (isotipo + "Listo" que va a home, no "volver").

## Delivery

La implementación de D-008/UX-006 (sacar la barra de filtros vieja de `/buscar`, agregar la densidad
chica a `CompactSearchBar`, usarla en `AppHeader`) sigue en la PR #165, ya en curso.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016BuY9yCnEw9UUExMS5NVRy