### PR TITLE
docs(docs): cerrar misión 09, S-008 queda bloqueado por la misión 12

### DIFF
--- a/docs/missions/09-layout-general/README.md
+++ b/docs/missions/09-layout-general/README.md
@@ -2,18 +2,21 @@
 
 **Tipo:** producto. **Abierta el** 2026-08-31. **Nace de:** ninguna.
 
-**Estado de la misión:** en construcción
+**Estado de la misión:** cerrada 2026-09-04, con una excepción — ver abajo.
 
-**Última actualización:** 2026-09-02
+**Última actualización:** 2026-09-04
 
 **Documentos:** [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-**Próximo hito:** los 8 issues del plan de construcción ya están abiertos
-([#148](https://github.com/PatricioTabilo/datealo/issues/148) a
-[#155](https://github.com/PatricioTabilo/datealo/issues/155), ver tabla en
-[`ingenieria.md`](./ingenieria.md#plan-de-construcción)) — arrancar por S-001, S-003 y S-004 (sin
-dependencias entre sí), en la raíz del repo, un PR chico por issue. Sin fecha límite todavía.
+**Cierre:** 7 de los 8 slices del plan de construcción están mergeados (S-001 a S-007,
+[#148](https://github.com/PatricioTabilo/datealo/issues/148) a
+[#154](https://github.com/PatricioTabilo/datealo/issues/154)). Queda **S-008** (reescribir `LandingNavbar`,
+[#155](https://github.com/PatricioTabilo/datealo/issues/155)) explícitamente afuera: al implementarlo se
+encontraron bugs reales (el buscador se rompía en mobile) y una pregunta de fondo — si tiene sentido un
+buscador en el hero y otro en el nav a la vez — que depende de decisiones del hero, territorio de la
+misión 12. Como esa misión ya estaba planeada para el final (después de 09, 10 y 11 — ver su README),
+S-008 se retoma junto con ella en vez de bloquear el cierre de esta.
 
 `ingenieria.md` **vigente — aprobado por Patricio el 2026-09-02**: sin tablas nuevas (reutiliza
 `GET /api/professionals/me` y agrega una sola query de solo lectura, comunas frecuentes); layout de Nuxt

--- a/docs/missions/09-layout-general/experiencia.md
+++ b/docs/missions/09-layout-general/experiencia.md
@@ -28,7 +28,8 @@ descartadas y su porqué (ver D-001, D-005, D-006, D-007 de `producto.md`). Esta
 exploración — la traduce a secuencias verificables.
 
 - **Funcionalidades cubiertas:** F-001, F-002, F-003, F-004.
-- **Pendiente bloqueante:** ninguna.
+- **Pendiente bloqueante:** ninguna para cerrar esta misión — S-008 (`LandingNavbar` tras scroll) queda
+  fuera, bloqueado por la misión 12 (ver su README).
 
 Este documento pasó por una evaluación heurística en un agente sin memoria de su redacción (`ui-ux-pro-max`,
 `web-design-guidelines`, `frontend-design`, `ux-writing`, todos invocados de verdad). Encontró dos

--- a/docs/missions/09-layout-general/ingenieria.md
+++ b/docs/missions/09-layout-general/ingenieria.md
@@ -2,7 +2,7 @@
 
 **Estado:** vigente — aprobado por Patricio el 2026-09-02
 
-**Última actualización:** 2026-09-02
+**Última actualización:** 2026-09-04
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
@@ -169,6 +169,12 @@ hace falta tocar `server/db/sql/rls.sql` en esta misión.
 | S-006 | Construir `AppHeader`: botón de volver con destino por ruta, `CompactSearchBar` solo en `/buscar`, zona de avatar | TC-004, F-001, D-005, UX-003, UX-005 | Mobile: volver es solo ícono en toda superficie; desktop: volver lleva ícono+texto y el buscador queda centrado en un grid de 3 zonas; con sesión aparece el avatar a la derecha, sin sesión la zona derecha queda vacía fuera de la landing | S-003, S-005 | [#153](https://github.com/PatricioTabilo/datealo/issues/153) |
 | S-007 | Crear el layout `general.vue` y aplicarlo a `/buscar`, `/profesionales/[id]`, `/profesional/*` | F-001, F-003                       | Las cinco páginas muestran `AppHeader` + `AppFooter` envolviendo su contenido actual sin cambiar su lógica interna; `npx nuxi typecheck` y `npm run build` pasan | S-002, S-006 | [#154](https://github.com/PatricioTabilo/datealo/issues/154) |
 | S-008 | Reescribir `LandingNavbar`: "Categorías" + Publícate/Mi perfil (sin "Para profesionales" ni el CTA "Buscar" suelto), `CompactSearchBar` inline tras hacer scroll | F-001, D-005, UXF-003              | Antes de scroll: logo, Categorías (ancla), Publícate/Mi perfil; tras scroll: mismo nav pero con `CompactSearchBar` en vez de las anclas; con sesión activa, "Mi perfil" reemplaza a "Publícate" en ambos estados | S-003, S-005 | [#155](https://github.com/PatricioTabilo/datealo/issues/155) |
+
+**S-008 queda bloqueado, no cancelado:** se intentó en la PR #167 (cerrada sin mergear) — el buscador se
+rompía en mobile dentro de la fila del nav, y la transición al hacer scroll saltaba en vez de transicionar
+suave. De fondo, tener un buscador en el hero y otro en el nav es una pregunta que depende de decisiones
+del hero (misión 12, ya planeada para después de esta misión, la 10 y la 11). Se retoma junto con esa
+misión — ver el README de esta misión.
 
 ## Decisiones técnicas
 

--- a/docs/missions/README.md
+++ b/docs/missions/README.md
@@ -17,7 +17,7 @@ abrieron y de dónde salió cada una.
 | 06  | [búsqueda y resultados](./06-busqueda-resultados/) | producto | 2026-08-13 | cerrada 2026-08-31 | — | — |
 | 07  | [reseñas verificadas por contacto](./07-resenas-verificadas-por-contacto/) | producto | 2026-08-13 | cerrada 2026-08-31 | — | — |
 | 08  | [foto de perfil de profesional](./08-foto-perfil-profesional/) | producto | 2026-08-29 | cerrada 2026-09-02 | — | — |
-| 09  | [layout general (navbar, footer, TOS)](./09-layout-general/) | producto | 2026-08-31 | en construcción | — | — |
+| 09  | [layout general (navbar, footer, TOS)](./09-layout-general/) | producto | 2026-08-31 | cerrada 2026-09-04 (S-008 bloqueado, ver su README) | — | — |
 | 10  | [vista de resultados de búsqueda](./10-vista-resultados-busqueda/) | producto | 2026-09-01 | lista para construir | — | — |
 | 11  | [vista de detalle de perfil](./11-perfil-profesional/) | producto | 2026-09-01 | exploración | — | — |
 | 12  | [hero y copy de la landing](./12-hero-y-copy-landing/) | producto | 2026-09-01 | definición | Producto | — |


### PR DESCRIPTION
## Qué cambia

Cierra la misión 09 (layout general) en el registro — 7 de 8 slices mergeados. S-008 (`LandingNavbar` tras
scroll) queda documentado como bloqueado, no cancelado: se intentó en la PR #167 (cerrada sin mergear, ver
su comentario de cierre), y de fondo depende de decisiones del hero de la landing — territorio de la
misión 12, ya planeada por el dueño de producto para retomarse después de esta misión, la 10 y la 11.

- `docs/missions/README.md`: fila de la misión 09 pasa a `cerrada 2026-09-04`, con la excepción anotada.
- `docs/missions/09-layout-general/README.md`: estado actualizado, sección de cierre con el detalle.
- `ingenieria.md`: nota bajo la tabla del plan de construcción, sin borrar ni reescribir la fila de S-008.
- `experiencia.md`: "Pendiente bloqueante" actualizado para reflejar la excepción.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AJu3Kzw4SAau9xSJiyhVF4