### PR TITLE
feat(app): reescribir LandingNavbar — Categorías + Publícate/Mi perfil, buscador tras scroll

### DIFF
--- a/app/components/landing/LandingNavbar.vue
+++ b/app/components/landing/LandingNavbar.vue
@@ -22,6 +22,10 @@ const scrollToSection = (selector: string) => {
 const goToTop = () => {
   window.scrollTo({ top: 0, behavior: 'auto' })
 }
+
+const { professional } = await useProfessionalSession()
+const professionalLink = computed(() => professional.value ? '/profesional/perfil' : '/profesional/registro')
+const professionalLabel = computed(() => professional.value ? 'Mi perfil' : 'Publícate')
 </script>
 
 <template>
@@ -29,47 +33,36 @@ const goToTop = () => {
     class="fixed top-0 w-full z-50 transition-all duration-300"
     :class="scrolled ? 'bg-primary/95 backdrop-blur-xl shadow-lg shadow-primary-content/[0.05] border-b border-white/10 py-2' : 'bg-transparent py-4'"
   >
-    <div class="container mx-auto px-5 sm:px-8 flex items-center justify-between">
+    <div class="container mx-auto flex items-center justify-between gap-3 px-5 sm:gap-4 sm:px-8">
       <!-- Logo -->
       <UButton
         variant="link"
         color="neutral"
-        class="group flex items-baseline gap-0 p-0 text-3xl font-extrabold tracking-tight hover:bg-transparent"
+        class="group flex shrink-0 items-baseline gap-0 p-0 text-3xl font-extrabold tracking-tight hover:bg-transparent"
         @click="goToTop"
       >
         <span class="text-white">datea</span>
         <span class="text-secondary">lo</span>
       </UButton>
 
-      <div class="flex items-center gap-2 sm:gap-4">
-        <!-- Nav links -->
-        <UButton
-          variant="link"
-          color="neutral"
-          class="nav-link hidden sm:inline-flex items-center px-3.5 py-2 text-sm font-semibold text-white/80 hover:text-white active:text-white rounded-lg hover:bg-white/10 transition-all duration-200"
-          @click="scrollToSection('#categorias')"
-        >
-          Categorías
-        </UButton>
-        <UButton
-          variant="link"
-          color="neutral"
-          class="nav-link hidden sm:inline-flex items-center px-3.5 py-2 text-sm font-semibold text-white/80 hover:text-white active:text-white rounded-lg hover:bg-white/10 transition-all duration-200"
-          @click="scrollToSection('#profesionales')"
-        >
-          Para profesionales
-        </UButton>
+      <!-- Tras scroll, el buscador grande del hero ya no está a la vista — el compacto lo reemplaza acá. -->
+      <CompactSearchBar v-if="scrolled" class="min-w-0 flex-1 sm:flex-none" />
+      <UButton
+        v-else
+        variant="link"
+        color="neutral"
+        class="nav-link hidden items-center rounded-lg px-3.5 py-2 text-sm font-semibold text-white/80 transition-all duration-200 hover:bg-white/10 hover:text-white active:text-white sm:inline-flex"
+        @click="scrollToSection('#categorias')"
+      >
+        Categorías
+      </UButton>
 
-        <!-- CTA -->
-        <UButton
-          to="/buscar"
-          variant="link"
-          color="neutral"
-          class="inline-flex items-center h-10 px-5 rounded-xl text-sm font-bold text-primary hover:text-primary active:text-primary bg-white hover:bg-white shadow-md hover:shadow-lg hover:scale-105 transition-all duration-200 cursor-pointer"
-        >
-          Buscar
-        </UButton>
-      </div>
+      <NuxtLink
+        :to="professionalLink"
+        class="shrink-0 rounded-lg px-3.5 py-2 text-sm font-semibold text-white/80 transition-all duration-200 hover:bg-white/10 hover:text-white"
+      >
+        {{ professionalLabel }}
+      </NuxtLink>
     </div>
   </nav>
 </template>


### PR DESCRIPTION
Closes #155 (S-008 del plan de construcción de la misión 09).

## Sustento

F-001, D-005, UXF-003

## Qué construye

- Saca "Para profesionales" (anclaba a `#profesionales`) y el CTA suelto "Buscar" — ninguno está en F-001.
- **Antes de scroll:** logo, "Categorías" (ancla a `#categorias`), y a la derecha "Publícate" (sin sesión)
  → `/profesional/registro`, o "Mi perfil" (con sesión) → `/profesional/perfil`.
- **Tras scroll:** mismo nav (fondo sólido índigo, ya existente), pero reemplaza "Categorías" por
  `CompactSearchBar` inline — en su densidad **completa** (con nombre de campo sobre el valor; la densidad
  chica, sin nombre de campo, es solo para el header general fijo de `/buscar` y el perfil, D-008 de esta
  misma misión). El buscador grande del hero ya no está a la vista tras el scroll, así que el compacto lo
  reemplaza en el nav.
- "Publícate"/"Mi perfil" usa `useProfessionalSession()`, el mismo patrón ya probado en `AppHeader`.

## Criterio de aceptación

- [x] Antes de scroll: logo, "Categorías" (ancla), Publícate/Mi perfil — sin "Para profesionales", sin CTA
  "Buscar" suelto. Verificado en browser.
- [x] Tras scroll: mismo nav pero con `CompactSearchBar` en vez de la ancla "Categorías". Verificado en
  browser, mobile y desktop.
- [x] Con sesión activa, "Mi perfil" reemplaza a "Publícate" en ambos estados — verificado con sesión real.
- [x] Flujo completo probado: scroll → elegir categoría → elegir comuna → navega solo a `/buscar` con
  resultados reales, sin tocar nada más (auto-búsqueda ya decidida en esta misión).
- [x] `npx nuxi typecheck`, `npm test` (57/57) y `npm run build` sin errores.

No se pudo probar el estado sin sesión sin desloguear la sesión real de desarrollo — la lógica es la misma
que ya prueba `AppHeader` (`useProfessionalSession`), compartida y sin cambios acá.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016BuY9yCnEw9UUExMS5NVRy