### PR TITLE
fix(app): alt vacío en miniaturas del carrusel, ya descritas por su aria-label

### DIFF
--- a/app/components/professional-public/ProfessionalPublicPhotos.vue
+++ b/app/components/professional-public/ProfessionalPublicPhotos.vue
@@ -45,7 +45,10 @@ function selectPhoto(index: number) {
         :aria-current="index === activeIndex"
         @click="selectPhoto(index)"
       >
-        <img :src="url" :alt="`Miniatura ${index + 1} de ${displayName}`" class="h-full w-full object-cover">
+        <!-- alt vacío a propósito: el aria-label del botón ya es el nombre accesible completo de este
+             control (qué foto activa y su posición) — un lector de pantalla nunca anuncia el alt de la
+             imagen interna por separado, así que dejarlo con texto solo agrega algo que nadie escucha. -->
+        <img :src="url" alt="" class="h-full w-full object-cover">
       </button>
     </div>
   </div>


### PR DESCRIPTION
Closes #184

## Resumen

El issue original (hallazgo de la evaluación heurística de `experiencia.md`) apuntaba al mockup, que sí
tenía miniaturas con alt genérico ("Miniatura N") sin ningún control accesible detrás. Revisando el
componente real (`ProfessionalPublicPhotos.vue`), el botón de cada miniatura **ya** lleva
`aria-label="Ver foto N de M"` — el nombre accesible completo del control. El `alt` de la imagen interna
("Miniatura N de {nombre}") nunca se anuncia por separado en ese caso: queda como texto muerto, no como un
problema de accesibilidad real.

Cambio: ese `alt` pasa a `""` (vacío), marcando la imagen como decorativa en vez de repetir un texto que
ningún lector de pantalla llega a leer — más correcto que dejar un `alt` con contenido que no cumple
ninguna función.

## Test plan

- [x] `npx nuxi typecheck` — cero errores.
- [x] `npx vitest run` — 73 tests, todos pasan (sin test propio de este componente).
- [x] `npm run build` — compila.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RsYK55u75YJcmyyCV8YdUL