### PR TITLE
fix(app): logo del header general al mismo tamaño que el de la landing

### DIFF
--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -51,7 +51,7 @@ const { professional } = await useProfessionalSession()
       <NuxtLink
         v-if="showLogoInDesktop"
         to="/"
-        class="w-fit justify-self-start font-heading text-lg font-extrabold text-primary"
+        class="w-fit justify-self-start font-heading text-3xl font-extrabold text-primary"
       >
         datea<span class="text-secondary">lo</span>
       </NuxtLink>


### PR DESCRIPTION
Fix chico, encontrado en QA de la misión 09 — sin issue propio en el plan de construcción.

## Qué pasaba

El logo en el header general (desktop, `/buscar` y el perfil público) se veía notablemente más chico que
el de la landing — `text-lg` (18px) vs `text-3xl` (30px). No fue una decisión: copié el tamaño de
`LegalHeader.vue` al implementar D-009 sin cruzarlo contra el de `LandingNavbar`.

## Evidencia

Medí el logo real de `airbnb.cl` con JavaScript (`getBoundingClientRect()`), no a ojo: **32px de alto**,
idéntico en el home, en resultados y en el detalle de una propiedad — Airbnb no lo achica en ninguna
página interna.

## Qué cambia

`AppHeader.vue`: el logo pasa de `text-lg` a `text-3xl`, igualando al de `LandingNavbar`.

No toqué `LegalHeader.vue` (mismo `text-lg` original) — ahí el logo va en línea junto al título de la
página ("datealo / Términos y Condiciones"), un contexto distinto al de un nav standalone; agrandarlo
podría desbalancear esa fila. Queda fuera de este fix a propósito.

## Verificación

Verificado en browser en `/buscar` con sesión activa — el logo ahora tiene el mismo peso visual que en la
landing, sin romper el balance con el buscador ni el avatar. `npx nuxi typecheck`, `npm test` (57/57) y
`npm run build` sin errores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016BuY9yCnEw9UUExMS5NVRy