### PR TITLE
feat(server): exponer foto, rating y cantidad de reseñas en /api/search

### DIFF
--- a/app/types/search.ts
+++ b/app/types/search.ts
@@ -6,6 +6,9 @@ export type SearchResultProfessional = {
   comunaNombre: string
   priceFrom: number | null
   avatarUrl: string | null
+  photoUrl: string | null
+  ratingAverage: number | null
+  reviewCount: number
   createdAt: string
 }
 

--- a/server/utils/professionals.ts
+++ b/server/utils/professionals.ts
@@ -102,7 +102,7 @@ export async function validateProfessionalFields(
 
 // Compartido entre Professional (esta forma) y PublicProfessionalProfile (misión 05) — las dos guardan
 // solo el path del bucket y calculan la URL pública recién al responder.
-function buildPhotoUrls(photoPaths: string[]): string[] {
+export function buildPhotoUrls(photoPaths: string[]): string[] {
   const { public: pub } = useRuntimeConfig()
   return photoPaths.map(path => `${pub.supabaseUrl}/storage/v1/object/public/professional-photos/${path}`)
 }

--- a/server/utils/reviews.test.ts
+++ b/server/utils/reviews.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { buildReviewNotificationEmail, computeRatingAverage, isValidComment, isValidRating, resolveReviewerName } from './reviews'
+import { buildReviewNotificationEmail, computeRatingAverage, groupRatingsByProfessional, isValidComment, isValidRating, resolveReviewerName } from './reviews'
 
 describe('isValidRating', () => {
   it('acepta enteros de 1 a 5', () => {
@@ -42,6 +42,25 @@ describe('computeRatingAverage', () => {
 
   it('devuelve el rating tal cual con una sola reseña', () => {
     expect(computeRatingAverage([3])).toBe(3)
+  })
+})
+
+describe('groupRatingsByProfessional', () => {
+  it('agrupa cada rating bajo su propio profesional, mezclados en la misma lista', () => {
+    const groups = groupRatingsByProfessional([
+      { professionalId: 'a', rating: 5 },
+      { professionalId: 'b', rating: 3 },
+      { professionalId: 'a', rating: 4 },
+      { professionalId: 'a', rating: 5 },
+      { professionalId: 'b', rating: 2 },
+    ])
+
+    expect(groups.get('a')).toEqual([5, 4, 5])
+    expect(groups.get('b')).toEqual([3, 2])
+  })
+
+  it('lista vacía devuelve un Map vacío', () => {
+    expect(groupRatingsByProfessional([]).size).toBe(0)
   })
 })
 

--- a/server/utils/reviews.ts
+++ b/server/utils/reviews.ts
@@ -1,4 +1,4 @@
-import { desc, eq, sql } from 'drizzle-orm'
+import { desc, eq, inArray, sql } from 'drizzle-orm'
 import { escapeHtml } from './professionals'
 import { isUuid } from './validation'
 import { reviews } from '../db/schema/reviews'
@@ -47,6 +47,41 @@ function normalizeReviewerName(name: string | undefined): string | null {
 export function computeRatingAverage(ratings: number[]): number {
   const sum = ratings.reduce((total, rating) => total + rating, 0)
   return Math.round((sum / ratings.length) * 10) / 10
+}
+
+export type RatingSummary = {
+  ratingAverage: number | null
+  reviewCount: number
+}
+
+export function groupRatingsByProfessional(
+  rows: { professionalId: string, rating: number }[],
+): Map<string, number[]> {
+  const groups = new Map<string, number[]>()
+  for (const row of rows) {
+    const group = groups.get(row.professionalId)
+    if (group) group.push(row.rating)
+    else groups.set(row.professionalId, [row.rating])
+  }
+  return groups
+}
+
+// Una sola consulta IN para todo el conjunto de resultados de una búsqueda, no una por profesional —
+// evita el N+1 de llamar findReviewsForProfessional por cada resultado. Un profesional sin reseñas
+// simplemente no tiene entrada en el Map devuelto — el llamador decide el null/0 para ese caso.
+export async function findRatingSummaries(professionalIds: string[]): Promise<Map<string, RatingSummary>> {
+  if (professionalIds.length === 0) return new Map()
+
+  const rows = await useDb()
+    .select({ professionalId: reviews.professionalId, rating: reviews.rating })
+    .from(reviews)
+    .where(inArray(reviews.professionalId, professionalIds))
+
+  const summaries = new Map<string, RatingSummary>()
+  for (const [professionalId, ratings] of groupRatingsByProfessional(rows)) {
+    summaries.set(professionalId, { ratingAverage: computeRatingAverage(ratings), reviewCount: ratings.length })
+  }
+  return summaries
 }
 
 function toPublicReview(row: {

--- a/server/utils/search.test.ts
+++ b/server/utils/search.test.ts
@@ -1,5 +1,25 @@
-import { describe, expect, it } from 'vitest'
-import { rankByCompleteness, type ProfessionalCompletenessInput } from './search'
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+import { rankByCompleteness, toSearchResult, type ProfessionalCompletenessInput, type ProfessionalSearchRow } from './search'
+
+// buildAvatarUrl/buildPhotoUrls llaman a useRuntimeConfig(), el auto-import de Nitro — no existe fuera de
+// una request real, así que se stubea con la misma forma que el runtime expone en server/utils/professionals.ts.
+beforeAll(() => {
+  vi.stubGlobal('useRuntimeConfig', () => ({ public: { supabaseUrl: 'https://proyecto.supabase.co' } }))
+})
+
+function row(overrides: Partial<ProfessionalSearchRow> = {}): ProfessionalSearchRow {
+  return {
+    id: 'a',
+    displayName: 'Marcela Fuentes',
+    comunaNombre: 'Ñuñoa',
+    priceFrom: null,
+    avatarPath: null,
+    createdAt: new Date('2026-01-01'),
+    photoPaths: [],
+    description: null,
+    ...overrides,
+  }
+}
 
 function input(overrides: Partial<ProfessionalCompletenessInput> = {}): ProfessionalCompletenessInput {
   return {
@@ -32,5 +52,26 @@ describe('rankByCompleteness', () => {
     const a = input({ id: 'a' })
 
     expect(rankByCompleteness([b, a]).map(r => r.id)).toEqual(['a', 'b'])
+  })
+})
+
+describe('toSearchResult', () => {
+  it('con foto y reseñas, expone la primera foto y el resumen de rating', () => {
+    const result = toSearchResult(
+      row({ photoPaths: ['a/trabajo-1.jpg', 'a/trabajo-2.jpg'] }),
+      { ratingAverage: 4.7, reviewCount: 2 },
+    )
+
+    expect(result.photoUrl).toBe('https://proyecto.supabase.co/storage/v1/object/public/professional-photos/a/trabajo-1.jpg')
+    expect(result.ratingAverage).toBe(4.7)
+    expect(result.reviewCount).toBe(2)
+  })
+
+  it('sin fotos ni reseñas, nunca 0 ni NaN en el rating', () => {
+    const result = toSearchResult(row({ photoPaths: [] }), undefined)
+
+    expect(result.photoUrl).toBeNull()
+    expect(result.ratingAverage).toBeNull()
+    expect(result.reviewCount).toBe(0)
   })
 })

--- a/server/utils/search.ts
+++ b/server/utils/search.ts
@@ -1,5 +1,7 @@
 import { and, eq, inArray } from 'drizzle-orm'
 import { findVecinasActivas } from './comunas'
+import { buildAvatarUrl, buildPhotoUrls } from './professionals'
+import { findRatingSummaries, type RatingSummary } from './reviews'
 import { comunas } from '../db/schema/comunas'
 import { professionals } from '../db/schema/professionals'
 
@@ -11,6 +13,9 @@ export type SearchResultProfessional = {
   comunaNombre: string
   priceFrom: number | null
   avatarUrl: string | null
+  photoUrl: string | null
+  ratingAverage: number | null
+  reviewCount: number
   createdAt: string
 }
 
@@ -30,7 +35,7 @@ export type ProfessionalCompletenessInput = {
   hasPrice: boolean
 }
 
-type ProfessionalSearchRow = {
+export type ProfessionalSearchRow = {
   id: string
   displayName: string
   comunaNombre: string
@@ -67,21 +72,25 @@ function toCompletenessInput(row: ProfessionalSearchRow): ProfessionalCompletene
   }
 }
 
-function toSearchResult(row: ProfessionalSearchRow): SearchResultProfessional {
+export function toSearchResult(row: ProfessionalSearchRow, rating: RatingSummary | undefined): SearchResultProfessional {
   return {
     id: row.id,
     displayName: row.displayName,
     comunaNombre: row.comunaNombre,
     priceFrom: row.priceFrom,
     avatarUrl: buildAvatarUrl(row.avatarPath),
+    photoUrl: buildPhotoUrls(row.photoPaths)[0] ?? null,
+    ratingAverage: rating?.ratingAverage ?? null,
+    reviewCount: rating?.reviewCount ?? 0,
     createdAt: row.createdAt.toISOString(),
   }
 }
 
-function orderResults(rows: ProfessionalSearchRow[]): SearchResultProfessional[] {
+async function orderResults(rows: ProfessionalSearchRow[]): Promise<SearchResultProfessional[]> {
   const ranked = rankByCompleteness(rows.map(toCompletenessInput))
   const rowById = new Map(rows.map(row => [row.id, row]))
-  return ranked.map(({ id }) => toSearchResult(rowById.get(id)!))
+  const ratings = await findRatingSummaries(rows.map(row => row.id))
+  return ranked.map(({ id }) => toSearchResult(rowById.get(id)!, ratings.get(id)))
 }
 
 async function findActiveProfessionals(
@@ -127,14 +136,14 @@ async function existsActiveProfessionalForCategoria(categoriaSlug: string): Prom
 export async function findSearchResults(categoriaSlug: string, comunaCodigo: string): Promise<SearchResult> {
   const exactRows = await findActiveProfessionals(categoriaSlug, [comunaCodigo])
   if (exactRows.length > 0) {
-    return { results: orderResults(exactRows), matchType: 'exacta', categoryHasResultsInChile: true }
+    return { results: await orderResults(exactRows), matchType: 'exacta', categoryHasResultsInChile: true }
   }
 
   const vecinas = await findVecinasActivas(comunaCodigo)
   if (vecinas.length > 0) {
     const vecinaRows = await findActiveProfessionals(categoriaSlug, vecinas.map(vecina => vecina.codigo))
     if (vecinaRows.length > 0) {
-      return { results: orderResults(vecinaRows), matchType: 'vecina', categoryHasResultsInChile: true }
+      return { results: await orderResults(vecinaRows), matchType: 'vecina', categoryHasResultsInChile: true }
     }
   }
 


### PR DESCRIPTION
Closes #170 (S-001 del plan de construcción de la misión 10).

## Sustento

TC-001, T-001

## Qué construye

- `reviews.ts`: `groupRatingsByProfessional` (pura, testeable sin base de datos) + `findRatingSummaries` —
  una sola consulta `IN` a `reviews` para todo el conjunto de resultados de una búsqueda, no una por
  profesional (evita el N+1).
- `professionals.ts`: `buildPhotoUrls` pasa a exportarse (ya existía, privada).
- `search.ts`: `SearchResultProfessional` gana `photoUrl` (primera foto de trabajo o `null`),
  `ratingAverage` (`null` solo si `reviewCount` es `0`) y `reviewCount`. Reusa `computeRatingAverage` —
  mismo camino que ya usa el perfil público, para que el promedio nunca diverja entre las dos vistas.
- `app/types/search.ts`: refleja los tres campos nuevos.

`SearchResultCard.vue` y el layout de `/buscar` no cambian — los campos nuevos quedan sin consumir hasta
S-002.

## Criterio de aceptación

- [x] Un profesional con foto y reseñas devuelve `photoUrl` (la primera) y `ratingAverage`/`reviewCount`
  correctos — test unitario en `search.test.ts`.
- [x] Uno sin ninguna de las dos devuelve `null`/`null`/`0` — mismo test, y verificado en vivo contra
  `/api/search` con un profesional real sin reseñas.
- [x] `ratingAverage` es `null` si y solo si `reviewCount` es `0`.
- [x] Una sola consulta a `reviews` por llamada, sin importar cuántos resultados devuelva.
- [x] `npx nuxi typecheck`, `npm test` (61/61, 4 nuevos) y `npm run build` sin errores.

## Nota de testing

`toSearchResult` llama a `buildPhotoUrls`/`buildAvatarUrl`, que usan `useRuntimeConfig()` (auto-import de
Nitro, no existe fuera de una request real) — el test lo stubea con `vi.stubGlobal`, primera vez que esta
suite testea algo que toca ese global.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AJu3Kzw4SAau9xSJiyhVF4