### PR TITLE
fix(app): despegar la tarjeta de contacto sticky por debajo del header

### DIFF
--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -23,10 +23,13 @@ const backLabel = computed(() => (isBuscar.value ? 'Volver al inicio' : 'Volver 
 const showLogoInDesktop = computed(() => isBuscar.value || route.path.startsWith('/profesionales/'))
 
 const { professional } = await useProfessionalSession()
+
+const headerRef = useTemplateRef('header')
+useHeaderHeight(headerRef)
 </script>
 
 <template>
-  <header class="sticky top-0 z-20 border-b border-datealo-surface bg-datealo-bg">
+  <header ref="header" class="sticky top-0 z-20 border-b border-datealo-surface bg-datealo-bg">
     <div class="flex items-center gap-3 px-5 py-3.5 lg:hidden">
       <NuxtLink
         :to="backTo"

--- a/app/composables/useHeaderHeight.ts
+++ b/app/composables/useHeaderHeight.ts
@@ -1,0 +1,29 @@
+import { onMounted, onUnmounted, watch } from 'vue'
+import type { Ref } from 'vue'
+
+// Publica el alto real del header en --header-h (:root) en vez de asumir un número fijo — mismo criterio
+// que useContactBarHeight. Lo consume cualquier elemento sticky que deba despegarse por debajo del header
+// (z-20, opaco) en vez de bajo su fondo.
+export function useHeaderHeight(headerRef: Ref<HTMLElement | null>) {
+  let observer: ResizeObserver | null = null
+
+  onMounted(() => {
+    observer = new ResizeObserver((entries) => {
+      const height = entries[0]?.contentRect.height
+      if (height !== undefined) {
+        document.documentElement.style.setProperty('--header-h', `${height}px`)
+      }
+    })
+
+    watch(headerRef, (el, _previous, onCleanup) => {
+      if (!el) return
+      observer?.observe(el)
+      onCleanup(() => observer?.unobserve(el))
+    }, { immediate: true })
+  })
+
+  onUnmounted(() => {
+    observer?.disconnect()
+    document.documentElement.style.removeProperty('--header-h')
+  })
+}

--- a/app/pages/profesionales/[id].vue
+++ b/app/pages/profesionales/[id].vue
@@ -87,8 +87,10 @@ useSeoMeta({
            (row-span-2, la fila siguiente la usa ProfessionalPublicReviews con col-span-2) — sin el span,
            se despegaría al terminar esta columna. El borde/padding de tarjeta y el avatar+nombre+rating
            son solo de desktop: en mobile el bloque queda sin estilo propio, y su único hijo con presencia
-           real es el CTA (fixed, fuera del flujo normal). -->
-      <div class="lg:sticky lg:top-8 lg:row-span-2 lg:self-start lg:rounded-2xl lg:border lg:border-datealo-surface lg:p-6">
+           real es el CTA (fixed, fuera del flujo normal). El top usa --header-h (AppHeader, vía
+           useHeaderHeight) en vez de un valor fijo: con top-8 a secas, el header (sticky, z-20, fondo
+           opaco) tapaba el borde superior de la tarjeta apenas esta se volvía sticky. -->
+      <div class="lg:sticky lg:top-[calc(var(--header-h,4.5rem)+2rem)] lg:row-span-2 lg:self-start lg:rounded-2xl lg:border lg:border-datealo-surface lg:p-6">
         <div class="hidden items-center gap-3 lg:flex">
           <img
             v-if="professional.photoUrls.length && professional.avatarUrl"


### PR DESCRIPTION
Closes #197

## Resumen

- La tarjeta de contacto sticky del perfil público (`/profesionales/[id]`, desktop) usaba `lg:top-8`
  (32px), menor que el alto real del header (~69px, también sticky, `z-20`, fondo opaco). Apenas la
  tarjeta se volvía sticky, el header le tapaba el borde superior — en scrolls más marcados, hasta medio
  avatar. Confirmado con capturas reales del usuario y reproducido midiendo `getBoundingClientRect()` de
  ambos elementos (37px de superposición real).
- Nuevo composable `useHeaderHeight` (mismo patrón que `useContactBarHeight` ya existente): publica el
  alto real del header en `--header-h` vía `ResizeObserver`, en vez de asumir un número fijo que se pudre
  si el header cambia.
- La tarjeta ahora usa `lg:top-[calc(var(--header-h,4.5rem)+2rem)]`.

## Test plan

- [x] `npx nuxi typecheck` — cero errores.
- [x] `npx vitest run` — 73 tests, todos pasan.
- [x] `npm run build` — compila.
- [x] Playwright: `sidebarRect.top` pasa de 32 (superpuesto con el header) a 100, sin superposición, en
  varias posiciones de scroll.
- [x] Mobile (390px) sin cambios — el sticky solo aplica en `lg:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)