### PR TITLE
docs: discovery completo de la misión 11 (vista de detalle de perfil)

### DIFF
--- a/docs/missions/11-perfil-profesional/README.md
+++ b/docs/missions/11-perfil-profesional/README.md
@@ -3,7 +3,7 @@
 **Tipo:** producto. **Abierta el** 2026-09-01. **Nace de:** división de la misión 09 (ver su
 [README](../09-layout-general/README.md)).
 
-**Estado de la misión:** definición
+**Estado de la misión:** lista para construir
 
 **Última actualización:** 2026-09-04
 
@@ -17,7 +17,17 @@ quedan confirmadas tal cual (revisadas también contra `jobs-to-be-done` y `lean
 UX-005 quedan confirmadas — incluye el nombre junto al avatar del sidebar y el sidebar sticky en CSS Grid
 durante toda la lectura de reseñas (UX-005), agregados tras revisar el mockup con el dueño de producto.
 
-**Próximo hito:** trabajar `ingenieria.md` — contratos, modelo de datos y plan de construcción.
+`ingenieria.md` **vigente — aprobado por Patricio el 2026-09-04**: contratos (TC-001), sin cambios de
+datos ni RLS, y tres decisiones técnicas (T-001 CSS Grid, T-002 medir el CTA en vez de adivinar el buffer,
+T-003 corrige un bug preexistente de CL-003 que esta misión hizo visible), en 5 slices de construcción.
+Pasó por una auditoría en agente separado que encontró y corrigió dos hallazgos bloqueantes antes de
+llegar a este estado.
+
+**Discovery cerrado.** Próximo hito: los issues del plan de construcción (S-001 a S-005) ya están abiertos
+(ver tabla en [`ingenieria.md`](./ingenieria.md#plan-de-construcción)). La ejecución todavía no arranca:
+la misión 09 sigue `en construcción` (le queda el issue #155 abierto) y `CLAUDE.md` fija una sola misión en
+delivery a la vez — queda pendiente de que el dueño de producto decida si esperar a que la 09 cierre o
+hacer una excepción explícita.
 
 ## Brief
 

--- a/docs/missions/11-perfil-profesional/README.md
+++ b/docs/missions/11-perfil-profesional/README.md
@@ -3,15 +3,21 @@
 **Tipo:** producto. **Abierta el** 2026-09-01. **Nace de:** división de la misión 09 (ver su
 [README](../09-layout-general/README.md)).
 
-**Estado de la misión:** exploración
+**Estado de la misión:** definición
 
-**Última actualización:** 2026-09-01
+**Última actualización:** 2026-09-04
 
 **Documentos:** [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-**Próximo hito:** arrancar `investigacion.md` — sin fecha límite todavía, se agenda cuando se retome. El
-dueño de producto la ordenó después de la misión 10 (vista de resultados) y antes de la 12 (hero y copy).
+`producto.md` **vigente — aprobado por Patricio el 2026-09-03**: F-001 y las decisiones D-001 a D-003
+quedan confirmadas tal cual (revisadas también contra `jobs-to-be-done` y `lean-analytics`).
+
+`experiencia.md` **vigente — aprobado por Patricio el 2026-09-04**: UXF-001 y las decisiones UX-001 a
+UX-005 quedan confirmadas — incluye el nombre junto al avatar del sidebar y el sidebar sticky en CSS Grid
+durante toda la lectura de reseñas (UX-005), agregados tras revisar el mockup con el dueño de producto.
+
+**Próximo hito:** trabajar `ingenieria.md` — contratos, modelo de datos y plan de construcción.
 
 ## Brief
 
@@ -21,16 +27,19 @@ la vista en sí (galería de fotos, ficha de contacto, distribución en desktop)
 
 `app/pages/profesionales/[id].vue` ya tiene una distribución de dos columnas en desktop
 (`lg:flex`), pero — igual que la vista de resultados (misión 10) — nunca recibió una pasada de diseño
-dedicada.
+dedicada. Al auditar el código se confirmó además un bug concreto: el CTA fijo "Escribir por WhatsApp" se
+solapa visualmente con el footer general en mobile — el buffer que la misión 09 agregó para eso
+(`general.vue`, `pb-24`) no está pensado para el contenido de esta barra (ver
+[E-001](./investigacion.md#e-001)).
 
 ## Temas a explorar
-
-Notas sueltas, sin evidencia ni decisión todavía — punto de partida para `investigacion.md`, no su
-resultado.
 
 - **Galería de fotos (`ProfessionalPublicPhotos.vue`).** Cómo se ve en mobile (carrusel) y desktop
   (columna fija) — proporciones, cuántas fotos antes de necesitar scroll o expansión.
 - **Ficha de contacto.** Jerarquía de la información (nombre, categoría, comuna, precio orientativo,
-  reseñas) y del CTA de contacto (WhatsApp/teléfono) en ambos tamaños.
+  reseñas) y del CTA de contacto (WhatsApp/teléfono) en ambos tamaños. En investigación: sacar
+  identidad+ubicación de la tarjeta lateral (referencia de directorio de servicios) y mover las reseñas a
+  una sección propia, separada del contacto (referencia de Airbnb) — ver
+  [C-002](./investigacion.md#c-002) y [C-003](./investigacion.md#c-003).
 - **Estados de la vista** (cargando, tardando, no encontrado) — si necesitan la misma pasada de diseño que
   el estado con datos.

--- a/docs/missions/11-perfil-profesional/design-mockups/perfil-profesional.html
+++ b/docs/missions/11-perfil-profesional/design-mockups/perfil-profesional.html
@@ -412,9 +412,11 @@
               </h2>
               <!-- Grid de 2 columnas, no una sola card angosta flotando en un contenedor ancho — hallazgo
                    de la evaluación heurística: con las 12 reseñas del ejemplo de producto.md, una sola
-                   columna de 32rem dejaba la mitad del ancho en blanco. Cada card mantiene ~32rem (dentro
-                   del rango de 65-75ch recomendado para texto largo); el grid es lo que usa el ancho
-                   completo, no el ancho de cada card. -->
+                   columna de 32rem dejaba la mitad del ancho en blanco. Medido sobre el render real
+                   (segunda evaluación heurística, 2026-09-04): cada card ronda 21.5rem (~50 caracteres
+                   por línea con la tipografía real) dentro de este grid de 44rem, no 32rem — corregido
+                   en UX-002 de experiencia.md. El grid es lo que usa el ancho completo, no el ancho de
+                   cada card. -->
               <div style="display:grid;grid-template-columns:repeat(2, minmax(0, 1fr));gap:1rem;max-width:44rem;">
                 <div style="border:1px solid var(--ui-border);border-radius:0.75rem;padding:1rem;">
                   <div style="display:flex;align-items:center;gap:0.25rem;font-size:0.8125rem;margin-bottom:0.375rem;">

--- a/docs/missions/11-perfil-profesional/design-mockups/perfil-profesional.html
+++ b/docs/missions/11-perfil-profesional/design-mockups/perfil-profesional.html
@@ -1,0 +1,524 @@
+<!doctype html>
+<html lang="es-CL">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>V-001 Perfil de profesional — misión 11</title>
+
+    <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+    <link
+      href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&family=Plus+Jakarta+Sans:wght@600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../../design/datealo-mockup-kit.css" />
+    <style type="text/tailwindcss">
+      @theme {
+        --color-primary: var(--ui-primary);
+        --color-secondary: var(--ui-secondary);
+        --color-success: var(--ui-success);
+        --color-error: var(--ui-error);
+      }
+    </style>
+    <style>
+      /* Mismo max-w-5xl (1024px) que app/pages/profesionales/[id].vue usa hoy — esta misión reorganiza
+         el contenido, no el ancho de página (restricción aceptada en producto.md). */
+      .profile-container {
+        max-width: 64rem;
+        margin: 0 auto;
+        width: 100%;
+      }
+      .gallery-photo {
+        aspect-ratio: 4 / 3;
+        width: 100%;
+        object-fit: cover;
+        display: block;
+      }
+      .thumb-row {
+        display: flex;
+        gap: 0.5rem;
+        margin-top: 0.5rem;
+      }
+      .thumb {
+        width: 4rem;
+        height: 4rem;
+        border-radius: 0.5rem;
+        overflow: hidden;
+        object-fit: cover;
+        flex-shrink: 0;
+      }
+      .avatar-circle {
+        width: 5.5rem;
+        height: 5.5rem;
+        border-radius: 9999px;
+        background: color-mix(in oklab, var(--ui-primary) 12%, var(--ui-bg));
+        color: var(--ui-primary);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-family: var(--font-heading);
+        font-weight: 800;
+        font-size: 1.5rem;
+      }
+      .icon {
+        width: 1rem;
+        height: 1rem;
+        fill: none;
+        stroke: currentColor;
+        stroke-width: 2;
+        stroke-linecap: round;
+        stroke-linejoin: round;
+      }
+      .icon-star {
+        width: 0.875rem;
+        height: 0.875rem;
+        fill: #fbbf24;
+        stroke: none;
+      }
+      .sidebar-card {
+        border: 1px solid var(--ui-border);
+        border-radius: 1rem;
+        padding: 1.25rem;
+      }
+      .reviews-empty {
+        background: var(--ui-bg-muted);
+        border-radius: 1rem;
+        padding: 1rem;
+      }
+      .btn-primary {
+        flex: 1;
+        background: var(--ui-primary);
+        color: #fff;
+        border-radius: var(--ui-radius);
+        padding: 0.875rem 1rem;
+        font-weight: 700;
+        font-size: 0.875rem;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.5rem;
+      }
+      .btn-secondary {
+        border: 1.5px solid var(--ui-border-accented);
+        border-radius: var(--ui-radius);
+        padding: 0.875rem;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: var(--ui-text-toned);
+      }
+      .footer-mock {
+        background: var(--ui-bg-muted);
+        border-top: 1px solid var(--ui-border);
+        padding: 1.5rem 1.25rem;
+        font-size: 0.6875rem;
+        color: var(--ui-text-muted);
+        line-height: 1.6;
+      }
+      .footer-mock strong {
+        display: block;
+        font-family: var(--font-heading);
+        font-weight: 800;
+        font-size: 0.875rem;
+        color: var(--color-datealo-text);
+        margin-bottom: 0.375rem;
+      }
+      .skel {
+        background: var(--ui-bg-accented);
+        border-radius: 0.375rem;
+      }
+      /* Cada frame es una foto fija de una posición de scroll, no una página que se puede scrollear de
+         verdad — por eso el CTA es `position: absolute` dentro de `.scroll-window` (recortado con
+         `overflow: hidden`) en vez de `position: fixed`. El mecanismo real ya existe hoy en el código
+         (`[id].vue`, `fixed inset-x-0 bottom-0`) y sigue siendo `fixed`; acá solo hacía falta que el CTA
+         quedara pegado al borde inferior de CADA frame para mostrar dos momentos de scroll distintos
+         (recién abierto, y con el footer general a la vista) sin depender de JS de scroll. Evaluado en la
+         revisión heurística de esta misión: técnica correcta, solo necesitaba esta aclaración escrita. */
+      .scroll-window {
+        position: relative;
+        height: 100%;
+        overflow: hidden;
+      }
+      .cta-fixed {
+        position: absolute;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        border-top: 1px solid var(--ui-border);
+        background: var(--color-datealo-bg);
+        padding: 1rem;
+        display: flex;
+        gap: 0.5rem;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div class="frames">
+      <!-- ============================================================ MOBILE · CARGANDO ============ -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-001 · modo cargando
+          <small>skeleton actualizado: bloque de identidad+precio agrupado bajo la galería, ya no una
+            columna de líneas sueltas</small>
+        </div>
+        <div class="frame-viewport is-auto">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="skel" style="aspect-ratio:4/3;width:100%;border-radius:0;"></div>
+          <div style="padding:1.25rem;display:flex;flex-direction:column;gap:0.625rem;">
+            <div class="skel" style="height:1.25rem;width:60%;"></div>
+            <div class="skel" style="height:0.875rem;width:40%;"></div>
+            <div class="skel" style="height:1.125rem;width:35%;margin-top:0.375rem;"></div>
+            <div class="skel" style="height:3rem;width:100%;border-radius:0.75rem;margin-top:1rem;"></div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================================================ MOBILE · ENCONTRADO (arriba) === -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-001 · modo encontrado — recién abierto, sin scrollear
+          <small>foto, identidad y precio agrupados bajo la galería (D-001/D-002 producto.md); el CTA ya
+            es visible fijo abajo, sin haber scrolleado nada</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="scroll-window">
+            <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+            <img
+              class="gallery-photo"
+              alt="Tablero eléctrico instalado, foto de trabajo de Patricio Tabilo"
+              src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='300'%3E%3Crect width='400' height='300' fill='%23423ed0'/%3E%3Ctext x='200' y='150' font-family='sans-serif' font-size='22' fill='white' text-anchor='middle' dominant-baseline='middle'%3ETablero eléctrico%0Ainstalado%3C/text%3E%3C/svg%3E"
+            />
+            <div class="thumb-row" style="padding:0 1.25rem;">
+              <img class="thumb" style="outline:2px solid var(--ui-primary);outline-offset:2px;" alt="Ver foto 1: tablero eléctrico instalado" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='64' height='64'%3E%3Crect width='64' height='64' fill='%23423ed0'/%3E%3C/svg%3E" />
+              <img class="thumb" alt="Ver foto 2: cableado nuevo instalado" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='64' height='64'%3E%3Crect width='64' height='64' fill='%233ecbd7'/%3E%3C/svg%3E" />
+              <img class="thumb" alt="Ver foto 3: detalle del tablero terminado" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='64' height='64'%3E%3Crect width='64' height='64' fill='%231f2937'/%3E%3C/svg%3E" />
+            </div>
+            <div style="padding:1.25rem;">
+              <h1 style="font-family:var(--font-heading);font-weight:800;font-size:1.25rem;margin:0;color:var(--color-datealo-text);">
+                Patricio Tabilo
+              </h1>
+              <p style="margin:0.25rem 0 0;font-size:0.875rem;color:var(--ui-text-muted);">
+                Electricidad · Puerto Varas
+              </p>
+              <div style="margin-top:0.375rem;display:flex;align-items:center;gap:0.25rem;font-size:0.8125rem;">
+                <svg class="icon-star" aria-hidden="true" viewBox="0 0 24 24"><path d="M12 2l2.9 6.6 7.1.6-5.4 4.7 1.7 7-6.3-3.8-6.3 3.8 1.7-7L2 9.2l7.1-.6z" /></svg>
+                <span style="font-weight:700;">4,8</span>
+                <span style="color:var(--ui-text-muted);">· 12 reseñas</span>
+              </div>
+              <p style="margin-top:0.625rem;font-family:var(--font-heading);font-weight:800;font-size:1.0625rem;color:var(--color-datealo-text);">
+                Desde $15.000
+              </p>
+            </div>
+          </div>
+          <div class="cta-fixed">
+            <div class="btn-primary">
+              <svg class="icon" aria-hidden="true" style="stroke:#fff;" viewBox="0 0 24 24"><path d="M7.9 20A9 9 0 1 0 4 16.1L2 22Z" /></svg>
+              Escribir por WhatsApp
+            </div>
+            <div class="btn-secondary" aria-label="Llamar">
+              <svg class="icon" aria-hidden="true" viewBox="0 0 24 24"><path d="M13.832 16.568a1 1 0 0 0 1.213-.303l.355-.465A2 2 0 0 1 17 15h3a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2A18 18 0 0 1 2 4a2 2 0 0 1 2-2h3a2 2 0 0 1 2 2v3a2 2 0 0 1-.8 1.6l-.468.351a1 1 0 0 0-.288 1.223 14.1 14.1 0 0 0 6.288 6.394Z" /></svg>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================================================ MOBILE · DESCRIPCIÓN + RESEÑAS === -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-001 · modo encontrado — descripción y reseñas
+          <small>las reseñas ya no viven pegadas al CTA (D-002 producto.md): son su propia sección, después
+            de la descripción</small>
+        </div>
+        <div class="frame-viewport is-auto">
+          <div style="padding:1.25rem;">
+            <p style="font-size:0.875rem;line-height:1.6;color:var(--color-datealo-text);margin:0;">
+              Electricista con 10 años de experiencia. Trabajo en Puerto Varas y alrededores, atiendo
+              urgencias los fines de semana.
+            </p>
+            <div style="border-top:1px solid var(--ui-border);margin-top:1.5rem;padding-top:1.25rem;">
+              <h2 style="font-family:var(--font-heading);font-weight:800;font-size:1rem;margin:0 0 0.75rem;">
+                Reseñas
+              </h2>
+              <div style="border:1px solid var(--ui-border);border-radius:0.75rem;padding:0.875rem;">
+                <div style="display:flex;align-items:center;gap:0.25rem;font-size:0.8125rem;margin-bottom:0.375rem;">
+                  <svg class="icon-star" aria-hidden="true" viewBox="0 0 24 24"><path d="M12 2l2.9 6.6 7.1.6-5.4 4.7 1.7 7-6.3-3.8-6.3 3.8 1.7-7L2 9.2l7.1-.6z" /></svg>
+                  <svg class="icon-star" aria-hidden="true" viewBox="0 0 24 24"><path d="M12 2l2.9 6.6 7.1.6-5.4 4.7 1.7 7-6.3-3.8-6.3 3.8 1.7-7L2 9.2l7.1-.6z" /></svg>
+                  <svg class="icon-star" aria-hidden="true" viewBox="0 0 24 24"><path d="M12 2l2.9 6.6 7.1.6-5.4 4.7 1.7 7-6.3-3.8-6.3 3.8 1.7-7L2 9.2l7.1-.6z" /></svg>
+                  <svg class="icon-star" aria-hidden="true" viewBox="0 0 24 24"><path d="M12 2l2.9 6.6 7.1.6-5.4 4.7 1.7 7-6.3-3.8-6.3 3.8 1.7-7L2 9.2l7.1-.6z" /></svg>
+                  <svg class="icon-star" aria-hidden="true" viewBox="0 0 24 24"><path d="M12 2l2.9 6.6 7.1.6-5.4 4.7 1.7 7-6.3-3.8-6.3 3.8 1.7-7L2 9.2l7.1-.6z" /></svg>
+                  <span style="margin-left:0.375rem;color:var(--ui-text-muted);">Marcela F. · hace 2 semanas</span>
+                </div>
+                <p style="margin:0;font-size:0.8125rem;color:var(--color-datealo-text);">
+                  "Llegó puntual y dejó todo funcionando el mismo día. Muy recomendado."
+                </p>
+              </div>
+            </div>
+            <p style="margin-top:1.25rem;font-size:0.6875rem;color:var(--ui-text-muted);">
+              En Datealo desde agosto de 2026
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================================================ MOBILE · FONDO DE PÁGINA ======== -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-001 · modo encontrado — fondo de la página (footer general + CTA)
+          <small>D-003 producto.md: el CTA reserva su propio espacio y nunca tapa el footer general — acá
+            los dos conviven, separados</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="scroll-window" style="display:flex;flex-direction:column;justify-content:flex-end;">
+            <div class="footer-mock" style="padding-top:2rem;padding-bottom:6rem;">
+              <strong style="color:var(--ui-primary);">datealo</strong>
+              <p style="margin:0 0 0.75rem;">Encuentra al profesional que necesitas, cerca de ti.</p>
+              <p style="margin:0;">Buscar · Para profesionales · Términos · Privacidad</p>
+              <p style="margin:0.75rem 0 0;">hola@datealo.cl · Santiago, Chile</p>
+              <p style="margin:0.75rem 0 0;">© 2026 Datealo</p>
+            </div>
+          </div>
+          <div class="cta-fixed">
+            <div class="btn-primary">
+              <svg class="icon" aria-hidden="true" style="stroke:#fff;" viewBox="0 0 24 24"><path d="M7.9 20A9 9 0 1 0 4 16.1L2 22Z" /></svg>
+              Escribir por WhatsApp
+            </div>
+            <div class="btn-secondary" aria-label="Llamar">
+              <svg class="icon" aria-hidden="true" viewBox="0 0 24 24"><path d="M13.832 16.568a1 1 0 0 0 1.213-.303l.355-.465A2 2 0 0 1 17 15h3a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2A18 18 0 0 1 2 4a2 2 0 0 1 2-2h3a2 2 0 0 1 2 2v3a2 2 0 0 1-.8 1.6l-.468.351a1 1 0 0 0-.288 1.223 14.1 14.1 0 0 0 6.288 6.394Z" /></svg>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================================================ MOBILE · CASO LÍMITE ============ -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-001 · modo encontrado — sin fotos, sin precio, sin reseñas
+          <small>CL-001/CL-002/CL-003 de producto.md combinados en un solo perfil — el caso más frecuente
+            hoy, con la oferta recién arrancando</small>
+        </div>
+        <div class="frame-viewport is-auto">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div style="aspect-ratio:4/3;width:100%;display:flex;align-items:center;justify-content:center;background:var(--color-datealo-surface);">
+            <div class="avatar-circle" style="width:5.5rem;height:5.5rem;">HS</div>
+          </div>
+          <div style="padding:1.25rem;">
+            <h1 style="font-family:var(--font-heading);font-weight:800;font-size:1.25rem;margin:0;color:var(--color-datealo-text);">
+              Héctor Silva
+            </h1>
+            <p style="margin:0.25rem 0 0;font-size:0.875rem;color:var(--ui-text-muted);">
+              Gasfitería · Ñuñoa
+            </p>
+            <p style="margin-top:1rem;font-size:0.875rem;line-height:1.6;color:var(--color-datealo-text);">
+              Gasfitero matriculado, atiendo urgencias y trabajos de instalación en Ñuñoa y comunas
+              vecinas.
+            </p>
+            <div style="border-top:1px solid var(--ui-border);margin-top:1.5rem;padding-top:1.25rem;">
+              <h2 style="font-family:var(--font-heading);font-weight:800;font-size:1rem;margin:0 0 0.75rem;">
+                Reseñas
+              </h2>
+              <div class="reviews-empty">
+                <p style="margin:0 0 0.625rem;font-size:0.8125rem;font-weight:700;">
+                  Sé el primero en contarle a otros cómo te fue con Héctor Silva
+                </p>
+                <div style="background:var(--ui-primary);color:#fff;border-radius:var(--ui-radius);min-height:44px;display:flex;align-items:center;justify-content:center;text-align:center;font-size:0.8125rem;font-weight:700;">
+                  Dejar una reseña
+                </div>
+              </div>
+            </div>
+          </div>
+          <div style="padding:0 1.25rem 1.25rem;">
+            <div class="btn-primary" style="width:100%;">
+              <svg class="icon" aria-hidden="true" style="stroke:#fff;" viewBox="0 0 24 24"><path d="M7.9 20A9 9 0 1 0 4 16.1L2 22Z" /></svg>
+              Escribir por WhatsApp
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================================================ DESKTOP · ENCONTRADO ============ -->
+      <section class="frame frame-desktop">
+        <div class="frame-label">
+          V-001 · modo encontrado — desktop · ronda 3
+          <small>columna principal (galería + identidad + descripción) y sidebar acotada a rating breve +
+            contacto + "en Datealo desde" (UX-001), con el nombre junto al avatar (revisión 2026-09-04) —
+            reseñas en grid de 2 columnas debajo de ambas columnas (corregido tras la evaluación
+            heurística). Layout de `flex` a CSS Grid: el sidebar usa `grid-row: span 2` + `align-self:
+            start`, así el sticky sigue activo mientras se scrollea la descripción Y las reseñas, y se
+            despega solo al terminar el grid, sin buffer manual — mismo patrón que Airbnb ([UX-005](../experiencia.md#ux-005))</small>
+        </div>
+        <div class="frame-viewport is-auto">
+          <div class="profile-container" style="padding:2rem 2rem 3rem;">
+            <div style="display:grid;grid-template-columns:55fr 45fr;gap:2rem;">
+              <div>
+                <img
+                  class="gallery-photo"
+                  style="border-radius:1rem;"
+                  alt="Tablero eléctrico instalado, foto de trabajo de Patricio Tabilo"
+                  src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='300'%3E%3Crect width='400' height='300' fill='%23423ed0'/%3E%3Ctext x='200' y='150' font-family='sans-serif' font-size='22' fill='white' text-anchor='middle' dominant-baseline='middle'%3ETablero eléctrico%0Ainstalado%3C/text%3E%3C/svg%3E"
+                />
+                <div class="thumb-row">
+                  <img class="thumb" style="outline:2px solid var(--ui-primary);outline-offset:2px;width:5rem;height:5rem;" alt="Ver foto 1: tablero eléctrico instalado" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='64' height='64'%3E%3Crect width='64' height='64' fill='%23423ed0'/%3E%3C/svg%3E" />
+                  <img class="thumb" style="width:5rem;height:5rem;" alt="Ver foto 2: cableado nuevo instalado" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='64' height='64'%3E%3Crect width='64' height='64' fill='%233ecbd7'/%3E%3C/svg%3E" />
+                  <img class="thumb" style="width:5rem;height:5rem;" alt="Ver foto 3: detalle del tablero terminado" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='64' height='64'%3E%3Crect width='64' height='64' fill='%231f2937'/%3E%3C/svg%3E" />
+                </div>
+                <div style="margin-top:1.25rem;">
+                  <h1 style="font-family:var(--font-heading);font-weight:800;font-size:1.5rem;margin:0;color:var(--color-datealo-text);">
+                    Patricio Tabilo
+                  </h1>
+                  <p style="margin:0.25rem 0 0;font-size:0.9375rem;color:var(--ui-text-muted);">
+                    Electricidad · Puerto Varas
+                  </p>
+                  <p style="margin-top:0.5rem;font-family:var(--font-heading);font-weight:800;font-size:1.125rem;color:var(--color-datealo-text);">
+                    Desde $15.000
+                  </p>
+                  <p style="margin-top:0.875rem;font-size:0.875rem;line-height:1.6;color:var(--color-datealo-text);max-width:32rem;">
+                    Electricista con 10 años de experiencia. Trabajo en Puerto Varas y alrededores, atiendo
+                    urgencias los fines de semana.
+                  </p>
+                </div>
+              </div>
+              <div style="grid-row:span 2;align-self:start;position:sticky;top:2rem;">
+                <div class="sidebar-card">
+                  <div style="display:flex;align-items:center;gap:0.75rem;">
+                    <div class="avatar-circle" style="width:3.5rem;height:3.5rem;font-size:1rem;">PT</div>
+                    <div>
+                      <p style="margin:0;font-family:var(--font-heading);font-weight:800;font-size:0.9375rem;color:var(--color-datealo-text);">
+                        Patricio Tabilo
+                      </p>
+                      <div style="display:flex;align-items:center;gap:0.25rem;font-size:0.8125rem;margin-top:0.125rem;">
+                        <svg class="icon-star" aria-hidden="true" viewBox="0 0 24 24"><path d="M12 2l2.9 6.6 7.1.6-5.4 4.7 1.7 7-6.3-3.8-6.3 3.8 1.7-7L2 9.2l7.1-.6z" /></svg>
+                        <span style="font-weight:700;">4,8</span>
+                        <span style="color:var(--ui-text-muted);">· 12 reseñas</span>
+                      </div>
+                    </div>
+                  </div>
+                  <div style="display:flex;gap:0.5rem;margin-top:1.25rem;">
+                    <div class="btn-primary">
+                      <svg class="icon" aria-hidden="true" style="stroke:#fff;" viewBox="0 0 24 24"><path d="M7.9 20A9 9 0 1 0 4 16.1L2 22Z" /></svg>
+                      Escribir por WhatsApp
+                    </div>
+                    <div class="btn-secondary" aria-label="Llamar">
+                      <svg class="icon" aria-hidden="true" viewBox="0 0 24 24"><path d="M13.832 16.568a1 1 0 0 0 1.213-.303l.355-.465A2 2 0 0 1 17 15h3a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2A18 18 0 0 1 2 4a2 2 0 0 1 2-2h3a2 2 0 0 1 2 2v3a2 2 0 0 1-.8 1.6l-.468.351a1 1 0 0 0-.288 1.223 14.1 14.1 0 0 0 6.288 6.394Z" /></svg>
+                    </div>
+                  </div>
+                  <p style="margin-top:0.875rem;font-size:0.6875rem;color:var(--ui-text-muted);">
+                    En Datealo desde agosto de 2026
+                  </p>
+                </div>
+              </div>
+            <div style="grid-column:1 / -1;border-top:1px solid var(--ui-border);margin-top:2.5rem;padding-top:1.5rem;">
+              <h2 style="font-family:var(--font-heading);font-weight:800;font-size:1.125rem;margin:0 0 1rem;">
+                Reseñas
+              </h2>
+              <!-- Grid de 2 columnas, no una sola card angosta flotando en un contenedor ancho — hallazgo
+                   de la evaluación heurística: con las 12 reseñas del ejemplo de producto.md, una sola
+                   columna de 32rem dejaba la mitad del ancho en blanco. Cada card mantiene ~32rem (dentro
+                   del rango de 65-75ch recomendado para texto largo); el grid es lo que usa el ancho
+                   completo, no el ancho de cada card. -->
+              <div style="display:grid;grid-template-columns:repeat(2, minmax(0, 1fr));gap:1rem;max-width:44rem;">
+                <div style="border:1px solid var(--ui-border);border-radius:0.75rem;padding:1rem;">
+                  <div style="display:flex;align-items:center;gap:0.25rem;font-size:0.8125rem;margin-bottom:0.375rem;">
+                    <svg class="icon-star" aria-hidden="true" viewBox="0 0 24 24"><path d="M12 2l2.9 6.6 7.1.6-5.4 4.7 1.7 7-6.3-3.8-6.3 3.8 1.7-7L2 9.2l7.1-.6z" /></svg>
+                    <svg class="icon-star" aria-hidden="true" viewBox="0 0 24 24"><path d="M12 2l2.9 6.6 7.1.6-5.4 4.7 1.7 7-6.3-3.8-6.3 3.8 1.7-7L2 9.2l7.1-.6z" /></svg>
+                    <svg class="icon-star" aria-hidden="true" viewBox="0 0 24 24"><path d="M12 2l2.9 6.6 7.1.6-5.4 4.7 1.7 7-6.3-3.8-6.3 3.8 1.7-7L2 9.2l7.1-.6z" /></svg>
+                    <svg class="icon-star" aria-hidden="true" viewBox="0 0 24 24"><path d="M12 2l2.9 6.6 7.1.6-5.4 4.7 1.7 7-6.3-3.8-6.3 3.8 1.7-7L2 9.2l7.1-.6z" /></svg>
+                    <svg class="icon-star" aria-hidden="true" viewBox="0 0 24 24"><path d="M12 2l2.9 6.6 7.1.6-5.4 4.7 1.7 7-6.3-3.8-6.3 3.8 1.7-7L2 9.2l7.1-.6z" /></svg>
+                    <span style="margin-left:0.375rem;color:var(--ui-text-muted);">Marcela F. · hace 2 semanas</span>
+                  </div>
+                  <p style="margin:0;font-size:0.8125rem;color:var(--color-datealo-text);">
+                    "Llegó puntual y dejó todo funcionando el mismo día. Muy recomendado."
+                  </p>
+                </div>
+                <div style="border:1px solid var(--ui-border);border-radius:0.75rem;padding:1rem;">
+                  <div style="display:flex;align-items:center;gap:0.25rem;font-size:0.8125rem;margin-bottom:0.375rem;">
+                    <svg class="icon-star" aria-hidden="true" viewBox="0 0 24 24"><path d="M12 2l2.9 6.6 7.1.6-5.4 4.7 1.7 7-6.3-3.8-6.3 3.8 1.7-7L2 9.2l7.1-.6z" /></svg>
+                    <svg class="icon-star" aria-hidden="true" viewBox="0 0 24 24"><path d="M12 2l2.9 6.6 7.1.6-5.4 4.7 1.7 7-6.3-3.8-6.3 3.8 1.7-7L2 9.2l7.1-.6z" /></svg>
+                    <svg class="icon-star" aria-hidden="true" viewBox="0 0 24 24"><path d="M12 2l2.9 6.6 7.1.6-5.4 4.7 1.7 7-6.3-3.8-6.3 3.8 1.7-7L2 9.2l7.1-.6z" /></svg>
+                    <svg class="icon-star" aria-hidden="true" viewBox="0 0 24 24"><path d="M12 2l2.9 6.6 7.1.6-5.4 4.7 1.7 7-6.3-3.8-6.3 3.8 1.7-7L2 9.2l7.1-.6z" /></svg>
+                    <svg class="icon-star" aria-hidden="true" viewBox="0 0 24 24" style="fill:var(--ui-border-accented);"><path d="M12 2l2.9 6.6 7.1.6-5.4 4.7 1.7 7-6.3-3.8-6.3 3.8 1.7-7L2 9.2l7.1-.6z" /></svg>
+                    <span style="margin-left:0.375rem;color:var(--ui-text-muted);">Héctor S. · hace 1 mes</span>
+                  </div>
+                  <p style="margin:0;font-size:0.8125rem;color:var(--color-datealo-text);">
+                    "Buena atención, aunque llegó unos minutos tarde. Dejó todo ordenado."
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================================================ DESKTOP · CASO LÍMITE ========== -->
+      <section class="frame frame-desktop">
+        <div class="frame-label">
+          V-001 · modo encontrado — sin fotos, sin precio, sin reseñas · desktop · ronda 3
+          <small>verifica que el sidebar acotado (avatar + nombre + CTA + "en Datealo desde", sin la fila
+            de rating) no se vea desproporcionadamente vacío junto a la columna de 55% — hallazgo no
+            bloqueante de la evaluación heurística, nadie lo había visto en desktop; nombre agregado junto
+            al avatar (revisión 2026-09-04); mismo layout de grid que el frame anterior (`grid-row: span
+            2` en el sidebar) para que el sticky siga activo durante la sección de reseñas
+            ([UX-005](../experiencia.md#ux-005))</small>
+        </div>
+        <div class="frame-viewport is-auto">
+          <div class="profile-container" style="padding:2rem 2rem 3rem;">
+            <div style="display:grid;grid-template-columns:55fr 45fr;gap:2rem;">
+              <div>
+                <div style="aspect-ratio:4/3;width:100%;border-radius:1rem;display:flex;align-items:center;justify-content:center;background:var(--color-datealo-surface);">
+                  <div class="avatar-circle" style="width:5.5rem;height:5.5rem;">HS</div>
+                </div>
+                <div style="margin-top:1.25rem;">
+                  <h1 style="font-family:var(--font-heading);font-weight:800;font-size:1.5rem;margin:0;color:var(--color-datealo-text);">
+                    Héctor Silva
+                  </h1>
+                  <p style="margin:0.25rem 0 0;font-size:0.9375rem;color:var(--ui-text-muted);">
+                    Gasfitería · Ñuñoa
+                  </p>
+                  <p style="margin-top:0.875rem;font-size:0.875rem;line-height:1.6;color:var(--color-datealo-text);max-width:32rem;">
+                    Gasfitero matriculado, atiendo urgencias y trabajos de instalación en Ñuñoa y comunas
+                    vecinas.
+                  </p>
+                </div>
+              </div>
+              <div style="grid-row:span 2;align-self:start;position:sticky;top:2rem;">
+                <div class="sidebar-card">
+                  <div style="display:flex;align-items:center;gap:0.75rem;">
+                    <div class="avatar-circle" style="width:3.5rem;height:3.5rem;font-size:1rem;">HS</div>
+                    <p style="margin:0;font-family:var(--font-heading);font-weight:800;font-size:0.9375rem;color:var(--color-datealo-text);">
+                      Héctor Silva
+                    </p>
+                  </div>
+                  <div style="display:flex;gap:0.5rem;margin-top:1.25rem;">
+                    <div class="btn-primary">
+                      <svg class="icon" aria-hidden="true" style="stroke:#fff;" viewBox="0 0 24 24"><path d="M7.9 20A9 9 0 1 0 4 16.1L2 22Z" /></svg>
+                      Escribir por WhatsApp
+                    </div>
+                    <div class="btn-secondary" aria-label="Llamar">
+                      <svg class="icon" aria-hidden="true" viewBox="0 0 24 24"><path d="M13.832 16.568a1 1 0 0 0 1.213-.303l.355-.465A2 2 0 0 1 17 15h3a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2A18 18 0 0 1 2 4a2 2 0 0 1 2-2h3a2 2 0 0 1 2 2v3a2 2 0 0 1-.8 1.6l-.468.351a1 1 0 0 0-.288 1.223 14.1 14.1 0 0 0 6.288 6.394Z" /></svg>
+                    </div>
+                  </div>
+                  <p style="margin-top:0.875rem;font-size:0.6875rem;color:var(--ui-text-muted);">
+                    En Datealo desde agosto de 2026
+                  </p>
+                </div>
+              </div>
+            <div style="grid-column:1 / -1;border-top:1px solid var(--ui-border);margin-top:2.5rem;padding-top:1.5rem;">
+              <h2 style="font-family:var(--font-heading);font-weight:800;font-size:1.125rem;margin:0 0 1rem;">
+                Reseñas
+              </h2>
+              <div class="reviews-empty" style="max-width:22rem;">
+                <p style="margin:0 0 0.625rem;font-size:0.8125rem;font-weight:700;">
+                  Sé el primero en contarle a otros cómo te fue con Héctor Silva
+                </p>
+                <div style="background:var(--ui-primary);color:#fff;border-radius:var(--ui-radius);min-height:44px;display:flex;align-items:center;justify-content:center;text-align:center;font-size:0.8125rem;font-weight:700;">
+                  Dejar una reseña
+                </div>
+              </div>
+            </div>
+          </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  </body>
+</html>

--- a/docs/missions/11-perfil-profesional/experiencia.md
+++ b/docs/missions/11-perfil-profesional/experiencia.md
@@ -1,183 +1,340 @@
-# Misión: <nombre> — Experiencia
+# Misión 11: vista de detalle de perfil de profesional — Experiencia
 
-**Estado:** borrador
+**Estado:** vigente — aprobado por Patricio el 2026-09-04
 
-**Última actualización:** AAAA-MM-DD
+**Última actualización:** 2026-09-04
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-<!--
-Fuente de verdad para flujos, estados, contenido e interacción. No redefine reglas de producto: si el
-diseño descubre una regla nueva o invalida una, abre o actualiza una decisión en producto.md.
+## Decisión de experiencia: la identidad y el precio se pegan a la galería, el sidebar queda solo para contacto, y las reseñas pasan a ser su propia sección
 
-Núcleo obligatorio: vistas, mapa de estados, flujos críticos y estados por superficie. Las secciones bajo
-demanda (modelo mental, jerarquía de información, validación) se agregan solo cuando una decisión las
-necesita.
+V-001 (la misma vista de `/profesionales/[id]`, sin ruta nueva) reorganiza su contenido: en desktop, la
+columna principal (junto a la galería) pasa a llevar nombre, categoría, comuna, precio y descripción; el
+sidebar que hoy mezcla todo eso queda acotado a una identidad breve (avatar + nombre), rating, el bloque de
+contacto y "en Datealo desde" — sticky durante toda la columna, reseñas incluidas: el sidebar sigue a la
+vista mientras se lee la descripción y las reseñas, y se despega solo justo antes del footer, sin buffer
+manual (mismo patrón que Airbnb, [E-005](./investigacion.md#e-005)). En mobile, el orden de scroll cambia —
+identidad y precio se leen justo debajo de la foto, antes de la descripción — y las reseñas se mueven
+después de la descripción, dejando de competir con el bloque de contacto por la misma columna; el botón de
+contacto en sí no es un paso del scroll, es un overlay fijo al fondo de la pantalla, visible desde que se
+abre la vista. El CTA fijo de mobile deja de depender del buffer genérico que el layout `general.vue`
+reserva para el footer (`pb-24`, pensado para el buscador de la misión 09): esta vista reserva su propio
+espacio, así el footer y el botón de contacto nunca se solapan.
 
-Gate de salida — experiencia.md está lista para ingenieria.md cuando:
-- cada flujo crítico tiene secuencia, variantes, recuperación y criterio de término
-- cada estado tiene contenido concreto (texto real, información visible, acción disponible)
-- cada vista lista sus modos, y el mapa de estados cubre todas las transiciones entre ellos
-- cada modo tiene su indicador permanente de estado, y cada flujo tiene todas sus salidas documentadas
-- los casos límite de producto.md tienen flujo o estado mapeado
-- cada flujo crítico está mockeado en móvil (390px), y en desktop si también vive ahí
-- ninguna pantalla queda descrita como "similar a X" sin especificar qué cambia
--->
-
-## Decisión de experiencia: <qué cambia para quien usa el producto>
-
-<Modelo de interacción elegido, flujo más importante y la incertidumbre que sigue abierta.>
-
-- **Funcionalidades cubiertas:** F-001, <otras>.
-- **Pendiente bloqueante:** <pregunta o "ninguna">.
+- **Funcionalidades cubiertas:** F-001.
+- **Pendiente bloqueante:** ninguna. La evaluación heurística en agente separado dejó 3 hallazgos
+  bloqueantes (dónde vive "en Datealo desde", el layout de reseñas cuando hay varias, un token de color
+  que habría regresionado el contraste actual) — los tres se investigaron y resolvieron antes de este
+  estado (ver "Decisiones de experiencia"). Una revisión posterior del dueño de producto sobre el mockup
+  agregó el nombre junto al avatar del sidebar (UX-001) y el mecanismo de sticky durante las reseñas
+  (UX-005) — ver sus secciones para el sustento.
 
 ## Vistas
 
-<!--
-El listado de pantallas que define la experiencia — el mapa que se entrega antes de los flujos. Una línea
-por vista, sin tabla, con sus modos anidados debajo. Una vista es un destino: se llega a ella. Un modo es
-un estado de esa vista que cambia qué se puede hacer y qué se ve — se anida, nunca se lista como vista
-hermana.
-
-El porqué de cada vista, su trade-off o su justificación no van aquí: viven en su flujo (UXF) o en una
-decisión (UX-xxx). Regla de formato para todo el documento: las tablas se reservan para índices de celdas
-cortas; lo que lleva justificación extensa va en secciones con header + bullets, nunca en una celda.
--->
-
-- **V-001 — <vista>** · móvil / desktop · resuelve F-001 · flujos UXF-001 · pendiente
-  - modo **<nombre>** — <qué lo distingue y qué se puede hacer en él>
-  - modo **<nombre>** — <ídem>
+- **V-001 — Perfil de profesional** · móvil / desktop · resuelve [F-001](./producto.md#f-001) · flujo
+  UXF-001
+  - modo **cargando** — skeleton actualizado a la nueva forma (bloque de galería + bloque de
+    identidad+precio agrupado, en vez de líneas sueltas)
+  - modo **tardando** (>10s) — sin cambios respecto a la implementación actual (misión 05)
+  - modo **no encontrado** — sin cambios respecto a la implementación actual (misión 05)
+  - modo **encontrado** — el que rediseña esta misión: identidad+precio bajo la galería, sidebar acotado
+    a contacto (desktop), reseñas como sección propia, CTA que nunca se tapa
 
 ## Mapa de estados
 
-<!--
-Vistas y flujos son listas, y una lista no muestra un camino. Esta tabla conecta los modos: qué acción
-lleva de uno a otro y qué pasa con el trabajo del usuario en cada salto. Cada fila que falte es una
-pregunta que ingeniería resuelve inventando.
--->
+| Desde     | Acción                              | Queda en    | Qué pasa con el trabajo                              |
+| --------- | -------------------------------------- | ----------- | --------------------------------------------------------- |
+| cargando  | responde antes de 10s con datos        | encontrado  | —                                                           |
+| cargando  | pasan 10s sin respuesta                | tardando    | —                                                           |
+| cualquiera | la API responde 404                   | no encontrado | —                                                         |
+| tardando  | toca "Reintentar" y responde con datos | encontrado  | —                                                           |
+| tardando  | toca "Reintentar" y sigue sin responder | tardando   | —                                                           |
+| encontrado | desliza el carrusel o toca una miniatura | encontrado | la foto activa cambia; el resto de la pantalla no se mueve |
+| encontrado | toca "Dejar una reseña"               | encontrado (sheet abierto) | al publicar, la reseña nueva aparece arriba de la lista, sin recargar la página |
+| encontrado | toca "Escribir por WhatsApp" o el teléfono | sale de la app (WhatsApp/marcador) | al volver con el botón atrás del navegador, la página sigue en la misma posición de scroll |
 
-| Desde  | Acción             | Queda en | Qué pasa con el trabajo              |
-| ------ | ------------------ | -------- | ------------------------------------ |
-| <modo> | <acción concreta>  | <modo>   | <qué se aplicó, qué quedó pendiente> |
-| <modo> | <salir sin cerrar> | <modo>   | <qué se pierde o se conserva>        |
+## UXF-001 — Evaluar a un profesional y contactarlo
 
-## UXF-001 — <flujo principal en verbo>
+**Objetivo:** que alguien que llegó desde los resultados de búsqueda confirme en segundos si el
+profesional le sirve y lo contacte sin dudar. **Contrato:** [F-001](./producto.md#f-001).
 
-<!--
-Duplica por flujo crítico. Cada paso describe acción → respuesta al nivel de "el usuario toca X → Datealo
-muestra Y". Un mockup no reemplaza la secuencia porque no explica estados ni recuperación.
--->
+**Punto de entrada:** llega a `/profesionales/[id]` desde una card de `/buscar` (o un link directo) — sin
+haber leído nada más sobre el profesional que lo que la card ya mostraba (foto, nombre, comuna, rating,
+precio).
 
-**Objetivo:** <qué se completa o comprende>. **Contrato:** [F-001](./producto.md#f-001).
+**Criterio de término:** toca "Escribir por WhatsApp" o el botón de llamar — la vista no tiene otra acción
+que constituya "terminar bien" (no hay un formulario que enviar ni una compra que confirmar).
 
-**Punto de entrada:** <estado y superficie inicial, y qué acción trae al usuario hasta acá>.
+**Cómo sabe el usuario dónde está:** el header general (misión 09, sin cambios) más el título de la
+pestaña (`{nombre} · {categoría} en {comuna}`, ya implementado). Esta vista no tiene submodos navegables
+(rutas) que confundir — es una sola pantalla que crece con el scroll. El "sheet abierto" que aparece en el
+Mapa de estados es una capa transitoria sobre el modo encontrado (se abre y cierra sin navegar), no un modo
+ni una vista nueva.
 
-**Criterio de término:** <estado observable que confirma que el flujo terminó bien>.
+### Divergencia antes de converger
 
-**Cómo sabe el usuario dónde está:** <el elemento concreto y permanente en pantalla que se lo dice, por
-cada modo que toca este flujo>.
+Para reorganizar la información (JTBD: confiar rápido, sin depender de que alguien más lo valide — ver
+`producto.md`) se generaron tres enfoques, dentro de la restricción ya aceptada en `producto.md` de
+conservar el layout de dos columnas en desktop (no reemplazarlo):
+
+- **Enfoque A — identidad y precio bajo la galería, sidebar acotado a contacto.** En desktop, nombre,
+  categoría, comuna, precio y descripción viven en la columna de la galería (55%); el sidebar (45%,
+  sticky) lleva un resumen de rating, el bloque de contacto y "en Datealo desde". En mobile, el orden de
+  scroll es foto → identidad+precio → descripción → reseñas — el botón de contacto no es un paso de este
+  orden, es un overlay fijo al fondo de la pantalla, visible desde que se abre la vista. Las reseñas bajan
+  a una sección de ancho completo, fuera de ambas columnas.
+- **Enfoque B — cambio mínimo: mismo sidebar de hoy, solo sacar las reseñas.** El sidebar sigue
+  concentrando avatar, nombre, categoría, rating, descripción, precio y CTA; lo único que se mueve es el
+  bloque de reseñas, a una sección propia debajo. Es el cambio con menos superficie, pero dentro del
+  sidebar la identidad, el precio y el contacto siguen compitiendo por el mismo espacio angosto — el
+  "desorden" que motivó la misión ([C-001](./investigacion.md#c-001)) sobrevive ahí adentro.
+- **Enfoque C — overlay de identidad sobre la foto** (estilo tienda online: nombre y categoría
+  superpuestos en la esquina inferior de la galería, con un degradado para legibilidad). Libera aún más
+  espacio vertical que A, pero las fotos de trabajo de un profesional (herramientas, tableros, cañerías)
+  no tienen el control de composición de una foto de producto — un degradado fijo puede quedar ilegible
+  sobre una foto clara, y ninguna evidencia de `investigacion.md` pidió este patrón específico (ninguna de
+  las dos referencias del dueño de producto lo usa).
+
+**Elegido: A.** Resuelve las tres conclusiones de investigación a la vez
+([C-001](./investigacion.md#c-001), [C-002](./investigacion.md#c-002),
+[C-003](./investigacion.md#c-003)) y es lo que `producto.md` ya definió literalmente en las reglas de
+[F-001](./producto.md#f-001) ("nombre, categoría, comuna y precio... se agrupan junto a la galería... no
+dentro de la tarjeta de contacto"). B se descarta porque dejaría sin resolver el motivo original de la
+misión. C se descarta por riesgo de legibilidad sin control de contenido (fotos de trabajo variables, no
+fotos de producto curadas) y por no tener sustento en ninguna referencia aportada.
 
 ### Salidas
 
-<!--
-Todas las formas de irse, no solo terminar bien. El criterio de término cubre la salida buena; las otras
-son las que el usuario encuentra primero. Un modo del que no se sabe salir es un modo donde el usuario se
-pierde.
--->
-
-| Salida                | Cómo se ejecuta       | Qué queda del trabajo           |
-| --------------------- | --------------------- | ------------------------------- |
-| <termina bien>        | <acción>              | <qué se aplicó y dónde>         |
-| <descarta>            | <acción, Esc, cerrar> | <nada, ni a medias>             |
-| <abandona sin cerrar> | <navega a otra parte> | <se conserva, se pierde, avisa> |
+| Salida                                  | Cómo se ejecuta                          | Qué queda del trabajo                                          |
+| ---------------------------------------- | ------------------------------------------ | ------------------------------------------------------------------ |
+| Contacta por WhatsApp o teléfono (bien)  | Toca el CTA correspondiente                | Se registra el contacto (`sendBeacon`, ya implementado); la página sigue intacta si vuelve |
+| Deja o cierra la hoja de reseña          | Publica, o cierra sin publicar             | Si publicó, la reseña aparece arriba de la lista sin recargar; si cerró sin publicar, nada cambia |
+| Navega a otra parte (buscar, otro perfil) | Toca el header o un link                   | No hay nada que perder — es una vista de solo lectura              |
+| Cierra la pestaña o vuelve atrás         | Gesto del navegador                         | Nada que perder                                                    |
 
 ### Secuencia principal
 
-| Paso | Acción            | Respuesta del sistema         | Información visible |
-| ---- | ----------------- | ----------------------------- | ------------------- |
-| 1    | <acción concreta> | <feedback o cambio de estado> | <dato y jerarquía>  |
+| Paso | Acción                                                        | Respuesta del sistema                                                                                     | Información visible |
+| ---- | ------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| 1    | Llega a `/profesionales/[id]`                                  | Si tarda más de 300ms, ve el skeleton con la forma nueva (galería + bloque de identidad agrupado)                | Ninguna real todavía, solo la forma |
+| 2    | El servidor responde con los datos del profesional              | Ve la foto, y debajo (mobile) o al lado (desktop) el nombre, categoría, comuna y precio agrupados; el CTA ya visible | Foto, nombre, categoría, comuna, precio, botón de contacto |
+| 3    | Sigue bajando (mobile) o mira la columna completa (desktop)     | Ve la descripción que el profesional escribió                                                                    | Descripción |
+| 4    | Sigue bajando / mirando                                         | Ve la sección de reseñas, como bloque propio — con reseñas reales o la invitación a dejar la primera             | Reseñas o invitación a dejar la primera |
+| 5    | Decide contactar                                                 | Toca "Escribir por WhatsApp" (siempre visible, nunca tapado) — se abre WhatsApp con el mensaje pre-armado        | — |
 
 ### Variantes y recuperación
 
-| Condición          | Qué cambia              | Cómo se entiende    | Cómo se recupera             |
-| ------------------ | ----------------------- | ------------------- | ---------------------------- |
-| <sin resultados>   | <estado>                | <mensaje concreto>  | <acción disponible>          |
-| <sin permiso de ubicación> | <comportamiento> | <indicador visible> | <alternativa manual>         |
-| <conexión lenta>   | <skeleton, no spinner>  | <qué se ve mientras>| <qué pasa si falla>          |
+| Condición                                            | Qué cambia                                                                 | Cómo se entiende                                        | Cómo se recupera |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------ | ---------------------- |
+| Sin fotos ([CL-001](./producto.md#cl-001))               | El espacio de la galería muestra el avatar o las iniciales, mismo tamaño de bloque | El espacio ocupa lo mismo que una foto, no queda un hueco     | Ninguna — es el estado real del perfil |
+| Sin precio orientativo ([CL-002](./producto.md#cl-002))  | La línea de precio no aparece                                                    | El resto del bloque de identidad queda igual                 | Ninguna — es el estado real |
+| Sin reseñas ([CL-003](./producto.md#cl-003))             | La sección de reseñas muestra la invitación a dejar la primera                    | Mismo lugar donde irían reseñas reales, mismo ancho de bloque | Puede dejar la primera reseña ahí mismo |
+| Descripción muy larga o muy corta ([CL-004](./producto.md#cl-004)) | El bloque de identidad crece o se achica con el texto real            | Sin alto fijo — no corta ni deja espacio vacío                | — |
+| Conexión lenta (>300ms)                                  | Skeleton con la forma nueva                                                       | Igual al resto de Datealo                                    | Si pasa de 10s, modo tardando ("Reintentar") |
 
 ### Decisiones que no deben quedar implícitas
 
-- <qué ocurre al cancelar, volver atrás, reintentar o confirmar>.
-- <qué cambio se guarda inmediato y cuál necesita confirmación>.
+- El skeleton de carga tiene que reflejar el bloque agrupado (galería + identidad + precio) en vez de
+  líneas sueltas del layout viejo — si no, la carga "salta" de una forma a otra cuando llegan los datos.
+- El CTA de mobile reserva su propio espacio, independiente del `pb-24` que `general.vue` agrega al
+  footer general — ese buffer se pensó para el buscador de la misión 09, no para esta barra
+  ([D-003](./producto.md#d-003) de producto.md). El requisito de experiencia es el comportamiento (nunca
+  tapado, en cualquier tamaño de pantalla y cualquier largo de contenido de la barra); el mecanismo exacto
+  (un buffer propio más generoso, medir el alto real de la barra, u otro) es decisión de `ingenieria.md`.
+  Que el CTA tape momentáneamente contenido mientras se scrollea (la foto, la descripción, una reseña) es
+  esperado y no es el bug — cualquier barra fija hace eso. Lo que "nunca tapado" prohíbe es que, en reposo
+  (scroll agotado), el CTA quede sobre contenido real del footer en vez de sobre el colchón vacío que este
+  reserva para ese propósito.
+- En desktop, el sidebar sticky (galería + identidad + sidebar, ahora en `grid-row: span 2`) sigue activo
+  durante toda la lectura de la descripción y las reseñas, no solo durante la fila superior — ver
+  [UX-005](#ux-005) para el mecanismo exacto (CSS Grid, sin JS ni buffer manual).
+- La sección de reseñas de ancho completo en desktop usa el mismo ancho máximo que el resto de la página
+  (`max-w-5xl`, sin ensancharlo) — no es un cambio de layout de página, solo de dónde vive el bloque
+  dentro de ese ancho.
+- El resumen de rating en el sidebar de desktop (ícono `Star` + promedio + cantidad) reusa el mismo
+  formato que ya existe hoy — no se inventa una segunda forma de mostrar rating en la misma pantalla. El
+  nombre que va junto al avatar del sidebar (UX-001) es el mismo dato que ya aparece bajo la galería, no
+  un segundo nombre editable ni una fuente de verdad distinta — es una repetición visual, no un campo
+  nuevo.
+- El breakpoint sigue siendo `lg` (1024px), el mismo que ya usa `[id].vue` — esta misión no agrega un
+  breakpoint intermedio.
+- Ningún ícono nuevo es un emoji — se mantiene `@lucide/vue` (`MessageCircle`, `Phone`, `Star`), igual que
+  hoy.
+- Las miniaturas del carrusel llevan alt descriptivo del contenido y la acción ("Ver foto 2: cableado
+  nuevo instalado"), no un rótulo genérico de posición ("Miniatura 2") — son controles interactivos que
+  cambian la foto activa, no imágenes decorativas (hallazgo de la evaluación heurística contra
+  `web-design-guidelines`).
+- "En Datealo desde…" vive junto al bloque de contacto: dentro del `sidebar-card` en desktop (debajo del
+  CTA), y en mobile después de la sección de reseñas — no es un dato de identidad (no va junto a
+  nombre/categoría/precio), es contexto que acompaña la decisión de contactar (ver UX-003, agregada tras
+  la evaluación heurística: el primer borrador de este documento no decía dónde vivía, solo el mockup lo
+  mostraba).
+- El texto "En Datealo desde…" usa el mismo tono que hoy (`text-muted`, ~4.6:1 de contraste), no un tono
+  más claro — un token más claro (`text-dimmed`, ~2.6:1) regresionaría el contraste que el texto ya
+  cumple en producción (ver UX-004).
+- La técnica del mockup para simular el CTA fijo (`position: absolute` dentro de un frame recortado) es
+  solo para mostrar dos momentos de scroll en una imagen estática — el mecanismo real sigue siendo
+  `position: fixed` respecto al viewport, ya implementado hoy en `[id].vue`.
 
 ## Estados por superficie
 
-<!--
-El contenido es concreto: texto real, no "mensaje apropiado". El estado vacío de un marketplace
-pre-lanzamiento no es un detalle: para muchas búsquedas será el estado principal durante meses.
--->
-
-| Estado  | Qué se muestra (texto e información real) | Acción disponible                   |
-| ------- | ----------------------------------------- | ----------------------------------- |
-| inicial | <contenido>                               | <acción>                            |
-| vacío   | <por qué está vacío, con texto concreto>  | <cómo avanzar, o ninguna y por qué> |
-| carga   | <skeleton de qué forma>                   | <ninguna>                           |
-| error   | <causa útil y alcance>                    | <recuperación>                      |
+| Estado                                   | Qué se muestra (texto e información real)                                                                 | Acción disponible |
+| ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ---------------------- |
+| cargando                                       | Skeleton: bloque de foto (`aspect-4/3`) + bloque de identidad agrupado debajo, forma nueva                          | Ninguna |
+| encontrado, con foto/precio/reseñas            | "Patricio Tabilo" · "Electricidad · Puerto Varas" · ★ "4,8 · 12 reseñas" · "Desde $15.000" · descripción · 2 reseñas en grid (desktop) o lista (mobile) · "En Datealo desde agosto de 2026" · CTA | Contactar, ver fotos, dejar reseña |
+| encontrado, sin foto/precio/reseñas (CL-001 a CL-003) | "Héctor Silva" · avatar de iniciales · "Gasfitería · Ñuñoa" · sin línea de precio · "Sé el primero en contarle a otros cómo te fue con Héctor Silva" + botón "Dejar una reseña" · "En Datealo desde agosto de 2026" | Contactar, dejar la primera reseña |
+| tardando (>10s)                                | Sin cambios: "Esto está tardando más de lo normal" + "Reintentar"                                                  | Reintentar |
+| no encontrado                                  | Sin cambios: "No encontramos este perfil" + "Buscar profesionales"                                                 | Volver a buscar |
 
 ## Mockups
 
-<!--
-Los mockups viven en design-mockups/ como HTML (ver el skill discovery-ux y docs/design/README.md).
-Exploran o materializan una decisión; no son fuente de verdad de reglas de producto.
--->
-
-| Mockup   | Cubre   | Estado                 | Ruta                              |
-| -------- | ------- | ---------------------- | --------------------------------- |
-| <nombre> | UXF-001 | exploración o validado | `./design-mockups/<archivo>.html` |
+| Mockup                | Cubre    | Estado                                                                                 | Ruta |
+| ---------------------- | -------- | --------------------------------------------------------------------------------------- | ------ |
+| perfil-profesional     | UXF-001 (V-001) | validado — 7 frames (cargando, encontrado arriba, descripción+reseñas, fondo de página con footer+CTA, caso límite combinado mobile, desktop, caso límite combinado desktop), 2 rondas de evaluación heurística en agente separado (ronda 1: grid de 2 columnas para reseñas múltiples, contraste de "en Datealo desde", touch target del botón "Dejar una reseña", `aria-hidden` en íconos decorativos; ronda 2, con verificación empírica en Chrome real: ancho real de card de reseña corregido en UX-002, descripción del mecanismo de grid corregida en UX-005, alt descriptivo en miniaturas), 2 rondas de revisión directa del dueño de producto (nombre junto al avatar del sidebar, UX-001; sidebar sticky durante las reseñas vía CSS Grid, UX-005) | `./design-mockups/perfil-profesional.html` |
 
 ## Cobertura
 
-<!-- Detecta huecos antes de construir. Una funcionalidad sin pantalla nueva igual tiene estados. -->
-
-| Funcionalidad | Flujo   | Estados cubiertos       | Estado    |
-| ------------- | ------- | ----------------------- | --------- |
-| F-001         | UXF-001 | principal, vacío, error | pendiente |
-
-## Secciones bajo demanda
-
-<!--
-Agregar solo cuando una decisión las necesite, con estos títulos:
-
-- "Modelo mental y lenguaje": cuando un concepto de producto pueda confundirse en la interfaz.
-- "Jerarquía de información": cuando una superficie densa exija decidir qué se ve primero (una card de
-  resultado con foto, rating, distancia, precio y disponibilidad es exactamente ese caso).
-- "Validación (UXV-xxx)": cuando una incertidumbre de diseño necesite prueba con usuarios.
-- "Accesibilidad y adaptación": cuando el contexto de uso cambie el flujo o la representación.
--->
+| Funcionalidad | Flujo   | Estados cubiertos                                                                 | Estado    |
+| ------------- | ------- | ---------------------------------------------------------------------------------- | --------- |
+| F-001         | UXF-001 | con todo, sin fotos (CL-001), sin precio (CL-002), sin reseñas (CL-003), cargando, tardando (heredado), no encontrado (heredado) | vigente |
 
 ## Decisiones de experiencia
 
 <a id="ux-001"></a>
 
-### UX-001 — <decisión en una frase>
+### UX-001 — Identidad y precio se agrupan bajo la galería; el sidebar de desktop queda acotado a rating breve + contacto
 
-- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
-- **Sustento:** F-001 o <hallazgo>.
-- **Alternativas descartadas:** <opciones relevantes y trade-off, con el porqué del rechazo>.
-- **Decisión y consecuencia:** <qué flujo o superficie cambia>.
-- **Impacto en producto:** <ninguno o enlace a D-xxx/F-xxx actualizado>.
+- **Estado:** aceptada. **Fecha:** 2026-09-03.
+- **Sustento:** ver "Divergencia antes de converger" de UXF-001; [C-001](./investigacion.md#c-001),
+  [C-002](./investigacion.md#c-002) de investigación; reglas de [F-001](./producto.md#f-001).
+- **Alternativas descartadas:** cambio mínimo dejando todo en el sidebar salvo reseñas (no resuelve el
+  desorden que motivó la misión); overlay de identidad sobre la foto (riesgo de legibilidad sin control de
+  contenido de las fotos, sin sustento en las referencias) — detalle en "Divergencia antes de converger".
+- **Decisión y consecuencia:** en desktop, la columna de la galería lleva identidad+precio+descripción; el
+  sidebar sticky queda con rating breve + CTA. En mobile, el orden de scroll pasa a ser
+  foto → identidad+precio → descripción → reseñas; el CTA es un overlay fijo, no un paso de ese orden.
+- **Impacto en producto:** ninguno — es la aplicación literal de las reglas de F-001.
+
+**Revisión (2026-09-03):** la evaluación heurística en agente separado no logró tumbar esta decisión —
+intentó cuestionar el sidebar de 45% por verse desproporcionadamente corto junto a la columna de 55%, pero
+confirmó que es el mismo patrón que la propia referencia de Airbnb citada en
+[E-005](./investigacion.md#e-005) (columna larga + tarjeta lateral corta y sticky), así que sobrevive. Sí
+encontró que nadie había verificado ese sidebar en su versión más vacía (sin rating, [CL-003](./producto.md#cl-003))
+en desktop — se agregó un séptimo frame al mockup para confirmarlo, sin cambiar la decisión.
+
+**Revisión (2026-09-04):** el dueño de producto observó que el avatar del sidebar quedaba sin nombre al
+lado — solo rating y CTA. Se agrega "Patricio Tabilo" junto al avatar, arriba del rating (jerarquía
+avatar → nombre → rating, el mismo orden que usan las tarjetas de contacto en general). El motivo de fondo
+es propio de Datealo, no solo estético: como el sidebar es sticky (ver [UX-005](#ux-005)), es el único
+bloque que sigue en pantalla una vez que el scroll deja atrás el encabezado bajo la galería — sin el
+nombre ahí, en ese momento el usuario ve un círculo con iniciales sin poder confirmar a quién está por
+contactar. Se aplicó en ambos frames de desktop del mockup, incluida la versión sin rating
+([CL-003](./producto.md#cl-003)), donde el nombre queda directo sobre el CTA.
+
+<a id="ux-002"></a>
+
+### UX-002 — Las reseñas viven en una sección de ancho completo, fuera de ambas columnas
+
+- **Estado:** aceptada. **Fecha:** 2026-09-03.
+- **Sustento:** [C-003](./investigacion.md#c-003) de investigación; [D-002](./producto.md#d-002) de
+  producto.md.
+- **Alternativas descartadas:** dejar las reseñas dentro de la columna de identidad, debajo del CTA —
+  descartado porque en desktop esa columna mide 55% de ancho, angosto para reseñas con texto largo, y en
+  mobile no cambia nada respecto del problema original (siguen compitiendo por el mismo espacio que el
+  precio).
+- **Decisión y consecuencia:** la sección de reseñas ocupa el ancho completo de la página (mismo
+  `max-w-5xl`), debajo de la galería+identidad y del sidebar, en ambos tamaños de pantalla. En desktop, las
+  reseñas se muestran en un grid de 2 columnas (cada card ronda 21.5rem de ancho real, medido sobre el
+  mockup renderizado — no una sola card angosta flotando en el ancho completo). En mobile siguen apiladas
+  en una columna, como hoy.
+- **Impacto en producto:** ninguno.
+
+**Revisión (2026-09-03):** la evaluación heurística intentó tumbar esta decisión con el ejemplo verificable
+de `producto.md` (12 reseñas): el mockup original solo maqueaba una card de `max-width: 32rem` dentro de un
+contenedor de 1024px, dejando la mitad del ancho en blanco y sin decir qué pasa con la reseña 2 en
+adelante — la "sección de ancho completo" era retórica si el contenido real no la usaba. La decisión de
+"sección propia, fuera de ambas columnas" sobrevive (angostar el texto de cada reseña es correcto para
+legibilidad), pero se corrigió agregando el grid de 2 columnas, ya reflejado arriba y en el mockup.
+
+**Revisión (2026-09-04):** una evaluación heurística en agente separado midió el grid ya renderizado en
+Chrome (no el CSS a simple vista) y encontró que la cita anterior era falsa contra su propia
+implementación: el grid mide 704px reales sobre un contenedor de 1024px, y cada card **344px (21.5rem)**,
+no los "~32rem, dentro del rango de 65-75 caracteres" que decía la redacción original — con la tipografía
+real (`13px DM Sans`), eso rinde ~50 caracteres por línea. La decisión sobrevive: 50 caracteres sigue
+dentro de rangos tipográficos aceptados para texto corto como una reseña (Bringhurst cita 45-75 como rango
+utilizable, no solo 65-75 como ideal), así que no se cambió el layout — se corrigió la cifra citada arriba
+para que describa lo que el mockup realmente hace.
+
+<a id="ux-003"></a>
+
+### UX-003 — "En Datealo desde…" vive junto al bloque de contacto, no junto a la identidad
+
+- **Estado:** aceptada. **Fecha:** 2026-09-03.
+- **Sustento:** hallazgo de la evaluación heurística en agente separado — el primer borrador de este
+  documento no decía dónde vivía este dato; solo el mockup lo mostraba (dentro del sidebar en desktop, al
+  final en mobile), invisible para quien leyera la prosa.
+- **Alternativas descartadas:** agruparlo con nombre/categoría/precio bajo la galería — descartado porque
+  no es un dato de identidad del profesional, es contexto de confianza que acompaña la decisión de
+  contactar (cuánto tiempo lleva en la plataforma), más cercano al bloque de contacto que al de identidad.
+- **Decisión y consecuencia:** el dato vive dentro del `sidebar-card` en desktop (debajo del CTA) y después
+  de la sección de reseñas en mobile — mismo lugar que ya lo tenía el mockup, ahora explícito en el
+  documento.
+- **Impacto en producto:** ninguno.
+
+<a id="ux-004"></a>
+
+### UX-004 — El texto "En Datealo desde…" no cambia de tono respecto de hoy
+
+- **Estado:** aceptada. **Fecha:** 2026-09-03.
+- **Sustento:** hallazgo de la evaluación heurística — el mockup usaba `--ui-text-dimmed` (~2,6:1 de
+  contraste) donde la producción actual usa `text-datealo-muted`/`#6b7280` (~4,6:1, sobre el mínimo AA de
+  4.5:1 para texto normal).
+- **Alternativas descartadas:** ninguna real — no había una razón de diseño para aclarar este texto, fue un
+  token elegido sin verificar contra el actual.
+- **Decisión y consecuencia:** el texto mantiene el mismo tono que hoy (`text-muted` semántico, equivalente
+  a `text-datealo-muted`); ingeniería no debe copiar `--ui-text-dimmed` del mockup para este dato.
+- **Impacto en producto:** ninguno.
+
+<a id="ux-005"></a>
+
+### UX-005 — El sidebar de desktop sigue sticky durante toda la columna de contenido, reseñas incluidas
+
+- **Estado:** aceptada. **Fecha:** 2026-09-04.
+- **Sustento:** [C-004](./investigacion.md#c-004) e ideal de `investigacion.md` ("una tarjeta de contacto
+  que se queda fija en pantalla mientras se hace scroll por la descripción **y las reseñas**"), sustentado
+  en [E-005](./investigacion.md#e-005) (Airbnb: el sidebar de reserva sigue visible durante toda la
+  descripción y las reseñas, se despega solo antes del footer).
+- **Alternativas descartadas:** dejar el sidebar sticky solo mientras dura la fila superior (galería +
+  identidad + descripción), como quedó en la primera versión del mockup — se descarta porque, al ser las
+  reseñas una sección de ancho completo fuera de esa fila ([UX-002](#ux-002)), el sidebar se despega apenas
+  termina la descripción y el CTA queda fuera de vista durante toda la lectura de reseñas, contradiciendo
+  el ideal ("CTA accesible en cualquier momento del scroll, en cualquier tamaño de pantalla"). Una barra
+  de contacto delgada que reaparece al perder de vista el sidebar — se descarta por agregar un elemento de
+  interfaz nuevo que la vista no tiene hoy, para resolver algo que CSS puro ya resuelve sin él.
+- **Decisión y consecuencia:** el contenedor de dos columnas pasa de `flex` a **CSS Grid**
+  (`grid-template-columns: 55fr 45fr`). El sidebar ocupa `grid-row: span 2` + `align-self: start` (el
+  `align-self` es necesario: un ítem de grid se estira por default a la altura de su fila, y un `sticky`
+  estirado no tiene margen para "pegarse" a nada). La sección de reseñas, con `grid-column: 1 / -1`, cae en
+  una fila nueva del mismo grid por auto-placement — no la fila 2 (esa columna ya está ocupada por el
+  sidebar, que abarca las filas 1 y 2), sino la fila 3 implícita que el navegador crea solo — sin perder lo
+  que ya definió [UX-002](#ux-002). Con esto, el sidebar sigue sticky mientras se lee la descripción y las
+  reseñas, y se despega solo, de forma automática, al terminar el grid — sin buffer manual ni JS, porque el
+  footer general vive fuera de ese contenedor. Es distinto al mecanismo de mobile ([D-003](./producto.md#d-003)),
+  que sí necesita reservar espacio a mano porque ahí el CTA es `fixed` al viewport, no `sticky` a un
+  contenedor.
+- **Advertencia para ingeniería:** no fijar `grid-template-rows` explícito pensando que "faltan filas" —
+  el auto-placement ya resuelve esto solo, y forzar un valor explícito puede romper el sticky. Comportamiento
+  verificado con scroll real en Chrome (no solo lectura del CSS): el sidebar permanece `sticky` durante toda
+  la lectura de reseñas y se despega recién cerca del footer, tal como promete esta decisión.
+- **Impacto en producto:** ninguno — es la aplicación literal de la capacidad "CTA de contacto siempre
+  accesible y nunca tapado" que `investigacion.md` ya listaba para "cualquier tamaño de pantalla".
 
 ## Preguntas
 
-<!--
-Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
-Estado: abierta | resuelta AAAA-MM-DD | disuelta AAAA-MM-DD. Solo las abiertas llevan bloque de detalle.
--->
+Ninguna bloquea UXF-001 tal como queda definido acá — el mecanismo exacto del CTA fijo (ver "Decisiones
+que no deben quedar implícitas") es una decisión de ingeniería, no una duda de experiencia.
 
-<Una frase que responde "¿qué falta?": la pregunta que bloquea construcción y qué bloquea.>
-
-| ID      | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
-| ------- | ---------------------- | ------------------- | --------------------------------------------------------------- |
-| UXQ-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
-| UXQ-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |
+| ID | La duda | Estado | Respuesta, o quién la resuelve |
+| -- | ------- | ------ | ------------------------------- |
+| —  | —       | —      | sin preguntas abiertas propias de experiencia |

--- a/docs/missions/11-perfil-profesional/ingenieria.md
+++ b/docs/missions/11-perfil-profesional/ingenieria.md
@@ -1,162 +1,254 @@
-# Misión: <nombre> — Ingeniería
+# Misión 11: vista de detalle de perfil de profesional — Ingeniería
 
-**Estado:** borrador
+**Estado:** vigente — aprobado por Patricio el 2026-09-04
 
-**Última actualización:** AAAA-MM-DD
+**Última actualización:** 2026-09-04
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-<!--
-Fuente de verdad para arquitectura, datos, contratos, factibilidad y pruebas. Consume el comportamiento
-definido en producto. Una limitación técnica cambia el alcance solo mediante una decisión explícita en
-producto.md.
+## Decisión técnica: reorganizar presentación en `app/`, sin tocar datos ni endpoints
 
-Núcleo obligatorio: contratos, modelo de datos, RLS y riesgos de factibilidad. Las secciones bajo demanda
-(migración, rendimiento, entrega por etapas) se agregan solo cuando el riesgo lo justifica.
+F-001 reordena información que `GET /api/professionals/[id]` ya devuelve completa hoy
+(`PublicProfessionalProfile`: nombre, categoría, comuna, precio, descripción, fotos, avatar, reseñas,
+rating, fecha de alta) — auditado línea por línea contra `experiencia.md` y no falta ningún campo. Esta
+misión no toca `server/`, `server/db/schema/` ni `server/db/sql/rls.sql`: es una reorganización de layout
+en `app/pages/profesionales/[id].vue` y sus componentes hijos.
 
-Gate de salida — ingenieria.md está lista para construir cuando:
-- los contratos definen qué entra, qué sale y qué invariantes se mantienen, sin ambigüedad
-- el modelo de datos soporta los casos límite de producto.md sin workarounds
-- el impacto en RLS está resuelto: qué policy se crea o cambia, o por qué ninguna
-- la migración de datos existentes tiene estrategia o está explícitamente fuera del alcance
-- los escenarios verificables de producto están mapeados a pruebas
-- el plan de construcción corta el diseño en slices atómicos ordenados (un slice = un Issue = un PR)
--->
+El riesgo real no está en los datos — está en que el requisito "el CTA nunca tapa nada, en cualquier
+tamaño de pantalla y cualquier largo de contenido" ([D-003](./producto.md#d-003)) hoy se resuelve con
+números adivinados (`pb-28` en el contenido, `pb-24` en `AppFooter`), justo el patrón que
+[C-004](./investigacion.md#c-004) de `investigacion.md` señala como fràgil. Esta entrega lo reemplaza por
+un mecanismo que mide el alto real de la barra en vez de asumirlo.
 
-## Decisión técnica: <arquitectura y riesgo principal>
+- **Contratos de producto cubiertos:** F-001.
+- **Riesgo bloqueante:** ninguno — el mecanismo de medición (T-002) usa una API nativa del navegador
+  (`ResizeObserver`), sin librería nueva, y es acotable a un spike de una tarde si algo no calza (ver
+  TR-001).
+- **Vocabulario:** sin términos nuevos. Esta misión no introduce ninguna entidad ni concepto de dominio —
+  es reordenamiento de presentación sobre campos que `professionals` y `reviews` ya tienen nombrados
+  (`domain-driven-design` clasifica subdominios de modelo de negocio, no páginas; la nota es solo para
+  decir que no hay lenguaje ubicuo nuevo que acordar, no una clasificación formal de subdominio).
 
-<Dirección técnica, trade-off principal y el riesgo que todavía podría invalidarla.>
+## Arquitectura: el layout se reorganiza en la capa de presentación, el resto no se entera
 
-- **Contratos de producto cubiertos:** F-001, <otros>.
-- **Riesgo bloqueante:** <incertidumbre o "ninguna">.
+`[id].vue` sigue siendo el único que decide **dónde** vive cada bloque en pantalla; `ProfessionalPublicPhotos`,
+`ProfessionalPublicReviews` y `ProfessionalPublicContactBar` no cambian su comportamiento interno — solo
+cambia qué clases y en qué orden `[id].vue` los monta. El único código nuevo es un composable pequeño que
+mide el alto real de la barra de contacto y lo expone como variable CSS, consumida por `AppFooter` (que
+hoy tiene un valor fijo) y ya no por el propio `[id].vue` (que hoy tiene un buffer redundante que esta
+reorganización elimina — ver T-002).
 
-## Arquitectura: <cómo se divide la responsabilidad>
-
-<!--
-La lógica de negocio se separa de la infraestructura: funciones puras en utils/ y server/utils/,
-reactividad en composables, acceso a datos en server/api/ con Drizzle. Incluye diagrama solo cuando tres o
-más partes interactúan.
--->
-
-<Descripción del enfoque y por qué satisface los contratos con menor riesgo.>
-
-| Componente | Responsabilidad       | No debe decidir | Contratos |
-| ---------- | --------------------- | --------------- | --------- |
-| <nombre>   | <una responsabilidad> | <frontera>      | F-001     |
+| Componente                        | Responsabilidad                                                        | No debe decidir                                          | Contratos      |
+| ---------------------------------- | ------------------------------------------------------------------------ | ---------------------------------------------------------- | -------------- |
+| `[id].vue`                        | Orquesta el layout (grid desktop, orden mobile) y pasa datos a los hijos | Contenido visual de fotos, reseñas o el botón de contacto   | F-001          |
+| `ProfessionalPublicPhotos.vue`    | Galería + miniaturas — sin cambios de comportamiento                    | El layout de la página que la envuelve                     | F-001          |
+| `ProfessionalPublicReviews.vue`   | Lista de reseñas + invitación a dejar la primera — se corrige un caso, ver Modelo de datos | El layout de la página que la envuelve | F-001, CL-003 |
+| `ProfessionalPublicContactBar.vue`| Botones de contacto — sin cambios                                       | Cuánto espacio reserva el resto de la página para no taparla | F-001, D-003 |
+| `useContactBarHeight`             | Mide el alto real del elemento que le pasan y lo escribe en `:root`      | Qué elemento medir, ni quién consume el valor               | D-003, T-002   |
+| `general.vue` / `AppFooter.vue`   | Consume la variable CSS como su propio `padding-bottom` **solo en mobile** — en desktop el CTA no es fijo y no reserva nada, igual que hoy | El valor de la variable — eso lo decide quien la setea | D-003, T-002 |
 
 ## Contratos
 
-<!--
-Cada contrato especifica entrada, salida e invariantes al nivel en que se puede implementar sin reuniones
-de aclaración. Incluye los errores observables y el código HTTP cuando es un endpoint.
--->
+### TC-001 — `useContactBarHeight(barRef)` mide un elemento y publica su alto como variable CSS global
 
-### TC-001 — <contrato en una frase>
-
-- **Entrada:** <datos y precondiciones, con tipos y forma concreta>.
-- **Salida:** <resultado y su forma concreta>.
-- **Invariantes:** <qué se cumple siempre: atomicidad, consistencia, idempotencia>.
-- **Errores:** <condición → código HTTP y cuerpo `{ error, code? }`, y qué puede hacer el llamador>.
-- **Contrato de producto:** [F-001](./producto.md#f-001).
+- **Entrada:** `barRef: Ref<HTMLElement | null>` — el elemento cuyo alto renderizado importa (la barra de
+  contacto fija de mobile).
+- **Salida:** ningún valor de retorno consumido por el llamador — el efecto observable es que
+  `document.documentElement.style` gana la propiedad `--contact-bar-h: <alto en px>px` mientras el
+  composable está montado, y la pierde (vuelve al fallback CSS) al desmontarse.
+- **Invariantes:**
+  - Lee `entry.contentRect.height` del callback de `ResizeObserver` (no `borderBoxSize`, que no tiene
+    soporte parejo entre navegadores) — se fija acá para que quien escriba el test sepa exactamente qué
+    forma de entrada simular, sin tener que decidirlo a mitad de la implementación.
+  - Antes del primer callback (SSR, primer paint del cliente) no escribe nada — el consumidor siempre debe
+    declarar su propio fallback (`var(--contact-bar-h, 6rem)`), nunca asumir que la variable ya existe.
+  - `onUnmounted` limpia la propiedad (`removeProperty`) — navegar a otra ruta que use `general.vue` (ej.
+    `/buscar`) no debe heredar el alto de una barra que ya no existe en el DOM. Esto cubre navegación entre
+    rutas distintas; **no** cubre pasar de `/profesionales/A` a `/profesionales/B` sin salir de `[id].vue`
+    — Vue Router reutiliza la instancia del componente cuando solo cambia el parámetro dinámico de la
+    misma ruta, así que `onMounted`/`onUnmounted` no se disparan de nuevo. Hoy no hay ningún link directo
+    de un perfil a otro (solo se llega vía `/buscar`, con unmount real), así que esto no es explotable
+    todavía — queda anotado para que no se asuma cubierto si alguna vez se agrega un link de "profesionales
+    relacionados".
+  - No corre en servidor: la función es un no-op fuera de `onMounted` (`ResizeObserver` no existe en Nitro).
+- **Errores:** ninguno — `barRef` en `null` (ej. la vista está en modo `cargando`, sin barra montada
+  todavía) es un estado válido; el composable simplemente no observa nada hasta que la ref se llena.
+- **Contrato de producto:** [F-001](./producto.md#f-001), [D-003](./producto.md#d-003).
 
 ## Modelo de datos
 
-<!-- Entidades con significado, escritura y ciclo de vida. El schema completo vive en server/db/. -->
+Sin cambios. `PublicProfessionalProfile` (`app/types/professional.ts`) ya trae cada campo que
+`experiencia.md` reorganiza:
 
-| Entidad o campo | Significado             | Escritura          | Retención o historial |
-| --------------- | ----------------------- | ------------------ | --------------------- |
-| <dato>          | <semántica de producto> | <endpoint o acción>| <política>            |
+| Campo de `PublicProfessionalProfile`                          | Dónde se usa en la vista reorganizada                          |
+| --------------------------------------------------------------- | ------------------------------------------------------------------ |
+| `displayName`, `categoriaNombre`, `comunaNombre`, `priceFrom`   | Bloque de identidad bajo la galería (mobile y desktop)             |
+| `photoUrls`, `avatarUrl`                                        | `ProfessionalPublicPhotos` — sin cambios                            |
+| `description`                                                   | Bloque de descripción, tras identidad                              |
+| `reviews`, `ratingAverage`, `reviewCount`                       | Resumen de rating en el sidebar (desktop) + sección de reseñas (`ProfessionalPublicReviews`, sin cambios) |
+| `createdAt`                                                     | "En Datealo desde…", junto al bloque de contacto (UX-003)          |
+| `contact`                                                       | `ProfessionalPublicContactBar` — sin cambios                        |
+
+Los casos límite CL-001 (sin fotos), CL-002 (sin precio) y CL-004 (descripción corta o larga) ya están
+cubiertos por la nulabilidad existente de estos campos — ninguno necesita un campo nuevo ni un cambio de
+tipo, el `v-if` que ya existe alcanza.
+
+**CL-003 no está cubierto hoy, y esta misión lo corrige.** `ProfessionalPublicReviews.vue:49` envuelve
+toda la sección (título y bloque de invitación incluidos) en `v-if="reviews.length > 0 || hasToken"`.
+`hasToken` solo se vuelve `true` después de que el visitante ya contactó al profesional
+(`ensureToken()` corre en `ProfessionalPublicContactBar.vue:23`, al hacer clic en WhatsApp o llamar) — así
+que cualquier visitante que **todavía no contactó** y ve un perfil sin reseñas no ve la invitación "Sé el
+primero en contarle…": ve un hueco vacío. Esto contradice el "Ejemplo verificable" de
+[F-001](./producto.md#f-001) (que describe a un visitante genérico, sin precondición de haber contactado)
+y el propio [CL-003](./producto.md#cl-003) ("la sección de reseñas muestra la invitación... sin
+condición"). Es un bug preexistente, no introducido por esta misión, pero esta misión es quien lo hace
+visible (el mockup y `experiencia.md` ya asumen que funciona) y quien lo corrige — ver
+[T-003](#t-003) y el slice S-005.
 
 ### Invariantes de datos
 
-- <unicidad, pertenencia, orden o consistencia temporal>.
-- <qué operación es atómica o qué dato tiene una única fuente de verdad>.
+- Ninguna — no hay escritura nueva ni tabla nueva en esta misión.
 
 ### Impacto en RLS
 
-<!--
-Obligatorio. Fuente de verdad: server/db/sql/rls.sql. Si el cambio no toca ownership ni relaciones usadas
-en policies, decirlo explícitamente con esa razón — no dejar la sección vacía.
--->
+| Tabla           | Cambio    | Policy afectada | Acción   |
+| ---------------- | --------- | ---------------- | -------- |
+| `professionals`  | ninguno  | —                 | ninguna  |
+| `reviews`         | ninguno  | —                 | ninguna  |
 
-| Tabla    | Cambio                 | Policy afectada | Acción                    |
-| -------- | ---------------------- | --------------- | ------------------------- |
-| <tabla>  | <nueva, ownership, FK> | <nombre>        | <crear, actualizar, nada> |
+Ninguna tabla ni columna cambia de ownership ni de relación. `professionals_select_public` (lectura
+pública, `server/db/sql/rls.sql:55-57`) ya cubre exactamente el acceso que `GET /api/professionals/[id]`
+hace hoy, sin cambios de forma de respuesta ni de columnas seleccionadas — el endpoint ya usa `select`
+explícito (A-005), no la fila cruda de Drizzle. Verificado leyendo `server/api/professionals/[id].get.ts`
+y `server/db/sql/rls.sql` completos antes de escribir esta sección, no asumido.
 
 ## Riesgos y experimentos de factibilidad
 
-<!--
-Un riesgo que podría cambiar el producto se enlaza como pregunta o decisión en producto.md. Un experimento
-tiene pregunta, límite de tiempo y resultado capaz de cerrar la incertidumbre.
--->
-
-| ID     | Riesgo o pregunta | Qué invalida        | Experimento o mitigación  | Criterio de salida      | Estado  |
-| ------ | ----------------- | ------------------- | ------------------------- | ----------------------- | ------- |
-| TR-001 | <incertidumbre>   | <alcance en riesgo> | <spike, prueba o recorte> | <resultado concluyente> | abierto |
+| ID     | Riesgo o pregunta | Qué invalida | Experimento o mitigación | Criterio de salida | Estado |
+| ------ | ------------------ | -------------- | --------------------------- | --------------------- | ------ |
+| TR-001 | El toolbar dinámico de Safari/Chrome mobile (se esconde y aparece con el scroll) puede hacer que un elemento `position: fixed; bottom: 0` salte o quede mal alineado un instante — Chrome DevTools no reproduce este comportamiento, solo un dispositivo real lo muestra | El CTA fijo de mobile podría taparse o saltar en el dispositivo real aunque se vea perfecto en el emulador | Probar la vista en un iPhone y un Android reales (ya es requisito de `CLAUDE.md` para cambios de UI) antes de mergear el slice del CTA fijo | El botón queda visible y en la misma posición relativa al fondo de la pantalla durante scroll normal, en ambos dispositivos | abierto |
 
 ## Estrategia de pruebas
 
-<!-- Mapea los ejemplos verificables de producto.md a niveles de prueba. Qué demuestra cada una. -->
+| Contrato o riesgo | Nivel                    | Caso principal                                                                 | Límite o falla |
+| ------------------- | -------------------------- | ---------------------------------------------------------------------------------- | ---------------- |
+| TC-001               | unidad (Vitest, jsdom)     | Con `ResizeObserver` simulado disparando una entrada con `contentRect.height: 84`, `--contact-bar-h` en `document.documentElement.style` queda `"84px"` | `barRef` en `null`: no lanza, no escribe nada. Al desmontar: la propiedad se remueve (`getPropertyValue` vuelve vacío) |
+| F-001, CL-001, CL-002, CL-004 | componente (Vitest, jsdom) | `[id].vue` en modo `encontrado` con datos completos renderiza identidad+precio bajo la galería, sidebar con avatar+nombre+rating+CTA, reseñas fuera de ambas columnas | Cada caso límite (sin fotos, sin precio, descripción corta/larga) renderiza sin `v-if` roto ni bloque vacío visible |
+| CL-003 (corregido por T-003) | componente (Vitest, jsdom), mismo patrón que `professional-reviews.test.ts` | Perfil sin reseñas y `hasToken` en `false` (visitante que no contactó): la sección "Reseñas" y la invitación "Sé el primero..." son visibles | Perfil con reseñas y `hasToken` en `true`: la invitación de "¿cómo te fue?" convive con la lista existente, sin duplicarse |
+| D-003 (CTA nunca tapado) | visual, dispositivo real  | Ver TR-001 — este contrato no es testeable de forma significativa con Vitest/jsdom (no hay layout real ni `ResizeObserver` con medidas reales) | Verificación manual obligatoria en mobile real de 390px, siguiendo la sección "Verificación visual" de `CLAUDE.md` |
 
-| Contrato o riesgo | Nivel                          | Caso principal | Límite o falla |
-| ----------------- | ------------------------------ | -------------- | -------------- |
-| F-001, CL-001     | <unidad, contrato, integración>| <caso>         | <caso>         |
+**Nota de infraestructura de test:** `jsdom` no implementa `ResizeObserver` (limitación conocida, sin
+resolver) y el repo no tiene ningún polyfill ni mock compartido para esto hoy — el slice S-001 tiene que
+definir un stub mínimo de `global.ResizeObserver` en su propio test, sin esperar que ya exista uno.
 
 ### Propiedades que deben probarse
 
-- <invariante bajo reintentos, concurrencia o distintas entradas>.
-- <ausencia de efectos parciales en falla>.
+- El fallback CSS (`var(--contact-bar-h, 6rem)`) sigue vigente en cualquier página que use `general.vue`
+  sin montar `useContactBarHeight` (ej. `/buscar`) — no debe quedar en blanco ni en `0`.
+- En desktop, `AppFooter` reserva `0` de espacio sin importar el valor de `--contact-bar-h` — la regla
+  `lg:pb-0` de hoy tiene que seguir ganando en ese breakpoint (ver T-002).
+- Desmontar `[id].vue` (navegar a `/buscar` u otra ruta) limpia `--contact-bar-h` y no deja observers
+  activos. Esta propiedad cubre salir de la ruta, no cambiar de un perfil a otro dentro de la misma ruta
+  (ver la invariante de TC-001 sobre reutilización de instancia de Vue Router).
 
 ## Plan de construcción
 
-<!--
-Se completa al final, cuando el gate de salida se cumple y ninguna pregunta bloqueante sigue abierta —
-cortar sobre decisiones abiertas produce issues que mueren. Cada slice es un cambio funcional atómico: un
-Issue, un PR, ejecutable sin haber leído la misión (el issue lleva su contrato inline) y con criterios
-pass/fail enumerables como tests. Guía completa en el skill discovery-engineering.
--->
+| ID    | Slice (una frase, sin "y")                                                          | Sustento              | Criterio de aceptación principal | Depende de |
+| ----- | -------------------------------------------------------------------------------------- | ------------------------ | ------------------------------------ | ---------- |
+| S-001 | Crear `useContactBarHeight` y conectar `AppFooter`/`general.vue` a `--contact-bar-h`   | TC-001, D-003, T-002     | Con un elemento de 84px de alto observado, el footer reserva 84px reales en mobile (en vez de los 96px fijos de hoy); en desktop reserva `0`, igual que hoy (`lg:pb-0` sigue ganando, sin importar el valor de la variable); en una página sin el composable montado (`/buscar`), el footer sigue reservando el fallback de 6rem en mobile y 0 en desktop, igual que hoy en ambos casos | — |
+| S-002 | Reestructurar `[id].vue` (modo `encontrado`) a la jerarquía de UXF-001                 | UX-001, UX-002, UX-005, D-001, D-002 | En desktop, identidad+precio+descripción quedan en la columna de la galería y el sidebar (grid, `grid-row: span 2`) lleva solo avatar+nombre+rating+CTA+"en Datealo desde"; en mobile, el orden es foto → identidad+precio → descripción → reseñas → "en Datealo desde", con el CTA como overlay fijo; las reseñas quedan a ancho completo fuera de ambas columnas | S-001 |
+| S-003 | Actualizar el skeleton de `cargando` a la forma nueva                                 | Reglas de F-001 ("no rediseña estados... más allá de que el esqueleto refleje las nuevas proporciones") | El skeleton muestra el bloque de galería + un bloque de identidad+precio agrupado, no líneas sueltas — no "salta" de forma al llegar los datos reales | S-002 |
+| S-004 | Alt descriptivo en las miniaturas del carrusel, en vez de "Miniatura N"                | hallazgo de la evaluación heurística de `experiencia.md` (`web-design-guidelines`) | Cada miniatura anuncia qué foto activa (`"Ver foto 2 de 3 de {nombre}"` o equivalente), no solo su posición | — |
+| S-005 | Mostrar la invitación a dejar la primera reseña aunque el visitante no haya contactado todavía | CL-003, T-003 | Perfil sin reseñas y visitante sin token: ve "Sé el primero en contarle..." + botón "Dejar una reseña". Perfil con reseñas y visitante con token: sigue viendo la lista de reseñas más la invitación a agregar la suya, sin duplicar nada | — |
 
-| ID    | Slice (una frase, sin "y") | Sustento      | Criterio de aceptación principal          | Depende de |
-| ----- | -------------------------- | ------------- | ----------------------------------------- | ---------- |
-| S-001 | <cambio atómico>           | TC-001, D-001 | <entrada concreta → resultado observable> | —          |
-
-## Secciones bajo demanda
-
-<!--
-Agregar solo cuando el riesgo lo justifique, con estos títulos:
-
-- "Migración y compatibilidad": cuando existan datos o consumidores que deben llegar al nuevo contrato.
-  Incluye rollback lógico si la migración física no puede revertirse.
-- "Rendimiento y observabilidad": cuando haya presupuesto de latencia o volumen que defender (búsqueda
-  geográfica y listados paginados son los candidatos naturales).
-- "SEO e indexación": cuando la superficie deba ser indexable (páginas por categoría + comuna, datos
-  estructurados).
-- "Entrega por etapas": cuando el cambio necesite despliegue incremental o feature flags.
--->
+Ningún slice depende de trabajo fuera de esta misión. S-004 y S-005 no dependen de ningún otro y pueden
+mergearse en cualquier momento del lote — de hecho, dado que S-005 corrige un bug que ya afecta a
+`/profesionales/[id]` hoy (no algo introducido por esta misión), conviene priorizarlo antes que S-002/S-003
+si se quiere el fix en producción cuanto antes, en vez de esperar al resto del reordenamiento.
 
 ## Decisiones técnicas
 
 <a id="t-001"></a>
 
-### T-001 — <decisión en una frase>
+### T-001 — El layout de dos columnas de desktop pasa de `flex` a CSS Grid
 
-- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
-- **Contratos:** F-001 y <regla relevante>.
-- **Alternativas descartadas:** <opciones y trade-offs, con el porqué del rechazo>.
-- **Decisión y consecuencias:** <enfoque elegido, beneficio, costo y trabajo futuro aceptado>.
-- **Reapertura:** <medición o cambio que justificaría revisar>.
+- **Estado:** aceptada. **Fecha:** 2026-09-04.
+- **Contratos:** F-001, [UX-001](./experiencia.md#ux-001), [UX-005](./experiencia.md#ux-005).
+- **Alternativas descartadas:** mantener `flex` y acotar el sticky del sidebar solo a la fila superior
+  (como quedó en la primera versión del mockup) — descartada en `experiencia.md` porque deja el CTA fuera
+  de vista durante toda la lectura de reseñas, contradiciendo el ideal de `investigacion.md`. Un segundo
+  elemento `sticky` independiente calculado con JS (IntersectionObserver siguiendo el scroll) — descartada
+  por agregar una dependencia de comportamiento en tiempo de ejecución para resolver algo que CSS Grid ya
+  resuelve solo, en contra del principio de mantener la lógica de presentación lo más declarativa posible.
+- **Decisión y consecuencias:** `grid-template-columns: 55fr 45fr` en el contenedor; el sidebar usa
+  `grid-row: span 2` + `align-self: start` (el `align-self` es obligatorio — sin él el ítem se estira a la
+  altura de la fila y el `sticky` no tiene margen para moverse); la sección de reseñas usa
+  `grid-column: 1 / -1` y cae en una fila implícita nueva por auto-placement de CSS Grid, no en una "fila 2"
+  literal (columna ocupada por el sidebar) — detalle verificado con DevTools en la evaluación heurística de
+  `experiencia.md`, no solo leído del CSS. Consecuencia aceptada: quien lea el CSS por primera vez puede
+  asumir que faltan filas explícitas — queda comentado en el componente para no repetir la confusión.
+- **Reapertura:** si algún día la columna de reseñas necesita volver a vivir dentro de una de las dos
+  columnas (por ejemplo, si UX-002 se revierte), este layout se revisa completo — no es un ajuste de una
+  línea.
+
+<a id="t-002"></a>
+
+### T-002 — El espacio que reserva el CTA fijo de mobile se mide en tiempo real, no se adivina
+
+- **Estado:** aceptada. **Fecha:** 2026-09-04.
+- **Contratos:** F-001, [D-003](./producto.md#d-003), sustentado en [C-004](./investigacion.md#c-004).
+- **Alternativas descartadas:** subir el `pb-24` fijo de `AppFooter` a un número más grande (ej. `pb-32`) —
+  descartada porque D-003 ya rechazó explícitamente esto en `producto.md`: sigue frágil si el contenido de
+  cualquiera de las barras que usan ese buffer cambia a futuro (hoy son dos: el buscador compacto de la
+  misión 09 y este CTA). Una librería de terceros para "safe area" o sticky bars — descartada por
+  YAGNI: `ResizeObserver` nativo resuelve el problema completo sin dependencia nueva, y el proyecto no usa
+  `@vueuse/core` ni ninguna librería equivalente hoy.
+- **Decisión y consecuencias:** `useContactBarHeight` (TC-001) observa el elemento real de
+  `ProfessionalPublicContactBar` con `ResizeObserver` y escribe `--contact-bar-h` en `:root`.
+  `AppFooter.vue` cambia su clase de `pb-24 lg:pb-0` (usado hoy por `general.vue` para **todas** las
+  páginas) a `pb-[var(--contact-bar-h,_6rem)] lg:pb-0` — mismo `lg:pb-0` de siempre, sin tocarlo: en
+  desktop el CTA de esta vista es `lg:static` (ya no `fixed`, vive inline en el sidebar) y no reserva
+  nada, exactamente igual que hoy. El cambio real es solo en mobile: el fallback de `6rem` (96px) preserva
+  el comportamiento actual para páginas que no montan el composable (`/buscar`, con el buscador compacto
+  de la misión 09, fuera de alcance de esta misión). Este punto se agregó tras una auditoría en agente
+  separado que encontró la primera redacción de esta decisión sin la exclusión de desktop — sin ella, el
+  slice S-001 solo habría regresionado el padding del footer en escritorio para **todas** las páginas que
+  usan `general.vue`, no solo esta. El `pb-28` que hoy tiene el contenido de `[id].vue` (buffer redundante
+  para el texto "en Datealo desde" antes del propio CTA) deja de necesitarse: en el nuevo orden mobile ese
+  texto vive después de las reseñas, como último elemento antes del footer — un solo buffer (el de
+  `AppFooter`) alcanza donde antes hacían falta dos.
+- **Reapertura:** si `general.vue` alguna vez necesita más de una barra fija simultánea compitiendo por el
+  mismo espacio reservado (hoy no ocurre: el buscador compacto vive en `/buscar`, este CTA en
+  `/profesionales/[id]`, nunca las dos rutas a la vez), este mecanismo de una sola variable CSS deja de
+  alcanzar y hay que revisarlo.
+
+<a id="t-003"></a>
+
+### T-003 — La invitación a dejar la primera reseña se muestra a cualquier visitante, no solo a quien ya contactó
+
+- **Estado:** aceptada. **Fecha:** 2026-09-04.
+- **Contratos:** [CL-003](./producto.md#cl-003), F-001.
+- **Alternativas descartadas:** dejar el comportamiento actual (invitación gateada por `hasToken`) y
+  documentar la diferencia como "fuera de alcance" — descartada porque CL-003 y el "Ejemplo verificable"
+  de F-001 ya son parte de lo aprobado en `producto.md`, no una funcionalidad nueva que se pueda recortar
+  acá; ignorarlo dejaría `ingenieria.md` construyendo sobre un contrato que el propio `producto.md`
+  contradice.
+- **Decisión y consecuencias:** en `ProfessionalPublicReviews.vue`, la sección deja de estar gateada por
+  `v-if="reviews.length > 0 || hasToken"` a nivel de toda la sección. El bloque de invitación/CTA de
+  reseña pasa a mostrarse cuando `reviews.length === 0` (siempre, cumple CL-003) **o** cuando `hasToken`
+  es verdadero (nudge a quien ya contactó, aunque ya haya reseñas de otras personas — comportamiento de
+  hoy, se conserva). La lista de reseñas existentes se sigue mostrando siempre que `reviews.length > 0`,
+  sin relación con `hasToken`. Con esto la sección entera queda visible en todos los casos que CL-001 a
+  CL-003 describen, sin gateo previo.
+- **Reapertura:** ninguna prevista — es la aplicación literal de un caso límite ya aprobado, no una
+  apuesta a revisar más adelante.
 
 ## Preguntas
 
-<!--
-Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
-Estado: abierta | resuelta AAAA-MM-DD | disuelta AAAA-MM-DD. Solo las abiertas llevan bloque de detalle.
--->
+Sin preguntas abiertas — el diseño no depende de ninguna decisión que el dueño de producto todavía no haya
+tomado.
 
-<Una frase que responde "¿qué falta?": la pregunta que bloquea construcción y qué bloquea.>
-
-| ID     | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
-| ------ | ---------------------- | ------------------- | --------------------------------------------------------------- |
-| TQ-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
-| TQ-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |
+| ID | La duda | Estado | Respuesta, o quién la resuelve |
+| -- | ------- | ------ | ------------------------------- |
+| —  | —       | —      | sin preguntas abiertas propias de ingeniería |

--- a/docs/missions/11-perfil-profesional/investigacion.md
+++ b/docs/missions/11-perfil-profesional/investigacion.md
@@ -1,118 +1,167 @@
-# Misión: <nombre> — Investigación
+# Misión 11: vista de detalle de perfil de profesional — Investigación
 
 **Estado:** activo
 
-**Última actualización:** AAAA-MM-DD
+**Última actualización:** 2026-09-03
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-<!--
-Este documento se acumula: la evidencia y las conclusiones no se borran cuando el alcance cambia, porque
-explican por qué el producto es como es. Lo que sí se actualiza es el ideal, que resume la dirección que
-la investigación sostiene hoy.
+## El problema aparece cuando alguien ya decidió que un profesional le interesa y va a contactarlo
 
-Gate de salida — la investigación sostiene un producto.md cuando:
-- el problema tiene situación y consecuencia concretas, no una categoría abstracta
-- al menos una conclusión con confianza alta o media respalda la dirección
-- el ideal describe capacidades observables, no intenciones
--->
+**Situación:** una persona buscó "electricista" en Puerto Varas, encontró a Patricio Tabilo en los
+resultados de `/buscar` y entró a su perfil (`/profesionales/[id]`) para confirmar que es quien necesita
+antes de escribirle.
 
-## El problema aparece cuando <historia concreta>
+**Acción o necesidad:** revisar fotos de trabajos, precio orientativo y reseñas para decidir si confía en
+él, y después tocar "Escribir por WhatsApp" sin que la interfaz le genere dudas justo en ese momento.
 
-<!--
-Una situación real o reconstruida con precisión. No abras con una categoría como "falta de confianza" —
-abre con quién estaba haciendo qué y qué salió mal. Nombra a la persona y el servicio concreto.
--->
+**Respuesta actual:** la vista ya tiene todo el contenido resuelto desde las misiones 05 a 07 (galería con
+carrusel y miniaturas, ficha con nombre/categoría/comuna/rating/descripción/precio, bloque de reseñas, CTA
+de WhatsApp y teléfono), pero nunca recibió una pasada de diseño dedicada — a diferencia del header/footer
+(misión 09) y de los resultados de búsqueda (misión 10), que sí la tuvieron. El dueño de producto la
+describe así al mirarla hoy: en desktop "se ve desordenada" — foto grande a la izquierda, todo lo demás
+apilado en una sola columna a la derecha sin jerarquía clara entre identidad, confianza y contacto; en
+mobile, el botón fijo "Escribir por WhatsApp" se solapa visualmente con el footer general de la página al
+llegar al final del scroll ([E-001](#e-001)).
 
-**Situación:** <qué está ocurriendo antes del problema>.
-
-**Acción o necesidad:** <qué se intenta resolver o decidir>.
-
-**Respuesta actual:** <qué hace hoy la persona: grupo de WhatsApp, Google, recomendación de un vecino,
-Datealo si ya existe la superficie>.
-
-**Consecuencia:** <error, demora, riesgo o decisión que no puede tomarse>.
+**Consecuencia:** la pantalla pierde prolijidad justo en el paso donde la persona ya decidió que el
+profesional le sirve y solo falta el empujón final de contactar — el peor punto del flujo para que la
+interfaz reste confianza. En mobile, el solape puede además tapar el botón mismo, el único camino de
+contacto de esta vista.
 
 ## Preguntas que la investigación debe resolver
 
-<!--
-Solo preguntas capaces de cambiar el ideal o una decisión. Al resolver una, moverla a evidencia o
-conclusión. No es un backlog.
--->
-
-- ¿<pregunta y decisión que depende de ella>?
+- ¿Qué jerarquía (foto → identidad → señales de confianza → precio → contacto, o algún otro orden) refleja
+  mejor cómo alguien evalúa a un profesional, en vez de apilar todo lo que el schema permite mostrar?
+- ¿Dónde vive el bloque de reseñas — junto a la ficha de contacto como hoy, o como sección propia más abajo
+  en la página, después del CTA?
+- ¿Qué causa el solape del CTA fijo con el footer en mobile, y por qué el buffer que `general.vue` ya
+  reserva (`pb-24`, agregado en la misión 09) no alcanza?
 
 ## Evidencia
 
-<!--
-Un hecho verificable con fuente y límite. Prioriza observación directa, entrevistas y comportamiento
-comprobado. Los benchmarks de otros productos también son evidencia: qué hacen, qué trade-off eligieron y
-qué no aplica a Datealo.
-
-Datealo no tiene datos de uso propios todavía. Cuando la única evidencia disponible sea un benchmark o
-una entrevista, la columna "límite" es lo que impide que se lea como dato duro.
--->
-
-| ID    | Tipo                                              | Fuente                | Hecho verificable | Límite de la evidencia |
-| ----- | ------------------------------------------------- | --------------------- | ----------------- | ---------------------- |
-| E-001 | <entrevista, benchmark, uso, código, observación> | <enlace o referencia> | <hecho>           | <qué no demuestra>     |
+| ID    | Tipo               | Fuente                                                                              | Hecho verificable | Límite de la evidencia |
+| ----- | ------------------ | ------------------------------------------------------------------------------------ | ------------------ | ----------------------- |
+| E-001 | código + observación | `app/pages/profesionales/[id].vue:108-118`, `app/layouts/general.vue:7`             | Ver desarrollo abajo | No mide impacto en usuarios reales — Datealo no tiene tráfico todavía. |
+| E-002 | código              | `app/pages/profesionales/[id].vue:60-119`                                            | El layout desktop es un `lg:flex` de dos columnas: galería al 55% de ancho, columna derecha con avatar+nombre+categoría+rating+descripción+precio+reseñas+"en Datealo desde"+CTA, todo con el mismo peso visual y sin separadores entre secciones salvo `mt-*`. | Confirma la estructura actual, no dice cuál es mejor — eso lo define esta misión. |
+| E-003 | código              | `app/components/professional-public/ProfessionalPublicPhotos.vue`                    | La galería ya tiene carrusel a `aspect-4/3` con `dots`, y en desktop (`lg:flex`) una tira de hasta N miniaturas de 64×64 debajo. Sin fotos, muestra el avatar o las iniciales centradas sobre un fondo plano. | Es una base sólida — la pregunta de esta misión es de proporción y jerarquía, no de funcionalidad faltante. |
+| E-004 | benchmark           | [listivo6.tangiblewp.com](https://listivo6.tangiblewp.com/) — mismo theme citado como [E-005 de la misión 09](../09-layout-general/investigacion.md#e-005), esta vez su vista de detalle de un listado ("John's Plumbing") — captura compartida por el dueño de producto en la conversación de discovery del 2026-09-03, sin archivo guardado en el repo (no hay forma de extraer una imagen pegada en el chat al filesystem) | Estructura de la columna principal: galería con contador ("1/3") y flechas superpuestas a la foto (sin miniaturas aparte), y **debajo** de la galería — no en una tarjeta separada — el nombre del negocio, un tag de categoría, la ubicación con link "See map", y una fila de tags de atributos (disponibilidad, idiomas). Sigue con bloques propios para "Description" y "Services". La columna lateral es una tarjeta de contacto acotada: datos del anunciante, teléfono enmascarado con botón para revelarlo, y los botones de chat/WhatsApp — sin reseñas ni rating ahí. | Theme genérico de directorio de listados con anuncios pagos y cuentas de comprador — el dueño de producto pidió explícitamente la estructura (foto con overlay + info debajo + tarjeta de contacto acotada), no sus features (sin "cuenta online", sin Viber, sin "listados destacados", sin masking de teléfono). |
+| E-005 | benchmark           | Airbnb, vista de detalle de un alojamiento — captura compartida por el dueño de producto en la misma conversación, sin archivo guardado en el repo (mismo límite que E-004) | El título va **arriba** de la galería (mosaico de fotos, no carrusel). Debajo del mosaico: título repetido + rating y conteo de reseñas en la misma línea que la info básica, antes de cualquier detalle del anfitrión. La tarjeta lateral es de acción (precio + CTA de reserva), no de identidad. Las reseñas completas viven como sección propia más abajo en la página, fuera de la tarjeta lateral. | Es una reserva con pago y fechas, no un contacto directo — el patrón que aplica a Datealo es la *posición* de las reseñas (sección propia, no comprimida en la tarjeta lateral), no el resto del flujo de compra. |
+| E-006 | código              | `app/components/professional-public/ProfessionalPublicReviews.vue`, `[id].vue:98-105` | Hoy las reseñas viven dentro de la misma columna que la ficha de contacto, entre la descripción/precio y el aviso "En Datealo desde…" — compitiendo por espacio con el resto de la información de identidad. | Confirma la ubicación actual; no dice si moverlas resuelve el desorden percibido — depende de cómo quede el resto de la jerarquía. |
 
 <a id="e-001"></a>
 
-### E-001 — <fuente o hecho en una frase>
+### E-001 — el CTA fijo se solapa con el footer general en mobile
 
-<!--
-Desarrollar solo cuando la tabla no alcanza para evaluar la calidad de la evidencia. Cierra con la
-consecuencia para la investigación.
--->
+`ProfessionalPublicContactBar` se envuelve en un contenedor `fixed inset-x-0 bottom-0` en mobile
+(`[id].vue:109-118`), con dos botones lado a lado (WhatsApp + teléfono) dentro de `p-4`. `general.vue:7`
+agrega `pb-24` (96px) al `AppFooter` para reservarle espacio a barras fijas como esta — buffer agregado en
+la misión 09 pensando en el buscador compacto, no en este CTA específico.
 
-<Observación precisa y contexto necesario.>
+En una pantalla angosta (390px, el caso principal de Datealo) el botón "Escribir por WhatsApp" lleva texto
+más el ícono; si el ancho disponible no alcanza para las dos ramas en una fila, el buffer fijo de 96px deja
+de ser suficiente apenas el contenido interno crece una línea. No se verificó todavía si eso es lo que
+ocurre o si el buffer simplemente nunca fue pensado para esta barra en particular — solo que el dueño de
+producto lo observó al revisar la pantalla real.
 
-Esto permite afirmar <alcance>, pero no demuestra <límite>.
+Esto permite afirmar que el ajuste de la misión 09 no cubre este caso, pero no determina todavía la causa
+exacta ni si la solución es agrandar el buffer, hacerlo dinámico, o cambiar cómo esta vista reserva espacio
+para su propio CTA — eso es una decisión de ingeniería, no de esta investigación.
 
 ## Conclusiones
 
-<!--
-Una conclusión interpreta evidencia; no es una preferencia ni una funcionalidad. El título expresa el
-hallazgo, no el tema.
--->
-
 <a id="c-001"></a>
 
-### C-001 — <conclusión en una frase>
+### C-001 — el desorden percibido viene de tratar toda la info con el mismo peso visual, no de que falte contenido
+
+- **Sustento:** [E-002](#e-002), [E-006](#e-006).
+- **Razonamiento:** el código ya tiene identidad, señales de confianza (rating, reseñas), precio y contacto
+  — el problema no es de cobertura de datos sino de que ninguno se destaca sobre el resto: mismo tamaño de
+  fuente relativo, mismo espaciado `mt-*`, sin secciones visualmente separadas.
+- **Implicación:** el rediseño es de jerarquía y agrupación (qué va junto, qué se separa, qué pesa más),
+  no de agregar funcionalidad nueva.
+- **Confianza:** alta porque se verificó leyendo el componente real, no una descripción de segunda mano.
+
+<a id="c-002"></a>
+
+### C-002 — la referencia de directorio de servicios valida sacar identidad+ubicación de la tarjeta lateral y ponerla bajo la galería
+
+- **Sustento:** [E-004](#e-004).
+- **Razonamiento:** tanto la referencia de directorio (E-004) como el layout deseado por el dueño de
+  producto coinciden en que nombre, categoría y ubicación se leen mejor pegados a la foto que dentro de una
+  tarjeta lateral compacta — libera esa tarjeta para ser solo el mecanismo de contacto.
+- **Implicación:** F-xxx de `producto.md` deberá describir una columna principal (galería + identidad +
+  descripción) y una tarjeta lateral acotada a precio + contacto, en vez de la tarjeta única de hoy que
+  mezcla ambas cosas.
+- **Confianza:** media — es un benchmark aportado por el dueño de producto (evidencia de intención, no de
+  comportamiento de usuarios), pero coincide con su propio criterio explícito, no es solo una lectura
+  nuestra del benchmark.
+
+<a id="c-003"></a>
+
+### C-003 — las reseñas ganan claridad como sección propia, separada del bloque de contacto
+
+- **Sustento:** [E-005](#e-005), [E-006](#e-006).
+- **Razonamiento:** Airbnb separa la decisión de reservar (tarjeta lateral) de la evaluación social
+  (sección de reseñas más abajo) — en Datealo la reseña es la señal de confianza principal (no hay pagos,
+  ni fechas, ni disponibilidad que mostrar en la tarjeta), así que separarla del bloque de contacto le da
+  espacio propio en vez de competir con el precio y el CTA por la misma columna angosta.
+- **Implicación:** `producto.md` debe decidir si las reseñas bajan a una sección de ancho completo (debajo
+  de todo el bloque superior) o si se quedan en la columna de identidad pero por debajo del CTA — cualquiera
+  de las dos saca reseñas de la tarjeta de contacto.
+- **Confianza:** media — mismo límite que C-002, benchmark de un producto con un modelo de negocio distinto.
+
+<a id="c-004"></a>
+
+### C-004 — el buffer fijo de la misión 09 no está pensado para el CTA de esta vista y necesita revisión propia
 
 - **Sustento:** [E-001](#e-001).
-- **Razonamiento:** <por qué la evidencia conduce a esta lectura y no a otra>.
-- **Implicación:** <qué deberá ser cierto en el producto o qué alternativa queda debilitada>.
-- **Confianza:** <alta, media o baja> porque <razón o validación pendiente>.
+- **Razonamiento:** el `pb-24` de `general.vue` se agregó para el buscador compacto de la misión 09; esta
+  vista tiene su propio elemento fijo con contenido que puede crecer (dos botones, uno con texto), y nadie
+  verificó que el mismo número de píxeles le alcance.
+- **Implicación:** el rediseño del CTA de contacto debe fijar su propio espacio reservado (o un mecanismo
+  que no dependa de adivinar un número fijo), no asumir que el buffer existente basta.
+- **Confianza:** alta en que el bug existe (reportado y verificable en el código); media en la causa exacta
+  — queda para `ingenieria.md` confirmar el porqué preciso.
 
-## El ideal: <resultado completo, sin recortar>
-
-<!--
-El ideal es el producto de la investigación: la dirección que la evidencia sostiene, sin restricciones de
-implementación. El recorte a la primera entrega no vive aquí — vive en producto.md como decisión de
-alcance. Esta sección sí se reescribe cuando nueva evidencia cambia la dirección.
--->
+## El ideal: cualquier perfil de profesional se lee de un vistazo, sin importar cuántos datos tenga cargados
 
 ### El resultado ideal se ve así
 
-<Narra de principio a fin una situación futura con datos concretos: nombres, comunas, oficios, horarios.
-Qué acción ocurre, qué responde Datealo, qué decisión puede tomar la persona. Evita "una experiencia
-simple" sin comportamiento observable.>
+Alguien entra al perfil de Patricio Tabilo, electricista en Puerto Varas, desde el celular. Lo primero que
+ve es una foto grande de un trabajo suyo (el tablero eléctrico instalado), con miniaturas debajo para las
+otras dos fotos que subió. Debajo de la foto: su nombre, "Electricidad · Puerto Varas", y de inmediato el
+precio ("Desde $15.000") — sin tener que buscar esa información entre otros bloques. Un botón grande
+"Escribir por WhatsApp" queda siempre visible al fondo de la pantalla, sin que ningún otro elemento de la
+página (footer incluido) lo tape nunca, en ningún tamaño de pantalla ni cantidad de contenido. Si sigue
+bajando, encuentra la descripción que Patricio escribió sobre su experiencia, y más abajo una sección
+propia de reseñas — sea la de alguien que ya lo contrató, o la invitación a ser el primero en dejar una si
+todavía no tiene ninguna. En desktop, la misma información se organiza en dos columnas: la galería a la
+izquierda con más espacio para mostrar fotos grandes, y a la derecha una tarjeta de contacto que se queda
+fija en pantalla mientras se hace scroll por la descripción y las reseñas — nunca una tarjeta que intenta
+contener todo a la vez.
 
 ### Capacidades del ideal
 
-| Capacidad | Acción habilitada    | Respuesta esperada              | Conclusión que la justifica |
-| --------- | -------------------- | ------------------------------- | --------------------------- |
-| <nombre>  | <qué se puede hacer> | <qué produce o explica Datealo> | [C-001](#c-001)             |
+| Capacidad                          | Acción habilitada                                              | Respuesta esperada                                                      | Conclusión que la justifica |
+| ----------------------------------- | ---------------------------------------------------------------- | -------------------------------------------------------------------------- | ---------------------------- |
+| Jerarquía clara de identidad y precio | Evaluar en segundos si el profesional y su precio calzan con lo que se busca | Foto, nombre, categoría/comuna y precio se leen antes que cualquier otro dato, agrupados y separados del resto | [C-001](#c-001), [C-002](#c-002) |
+| CTA de contacto siempre accesible y nunca tapado | Tocar "Escribir por WhatsApp" en cualquier momento del scroll, sin que otro elemento lo cubra | El botón queda visible y clickeable en todo momento, en cualquier tamaño de pantalla | [C-004](#c-004) |
+| Reseñas como sección propia | Evaluar la reputación del profesional sin que compita visualmente con el contacto | Bloque de reseñas con su propio espacio, separado de la tarjeta de contacto | [C-003](#c-003) |
 
-### El ideal no significa <confusión probable>
+### El ideal no significa copiar el diseño de Airbnb o de un directorio de listados
 
-- <límite conceptual que evita una interpretación incorrecta>.
+- Datealo no vende reservas ni anuncios pagos — no hay fechas, disponibilidad, ni "listados destacados" que
+  mostrar en la tarjeta lateral, aunque la referencia los tenga.
+- No implica agregar funcionalidad nueva (chat interno, mapa, tags de atributos) — el recorte de qué se
+  construye en esta entrega es decisión de `producto.md`, no de esta investigación.
 
 ## Referencias
 
-<!-- Fuentes primarias citadas por las evidencias. El enlace no sustituye el hecho y el límite en E-xxx. -->
-
-- [<título descriptivo>](URL): usado en E-001 para <afirmación concreta>.
+- [listivo6.tangiblewp.com](https://listivo6.tangiblewp.com/): usado en E-004 para la estructura de galería
+  con overlay + identidad debajo + tarjeta de contacto acotada. Mismo theme citado en
+  [E-005 de la misión 09](../09-layout-general/investigacion.md#e-005).
+- Airbnb (vista de detalle de un alojamiento, captura compartida por el dueño de producto en el chat de
+  discovery, sin archivo en el repo): usado en E-005 para la posición de las reseñas como sección propia,
+  separada de la tarjeta de acción.

--- a/docs/missions/11-perfil-profesional/producto.md
+++ b/docs/missions/11-perfil-profesional/producto.md
@@ -1,149 +1,187 @@
-# Misión: <nombre> — Producto
+# Misión 11: vista de detalle de perfil de profesional — Producto
 
-**Estado:** borrador
+**Estado:** vigente — aprobado por Patricio el 2026-09-03
 
-**Última actualización:** AAAA-MM-DD
+**Última actualización:** 2026-09-03
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-<!--
-Este documento es la spec viva del resultado: qué construimos ahora y bajo qué reglas. El porqué vive en
-investigacion.md — aquí solo se enlaza. Se reescribe cuando el alcance cambia; no acumula historia.
+## Qué construimos: la vista de detalle se lee de un vistazo, sin agregar contenido nuevo
 
-Gate de salida — producto.md está listo para experiencia.md cuando:
-- cada funcionalidad tiene formato JTBD, reglas y al menos un caso límite con comportamiento definido
-- cada funcionalidad enlaza una conclusión de investigacion.md y una señal de éxito
-- cada funcionalidad declara a qué lado del marketplace sirve, y qué necesita del otro lado para funcionar
-- no hay decisiones de producto delegadas a diseño o ingeniería
-- las decisiones propuestas tienen fecha límite en el README
--->
+**Resultado:** al terminar esta entrega, cualquier persona que abra `/profesionales/[id]` ve foto,
+identidad (nombre, categoría, comuna) y precio agrupados junto a la galería, un botón de contacto que
+nunca queda tapado por otro elemento de la página, y las reseñas como su propia sección — en vez de una
+sola columna donde todo pesa igual.
 
-## Qué construimos: <resultado en una frase>
+**Recorte respecto del ideal:** [el ideal](./investigacion.md) es una vista que se lee de un vistazo con
+cualquier cantidad de datos; esta entrega reorganiza y prioriza la información que el perfil **ya
+muestra hoy** (fotos, nombre, categoría, comuna, rating, descripción, precio, reseñas, contacto) — no
+agrega campos nuevos al schema ni funcionalidad nueva (tags de atributos, mapa, disponibilidad). Sigue
+siendo el mismo resultado central del ideal (evaluar y contactar sin fricción) con menos superficie de
+cambio.
 
-<!--
-El recorte vigente del ideal y por qué sigue entregando el resultado central. Máximo cuatro párrafos
-cortos. El ideal completo vive en investigacion.md.
--->
-
-**Resultado:** <qué podrá lograr una persona al finalizar esta entrega>.
-
-**Recorte respecto del ideal:** <qué dimensión se reduce y por qué sigue siendo suficiente>
-(ver [el ideal](./investigacion.md)).
-
-**Restricciones aceptadas:** <plataforma, cobertura geográfica, categorías, volumen inicial de
-profesionales>.
+**Restricciones aceptadas:** mobile 390px sigue siendo el caso principal; desktop reutiliza el layout de
+dos columnas que ya existe (`lg:flex`), reorganizando su contenido, no reemplazándolo por un layout
+distinto; sin nueva funcionalidad de datos (ver "Fuera de alcance").
 
 ## Funcionalidades
 
-| ID    | Funcionalidad                  | Lado         | Sustento     | Éxito |
-| ----- | ------------------------------ | ------------ | ------------ | ----- |
-| F-001 | <verbo + resultado observable> | buscador     | C-001, D-001 | M-001 |
+| ID    | Funcionalidad                                          | Lado  | Sustento                        | Éxito |
+| ----- | -------------------------------------------------------- | ----- | ---------------------------------- | ----- |
+| F-001 | Vista de detalle reorganizada por jerarquía de decisión | ambos | C-001, C-002, C-003, C-004, D-001, D-002, D-003 | M-001 |
 
 <a id="f-001"></a>
 
-### F-001 — <verbo + resultado observable>
+### F-001 — Vista de detalle reorganizada por jerarquía de decisión
 
-<!--
-Duplica este bloque por funcionalidad. Se escribe desde el resultado del usuario (working backwards):
-primero el JTBD, después las reglas. Si la respuesta de Datealo no se puede describir sin hablar de tablas
-o componentes, falta cerrar la decisión de producto.
--->
+Cuando entro al perfil de un profesional que me interesó en los resultados de búsqueda,
+quiero confirmar rápido que es alguien de fiar, cuánto cobra y cómo contactarlo,
+para decidir por mi cuenta si me arriesgo con un desconocido, sin tener que preguntarle a nadie más
+si conviene.
 
-Cuando <usuario en contexto concreto>,
-quiero <acción>,
-para <resultado observable>.
+**Dimensiones del job** (framework `jobs-to-be-done`): funcional — ver identidad, precio y contacto sin
+leer toda la pantalla; emocional — sentir que puede confiar en dejar entrar a un desconocido a resolver
+algo en su casa; social — decidir sin depender de la validación de un tercero (pareja, vecino, el grupo de
+WhatsApp del edificio), que es la competencia real de esta pantalla, no otro marketplace.
 
-**Lado del marketplace:** buscador, profesional o ambos. **Qué necesita del otro lado:** <volumen mínimo
-de perfiles, reseñas o cobertura sin el cual esta funcionalidad no entrega su resultado>.
+**Lado del marketplace:** ambos — el buscador evalúa más rápido y con más confianza; el profesional se
+beneficia de que su foto, precio y reseñas se noten en vez de perderse en una columna plana. **Qué necesita
+del otro lado:** nada — es una reorganización de datos que el perfil ya tiene, no depende de volumen de
+profesionales ni de reseñas.
 
-**Sustento:** [C-001](./investigacion.md#c-001) y [D-001](#d-001). **Éxito:** [M-001](#m-001).
+**Sustento:** [C-001](./investigacion.md#c-001), [C-002](./investigacion.md#c-002),
+[C-003](./investigacion.md#c-003), [C-004](./investigacion.md#c-004) y [D-001](#d-001), [D-002](#d-002),
+[D-003](#d-003). **Éxito:** [M-001](#m-001).
 
 **Reglas:**
 
-- Si <condición>, Datealo <comportamiento esperado>.
-- Si <caso límite>, Datealo <comportamiento seguro y qué información muestra>.
-- Datealo nunca <comportamiento que rompería el significado o la confianza>.
+- Nombre, categoría, comuna y precio orientativo se agrupan junto a la galería (no dentro de la tarjeta de
+  contacto), en el mismo bloque visual que la foto — son lo primero que se lee después de la imagen.
+- El botón de contacto (WhatsApp y teléfono) queda visible y clickeable en todo momento del scroll, sin que
+  el footer general ni ningún otro elemento de la página lo tape, en cualquier tamaño de pantalla y
+  cualquier largo de contenido (ver [D-003](#d-003)).
+- Las reseñas viven en su propia sección, separadas del bloque de contacto — ni la tarjeta de contacto ni
+  el bloque de identidad las contienen.
+- Si el profesional no tiene fotos, Datealo muestra su avatar o iniciales en el mismo espacio que ocuparía
+  la galería, sin dejar un hueco vacío ni reducir el tamaño del bloque de identidad.
+- Si el profesional no tiene precio orientativo cargado, Datealo omite esa línea sin dejar un espacio en
+  blanco ni un placeholder tipo "Precio no disponible".
+- Si el profesional no tiene reseñas, la sección de reseñas muestra la invitación a dejar la primera (ya
+  construida en la misión 07) en el mismo lugar donde irían las reseñas reales.
 
-**Ejemplo verificable:** dado <estado con datos concretos>, cuando <acción>, entonces <resultado
-observable>.
+**Ejemplo verificable:** dado el perfil de Patricio Tabilo (electricista en Puerto Varas, con 3 fotos,
+precio "Desde $15.000" y cero reseñas), cuando alguien lo abre desde el celular, entonces ve la foto,
+debajo su nombre + "Electricidad · Puerto Varas" + el precio, el botón "Escribir por WhatsApp" fijo y
+visible en todo momento, y al bajar la invitación a dejar la primera reseña como su propia sección — el
+footer general nunca cubre el botón, sin importar cuánto se desplace la página.
 
-**No incluye:** <variante del ideal excluida de esta funcionalidad>.
+**No incluye:** tags de atributos, mapa o ubicación exacta, disponibilidad por horario, ni ningún dato que
+el schema no tenga hoy (ver "Fuera de alcance"). No rediseña los estados de cargando/tardando/no encontrado
+más allá de que el esqueleto de carga refleje las nuevas proporciones para no saltar al cargar el contenido
+real.
 
-**Experiencia:** <enlace a UXF-xxx cuando exista>. **Ingeniería:** <enlace a T-xxx cuando exista>.
+**Experiencia:** pendiente (`experiencia.md`). **Ingeniería:** pendiente (`ingenieria.md`).
 
 ## Casos límite que cruzan funcionalidades
 
-<!--
-Solo condiciones que afectan varias funcionalidades. Las propias de una viven en su bloque. Un caso
-retirado no se borra ni se reutiliza: conserva su fila, o se nombra con su motivo en una línea debajo.
-
-Los casos límite propios de un marketplace pre-lanzamiento aparecen acá: cero resultados en una comuna,
-un profesional sin reseñas, una categoría con un solo perfil, un perfil sin verificar.
--->
-
-| ID     | Condición concreta     | Comportamiento esperado | Funcionalidades |
-| ------ | ---------------------- | ----------------------- | --------------- |
-| CL-001 | <estado o combinación> | <qué hace Datealo>      | F-001           |
+| ID     | Condición concreta                                  | Comportamiento esperado                                                                 | Funcionalidades |
+| ------ | ------------------------------------------------------ | ------------------------------------------------------------------------------------------ | --------------- |
+| CL-001 | Profesional sin fotos                                  | Avatar o iniciales ocupan el espacio de la galería, sin achicar el bloque de identidad     | F-001            |
+| CL-002 | Profesional sin precio orientativo                     | La línea de precio no aparece; nada la reemplaza                                            | F-001            |
+| CL-003 | Profesional sin reseñas                                | La sección de reseñas muestra la invitación a dejar la primera, no un hueco vacío           | F-001            |
+| CL-004 | Descripción del profesional muy larga o muy corta      | El bloque de identidad no fuerza un alto fijo — crece o se achica con el texto real          | F-001            |
 
 ## Fuera de alcance
 
-<!-- Distingue postergado de descartado y qué condición justificaría reabrirlo. -->
-
-| Capacidad o caso      | Estado                  | Razón del recorte | Condición para reconsiderar |
-| --------------------- | ----------------------- | ----------------- | --------------------------- |
-| <capacidad del ideal> | postergada o descartada | <trade-off>       | <evidencia o hito>          |
+| Capacidad o caso                                             | Estado     | Razón del recorte                                                                                   | Condición para reconsiderar |
+| ---------------------------------------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| Tags de atributos (disponibilidad, idiomas, "atiende fines de semana") | postergada | El schema de `professionals` no tiene estos campos hoy — agregarlos es una decisión de producto propia, no un ajuste de layout | Si una futura misión define y prioriza estos campos |
+| Mapa o "ver ubicación exacta"                                     | descartada | Datealo no usa geolocalización en ningún punto del código (confirmado en [E-020 de la misión 09](../09-layout-general/investigacion.md#e-020)); mostrar un mapa sin esa base es agregar una funcionalidad nueva, no reorganizar la existente | Si Datealo agrega geolocalización como funcionalidad propia |
+| Teléfono enmascarado con botón para revelarlo                    | descartada | Choca con el principio de contacto directo sin fricción (ver `CLAUDE.md`) — Datealo no pone pasos entre el buscador y el profesional | No aplica mientras el contacto directo siga siendo un guardrail de producto |
+| Rediseño completo de estados de cargando/tardando/no encontrado  | postergada | No son el problema que motivó esta misión (ver `investigacion.md`); solo se ajusta el esqueleto de carga para que calce con las nuevas proporciones | Si una revisión futura de estados vacíos/de error cubre toda la app a la vez |
 
 ## Señales de éxito
 
 <a id="m-001"></a>
 
-### M-001 — <señal que demuestra el resultado>
+### M-001 — la vista se entiende sin explicación
 
-- **Pregunta:** ¿<qué queremos comprobar>?
-- **Señal:** <comportamiento o resultado observable>.
-- **Método y umbral:** <instrumentación o revisión, qué resultado, en qué población y ventana>.
-- **Guardrail:** <daño que no debe aumentar para conseguir la señal>.
+- **Pregunta:** ¿alguien que nunca vio esta pantalla identifica en segundos quién es el profesional, cuánto
+  cobra y cómo contactarlo?
+- **Señal:** se le muestra la vista nueva (en el celular, sin contexto previo) a 5 personas ajenas al
+  proyecto. Al menos 4 de las 5 dicen sin ayuda, en menos de 10 segundos, el nombre/oficio, el precio
+  orientativo y cómo contactar — y ninguna la describe como "desordenada" o "confusa" sin que se le
+  pregunte por eso.
+- **Línea en la arena:** si menos de 4 de 5 lo logran, la entrega no se da por terminada — se revisa la
+  jerarquía visual antes de abrir el PR, no se corrige después de mergeado.
+- **Método:** revisión cualitativa, conversación uno a uno mostrando la pantalla — no hay instrumentación
+  automática posible sin usuarios reales todavía (etapa "Empatía" del framework `lean-analytics`, igual que
+  en la misión 09: la métrica esperada en esta etapa son notas de conversación, no un número instrumentado).
+- **Guardrail (contramétrica):** no aumentar el tiempo de carga de la página ni introducir scroll horizontal
+  en ningún tamaño de pantalla — evita que "se ve más ordenado" se logre a costa de rendimiento o de romper
+  el layout mobile.
 
 ## Decisiones de producto
 
-<!--
-Solo decisiones con alternativas reales. No borres decisiones reemplazadas: explican por qué el producto
-es como es. Toda decisión propuesta se refleja en el README con fecha límite.
--->
-
 <a id="d-001"></a>
 
-### D-001 — <decisión en una frase que se entiende sola>
+### D-001 — esta entrega reorganiza datos existentes; no agrega campos nuevos al perfil
 
-- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
-- **Sustento:** [C-001](./investigacion.md#c-001).
-- **Tensión:** <criterios que no podían maximizarse al mismo tiempo>.
-- **Alternativas descartadas:** <opciones y razón concreta del rechazo, en la misma línea>.
-- **Decisión y consecuencia:** <qué se hará y qué habilita, limita o exige revisar en UX e ingeniería>.
-- **Reapertura:** <evidencia o cambio que justificaría revisarla>.
+- **Estado:** propuesta. **Fecha:** 2026-09-10.
+- **Sustento:** [C-002](./investigacion.md#c-002).
+- **Tensión:** la referencia de directorio de servicios ([E-004](./investigacion.md#e-004)) trae tags de
+  atributos y ubicación con mapa, que harían la ficha más rica — pero ninguno de esos datos existe hoy en
+  el schema de `professionals`.
+- **Alternativas descartadas:** agregar esos campos en la misma misión, para calzar más con la referencia
+  — se descarta porque mezclaría una decisión de qué datos nuevos pedirle a un profesional (con su propio
+  costo de fricción en el registro) con un problema que es puramente de layout; encarece y alarga esta
+  misión sin necesidad.
+- **Decisión y consecuencia:** el recorte reorganiza y prioriza lo que el perfil ya muestra. Habilita que
+  `experiencia.md` e `ingenieria.md` trabajen solo sobre componentes existentes, sin tocar `server/db/schema`.
+- **Reapertura:** si una misión futura decide agregar atributos o ubicación al perfil de profesional.
+
+<a id="d-002"></a>
+
+### D-002 — las reseñas salen de la tarjeta de contacto y pasan a ser una sección propia
+
+- **Estado:** propuesta. **Fecha:** 2026-09-10.
+- **Sustento:** [C-003](./investigacion.md#c-003).
+- **Tensión:** dejarlas donde están hoy (dentro de la misma columna que el CTA) es el cambio más chico;
+  moverlas a una sección propia es más trabajo de layout pero libera esa columna para que sea solo de
+  contacto.
+- **Alternativas descartadas:** dejar las reseñas donde están y solo separar visualmente con más espaciado
+  — se descarta porque no resuelve que compitan por la misma columna angosta que el precio y el CTA, que es
+  justo lo que el dueño de producto señaló como parte del desorden.
+- **Decisión y consecuencia:** las reseñas se diseñan en `experiencia.md` como bloque de ancho completo (o
+  equivalente), separado del bloque de identidad+contacto. En mobile esto cambia el orden de scroll actual
+  (hoy: descripción → precio → reseñas → CTA fijo).
+- **Reapertura:** si en el diseño de `experiencia.md` una sección separada resulta peor en mobile por el
+  espacio que ocupa — se evaluaría ahí, no acá.
+
+<a id="d-003"></a>
+
+### D-003 — el botón de contacto reserva su propio espacio; no depende del buffer genérico del footer
+
+- **Estado:** propuesta. **Fecha:** 2026-09-10.
+- **Sustento:** [C-004](./investigacion.md#c-004).
+- **Tensión:** la solución más simple es agrandar el `pb-24` que `general.vue` ya reserva — pero ese número
+  fue pensado para el buscador compacto de la misión 09, no para esta barra, y un número fijo más grande
+  sigue siendo frágil si el contenido de cualquiera de las dos barras cambia a futuro.
+- **Alternativas descartadas:** subir el buffer genérico a un número más grande y probar — se descarta como
+  decisión de producto porque es un parche que no explica por qué ese número es el correcto; queda como
+  posible solución técnica, pero la decisión de producto es que el comportamiento (nunca taparse) no puede
+  depender de que alguien adivine bien un número de píxeles.
+- **Decisión y consecuencia:** el requisito de producto es el comportamiento ("nunca tapado"), no el
+  mecanismo — cómo se reserva ese espacio exactamente (buffer propio, medición dinámica, u otro) es
+  decisión de `ingenieria.md`.
+- **Reapertura:** no aplica — es el tipo de decisión que no debería necesitar reabrirse si `ingenieria.md`
+  la resuelve bien la primera vez.
 
 ## Preguntas
 
-<!--
-Solo preguntas que pueden cambiar una decisión o funcionalidad. Lo demás va a un issue.
-Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
-Estado: abierta | resuelta AAAA-MM-DD (alguien la respondió) | disuelta AAAA-MM-DD (el producto cambió y la
-pregunta dejó de tener sentido). Solo las abiertas llevan bloque de detalle debajo de la tabla.
--->
+Sin preguntas abiertas — el recorte de esta entrega quedó definido en D-001 a D-003.
 
-<Una frase que responde "¿qué falta?": la pregunta que bloquea y qué bloquea.>
-
-| ID    | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
-| ----- | ---------------------- | ------------------- | --------------------------------------------------------------- |
-| Q-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
-| Q-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |
-
-<a id="q-001"></a>
-
-### Q-001 — <la pregunta en una frase que se entiende sola>
-
-- **La duda, con un ejemplo:** <el caso concreto que muestra por qué hay dos respuestas posibles>.
-- **Afecta a:** D-001 o F-001.
-- **Cómo se resolverá:** <quién y con qué método>.
-- **¿Bloquea algo?:** <qué bloquea y su fecha límite, o no>.
+| ID | La duda | Estado | Respuesta, o quién la resuelve |
+| -- | ------- | ------ | ------------------------------- |
+| —  | —       | —      | —                                |

--- a/docs/missions/README.md
+++ b/docs/missions/README.md
@@ -19,7 +19,7 @@ abrieron y de dónde salió cada una.
 | 08  | [foto de perfil de profesional](./08-foto-perfil-profesional/) | producto | 2026-08-29 | cerrada 2026-09-02 | — | — |
 | 09  | [layout general (navbar, footer, TOS)](./09-layout-general/) | producto | 2026-08-31 | en construcción | — | — |
 | 10  | [vista de resultados de búsqueda](./10-vista-resultados-busqueda/) | producto | 2026-09-01 | lista para construir | — | — |
-| 11  | [vista de detalle de perfil](./11-perfil-profesional/) | producto | 2026-09-01 | exploración | — | — |
+| 11  | [vista de detalle de perfil](./11-perfil-profesional/) | producto | 2026-09-01 | definición | Ingeniería | — |
 | 12  | [hero y copy de la landing](./12-hero-y-copy-landing/) | producto | 2026-09-01 | definición | Producto | — |
 
 Misiones 02 a 07 son las seis que llevan al MVP (registrarse, mostrarse, buscar, reseñar), en el orden de

--- a/docs/missions/README.md
+++ b/docs/missions/README.md
@@ -19,7 +19,7 @@ abrieron y de dónde salió cada una.
 | 08  | [foto de perfil de profesional](./08-foto-perfil-profesional/) | producto | 2026-08-29 | cerrada 2026-09-02 | — | — |
 | 09  | [layout general (navbar, footer, TOS)](./09-layout-general/) | producto | 2026-08-31 | en construcción | — | — |
 | 10  | [vista de resultados de búsqueda](./10-vista-resultados-busqueda/) | producto | 2026-09-01 | lista para construir | — | — |
-| 11  | [vista de detalle de perfil](./11-perfil-profesional/) | producto | 2026-09-01 | definición | Ingeniería | — |
+| 11  | [vista de detalle de perfil](./11-perfil-profesional/) | producto | 2026-09-01 | lista para construir | — | — |
 | 12  | [hero y copy de la landing](./12-hero-y-copy-landing/) | producto | 2026-09-01 | definición | Producto | — |
 
 Misiones 02 a 07 son las seis que llevan al MVP (registrarse, mostrarse, buscar, reseñar), en el orden de


### PR DESCRIPTION
## Resumen

Discovery completo de la misión 11 (vista de detalle de perfil de profesional, `/profesionales/[id]`) — los cuatro documentos vigentes, aprobados por Patricio:

- `investigacion.md`: problema (el CTA se solapa con el footer en mobile, el desktop se ve desordenado), evidencia y el ideal.
- `producto.md`: F-001, D-001 a D-003, aprobado 2026-09-03.
- `experiencia.md`: UXF-001, UX-001 a UX-005 (incluye el nombre junto al avatar del sidebar y el sticky en CSS Grid durante las reseñas), aprobado 2026-09-04. Pasó por evaluación heurística en agente separado, dos rondas.
- `ingenieria.md`: sin cambios de datos ni RLS, tres decisiones técnicas (T-001 CSS Grid, T-002 medir el CTA en vez de adivinar el buffer, T-003 corrige un bug preexistente de CL-003), 5 slices de construcción. Pasó por auditoría en agente separado que encontró y corrigió dos hallazgos bloqueantes.

## Test plan

- [x] Cada documento pasó su propio proceso de aprobación (dueño de producto) y evaluación/auditoría en agente separado.
- [ ] N/A — es discovery, sin código que ejecutar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RsYK55u75YJcmyyCV8YdUL