### PR TITLE
feat(app): skeleton de carga con la forma de la card nueva

### DIFF
--- a/app/pages/buscar/index.vue
+++ b/app/pages/buscar/index.vue
@@ -66,10 +66,14 @@ useSeoMeta({
     </div>
 
     <!-- cargando -->
-    <div v-else-if="pending" class="flex flex-col gap-3 p-4" aria-busy="true">
-      <div v-for="n in 4" :key="n" class="flex gap-3 rounded-2xl border border-datealo-surface bg-white p-3.5">
-        <div class="h-12 w-12 shrink-0 animate-pulse rounded-full bg-datealo-surface" />
-        <div class="flex-1 space-y-2">
+    <div
+      v-else-if="pending"
+      class="flex flex-col gap-3 p-4 lg:grid lg:grid-cols-3 lg:gap-4 lg:p-8"
+      aria-busy="true"
+    >
+      <div v-for="n in 4" :key="n" class="overflow-hidden rounded-2xl border border-datealo-surface bg-white">
+        <div class="aspect-4/3 w-full animate-pulse bg-datealo-surface" />
+        <div class="space-y-2 p-3.5">
           <div class="h-4 w-32 animate-pulse rounded bg-datealo-surface" />
           <div class="h-3 w-20 animate-pulse rounded bg-datealo-surface" />
           <div class="h-3 w-24 animate-pulse rounded bg-datealo-surface" />


### PR DESCRIPTION
Closes #177

Actualiza el skeleton de `/buscar` a la forma de la card nueva (S-002): bloque `aspect-4/3` arriba + 3 líneas de texto debajo, en vez de la fila horizontal (avatar circular + texto al lado) que quedó de la card vieja. Sin este cambio, la carga saltaba de un skeleton horizontal a una card vertical.

Verificado en browser inyectando temporalmente un delay en `/api/search` (revertido antes de commitear): el skeleton respeta la misma grilla y forma que `SearchResultCard.vue`, sin salto visual al resolver.

## Test plan
- [x] `npx nuxi typecheck` — cero errores
- [x] `npm run build` — compila
- [x] `npx vitest run` — 70/70 tests
- [x] Verificación visual en browser (mobile, forzando el estado `pending`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AJu3Kzw4SAau9xSJiyhVF4