### PR TITLE
docs(docs): cerrar misión 10, los 4 slices ya están mergeados en main

### DIFF
--- a/docs/missions/10-vista-resultados-busqueda/README.md
+++ b/docs/missions/10-vista-resultados-busqueda/README.md
@@ -3,19 +3,21 @@
 **Tipo:** producto. **Abierta el** 2026-09-01. **Nace de:** división de la misión 09 (ver su
 [README](../09-layout-general/README.md)).
 
-**Estado de la misión:** lista para construir
+**Estado de la misión:** cerrada 2026-09-04
 
 **En foco:** —
 
-**Última actualización:** 2026-09-02
+**Última actualización:** 2026-09-04
 
 **Documentos:** [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-**Próximo hito:** discovery cerrado — `producto.md`, `experiencia.md` e `ingenieria.md` vigentes, los tres
-aprobados por Patricio el 2026-09-02. Plan de construcción con 4 slices (S-001 a S-004) listo en
-`ingenieria.md`, sin issues abiertos todavía por pedido explícito — se crean cuando el dueño de producto lo
-pida.
+**Cierre:** los 4 slices del plan de construcción (S-001 a S-004) están mergeados en `main` — foto/rating
+en `/api/search` (#171), `SearchResultCard.vue` vertical foto-arriba (#173), ancho máximo `max-w-6xl` y
+grid `auto-fit` centrado (#175), skeleton con la misma forma que la card nueva (#178). S-003 tuvo una
+corrección en vivo del dueño de producto ya reflejada en `experiencia.md` (UX-003, revisión 2026-09-04,
+[PR #176](https://github.com/PatricioTabilo/datealo/pull/176)): centra el contenedor, no las cards dentro
+de su fila.
 
 ## Brief
 

--- a/docs/missions/README.md
+++ b/docs/missions/README.md
@@ -18,7 +18,7 @@ abrieron y de dónde salió cada una.
 | 07  | [reseñas verificadas por contacto](./07-resenas-verificadas-por-contacto/) | producto | 2026-08-13 | cerrada 2026-08-31 | — | — |
 | 08  | [foto de perfil de profesional](./08-foto-perfil-profesional/) | producto | 2026-08-29 | cerrada 2026-09-02 | — | — |
 | 09  | [layout general (navbar, footer, TOS)](./09-layout-general/) | producto | 2026-08-31 | en construcción | — | — |
-| 10  | [vista de resultados de búsqueda](./10-vista-resultados-busqueda/) | producto | 2026-09-01 | lista para construir | — | — |
+| 10  | [vista de resultados de búsqueda](./10-vista-resultados-busqueda/) | producto | 2026-09-01 | cerrada 2026-09-04 | — | — |
 | 11  | [vista de detalle de perfil](./11-perfil-profesional/) | producto | 2026-09-01 | exploración | — | — |
 | 12  | [hero y copy de la landing](./12-hero-y-copy-landing/) | producto | 2026-09-01 | definición | Producto | — |
 


### PR DESCRIPTION
Cierra formalmente la misión 10 (vista de resultados de búsqueda) — S-001 a S-004 ya están mergeados en `main`:

- #171 — foto/rating/reseñas en `/api/search`
- #173 — `SearchResultCard.vue` vertical foto-arriba
- #175 — ancho máximo `max-w-6xl` y grid `auto-fit` centrado
- #178 — skeleton con la misma forma que la card nueva

Solo cambios de docs: estado de la misión a `cerrada 2026-09-04` en su README y en el registro de misiones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AJu3Kzw4SAau9xSJiyhVF4