### PR TITLE
docs: misión 11 pasa a en construcción

### DIFF
--- a/docs/missions/11-perfil-profesional/README.md
+++ b/docs/missions/11-perfil-profesional/README.md
@@ -3,7 +3,7 @@
 **Tipo:** producto. **Abierta el** 2026-09-01. **Nace de:** división de la misión 09 (ver su
 [README](../09-layout-general/README.md)).
 
-**Estado de la misión:** lista para construir
+**Estado de la misión:** en construcción
 
 **Última actualización:** 2026-09-04
 
@@ -23,13 +23,11 @@ T-003 corrige un bug preexistente de CL-003 que esta misión hizo visible), en 5
 Pasó por una auditoría en agente separado que encontró y corrigió dos hallazgos bloqueantes antes de
 llegar a este estado.
 
-**Discovery cerrado.** Próximo hito: los issues del plan de construcción ya están abiertos
+**Discovery cerrado.** La misión 09 se cerró el 2026-09-04 (S-008 movido a la misión 12), así que esta
+pasa a ser la única misión en delivery. **Próximo hito:** ejecutar el plan de construcción
 ([#181](https://github.com/PatricioTabilo/datealo/issues/181) a
 [#185](https://github.com/PatricioTabilo/datealo/issues/185), ver tabla en
-[`ingenieria.md`](./ingenieria.md#plan-de-construcción)). La ejecución todavía no arranca: la misión 09
-sigue `en construcción` (le queda el issue #155 abierto) y `CLAUDE.md` fija una sola misión en delivery a
-la vez — queda pendiente de que el dueño de producto decida si esperar a que la 09 cierre o hacer una
-excepción explícita.
+[`ingenieria.md`](./ingenieria.md#plan-de-construcción)) — arrancando por S-001.
 
 ## Brief
 

--- a/docs/missions/README.md
+++ b/docs/missions/README.md
@@ -19,7 +19,7 @@ abrieron y de dónde salió cada una.
 | 08  | [foto de perfil de profesional](./08-foto-perfil-profesional/) | producto | 2026-08-29 | cerrada 2026-09-02 | — | — |
 | 09  | [layout general (navbar, footer, TOS)](./09-layout-general/) | producto | 2026-08-31 | cerrada 2026-09-04 | — | — |
 | 10  | [vista de resultados de búsqueda](./10-vista-resultados-busqueda/) | producto | 2026-09-01 | lista para construir | — | — |
-| 11  | [vista de detalle de perfil](./11-perfil-profesional/) | producto | 2026-09-01 | lista para construir | — | — |
+| 11  | [vista de detalle de perfil](./11-perfil-profesional/) | producto | 2026-09-01 | en construcción | — | — |
 | 12  | [hero y copy de la landing](./12-hero-y-copy-landing/) | producto | 2026-09-01 | definición | Producto | — |
 
 Misiones 02 a 07 son las seis que llevan al MVP (registrarse, mostrarse, buscar, reseñar), en el orden de


### PR DESCRIPTION
La misión 09 se cerró (S-008 movido a la misión 12), liberando el foco de
"una misión en construcción a la vez" para la misión 11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RsYK55u75YJcmyyCV8YdUL