### PR TITLE
chore(docs): usar Playwright headless para verificación visual

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,8 +112,22 @@ npx nuxi typecheck      # Cero errores
 npm run build           # Compila
 ```
 
-**Verificación visual**: para cambios de UI, levantar `npm run dev` (puerto 3001) y probar en el browser
-antes de dar el cambio por hecho. Móvil primero: 390px de ancho es el caso principal, no una variante.
+**Verificación visual**: para cambios de UI, levantar `npm run dev` (puerto 3001) y probar antes de dar el
+cambio por hecho. Móvil primero: 390px de ancho es el caso principal, no una variante.
+
+Para la captura automatizada, usar Playwright headless (`devDependency` del repo), nunca `claude-in-chrome`:
+`tabs_context_mcp({createIfEmpty: true})` no garantiza una ventana aislada — en la práctica puede adjuntarse
+a una ventana real del usuario y redimensionarla o interactuar con ella sin que el usuario lo pida (pasó dos
+veces, documentado en incidentes reales). Playwright headless corre en un proceso de Chromium propio, sin
+ninguna relación con el Chrome del usuario, así que el riesgo no existe:
+
+```bash
+npx playwright screenshot --viewport-size=390,844 http://localhost:3001/ruta output.png
+```
+
+`claude-in-chrome` queda reservado para cuando se necesite de verdad una sesión logueada o interacción en
+vivo que el usuario pueda ver — y ahí, confirmar con el usuario antes de cualquier acción que cambie estado
+de su navegador (resize, navegación, cierre de tabs), nunca asumir aislamiento.
 
 ## Escribir código
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@vue/test-utils": "^2.4.11",
         "drizzle-kit": "^0.31.10",
         "jsdom": "^29.1.1",
+        "playwright": "^1.63.0",
         "tsx": "^4.23.12",
         "typescript": "^6.0.3",
         "vitest": "^4.1.10",
@@ -11003,6 +11004,35 @@
         "confbox": "^0.2.4",
         "exsolve": "^1.0.8",
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0.tgz",
+      "integrity": "sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0.tgz",
+      "integrity": "sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/point-in-polygon-hao": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@vue/test-utils": "^2.4.11",
     "drizzle-kit": "^0.31.10",
     "jsdom": "^29.1.1",
+    "playwright": "^1.63.0",
     "tsx": "^4.23.12",
     "typescript": "^6.0.3",
     "vitest": "^4.1.10",


### PR DESCRIPTION
Closes #195

## Resumen

- `claude-in-chrome` no garantiza una ventana aislada del agente: `tabs_context_mcp({createIfEmpty: true})`
  puede adjuntarse a una ventana real del usuario. Confirmado en vivo: `resize_window` devolvió éxito pero
  redimensionó una ventana que el usuario estaba usando en ese momento (no una nueva y aislada).
- Es un límite conocido y sin resolver de la extensión (`anthropics/claude-code#66741`, `#27644`),
  no algo que se arregle con más guardrails de prompt — ya se había intentado antes y volvió a fallar.
- Se agrega `playwright` como devDependency y se actualiza la sección "Verificación visual" de `CLAUDE.md`
  para usar Playwright headless (proceso de Chromium propio, sin relación con el navegador real del
  usuario) en las capturas automatizadas. `claude-in-chrome` queda reservado solo para sesiones
  interactivas explícitas, con confirmación previa a cualquier acción que cambie estado del navegador.

## Test plan

- [x] `npx playwright screenshot --viewport-size=390,844 http://localhost:3001 ...` — funciona, sin tocar
  ningún navegador del usuario.
- [x] Repetido contra `/profesionales/1a51edff-c6d8-469c-ad0c-63e5951b7bd5` — mismo resultado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)