### PR TITLE
feat(app): reestructurar el perfil de profesional a la jerarquía nueva

### DIFF
--- a/app/pages/profesionales/[id].vue
+++ b/app/pages/profesionales/[id].vue
@@ -60,58 +60,60 @@ useSeoMeta({
     </div>
 
     <!-- encontrado -->
-    <div v-else-if="professional" class="mx-auto max-w-5xl lg:flex lg:items-start lg:gap-8 lg:px-8 lg:py-8">
-      <ProfessionalPublicPhotos
-        :photo-urls="professional.photoUrls"
-        :display-name="professional.displayName"
-        :avatar-url="professional.avatarUrl"
-        class="lg:w-[55%]"
-      />
+    <div v-else-if="professional" class="mx-auto max-w-5xl lg:grid lg:grid-cols-[55fr_45fr] lg:items-start lg:gap-8 lg:px-8 lg:py-8">
+      <!-- Columna principal: galería + identidad + precio + descripción -->
+      <div>
+        <ProfessionalPublicPhotos
+          :photo-urls="professional.photoUrls"
+          :display-name="professional.displayName"
+          :avatar-url="professional.avatarUrl"
+        />
 
-      <div
-        class="px-5 pb-28 pt-5 lg:flex-1 lg:sticky lg:top-8 lg:self-start lg:rounded-2xl lg:border lg:border-datealo-surface lg:p-6"
-      >
-        <div class="flex items-center gap-3">
+        <div class="px-5 pt-4 lg:px-0">
+          <h1 class="text-xl font-extrabold text-datealo-text lg:text-2xl">{{ professional.displayName }}</h1>
+          <p class="mt-0.5 text-sm text-datealo-muted">{{ professional.categoriaNombre }} · {{ professional.comunaNombre }}</p>
+
+          <p v-if="professional.priceFrom" class="mt-2 text-base font-bold text-datealo-text lg:text-lg">
+            Desde ${{ formatPriceFrom(professional.priceFrom) }}
+          </p>
+
+          <p v-if="professional.description" class="mt-4 text-sm leading-relaxed text-datealo-text">
+            {{ professional.description }}
+          </p>
+        </div>
+      </div>
+
+      <!-- El sticky sigue activo durante las reseñas porque este bloque ocupa dos filas del grid
+           (row-span-2, la fila siguiente la usa ProfessionalPublicReviews con col-span-2) — sin el span,
+           se despegaría al terminar esta columna. El borde/padding de tarjeta y el avatar+nombre+rating
+           son solo de desktop: en mobile el bloque queda sin estilo propio, y su único hijo con presencia
+           real es el CTA (fixed, fuera del flujo normal). -->
+      <div class="lg:sticky lg:top-8 lg:row-span-2 lg:self-start lg:rounded-2xl lg:border lg:border-datealo-surface lg:p-6">
+        <div class="hidden items-center gap-3 lg:flex">
           <img
             v-if="professional.photoUrls.length && professional.avatarUrl"
             :src="professional.avatarUrl"
             :alt="professional.displayName"
-            class="h-12 w-12 shrink-0 rounded-full object-cover ring-2 ring-datealo-surface ring-offset-2 ring-offset-datealo-bg"
+            class="h-14 w-14 shrink-0 rounded-full object-cover ring-2 ring-datealo-surface ring-offset-2 ring-offset-datealo-bg"
           >
+          <div v-else class="flex h-14 w-14 shrink-0 items-center justify-center rounded-full bg-primary text-base font-extrabold text-white">
+            {{ initials(professional.displayName) }}
+          </div>
           <div>
-            <h1 class="text-xl font-extrabold text-datealo-text lg:text-2xl">{{ professional.displayName }}</h1>
-            <p class="mt-0.5 text-sm text-datealo-muted">{{ professional.categoriaNombre }} · {{ professional.comunaNombre }}</p>
+            <p class="font-extrabold text-datealo-text">{{ professional.displayName }}</p>
+            <div v-if="professional.ratingAverage !== null" class="mt-0.5 flex items-center gap-1 text-sm">
+              <Star class="h-3.5 w-3.5 fill-amber-400 text-amber-400" />
+              <span class="font-bold text-datealo-text">{{ professional.ratingAverage.toFixed(1).replace('.', ',') }}</span>
+              <span class="text-datealo-muted">· {{ professional.reviewCount }} reseñas</span>
+            </div>
           </div>
         </div>
 
-        <div v-if="professional.ratingAverage !== null" class="mt-2 flex items-center gap-1 text-sm">
-          <Star class="h-3.5 w-3.5 fill-amber-400 text-amber-400" />
-          <span class="font-bold text-datealo-text">{{ professional.ratingAverage.toFixed(1).replace('.', ',') }}</span>
-          <span class="text-datealo-muted">· {{ professional.reviewCount }} reseñas</span>
-        </div>
-
-        <p v-if="professional.description" class="mt-4 text-sm leading-relaxed text-datealo-text">
-          {{ professional.description }}
-        </p>
-
-        <p v-if="professional.priceFrom" class="mt-3 text-base font-bold text-datealo-text lg:text-lg">
-          Desde ${{ formatPriceFrom(professional.priceFrom) }}
-        </p>
-
-        <ProfessionalPublicReviews
-          class="mt-6"
-          :professional-id="professional.id"
-          :display-name="professional.displayName"
-          :categoria-nombre="professional.categoriaNombre"
-          :reviews="professional.reviews"
-          @published="onReviewPublished"
-        />
-
-        <p class="mt-3 text-xs text-datealo-muted">En Datealo desde {{ memberSince }}</p>
-
+        <!-- El mismo CTA sirve a ambos tamaños: fixed al fondo del viewport en mobile, inline dentro de
+             la tarjeta en desktop — un solo componente, sin duplicar su lógica de contacto. -->
         <div
           ref="contactBar"
-          class="fixed inset-x-0 bottom-0 z-10 border-t border-datealo-surface bg-datealo-bg p-4 lg:static lg:mt-8 lg:border-0 lg:bg-transparent lg:p-0"
+          class="fixed inset-x-0 bottom-0 z-10 border-t border-datealo-surface bg-datealo-bg p-4 lg:static lg:mt-5 lg:border-0 lg:bg-transparent lg:p-0"
         >
           <ProfessionalPublicContactBar
             :professional-id="professional.id"
@@ -120,7 +122,24 @@ useSeoMeta({
             :categoria-nombre="professional.categoriaNombre"
           />
         </div>
+
+        <p class="mt-3.5 hidden text-xs text-datealo-muted lg:block">En Datealo desde {{ memberSince }}</p>
       </div>
+
+      <!-- Reseñas: ancho completo, fuera de ambas columnas -->
+      <ProfessionalPublicReviews
+        class="mt-8 px-5 lg:col-span-2 lg:mt-10 lg:px-0"
+        :professional-id="professional.id"
+        :display-name="professional.displayName"
+        :categoria-nombre="professional.categoriaNombre"
+        :reviews="professional.reviews"
+        @published="onReviewPublished"
+      />
+
+      <!-- Mobile: "en Datealo desde" va después de las reseñas, no junto a la identidad — es el último
+           elemento antes del footer, así que el buffer de AppFooter (useContactBarHeight) ya alcanza
+           para que el CTA fijo no lo tape; no necesita su propio padding-bottom. -->
+      <p class="mt-3 px-5 text-xs text-datealo-muted lg:hidden">En Datealo desde {{ memberSince }}</p>
     </div>
   </div>
 </template>


### PR DESCRIPTION
Closes #182

## Resumen

- **Desktop:** identidad, precio y descripción se mueven a la columna de la galería (55%). El sidebar (45%) usa CSS Grid (`row-span-2` + `self-start`) y queda acotado a avatar+nombre+rating+contacto+"en Datealo desde" — sticky mientras se lee la descripción y las reseñas (se despega solo, cerca del footer).
- **Mobile:** el orden pasa a foto → identidad+precio → descripción → reseñas → "en Datealo desde". El CTA sigue siendo el mismo overlay fijo de siempre (un solo componente, sin duplicar su lógica de contacto entre mobile/desktop).
- **Reseñas:** ancho completo (`col-span-2`), fuera de ambas columnas.
- El `pb-28` que reservaba espacio para "en Datealo desde" en el layout viejo ya no hace falta — en el nuevo orden mobile ese texto es el último elemento antes del footer, y el buffer de `AppFooter` (`useContactBarHeight`, de #189) ya alcanza.

Sustento: UX-001, UX-002, UX-005, D-001, D-002 (`docs/missions/11-perfil-profesional/experiencia.md` y `producto.md`).

## Test plan

- [x] `npx nuxi typecheck` — cero errores.
- [x] `npx vitest run` — 73 tests, todos pasan.
- [x] `npm run build` — compila y genera el output de Vercel sin errores.
- [ ] Verificación visual: no la hice en esta sesión — la vez anterior terminé interactuando por error con una ventana de Chrome que no era mía (ver conversación), así que esta vez prefiero pedir que se revise en `npm run dev` en vez de arriesgarme otra vez. Casos a mirar en mobile (390px) y desktop: sidebar sticky durante reseñas, CTA fijo sin tapar el footer, caso sin fotos/precio/reseñas (CL-001 a CL-003).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RsYK55u75YJcmyyCV8YdUL