### PR TITLE
fix(app): los dots de paginación del carrusel eran invisibles

### DIFF
--- a/app/components/professional-public/ProfessionalPublicPhotos.vue
+++ b/app/components/professional-public/ProfessionalPublicPhotos.vue
@@ -18,11 +18,20 @@ function selectPhoto(index: number) {
 
 <template>
   <div v-if="photoUrls.length">
+    <!-- dots solo mobile: ahí es la única señal de que hay más de una foto. En desktop la tira de
+         miniaturas de abajo ya cumple lo mismo con preview real, y los dots (centrados bajo todo el ancho
+         del carrusel) terminan superpuestos con las miniaturas apenas hay 4 fotos o más. -->
     <UCarousel
       ref="carousel"
       :items="photoUrls"
       dots
-      class="aspect-4/3 w-full overflow-hidden lg:rounded-2xl"
+      class="w-full"
+      :ui="{
+        viewport: 'aspect-4/3 overflow-hidden lg:rounded-2xl',
+        container: 'h-full',
+        item: 'h-full',
+        dots: 'lg:hidden',
+      }"
       @select="activeIndex = $event"
     >
       <template #default="{ item, index }">


### PR DESCRIPTION
Closes #199

## Resumen

- `aspect-4/3 overflow-hidden` estaba en el root de `UCarousel`, pero los dots de paginación (Nuxt UI)
  se renderizan `absolute -bottom-7` (28px por debajo del borde inferior del root) — con `overflow: hidden`
  ahí, quedaban recortados y 100% invisibles. Confirmado midiendo `getBoundingClientRect()`: la posición de
  los dots cae 28px pasado el borde del contenedor que los recorta.
- Afecta sobre todo a **mobile**: la tira de miniaturas (única otra señal de "hay más de una foto") está
  oculta ahí (`hidden lg:flex`, solo desktop) — sin dots visibles, mobile no tenía ninguna forma de saber
  que había más fotos.
- Fix: `aspect-4/3 overflow-hidden lg:rounded-2xl` se mueve al slot `viewport` (solo la imagen), dejando el
  root con alto libre. Los dots se ocultan en desktop (`ui: { dots: 'lg:hidden' }`) porque ahí la tira de
  miniaturas ya cumple lo mismo con preview real — y, simulando 6 fotos, confirmé que los dots (centrados
  bajo todo el carrusel) empiezan a superponerse con las miniaturas (que crecen desde la izquierda) desde
  la 4ª foto en adelante.

## Test plan

- [x] `npx nuxi typecheck` — cero errores.
- [x] `npx vitest run` — 73 tests, todos pasan.
- [x] `npm run build` — compila.
- [x] Mobile (390px): los 3 dots ahora se ven, sin nada que los tape.
- [x] Desktop (1280px): sin dots, solo miniaturas — sin superposición simulando hasta 6 fotos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)