### PR TITLE
fix(app): SSR real en /buscar y grid que sí llena 3 columnas

### DIFF
--- a/app/composables/useSearchResults.ts
+++ b/app/composables/useSearchResults.ts
@@ -1,22 +1,33 @@
 import type { Ref } from 'vue'
 import type { SearchApiResponse, SearchMatchType, SearchResultProfessional } from '~/types/search'
 
-// immediate/watch en false: no dispara ninguna request hasta que categoría y comuna tengan valor —
-// "todavía no se buscó" y "se buscó y no hay nada" tienen que quedar como dos estados distintos, y
-// dejar que useFetch dispare solo con la query vacía los mezclaría en uno.
+// watch: false en useFetch — no dispara ninguna request hasta que categoría y comuna tengan valor;
+// dejarlo reactivo a la query dispararía apenas cambia una de las dos, aunque la otra siga vacía, y
+// mezclaría "todavía no se buscó" con "se buscó y no hay nada".
+//
+// immediate se evalúa una sola vez, con el valor de `ready` en ese instante — no `false` fijo. Server
+// y cliente arrancan del mismo route.query, así que si la búsqueda ya viene lista en la URL (el caso
+// que le importa a un crawler o a un link compartido), los dos coinciden en pedir el fetch de entrada,
+// y el SSR lo espera antes de mandar el HTML. Con `immediate: false` a secas y el refresh() disparado
+// a mano más abajo, el servidor mandaba el esqueleto de "cargando" sin esperar nada (Nuxt solo trackea
+// para el SSR los fetches que useFetch dispara por su cuenta, no un refresh() llamado aparte) mientras
+// el cliente hidrataba ya con los datos resueltos — el choque rompía el grid de resultados en pantalla.
 export function useSearchResults(categoriaSlug: Ref<string | null>, comunaCodigo: Ref<string | null>) {
   const ready = computed(() => Boolean(categoriaSlug.value) && Boolean(comunaCodigo.value))
 
   const { data, pending, error, refresh } = useFetch<SearchApiResponse>('/api/search', {
     key: 'search-results',
     query: computed(() => ({ categoria: categoriaSlug.value, comuna: comunaCodigo.value })),
-    immediate: false,
+    immediate: ready.value,
     watch: false,
   })
 
+  // Sin immediate acá: el fetch de entrada, cuando ya estaba listo al montar, ya lo cubrió el
+  // `immediate` de arriba. Este watch solo cubre lo que pasa después del montaje — cambiar de
+  // categoría o comuna, o quedar "listo" recién en ese momento.
   watch([categoriaSlug, comunaCodigo], () => {
     if (ready.value) refresh()
-  }, { immediate: true })
+  })
 
   const results = computed<SearchResultProfessional[]>(() => data.value?.results ?? [])
   const matchType = computed<SearchMatchType | null>(() => data.value?.matchType ?? null)

--- a/app/pages/buscar/index.vue
+++ b/app/pages/buscar/index.vue
@@ -69,7 +69,7 @@ useSeoMeta({
       <!-- cargando -->
       <div
         v-else-if="pending"
-        class="grid gap-4 p-4 lg:p-8 lg:[grid-template-columns:repeat(auto-fit,minmax(17.5rem,23.75rem))]"
+        class="grid gap-4 p-4 lg:p-8 lg:[grid-template-columns:repeat(auto-fit,minmax(17.5rem,21rem))]"
         aria-busy="true"
       >
         <div v-for="n in 4" :key="n" class="overflow-hidden rounded-2xl border border-datealo-surface bg-white">
@@ -101,7 +101,11 @@ useSeoMeta({
           {{ results.length }} {{ results.length === 1 ? 'resultado' : 'resultados' }}
         </p>
 
-        <div class="grid gap-4 lg:[grid-template-columns:repeat(auto-fit,minmax(17.5rem,23.75rem))]">
+        <!-- El máximo de la tarjeta (21rem) no es solo un tope de ancho: con auto-fit, cuando el máximo
+             de minmax() es un valor fijo (no 1fr), el navegador lo usa a ÉL — no al mínimo — para
+             calcular cuántas columnas entran. Con 23.75rem el cálculo daba justo 2 en el ancho de
+             max-w-6xl, sin importar cuánto más ancha fuera la pantalla; 21rem dejan entrar 3 con margen. -->
+        <div class="grid gap-4 lg:[grid-template-columns:repeat(auto-fit,minmax(17.5rem,21rem))]">
           <SearchResultCard
             v-for="professional in results"
             :key="professional.id"

--- a/docs/missions/10-vista-resultados-busqueda/experiencia.md
+++ b/docs/missions/10-vista-resultados-busqueda/experiencia.md
@@ -244,6 +244,12 @@ como fuente. Con esto la decisión queda cerrada.
   ancho extra se traduzca en fotos más grandes, no en más margen.
 - **Impacto en producto:** ninguno.
 
+**Revisión (2026-09-04):** el tope de 380px de UX-003 volvió a bajar a 336px — con un máximo fijo,
+`auto-fit` nunca lograba 3 columnas dentro de este mismo `max-w-6xl` (detalle en la revisión de
+[UX-003](#ux-003)). El contenedor sigue en `max-w-6xl`; lo que cambia es que ya no hay margen para que las
+cards crezcan más allá de 336px al ensancharse la pantalla — se prioriza que 3 resultados llenen la fila
+(el caso común, y lo que esta vista promete) sobre cards más grandes en monitores anchos.
+
 <a id="ux-003"></a>
 
 ### UX-003 — El grid de desktop usa columnas `auto-fit` con `justify-content: center`, no `grid-cols-3` fijo
@@ -273,6 +279,16 @@ izquierda, como en cualquier grid normal. `auto-fit` + `minmax` por sí solo ya 
 original que motivó esta decisión (columnas fijas desperdiciando espacio en un contenedor ahora acotado)
 sin necesitar `justify-content: center`. La decisión queda: `grid-template-columns:
 repeat(auto-fit, minmax(280px, 380px))`, sin `justify-content`.
+
+**Revisión (2026-09-04, segunda):** con un máximo *fijo* (380px, no `1fr`), el navegador usa ese máximo
+—no el mínimo— para calcular cuántas columnas entran en `auto-fit`: 3 columnas necesitan
+`3×380px + 2×16px = 1172px`, más de lo que `max-w-6xl` entrega disponible (1088px, ver
+[UX-002](#ux-002)) — nunca alcanzan 3, sin importar el ancho de pantalla, contradiciendo "con 3
+resultados el efecto es prácticamente el mismo de un grid fijo" de esta misma decisión. Encontrado
+probando la vista con datos reales (4 profesionales) recién ahora, con 1-2 resultados el síntoma no era
+visible. El máximo baja a `336px` (`3×336 + 32 = 1040px`, con margen real) para que 3 quepan de verdad —
+revierte el valor que [UX-002](#ux-002) había subido a 380px, así que esa decisión también queda
+corregida. La decisión queda: `grid-template-columns: repeat(auto-fit, minmax(280px, 336px))`.
 
 ## Preguntas
 


### PR DESCRIPTION
## Resumen

Dos bugs distintos en `/buscar`, encontrados probando la vista con 4 profesionales reales en vez de 1 (con un solo resultado, ninguno de los dos síntomas era visible).

### 1. El SSR no esperaba los resultados de búsqueda (rompía SEO y el layout)

`useSearchResults.ts` disparaba el fetch a mano desde un `watch(..., { immediate: true })` externo, con `useFetch({ immediate: false, watch: false })`. Nuxt solo espera, durante el SSR, los fetches que `useFetch` dispara por su cuenta — no un `refresh()` llamado aparte. Confirmado con `curl` a la vista real: la respuesta SSR nunca traía ningún profesional ni el contador de resultados, solo el esqueleto de "cargando" — es decir, **un crawler que entra directo a `/buscar?categoria=X&comuna=Y` no ve ningún resultado**, justo lo que Nuxt con SSR está pensado para evitar.

Además, el cliente hidrataba ya con los datos resueltos → choque de hidratación de Vue (visible en consola: `Hydration class mismatch`) → el grid de resultados quedaba anidado dentro del `div` del skeleton viejo, angostado a una sola columna de 380px.

**Fix:** `immediate: ready.value` — se evalúa una sola vez, con el mismo valor en servidor y cliente (los dos arrancan del mismo `route.query`), así el SSR espera el fetch cuando la búsqueda ya viene lista en la URL. Sigue sin llamar a la API hasta tener categoría y comuna (mismo criterio de antes).

### 2. El grid nunca lograba 3 columnas, sin importar el ancho de pantalla

Con un máximo *fijo* en `minmax()` (380px, no `1fr`), el navegador usa ese máximo —no el mínimo— para calcular cuántas columnas entran en `auto-fit`. 3 columnas necesitan `3×380px + 2×16px = 1172px`; `max-w-6xl` solo entrega 1088px disponibles. Nunca alcanzaban.

**Fix:** el máximo baja a 336px (`3×336 + 32 = 1040px`, con margen real). Esto revierte el valor que UX-002/UX-003 de la misión 10 habían subido a 380px a propósito (para que un contenedor más ancho agrandara las cards) — documentado como corrección en `experiencia.md` de esa misión, con el trade-off explícito: se prioriza que 3 resultados llenen la fila (el caso común que la misión esperaba) sobre cards más grandes en monitores anchos.

## Test plan

- [x] `npx nuxi typecheck` — cero errores.
- [x] `npx vitest run` — 73 tests, todos pasan.
- [x] `npm run build` — compila.
- [x] Verificado en vivo (ventana propia, Chrome): `curl` a la respuesta SSR ahora trae los 4 profesionales y "4 resultados" en el HTML crudo; sin warnings de hidratación en consola; grid muestra 3 tarjetas por fila con la 4ª en la fila siguiente, en vez de 1 columna angosta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RsYK55u75YJcmyyCV8YdUL