### PR TITLE
docs: cerrar la misión 09, S-008 movido a la misión 12

### DIFF
--- a/docs/missions/09-layout-general/README.md
+++ b/docs/missions/09-layout-general/README.md
@@ -2,18 +2,19 @@
 
 **Tipo:** producto. **Abierta el** 2026-08-31. **Nace de:** ninguna.
 
-**Estado de la misión:** en construcción
+**Estado de la misión:** cerrada 2026-09-04
 
-**Última actualización:** 2026-09-02
+**Última actualización:** 2026-09-04
 
 **Documentos:** [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-**Próximo hito:** los 8 issues del plan de construcción ya están abiertos
-([#148](https://github.com/PatricioTabilo/datealo/issues/148) a
-[#155](https://github.com/PatricioTabilo/datealo/issues/155), ver tabla en
-[`ingenieria.md`](./ingenieria.md#plan-de-construcción)) — arrancar por S-001, S-003 y S-004 (sin
-dependencias entre sí), en la raíz del repo, un PR chico por issue. Sin fecha límite todavía.
+S-001 a S-007 del plan de construcción están mergeados. **S-008 se retiró del plan a propósito** (no
+quedó sin hacer) — al ejecutarlo, tocaba una decisión que en realidad es de la
+[misión 12](../12-hero-y-copy-landing/) (si el hero necesita su propio buscador una vez que el nav ya
+tiene uno). El issue [#155](https://github.com/PatricioTabilo/datealo/issues/155) quedó cerrado con esa
+nota; se retoma junto con la misión 12, no como parte de esta. Detalle en
+[`ingenieria.md`](./ingenieria.md#plan-de-construcción).
 
 `ingenieria.md` **vigente — aprobado por Patricio el 2026-09-02**: sin tablas nuevas (reutiliza
 `GET /api/professionals/me` y agrega una sola query de solo lectura, comunas frecuentes); layout de Nuxt

--- a/docs/missions/09-layout-general/ingenieria.md
+++ b/docs/missions/09-layout-general/ingenieria.md
@@ -168,7 +168,15 @@ hace falta tocar `server/db/sql/rls.sql` en esta misión.
 | S-005 | Construir `CompactSearchBar`: resumen + panel categoría→comuna, "Buscar" habilitado solo con ambos | TC-002, F-002, C-016, UX-001       | Mobile: hoja completa, categoría se abre primero, su lista de opciones queda directo debajo del campo activo; desktop: panel flotante inline; en ambos, "Buscar" deshabilitado hasta tener categoría y comuna; el botón fijo de mobile queda visible con el teclado virtual abierto ([TR-001](#riesgos-y-experimentos-de-factibilidad)) | S-004      | [#152](https://github.com/PatricioTabilo/datealo/issues/152) |
 | S-006 | Construir `AppHeader`: botón de volver con destino por ruta, `CompactSearchBar` solo en `/buscar`, zona de avatar | TC-004, F-001, D-005, UX-003, UX-005 | Mobile: volver es solo ícono en toda superficie; desktop: volver lleva ícono+texto y el buscador queda centrado en un grid de 3 zonas; con sesión aparece el avatar a la derecha, sin sesión la zona derecha queda vacía fuera de la landing | S-003, S-005 | [#153](https://github.com/PatricioTabilo/datealo/issues/153) |
 | S-007 | Crear el layout `general.vue` y aplicarlo a `/buscar`, `/profesionales/[id]`, `/profesional/*` | F-001, F-003                       | Las cinco páginas muestran `AppHeader` + `AppFooter` envolviendo su contenido actual sin cambiar su lógica interna; `npx nuxi typecheck` y `npm run build` pasan | S-002, S-006 | [#154](https://github.com/PatricioTabilo/datealo/issues/154) |
-| S-008 | Reescribir `LandingNavbar`: "Categorías" + Publícate/Mi perfil (sin "Para profesionales" ni el CTA "Buscar" suelto), `CompactSearchBar` inline tras hacer scroll | F-001, D-005, UXF-003              | Antes de scroll: logo, Categorías (ancla), Publícate/Mi perfil; tras scroll: mismo nav pero con `CompactSearchBar` en vez de las anclas; con sesión activa, "Mi perfil" reemplaza a "Publícate" en ambos estados | S-003, S-005 | [#155](https://github.com/PatricioTabilo/datealo/issues/155) |
+| S-008 | **Retirado (2026-09-04)** — Reescribir `LandingNavbar`, movido a la misión 12 | F-001, D-005, UXF-003 | — | S-003, S-005 | [#155](https://github.com/PatricioTabilo/datealo/issues/155), cerrado |
+
+**S-008, retirado:** decía "Reescribir `LandingNavbar`: 'Categorías' + Publícate/Mi perfil, `CompactSearchBar`
+inline tras hacer scroll". Se sacó del plan de construcción de esta misión, a propósito — no quedó sin
+hacer, se movió. Al ejecutarlo, el enfoque original (buscador completo tras scroll, CTA "Publícate" como
+texto) resultó tener bugs reales en mobile, y revisándolo se vio que toca una decisión que en realidad es
+de la misión 12 ("hero y copy de la landing"): la landing tiene dos buscadores (hero + nav) y no está
+resuelto si el hero necesita el suyo propio una vez que el nav ya tiene uno. El issue #155 quedó cerrado
+con esa nota; se retoma junto con la misión 12, no como parte de esta.
 
 ## Decisiones técnicas
 

--- a/docs/missions/README.md
+++ b/docs/missions/README.md
@@ -17,7 +17,7 @@ abrieron y de dónde salió cada una.
 | 06  | [búsqueda y resultados](./06-busqueda-resultados/) | producto | 2026-08-13 | cerrada 2026-08-31 | — | — |
 | 07  | [reseñas verificadas por contacto](./07-resenas-verificadas-por-contacto/) | producto | 2026-08-13 | cerrada 2026-08-31 | — | — |
 | 08  | [foto de perfil de profesional](./08-foto-perfil-profesional/) | producto | 2026-08-29 | cerrada 2026-09-02 | — | — |
-| 09  | [layout general (navbar, footer, TOS)](./09-layout-general/) | producto | 2026-08-31 | en construcción | — | — |
+| 09  | [layout general (navbar, footer, TOS)](./09-layout-general/) | producto | 2026-08-31 | cerrada 2026-09-04 | — | — |
 | 10  | [vista de resultados de búsqueda](./10-vista-resultados-busqueda/) | producto | 2026-09-01 | lista para construir | — | — |
 | 11  | [vista de detalle de perfil](./11-perfil-profesional/) | producto | 2026-09-01 | lista para construir | — | — |
 | 12  | [hero y copy de la landing](./12-hero-y-copy-landing/) | producto | 2026-09-01 | definición | Producto | — |


### PR DESCRIPTION
## Resumen

- S-001 a S-007 del plan de construcción de la misión 09 ya estaban mergeados.
- S-008 (reescribir `LandingNavbar` con `CompactSearchBar` inline tras scroll) se retira del plan a propósito — al ejecutarlo tocaba una decisión de la misión 12 (si el hero necesita su propio buscador una vez que el nav ya tiene uno).
- Issue #155 cerrado con esa nota.
- Misión 09 pasa a `cerrada 2026-09-04` en su README y en el registro de misiones.

Esto libera el foco de "una misión en construcción a la vez" para que la misión 11 pueda arrancar su plan de construcción.

## Test plan

- N/A — solo documentación.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RsYK55u75YJcmyyCV8YdUL