### PR TITLE
feat(app): medir el CTA de contacto en vez de adivinar el buffer del footer

### DIFF
--- a/app/composables/useContactBarHeight.test.ts
+++ b/app/composables/useContactBarHeight.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+import { defineComponent, ref } from 'vue'
+import type { Ref } from 'vue'
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { useContactBarHeight } from './useContactBarHeight'
+
+// jsdom no implementa ResizeObserver — este stub deja disparar el callback a mano con la altura que cada
+// test necesite, en vez de depender de un resize real que jsdom no puede producir.
+class FakeResizeObserver {
+  static instances: FakeResizeObserver[] = []
+  observed: Element[] = []
+
+  constructor(private callback: (entries: [{ contentRect: { height: number } }]) => void) {
+    FakeResizeObserver.instances.push(this)
+  }
+
+  observe(el: Element) {
+    this.observed.push(el)
+  }
+
+  unobserve(el: Element) {
+    this.observed = this.observed.filter(observed => observed !== el)
+  }
+
+  disconnect() {
+    this.observed = []
+  }
+
+  trigger(height: number) {
+    this.callback([{ contentRect: { height } }])
+  }
+}
+
+function mountUseContactBarHeight(barRef: Ref<HTMLElement | null>) {
+  return mount(defineComponent({
+    setup() {
+      useContactBarHeight(barRef)
+      return {}
+    },
+    template: '<div />',
+  }))
+}
+
+describe('useContactBarHeight', () => {
+  beforeEach(() => {
+    FakeResizeObserver.instances = []
+    // @ts-expect-error stub deliberadamente más chico que el ResizeObserver real del navegador
+    globalThis.ResizeObserver = FakeResizeObserver
+    document.documentElement.style.removeProperty('--contact-bar-h')
+  })
+
+  afterEach(() => {
+    document.documentElement.style.removeProperty('--contact-bar-h')
+  })
+
+  it('con barRef en null, no observa nada ni escribe la variable CSS', () => {
+    mountUseContactBarHeight(ref(null))
+
+    expect(FakeResizeObserver.instances[0]?.observed).toHaveLength(0)
+    expect(document.documentElement.style.getPropertyValue('--contact-bar-h')).toBe('')
+  })
+
+  it('con un elemento observado, publica su alto real en --contact-bar-h', () => {
+    const el = document.createElement('div')
+    mountUseContactBarHeight(ref(el))
+
+    FakeResizeObserver.instances[0]?.trigger(84)
+
+    expect(document.documentElement.style.getPropertyValue('--contact-bar-h')).toBe('84px')
+  })
+
+  it('al desmontar, limpia la variable CSS', () => {
+    const el = document.createElement('div')
+    const wrapper = mountUseContactBarHeight(ref(el))
+    FakeResizeObserver.instances[0]?.trigger(84)
+
+    wrapper.unmount()
+
+    expect(document.documentElement.style.getPropertyValue('--contact-bar-h')).toBe('')
+  })
+})

--- a/app/composables/useContactBarHeight.ts
+++ b/app/composables/useContactBarHeight.ts
@@ -1,0 +1,30 @@
+import { onMounted, onUnmounted, watch } from 'vue'
+import type { Ref } from 'vue'
+
+// Publica el alto real de la barra en --contact-bar-h (:root) en vez de asumir un número fijo — así el
+// espacio que reserva quien la usa (AppFooter) se ajusta solo si la barra cambia de alto, en vez de
+// quedar bien calibrado solo para el contenido de hoy. Import explícito de Vue (no auto-import de Nuxt),
+// mismo criterio que useSlowLoad: se puede testear con Vitest sin levantar un contexto de Nuxt completo.
+export function useContactBarHeight(barRef: Ref<HTMLElement | null>) {
+  let observer: ResizeObserver | null = null
+
+  onMounted(() => {
+    observer = new ResizeObserver((entries) => {
+      const height = entries[0]?.contentRect.height
+      if (height !== undefined) {
+        document.documentElement.style.setProperty('--contact-bar-h', `${height}px`)
+      }
+    })
+
+    watch(barRef, (el, _previous, onCleanup) => {
+      if (!el) return
+      observer?.observe(el)
+      onCleanup(() => observer?.unobserve(el))
+    }, { immediate: true })
+  })
+
+  onUnmounted(() => {
+    observer?.disconnect()
+    document.documentElement.style.removeProperty('--contact-bar-h')
+  })
+}

--- a/app/layouts/general.vue
+++ b/app/layouts/general.vue
@@ -4,6 +4,6 @@
     <div class="flex-1">
       <slot />
     </div>
-    <AppFooter class="pb-24 lg:pb-0" />
+    <AppFooter class="pb-[var(--contact-bar-h,_6rem)] lg:pb-0" />
   </div>
 </template>

--- a/app/pages/profesionales/[id].vue
+++ b/app/pages/profesionales/[id].vue
@@ -11,6 +11,9 @@ const { professional, pending, notFound, slow, refresh, updateProfessional } = u
 
 const memberSince = computed(() => professional.value ? formatMemberSince(professional.value.createdAt) : '')
 
+const contactBarRef = useTemplateRef('contactBar')
+useContactBarHeight(contactBarRef)
+
 function onReviewPublished(review: PublicReview) {
   if (!professional.value) return
   const reviews = upsertLocalReview(professional.value.reviews, review)
@@ -107,6 +110,7 @@ useSeoMeta({
         <p class="mt-3 text-xs text-datealo-muted">En Datealo desde {{ memberSince }}</p>
 
         <div
+          ref="contactBar"
           class="fixed inset-x-0 bottom-0 z-10 border-t border-datealo-surface bg-datealo-bg p-4 lg:static lg:mt-8 lg:border-0 lg:bg-transparent lg:p-0"
         >
           <ProfessionalPublicContactBar


### PR DESCRIPTION
Closes #181

## Resumen

- `useContactBarHeight(barRef)`: mide con `ResizeObserver` el alto real del elemento observado y lo publica en `document.documentElement.style` como `--contact-bar-h`. Limpia la propiedad al desmontar.
- `AppFooter` (vía `general.vue`) pasa de `pb-24 lg:pb-0` a `pb-[var(--contact-bar-h,_6rem)] lg:pb-0` — mismo `lg:pb-0` de siempre, sin tocar: en desktop el CTA de `/profesionales/[id]` es `lg:static`, no reserva nada, igual que hoy.
- `[id].vue` conecta el composable al wrapper real del CTA fijo de mobile.
- El fallback de `6rem` preserva el comportamiento actual en cualquier página que no monte el composable (`/buscar`, con el buscador compacto de la misión 09).

Sustento: TC-001, D-003, T-002 (`docs/missions/11-perfil-profesional/ingenieria.md`).

## Test plan

- [x] `npx vitest run app/composables/useContactBarHeight.test.ts` — 3 tests, con un stub de `ResizeObserver` (jsdom no lo implementa): `barRef` en `null` no observa ni escribe la variable; con un elemento observado publica su alto real; al desmontar limpia la variable.
- [x] `npx nuxi typecheck` — cero errores.
- [x] `npm run build` — compila y genera el output de Vercel sin errores.
- [ ] Verificación visual en el browser: intenté verificar en vivo (`npm run dev` + Chrome) que el CTA de mobile reserva el alto real y que desktop no cambia, pero la pestaña con la que contaba quedó en segundo plano (`document.hidden === true`) y los navegadores pausan `ResizeObserver` en pestañas no visibles — no pude confirmarlo empíricamente en esta sesión. Sí confirmé en esa misma pestaña que el footer calcula `padding-bottom: 0px` en desktop (`lg:pb-0` intacto) y que el elemento del CTA existe con el `ref` correcto. Recomiendo una pasada visual rápida en mobile real (390px) antes de mergear, en línea con la verificación de UI que pide `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RsYK55u75YJcmyyCV8YdUL