### PR TITLE
docs(docs): cerrar discovery de la misión 12 (hero y copy de la landing)

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -103,6 +103,14 @@ un host externo.
   reseñas)" revela los desbordes de texto que "Profesional 1" esconde.
 - **Vocabulario chileno y los términos decididos en `producto.md`.** Un mockup con jerga distinta a la del
   documento reabre discusiones ya cerradas.
+- **Sin em dash (—) en el copy real** — cualquier string entre comillas que un usuario final llegaría a
+  leer en la interfaz: labels, headline y subheadline, trust items, mensajes de error, empty states,
+  contenido de correos. Se reemplaza por coma, punto seguido o dos puntos según el caso. Es un tic
+  reconocible de escritura generada por IA que no aparece en el copy de otros productos (decisión de
+  Patricio, commit `5e9f091`, misión 04) — se repitió en las misiones 09 y 12 porque la regla solo vivía
+  en memoria y ningún skill genérico la conoce. La regla es solo sobre el texto citado que el usuario
+  final vería: la prosa explicativa del documento (justificaciones, "Decisiones que no deben quedar
+  implícitas", etc.) puede seguir usando em dash con libertad.
 - **Los tokens los pone el kit.** Un color hexadecimal escrito a mano en el mockup queda desactualizado sin
   que nadie lo note.
 - **JS puro solo si el flujo se evalúa mejor moviéndolo** — abrir un bottom sheet, cambiar de tab. Un

--- a/docs/missions/12-hero-y-copy-landing/README.md
+++ b/docs/missions/12-hero-y-copy-landing/README.md
@@ -3,16 +3,22 @@
 **Tipo:** producto. **Abierta el** 2026-09-01. **Nace de:** división de la misión 09 (ver su
 [README](../09-layout-general/README.md)) — investigación ya hecha, movida acá con su contenido.
 
-**Estado de la misión:** definición
+**Estado de la misión:** lista para construir
 
-**Última actualización:** 2026-09-01
+**En foco:** —
+
+**Última actualización:** 2026-09-06
 
 **Documentos:** [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-**Próximo hito:** que el dueño de producto revise y apruebe (o corrija) `producto.md` — F-001 y decisiones
-D-001, D-002 — fecha límite **2026-09-08**. El dueño de producto pidió explícitamente dejar esta misión
-para el final, después de 09, 10 y 11.
+`ingenieria.md` también está **vigente** — aprobado por Patricio el 2026-09-06: tres slices (S-001 copy,
+S-002 buscador del hero, S-003 CTA de profesionales del nav), auditado en contexto separado dos veces
+(F-001 y la ampliación F-002).
+
+**Próximo hito:** crear los issues de los tres slices y abrir el primer PR de delivery (S-001) — la misión
+09 ya cerró, así que deja de bloquear el único cupo de misión `en construcción` a la vez. TR-002 sigue
+abierto: verificar en mobile que el CTA del nav no repite el bug que pausó el issue #155.
 
 ## Brief
 
@@ -20,13 +26,28 @@ Nace de la misma investigación que arrancó como parte de la misión 09 ("mejor
 esa misión por tamaño de alcance, el hero y el copy de la landing quedaron como su propio problema: es una
 cuestión de mensaje y pulido visual de una sección específica, no de navegación general.
 
-`investigacion.md` ya tiene el problema (un copy que nunca fue revisado a propósito, solo heredado de un
-cambio técnico), cinco evidencias, cinco conclusiones y el ideal. La más importante: el hero y
+`investigacion.md` tiene el problema (un copy que nunca fue revisado a propósito, solo heredado de un
+cambio técnico), seis evidencias, seis conclusiones y el ideal. La más importante: el hero y
 `LandingSolution` usan la palabra "verificado" sin que exista ninguna funcionalidad de verificación de
 profesionales, ni planificada — el dueño de producto confirmó que se retira, no se pospone.
 
-`producto.md` recorta ese ideal a una funcionalidad: F-001, revisión de hero y copy, con dos decisiones
-(D-001: se revisa a propósito; D-002: sale la palabra "verificado").
+`producto.md` está **vigente** — aprobado por Patricio el 2026-09-04. Recorta ese ideal a una
+funcionalidad, F-001 (revisión de hero y copy), con tres decisiones: D-001 (se revisa a propósito), D-002
+(sale la palabra "verificado"), D-003 (el buscador del hero sigue el mismo lenguaje visual que
+`CompactSearchBar`, el buscador ya construido para `/buscar` — pill redondeada, campos segmentados, botón
+circular, en línea con el estándar Airbnb que pidió el dueño de producto).
+
+`experiencia.md` también está **vigente** — aprobado por Patricio el 2026-09-04, tras una evaluación
+heurística independiente y cuatro rondas de mockup (`design-mockups/hero.html`). El buscador del hero
+mantiene los dos campos siempre visibles (sin sheet, a diferencia de `CompactSearchBar`), con placeholder
+largo en mobile y corto en desktop (donde la pill es más angosta) — detalle en UX-001/UX-002.
+
+**Ampliación (2026-09-04):** se sumó F-002 — retomar la mitad simple del
+[issue #155](https://github.com/PatricioTabilo/datealo/issues/155) de la misión 09, que Patricio pausó y
+derivó acá: reemplazar "Para profesionales" en `LandingNavbar.vue` por un link directo, "Publícate"
+(sin sesión) o "Mi perfil" (con sesión), igual que ya hace `AppHeader.vue`. La otra mitad de ese issue —si
+el nav necesita `CompactSearchBar` tras hacer scroll, y si el hero seguiría necesitando su propio
+buscador— queda explícitamente fuera de esta misión (ver "Fuera de alcance" en `producto.md`).
 
 ## Temas a explorar
 
@@ -37,6 +58,6 @@ Ya cubiertos por la investigación y el producto actuales.
   headline nombra — falta reforzar lo que sí es distinto.
 - **Dimensión emocional del copy.** El copy cubre lo funcional, roza lo social, no nombra la ansiedad que
   `LANDING_PROBLEM` ya describe — pendiente de explorar en la redacción final.
-- **Buscador del hero.** El dueño de producto pidió inputs más grandes, con íconos por campo, y un botón
-  de búsqueda más amigable — sin fila de accesos rápidos por categoría.
+- **Buscador del hero.** Resuelto: sigue el patrón visual de `CompactSearchBar` (D-003) — campos grandes,
+  íconos por campo, botón circular — sin fila de accesos rápidos por categoría.
 - **"Verificado".** Resuelto: sale del copy. No hay funcionalidad de verificación ni plan de construirla.

--- a/docs/missions/12-hero-y-copy-landing/design-mockups/hero.html
+++ b/docs/missions/12-hero-y-copy-landing/design-mockups/hero.html
@@ -1,0 +1,247 @@
+<!doctype html>
+<html lang="es-CL">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>V-001 Hero de la landing — misión 12</title>
+
+    <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+    <link
+      href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&family=Plus+Jakarta+Sans:wght@600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../../design/datealo-mockup-kit.css" />
+    <style type="text/tailwindcss">
+      @theme {
+        --color-primary: var(--ui-primary);
+        --color-secondary: var(--ui-secondary);
+        --color-success: var(--ui-success);
+        --color-error: var(--ui-error);
+      }
+    </style>
+    <style>
+      .icon { width: 1em; height: 1em; display: inline-block; vertical-align: middle; }
+      .hero-bg { background: var(--color-datealo-primary); }
+      .field-box { background: #fff; border: 1px solid var(--ui-border); }
+      .field-icon { background: var(--color-datealo-surface); color: var(--color-datealo-primary); }
+    </style>
+  </head>
+
+  <body>
+    <div class="frames">
+      <!-- ============================================================ MOBILE · inicial ============ -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-001 · modo inicial
+          <small>ronda 3 — copy sin em dash en el texto real (solo queda en las anotaciones del mockup)</small>
+        </div>
+        <div class="frame-viewport hero-bg">
+          <div class="status-bar text-white"><span>9:41</span><span>▮▮▮</span></div>
+
+          <div class="px-5 pt-6 pb-8">
+            <h1 class="font-heading text-[2.1rem] font-extrabold leading-[1.12] text-white tracking-tight">
+              Deja de preguntarle al grupo del edificio
+              <span class="text-secondary block mt-1">y encuentra a alguien que sí te va a resolver.</span>
+            </h1>
+
+            <p class="mt-4 text-[0.9375rem] leading-relaxed text-white/80 font-medium">
+              Gasfiter, electricista, peluquera y más. Busca por categoría y comuna, no por quién
+                contesta primero en el chat del edificio.
+            </p>
+
+            <!-- Buscador: pill blanca, campos segmentados con ícono, botón ancho abajo -->
+            <div class="mt-6 rounded-3xl bg-white p-2 shadow-2xl shadow-black/20">
+              <button type="button" class="field-box flex w-full items-center gap-3 rounded-2xl px-4 py-3.5 text-left">
+                <span class="field-icon flex h-9 w-9 shrink-0 items-center justify-center rounded-xl">
+                  <svg class="icon w-[18px] h-[18px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg>
+                </span>
+                <span class="text-[0.9375rem] font-medium text-datealo-muted">¿Qué servicio buscas?</span>
+                <svg class="icon w-4 h-4 ml-auto text-datealo-muted" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
+              </button>
+
+              <div class="my-1 h-px bg-datealo-surface mx-2"></div>
+
+              <button type="button" class="field-box flex w-full items-center gap-3 rounded-2xl px-4 py-3.5 text-left">
+                <span class="field-icon flex h-9 w-9 shrink-0 items-center justify-center rounded-xl">
+                  <svg class="icon w-[18px] h-[18px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 1 1 16 0Z"/><circle cx="12" cy="10" r="3"/></svg>
+                </span>
+                <span class="text-[0.9375rem] font-medium text-datealo-muted">¿Qué comuna buscas?</span>
+                <svg class="icon w-4 h-4 ml-auto text-datealo-muted" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
+              </button>
+
+              <button type="button" disabled class="mt-1 flex w-full items-center justify-center gap-2 rounded-2xl bg-secondary/50 px-5 py-3.5 text-[0.9375rem] font-bold text-white">
+                <svg class="icon w-[18px] h-[18px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
+                Buscar
+              </button>
+            </div>
+
+            <ul class="flex flex-wrap items-center gap-x-5 gap-y-2.5 mt-6 text-[0.8125rem] text-white/80 font-semibold">
+              <li class="flex items-center gap-1.5">
+                <svg class="icon w-[15px] h-[15px] text-secondary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><path d="m9 11 3 3L22 4"/></svg>
+                Reseñas reales de tu zona
+              </li>
+              <li class="flex items-center gap-1.5">
+                <svg class="icon w-[15px] h-[15px] text-secondary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><path d="m9 11 3 3L22 4"/></svg>
+                Ordenados por cercanía
+              </li>
+              <li class="flex items-center gap-1.5">
+                <svg class="icon w-[15px] h-[15px] text-secondary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><path d="m9 11 3 3L22 4"/></svg>
+                Categorías claras
+              </li>
+            </ul>
+          </div>
+          <div class="fold" style="top: 640px"></div>
+        </div>
+      </section>
+
+      <!-- ============================================================ MOBILE · listo ================ -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-001 · modo listo
+          <small>ronda 3 — categoría y comuna elegidas, botón "Buscar" habilitado</small>
+        </div>
+        <div class="frame-viewport hero-bg">
+          <div class="status-bar text-white"><span>9:41</span><span>▮▮▮</span></div>
+
+          <div class="px-5 pt-6 pb-8">
+            <h1 class="font-heading text-[2.1rem] font-extrabold leading-[1.12] text-white tracking-tight">
+              Deja de preguntarle al grupo del edificio
+              <span class="text-secondary block mt-1">y encuentra a alguien que sí te va a resolver.</span>
+            </h1>
+
+            <p class="mt-4 text-[0.9375rem] leading-relaxed text-white/80 font-medium">
+              Gasfiter, electricista, peluquera y más. Busca por categoría y comuna, no por quién
+                contesta primero en el chat del edificio.
+            </p>
+
+            <div class="mt-6 rounded-3xl bg-white p-2 shadow-2xl shadow-black/20">
+              <button type="button" class="field-box flex w-full items-center gap-3 rounded-2xl px-4 py-3.5 text-left">
+                <span class="field-icon flex h-9 w-9 shrink-0 items-center justify-center rounded-xl">
+                  <svg class="icon w-[18px] h-[18px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg>
+                </span>
+                <span class="text-[0.9375rem] font-bold text-datealo-text">Gasfitería</span>
+                <svg class="icon w-4 h-4 ml-auto text-datealo-muted" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
+              </button>
+
+              <div class="my-1 h-px bg-datealo-surface mx-2"></div>
+
+              <button type="button" class="field-box flex w-full items-center gap-3 rounded-2xl px-4 py-3.5 text-left">
+                <span class="field-icon flex h-9 w-9 shrink-0 items-center justify-center rounded-xl">
+                  <svg class="icon w-[18px] h-[18px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 1 1 16 0Z"/><circle cx="12" cy="10" r="3"/></svg>
+                </span>
+                <span class="text-[0.9375rem] font-bold text-datealo-text">Ñuñoa</span>
+                <svg class="icon w-4 h-4 ml-auto text-datealo-muted" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
+              </button>
+
+              <button type="button" class="mt-1 flex w-full items-center justify-center gap-2 rounded-2xl bg-secondary px-5 py-3.5 text-[0.9375rem] font-bold text-white shadow-lg shadow-secondary/30">
+                <svg class="icon w-[18px] h-[18px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
+                Buscar
+              </button>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================================================ DESKTOP · inicial ============= -->
+      <section class="frame frame-desktop">
+        <div class="frame-label">
+          V-001 · modo inicial
+          <small>ronda 4 — pill más ancha, placeholder corto ("Elige categoría"/"Elige comuna"), sin wrap a 2 líneas</small>
+        </div>
+        <div class="frame-viewport hero-bg">
+          <div class="grid grid-cols-2 gap-16 items-center h-full px-20 py-16">
+            <div class="max-w-xl">
+              <h1 class="font-heading text-[3.4rem] font-extrabold leading-[1.08] text-white tracking-tight">
+                Deja de preguntarle al grupo del edificio
+                <span class="text-secondary block mt-2">y encuentra a alguien que sí te va a resolver.</span>
+              </h1>
+
+              <p class="mt-6 text-lg leading-relaxed text-white/80 font-medium max-w-md">
+                Gasfiter, electricista, peluquera y más. Busca por categoría y comuna, no por quién
+                contesta primero en el chat del edificio.
+              </p>
+
+              <div class="mt-8 flex items-center gap-1 rounded-full bg-white p-1.5 shadow-2xl shadow-black/20 max-w-2xl">
+                <button type="button" class="flex flex-1 items-center gap-2.5 rounded-full px-5 py-3.5 text-left hover:bg-datealo-surface">
+                  <svg class="icon w-[18px] h-[18px] text-primary shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg>
+                  <span class="whitespace-nowrap text-sm font-medium text-datealo-muted">Elige categoría</span>
+                </button>
+                <div class="w-px h-8 bg-datealo-surface shrink-0"></div>
+                <button type="button" class="flex flex-1 items-center gap-2.5 rounded-full px-5 py-3.5 text-left hover:bg-datealo-surface">
+                  <svg class="icon w-[18px] h-[18px] text-primary shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 1 1 16 0Z"/><circle cx="12" cy="10" r="3"/></svg>
+                  <span class="whitespace-nowrap text-sm font-medium text-datealo-muted">Elige comuna</span>
+                </button>
+                <button type="button" disabled class="flex shrink-0 items-center gap-2 rounded-full bg-secondary/50 px-7 py-3.5 text-sm font-bold text-white">
+                  <svg class="icon w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
+                  Buscar
+                </button>
+              </div>
+
+              <ul class="flex flex-wrap items-center gap-x-6 gap-y-3 mt-7 text-sm text-white/80 font-semibold">
+                <li class="flex items-center gap-2">
+                  <svg class="icon w-4 h-4 text-secondary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><path d="m9 11 3 3L22 4"/></svg>
+                  Reseñas reales de tu zona
+                </li>
+                <li class="flex items-center gap-2">
+                  <svg class="icon w-4 h-4 text-secondary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><path d="m9 11 3 3L22 4"/></svg>
+                  Ordenados por cercanía
+                </li>
+                <li class="flex items-center gap-2">
+                  <svg class="icon w-4 h-4 text-secondary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><path d="m9 11 3 3L22 4"/></svg>
+                  Categorías claras
+                </li>
+              </ul>
+            </div>
+
+            <div class="h-full w-full rounded-[2.5rem] bg-white/10 border-4 border-white/10 flex items-center justify-center">
+              <span class="text-white/40 text-sm font-semibold">Imagen del hero — sin cambios</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================================================ DESKTOP · listo =============== -->
+      <section class="frame frame-desktop">
+        <div class="frame-label">
+          V-001 · modo listo
+          <small>ronda 4 — categoría y comuna elegidas, botón "Buscar" habilitado</small>
+        </div>
+        <div class="frame-viewport hero-bg">
+          <div class="grid grid-cols-2 gap-16 items-center h-full px-20 py-16">
+            <div class="max-w-xl">
+              <h1 class="font-heading text-[3.4rem] font-extrabold leading-[1.08] text-white tracking-tight">
+                Deja de preguntarle al grupo del edificio
+                <span class="text-secondary block mt-2">y encuentra a alguien que sí te va a resolver.</span>
+              </h1>
+
+              <p class="mt-6 text-lg leading-relaxed text-white/80 font-medium max-w-md">
+                Gasfiter, electricista, peluquera y más. Busca por categoría y comuna, no por quién
+                contesta primero en el chat del edificio.
+              </p>
+
+              <div class="mt-8 flex items-center gap-1 rounded-full bg-white p-1.5 shadow-2xl shadow-black/20 max-w-2xl">
+                <button type="button" class="flex flex-1 items-center gap-2.5 rounded-full px-5 py-3.5 text-left hover:bg-datealo-surface">
+                  <svg class="icon w-[18px] h-[18px] text-primary shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg>
+                  <span class="whitespace-nowrap text-sm font-bold text-datealo-text">Gasfitería</span>
+                </button>
+                <div class="w-px h-8 bg-datealo-surface shrink-0"></div>
+                <button type="button" class="flex flex-1 items-center gap-2.5 rounded-full px-5 py-3.5 text-left hover:bg-datealo-surface">
+                  <svg class="icon w-[18px] h-[18px] text-primary shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 1 1 16 0Z"/><circle cx="12" cy="10" r="3"/></svg>
+                  <span class="whitespace-nowrap text-sm font-bold text-datealo-text">Ñuñoa</span>
+                </button>
+                <button type="button" class="flex shrink-0 items-center gap-2 rounded-full bg-secondary px-7 py-3.5 text-sm font-bold text-white shadow-lg shadow-secondary/30 hover:bg-secondary/90">
+                  <svg class="icon w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
+                  Buscar
+                </button>
+              </div>
+            </div>
+
+            <div class="h-full w-full rounded-[2.5rem] bg-white/10 border-4 border-white/10 flex items-center justify-center">
+              <span class="text-white/40 text-sm font-semibold">Imagen del hero — sin cambios</span>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  </body>
+</html>

--- a/docs/missions/12-hero-y-copy-landing/experiencia.md
+++ b/docs/missions/12-hero-y-copy-landing/experiencia.md
@@ -1,8 +1,8 @@
-# Misión: <nombre> — Experiencia
+# Misión: hero y copy de la landing — Experiencia
 
-**Estado:** borrador
+**Estado:** vigente — aprobado por Patricio el 2026-09-04, con F-002 sumada y aceptada el mismo día
 
-**Última actualización:** AAAA-MM-DD
+**Última actualización:** 2026-09-04
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
@@ -10,174 +10,211 @@
 <!--
 Fuente de verdad para flujos, estados, contenido e interacción. No redefine reglas de producto: si el
 diseño descubre una regla nueva o invalida una, abre o actualiza una decisión en producto.md.
-
-Núcleo obligatorio: vistas, mapa de estados, flujos críticos y estados por superficie. Las secciones bajo
-demanda (modelo mental, jerarquía de información, validación) se agregan solo cuando una decisión las
-necesita.
-
-Gate de salida — experiencia.md está lista para ingenieria.md cuando:
-- cada flujo crítico tiene secuencia, variantes, recuperación y criterio de término
-- cada estado tiene contenido concreto (texto real, información visible, acción disponible)
-- cada vista lista sus modos, y el mapa de estados cubre todas las transiciones entre ellos
-- cada modo tiene su indicador permanente de estado, y cada flujo tiene todas sus salidas documentadas
-- los casos límite de producto.md tienen flujo o estado mapeado
-- cada flujo crítico está mockeado en móvil (390px), y en desktop si también vive ahí
-- ninguna pantalla queda descrita como "similar a X" sin especificar qué cambia
 -->
 
-## Decisión de experiencia: <qué cambia para quien usa el producto>
+## Decisión de experiencia: el buscador del hero se ve como una pill segmentada con íconos, siempre visible, sin un panel que haya que abrir
 
-<Modelo de interacción elegido, flujo más importante y la incertidumbre que sigue abierta.>
+El hero mantiene sus dos campos (categoría, comuna) a la vista todo el tiempo — nunca detrás de un botón
+que abre un sheet, aunque comparta el lenguaje visual (pill redondeada, campos segmentados, botón de
+búsqueda) con `CompactSearchBar` de `/buscar` ([D-003](./producto.md#d-003)). El copy del headline,
+subheadline y trust items se reescribe para hablar directo contra el grupo de WhatsApp/Facebook del
+edificio, sin usar "verificado". El header general (`AppHeader.vue`) no cambia — el buscador del hero es
+un elemento del body de la landing, no del header fijo.
 
-- **Funcionalidades cubiertas:** F-001, <otras>.
-- **Pendiente bloqueante:** <pregunta o "ninguna">.
+`LandingNavbar.vue` (el nav propio de la landing, distinto de `AppHeader.vue`) sí cambia con F-002: su
+link "Para profesionales" pasa a ser directo ("Publícate"/"Mi perfil"), retomando el diseño que la misión
+09 dejó pausado en el [issue #155](https://github.com/PatricioTabilo/datealo/issues/155). El resto del nav
+(Categorías, Buscar, y su comportamiento al hacer scroll) no cambia — la pregunta de si el nav necesita su
+propio buscador tras el scroll queda fuera de esta misión ([D-004](./producto.md#d-004)).
+
+- **Funcionalidades cubiertas:** F-001, F-002.
+- **Pendiente bloqueante:** ninguna.
 
 ## Vistas
 
-<!--
-El listado de pantallas que define la experiencia — el mapa que se entrega antes de los flujos. Una línea
-por vista, sin tabla, con sus modos anidados debajo. Una vista es un destino: se llega a ella. Un modo es
-un estado de esa vista que cambia qué se puede hacer y qué se ve — se anida, nunca se lista como vista
-hermana.
-
-El porqué de cada vista, su trade-off o su justificación no van aquí: viven en su flujo (UXF) o en una
-decisión (UX-xxx). Regla de formato para todo el documento: las tablas se reservan para índices de celdas
-cortas; lo que lleva justificación extensa va en secciones con header + bullets, nunca en una celda.
--->
-
-- **V-001 — <vista>** · móvil / desktop · resuelve F-001 · flujos UXF-001 · pendiente
-  - modo **<nombre>** — <qué lo distingue y qué se puede hacer en él>
-  - modo **<nombre>** — <ídem>
+- **V-001 — Landing: hero (`/`)** · móvil + desktop · resuelve F-001 · flujos UXF-001 · validado
+  - modo **inicial** — ningún campo elegido, o solo uno de los dos; cada campo sin elegir muestra su
+    placeholder ("¿Qué servicio buscas?" / "¿Qué comuna buscas?"). El botón "Buscar" está atenuado
+    (`bg-secondary/50`).
+  - modo **listo** — categoría y comuna elegidas; ambos campos muestran su valor en negrita. El botón
+    "Buscar" pasa a su color sólido y navega a `/buscar` al tocarlo.
+- **V-002 — Landing: nav (`/`)** · móvil + desktop · resuelve F-002 · sin flujo dedicado (ver más abajo)
+  - modo **sin sesión de profesional** — el link de la derecha dice "Publícate" y navega a
+    `/profesional/registro`.
+  - modo **con sesión de profesional** — el mismo lugar dice "Mi perfil" y navega a
+    `/profesional/perfil`. Nunca los dos textos a la vez.
 
 ## Mapa de estados
 
-<!--
-Vistas y flujos son listas, y una lista no muestra un camino. Esta tabla conecta los modos: qué acción
-lleva de uno a otro y qué pasa con el trabajo del usuario en cada salto. Cada fila que falte es una
-pregunta que ingeniería resuelve inventando.
--->
+| Desde   | Acción                                  | Queda en                                | Qué pasa con el trabajo                                    |
+| ------- | ---------------------------------------- | ---------------------------------------- | ----------------------------------------------------------- |
+| inicial | elige categoría (falta comuna)           | inicial                                  | el campo categoría queda con el valor elegido               |
+| inicial | elige categoría (comuna ya elegida)      | listo                                    | los dos valores quedan elegidos; el botón se enciende       |
+| inicial | elige comuna (falta categoría)           | inicial                                  | el campo comuna queda con el valor elegido                  |
+| inicial | elige comuna (categoría ya elegida)      | listo                                    | los dos valores quedan elegidos; el botón se enciende       |
+| listo   | toca "Buscar"                            | sale de la vista, navega a `/buscar`     | categoría y comuna viajan como query (`categoria`, `comuna`) |
+| listo   | cambia uno de los dos campos             | listo                                    | el campo que no tocó se conserva; el botón sigue encendido  |
+| cualquiera | cierra un dropdown sin elegir (click afuera) | el mismo modo en que estaba          | el campo abierto vuelve a mostrar lo que ya tenía (valor o placeholder); nada se pierde |
+| cualquiera | sigue haciendo scroll a otra sección de la landing | el mismo modo, fuera de vista  | lo elegido se conserva en memoria del cliente mientras no recargue la página |
 
-| Desde  | Acción             | Queda en | Qué pasa con el trabajo              |
-| ------ | ------------------ | -------- | ------------------------------------ |
-| <modo> | <acción concreta>  | <modo>   | <qué se aplicó, qué quedó pendiente> |
-| <modo> | <salir sin cerrar> | <modo>   | <qué se pierde o se conserva>        |
+## UXF-001 — Buscar desde el hero
 
-## UXF-001 — <flujo principal en verbo>
+**Objetivo:** elegir categoría y comuna y llegar a los resultados de `/buscar`. **Contrato:**
+[F-001](./producto.md#f-001).
 
-<!--
-Duplica por flujo crítico. Cada paso describe acción → respuesta al nivel de "el usuario toca X → Datealo
-muestra Y". Un mockup no reemplaza la secuencia porque no explica estados ni recuperación.
--->
+**Punto de entrada:** alguien abre `datealo.cl` (`/`) por primera vez; el hero es la primera sección que
+ve, en modo inicial, con los dos campos del buscador mostrando su placeholder.
 
-**Objetivo:** <qué se completa o comprende>. **Contrato:** [F-001](./producto.md#f-001).
+**Criterio de término:** la navegación a `/buscar?categoria=<slug>&comuna=<codigo>` con los dos parámetros
+llenos.
 
-**Punto de entrada:** <estado y superficie inicial, y qué acción trae al usuario hasta acá>.
-
-**Criterio de término:** <estado observable que confirma que el flujo terminó bien>.
-
-**Cómo sabe el usuario dónde está:** <el elemento concreto y permanente en pantalla que se lo dice, por
-cada modo que toca este flujo>.
+**Cómo sabe el usuario dónde está:** el valor elegido reemplaza el placeholder dentro de su propio campo —
+es el indicador permanente por campo. El color del botón "Buscar" (atenuado vs. sólido) indica si ya puede
+buscar o todavía le falta un campo.
 
 ### Salidas
 
-<!--
-Todas las formas de irse, no solo terminar bien. El criterio de término cubre la salida buena; las otras
-son las que el usuario encuentra primero. Un modo del que no se sabe salir es un modo donde el usuario se
-pierde.
--->
-
-| Salida                | Cómo se ejecuta       | Qué queda del trabajo           |
-| --------------------- | --------------------- | ------------------------------- |
-| <termina bien>        | <acción>              | <qué se aplicó y dónde>         |
-| <descarta>            | <acción, Esc, cerrar> | <nada, ni a medias>             |
-| <abandona sin cerrar> | <navega a otra parte> | <se conserva, se pierde, avisa> |
+| Salida                          | Cómo se ejecuta                          | Qué queda del trabajo                                          |
+| -------------------------------- | ------------------------------------------ | ---------------------------------------------------------------- |
+| Termina bien                     | toca "Buscar" con los dos campos elegidos  | navega a `/buscar` con `categoria` y `comuna` en la query        |
+| Descarta la selección de un campo | cierra el dropdown sin elegir (click afuera) | el campo mantiene lo que tenía antes de abrirlo; nada se pierde |
+| Abandona sin buscar               | sigue el scroll a otra sección de la landing | lo elegido se conserva en memoria mientras no recargue la página |
 
 ### Secuencia principal
 
-| Paso | Acción            | Respuesta del sistema         | Información visible |
-| ---- | ----------------- | ----------------------------- | ------------------- |
-| 1    | <acción concreta> | <feedback o cambio de estado> | <dato y jerarquía>  |
+| Paso | Acción                                    | Respuesta del sistema                                                                                   | Información visible                                        |
+| ---- | ------------------------------------------ | --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| 1    | Toca el campo "¿Qué servicio buscas?"      | Se abre debajo el dropdown de categorías (mismo `CatalogSelect` que usa el resto de la app)               | Lista de categorías por nombre                              |
+| 2    | Elige "Gasfitería"                         | El campo pasa de mostrar el placeholder a mostrar "Gasfitería" en negrita; el dropdown se cierra          | El valor elegido reemplaza el placeholder                   |
+| 3    | Toca el campo "¿Qué comuna buscas?"        | Se abre el dropdown de comunas, con buscador de texto (catálogo grande)                                   | Lista de comunas frecuentes, o resultados al escribir        |
+| 4    | Elige "Ñuñoa"                              | El campo muestra "Ñuñoa"; con los dos campos llenos, el botón "Buscar" pasa de atenuado a su color sólido | El botón cambia de color — señal de que ya puede tocarlo    |
+| 5    | Toca "Buscar"                              | Navega a `/buscar?categoria=gasfiteria&comuna=nunoa`                                                       | Vista de resultados (fuera del alcance de esta misión)      |
 
 ### Variantes y recuperación
 
-| Condición          | Qué cambia              | Cómo se entiende    | Cómo se recupera             |
-| ------------------ | ----------------------- | ------------------- | ---------------------------- |
-| <sin resultados>   | <estado>                | <mensaje concreto>  | <acción disponible>          |
-| <sin permiso de ubicación> | <comportamiento> | <indicador visible> | <alternativa manual>         |
-| <conexión lenta>   | <skeleton, no spinner>  | <qué se ve mientras>| <qué pasa si falla>          |
+| Condición                                              | Qué cambia                          | Cómo se entiende                                                        | Cómo se recupera                            |
+| -------------------------------------------------------- | -------------------------------------- | --------------------------------------------------------------------------- | ---------------------------------------------- |
+| Solo eligió uno de los dos campos                       | el botón sigue atenuado                | el color apagado del botón                                                  | elige el campo que falta                       |
+| Toca "Buscar" sin completar los dos campos               | no navega (mismo comportamiento tolerante de hoy) | el botón hace un shake breve (200ms) — la única señal de que faltó algo, más allá del color atenuado | completa el campo que falta                    |
+| El catálogo de categorías o comunas falla al cargar      | el dropdown muestra el mensaje de error ya existente de `CatalogSelect` ("No pudimos cargar las categorías." / "...las comunas.") con botón "Reintentar" | mismo patrón que ya usa el resto de la app | toca "Reintentar"                              |
+| Conexión lenta cargando el catálogo                      | el dropdown muestra el skeleton ya existente de `CatalogSelect` (3 líneas animadas) | skeleton, no spinner                          | se resuelve solo cuando termina de cargar      |
 
 ### Decisiones que no deben quedar implícitas
 
-- <qué ocurre al cancelar, volver atrás, reintentar o confirmar>.
-- <qué cambio se guarda inmediato y cuál necesita confirmación>.
+- Tocar "Buscar" sin los dos campos elegidos no navega, pero el botón sí responde: un shake breve
+  (200ms) es la señal de que faltó algo — sin esto, un tap que no hace nada visible es indistinguible de
+  un botón roto ([UX-002](#ux-002)).
+- Cambiar un campo ya elegido no borra el otro — cada campo guarda su valor de forma independiente.
+- No hay botón "limpiar" ni "cancelar" — es un buscador de entrada, no un formulario con estado que deba
+  descartarse explícitamente.
+- Los dos campos y el botón "Buscar" llevan foco visible (`focus-visible:ring-*`, ya usado en el resto de
+  la app — ver `CompactSearchBarPanel`) — nunca `outline-none` sin reemplazo, para quien navega con
+  teclado.
+- El campo de categoría del hero usa un placeholder propio, "¿Qué servicio buscas?", en vez del
+  "¿Qué necesitas?" que trae `CategoriaSelect` por defecto — ahí sí tiene sentido (alguien busca un
+  servicio), a diferencia del formulario de registro de profesional donde el mismo componente se usa hoy
+  y "¿Qué necesitas?" no aplica. Es un override por prop, no un cambio del default — el resto de los usos
+  de `CategoriaSelect` no cambia.
+- En desktop, la pill mide como máximo lo que deja la columna de dos ([D-003](./producto.md#d-003)) —
+  bastante menos ancho que en mobile, donde el buscador ocupa todo el ancho disponible. Con el placeholder
+  en forma de pregunta ("¿Qué servicio buscas?" / "¿Qué comuna buscas?") el texto no cabía en una línea y
+  se quebraba a dos, y con eso el botón "Buscar" quedaba desproporcionado (una fila más alta a un lado,
+  el botón con su altura original al otro). Por eso el placeholder de desktop es más corto —
+  "Elige categoría" / "Elige comuna", el mismo estilo que ya usa `CompactSearchBarPanel` para sus estados
+  vacíos — y los tres elementos de la pill (los dos campos y el botón) comparten el mismo padding vertical.
+  Mobile conserva el placeholder en forma de pregunta, que ahí sí cabe cómodo en una línea.
 
 ## Estados por superficie
 
-<!--
-El contenido es concreto: texto real, no "mensaje apropiado". El estado vacío de un marketplace
-pre-lanzamiento no es un detalle: para muchas búsquedas será el estado principal durante meses.
--->
-
-| Estado  | Qué se muestra (texto e información real) | Acción disponible                   |
-| ------- | ----------------------------------------- | ----------------------------------- |
-| inicial | <contenido>                               | <acción>                            |
-| vacío   | <por qué está vacío, con texto concreto>  | <cómo avanzar, o ninguna y por qué> |
-| carga   | <skeleton de qué forma>                   | <ninguna>                           |
-| error   | <causa útil y alcance>                    | <recuperación>                      |
+| Estado                | Qué se muestra (texto e información real)                                                                | Acción disponible                                    |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------- |
+| campo sin elegir (mobile) | placeholder "¿Qué servicio buscas?" o "¿Qué comuna buscas?", ícono del campo (llave para categoría, pin para comuna), botón "Buscar" atenuado | abrir el dropdown de ese campo                          |
+| campo sin elegir (desktop) | placeholder corto "Elige categoría" o "Elige comuna" (la pill es más angosta que en mobile), mismo ícono por campo, botón "Buscar" atenuado | abrir el dropdown de ese campo                          |
+| campo elegido          | el valor elegido ("Gasfitería", "Ñuñoa") reemplaza el placeholder, en negrita                                | cambiar de campo, o tocar "Buscar" si el otro también está elegido |
+| carga del catálogo     | dentro del dropdown: 3 líneas skeleton animadas (ya existente en `CatalogSelect`)                             | ninguna, se resuelve solo                                |
+| error de catálogo      | dentro del dropdown: "No pudimos cargar las categorías." o "No pudimos cargar las comunas." + botón "Reintentar" | tocar "Reintentar"                                       |
 
 ## Mockups
 
-<!--
-Los mockups viven en design-mockups/ como HTML (ver el skill discovery-ux y docs/design/README.md).
-Exploran o materializan una decisión; no son fuente de verdad de reglas de producto.
--->
+| Mockup | Cubre   | Estado    | Ruta                          |
+| ------ | ------- | --------- | ------------------------------ |
+| hero   | UXF-001 | validado  | `./design-mockups/hero.html`  |
 
-| Mockup   | Cubre   | Estado                 | Ruta                              |
-| -------- | ------- | ---------------------- | --------------------------------- |
-| <nombre> | UXF-001 | exploración o validado | `./design-mockups/<archivo>.html` |
+F-002 no tiene mockup ni `UXF` propio: es el cambio de texto y destino de un link que ya existe y ya se ve
+en producción (`LandingNavbar.vue`), con el mismo criterio de sesión que `AppHeader.vue` ya implementa hoy
+— no hay interacción nueva que dibujar ni un estado que no se pueda leer directo de
+[F-002](./producto.md#f-002) y [UX-003](#ux-003).
 
 ## Cobertura
 
-<!-- Detecta huecos antes de construir. Una funcionalidad sin pantalla nueva igual tiene estados. -->
-
-| Funcionalidad | Flujo   | Estados cubiertos       | Estado    |
-| ------------- | ------- | ----------------------- | --------- |
-| F-001         | UXF-001 | principal, vacío, error | pendiente |
-
-## Secciones bajo demanda
-
-<!--
-Agregar solo cuando una decisión las necesite, con estos títulos:
-
-- "Modelo mental y lenguaje": cuando un concepto de producto pueda confundirse en la interfaz.
-- "Jerarquía de información": cuando una superficie densa exija decidir qué se ve primero (una card de
-  resultado con foto, rating, distancia, precio y disponibilidad es exactamente ese caso).
-- "Validación (UXV-xxx)": cuando una incertidumbre de diseño necesite prueba con usuarios.
-- "Accesibilidad y adaptación": cuando el contexto de uso cambie el flujo o la representación.
--->
+| Funcionalidad | Flujo   | Estados cubiertos                                                    | Estado      |
+| ------------- | ------- | ------------------------------------------------------------------------ | ------------ |
+| F-001         | UXF-001 | campo sin elegir, campo elegido, carga de catálogo, error de catálogo (CL-001 de tamaño de fuente cubierto por el mismo copy mockeado) | en revisión  |
+| F-002         | —       | sin sesión ("Publícate"), con sesión ("Mi perfil")                        | en revisión  |
 
 ## Decisiones de experiencia
 
 <a id="ux-001"></a>
 
-### UX-001 — <decisión en una frase>
+### UX-001 — El buscador del hero mantiene los dos campos siempre visibles, sin un panel que haya que abrir
 
-- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
-- **Sustento:** F-001 o <hallazgo>.
-- **Alternativas descartadas:** <opciones relevantes y trade-off, con el porqué del rechazo>.
-- **Decisión y consecuencia:** <qué flujo o superficie cambia>.
-- **Impacto en producto:** <ninguno o enlace a D-xxx/F-xxx actualizado>.
+- **Estado:** aceptada. **Fecha:** 2026-09-04.
+- **Sustento:** [D-003](./producto.md#d-003), [C-006](./investigacion.md#c-006), mockup `hero.html`
+  aprobado por el dueño de producto.
+- **Alternativas descartadas:** reusar `CompactSearchBar` tal cual — un solo botón que abre un panel o
+  sheet con los dos campos adentro — se descarta porque el hero tiene espacio de sobra (no es un header
+  angosto) y alguien que llega por primera vez entiende mejor el producto viendo los dos campos
+  (categoría + comuna) de entrada, sin un tap extra que los oculte; un solo campo ancho tipo "¿Qué
+  necesitas? · ¿Dónde?" que abre un panel combinado — se descarta por la misma razón, esconde la
+  estructura categoría+comuna que un visitante nuevo todavía no conoce.
+- **Decisión y consecuencia:** el hero usa dos campos segmentados dentro de una pill blanca (mobile:
+  apilados con divisor horizontal; desktop: en fila con divisor vertical), cada uno abre su propio
+  dropdown en el lugar (reusa `CatalogSelect`, sin sheet ni `Teleport`), con un botón "Buscar" (ícono +
+  texto) al final de la pill.
+- **Impacto en producto:** ninguno — mismo nivel de detalle que ya fija [D-003](./producto.md#d-003).
+
+<a id="ux-002"></a>
+
+### UX-002 — El botón "Buscar" nunca bloquea el tap; el color atenuado y un shake al tocarlo incompleto son la única señal
+
+- **Estado:** aceptada. **Fecha:** 2026-09-04, ajustada el 2026-09-04 tras la evaluación heurística
+  independiente (ver más abajo).
+- **Sustento:** comportamiento ya existente en `LandingHero.vue` (el CTA de hoy navega con lo que esté
+  elegido, sin exigir ambos campos).
+- **Alternativas descartadas:** deshabilitar el `<button>` de verdad (con `disabled` real, sin manejar el
+  click) como hace `CompactSearchBar` — se descarta porque introduciría una regla de validación nueva que
+  `producto.md` no pidió (F-001 no incluye cambiar la estructura funcional del buscador); el color
+  atenuado ya es señal suficiente sin bloquear nada.
+- **Decisión y consecuencia:** el botón siempre es clickeable. Si falta un campo, tocarlo navega a
+  `/buscar` con el o los parámetros que sí estén elegidos — mismo comportamiento tolerante que existe hoy.
+  El color atenuado (`bg-secondary/50`) es la señal permanente; un shake breve (200ms) al tocarlo
+  incompleto es la señal del momento del tap — sin ella, un tap sin efecto visible es indistinguible de un
+  botón roto. La evaluación heurística independiente atacó esta decisión (su sustento original era "es lo
+  que ya existe hoy", el mismo tipo de herencia sin cuestionar que D-001 prohíbe para el copy) y el shake
+  es la corrección que sobrevivió: la decisión de fondo (no bloquear el tap) se mantiene, lo que faltaba
+  era el feedback del momento.
+- **Impacto en producto:** ninguno.
+
+<a id="ux-003"></a>
+
+### UX-003 — El link de profesionales del nav de la landing reusa `useProfessionalSession`, pero no el comportamiento de `AppHeader.vue`: acá siempre muestra algo
+
+- **Estado:** aceptada. **Fecha:** 2026-09-04.
+- **Sustento:** [F-002](./producto.md#f-002), [D-004](./producto.md#d-004). `AppHeader.vue` ya usa
+  `useProfessionalSession` para decidir si muestra el avatar de perfil, pero solo con `v-if="professional"`
+  y sin `v-else` — sin sesión, ese lugar del header queda vacío, porque ahí es un acceso secundario. El nav
+  de la landing es la entrada principal de captación del lado profesional, así que no puede quedar vacío:
+  siempre muestra "Publícate" o "Mi perfil".
+- **Alternativas descartadas:** copiar el comportamiento de `AppHeader.vue` tal cual (nada visible sin
+  sesión) — se descarta porque dejaría a un visitante nuevo sin ningún acceso al lado profesional desde el
+  nav, que es exactamente el problema que motiva F-002.
+- **Decisión y consecuencia:** `LandingNavbar.vue` consume el mismo `useProfessionalSession` que
+  `AppHeader.vue`, pero con su propio `v-if`/`v-else` para nunca quedar vacío. Mientras la sesión resuelve
+  (el `await` inicial), el link no tiene todavía un estado definido en este documento — ver
+  [TR-002](./ingenieria.md) en `ingenieria.md`, que lo deja como riesgo a verificar en la implementación,
+  no como algo ya resuelto por copiar `AppHeader.vue`.
+- **Impacto en producto:** ninguno — F-002 ya lo especifica así.
 
 ## Preguntas
 
-<!--
-Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
-Estado: abierta | resuelta AAAA-MM-DD | disuelta AAAA-MM-DD. Solo las abiertas llevan bloque de detalle.
--->
-
-<Una frase que responde "¿qué falta?": la pregunta que bloquea construcción y qué bloquea.>
-
-| ID      | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
-| ------- | ---------------------- | ------------------- | --------------------------------------------------------------- |
-| UXQ-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
-| UXQ-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |
+Ninguna abierta.

--- a/docs/missions/12-hero-y-copy-landing/ingenieria.md
+++ b/docs/missions/12-hero-y-copy-landing/ingenieria.md
@@ -1,8 +1,8 @@
-# Misión: <nombre> — Ingeniería
+# Misión: hero y copy de la landing — Ingeniería
 
-**Estado:** borrador
+**Estado:** vigente — aprobado por Patricio el 2026-09-06
 
-**Última actualización:** AAAA-MM-DD
+**Última actualización:** 2026-09-06
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
@@ -11,152 +11,202 @@
 Fuente de verdad para arquitectura, datos, contratos, factibilidad y pruebas. Consume el comportamiento
 definido en producto. Una limitación técnica cambia el alcance solo mediante una decisión explícita en
 producto.md.
-
-Núcleo obligatorio: contratos, modelo de datos, RLS y riesgos de factibilidad. Las secciones bajo demanda
-(migración, rendimiento, entrega por etapas) se agregan solo cuando el riesgo lo justifica.
-
-Gate de salida — ingenieria.md está lista para construir cuando:
-- los contratos definen qué entra, qué sale y qué invariantes se mantienen, sin ambigüedad
-- el modelo de datos soporta los casos límite de producto.md sin workarounds
-- el impacto en RLS está resuelto: qué policy se crea o cambia, o por qué ninguna
-- la migración de datos existentes tiene estrategia o está explícitamente fuera del alcance
-- los escenarios verificables de producto están mapeados a pruebas
-- el plan de construcción corta el diseño en slices atómicos ordenados (un slice = un Issue = un PR)
 -->
 
-## Decisión técnica: <arquitectura y riesgo principal>
+## Decisión técnica: copy estático + un componente de buscador nuevo, sin tocar backend ni schema
 
-<Dirección técnica, trade-off principal y el riesgo que todavía podría invalidarla.>
+Todo el alcance de F-001 vive en el cliente: tres constantes de `app/constants/landing.ts` (contenido) y
+un componente de buscador nuevo, `LandingHeroSearch.vue`, extraído de `LandingHero.vue` para que este
+último se quede solo con texto e imagen ([vue-composition](../../.claude/skills/vue-composition/)). No hay
+tabla, endpoint ni policy involucrados — el único riesgo real es que el override de `placeholder`/
+`leadingIcon` que necesita `CatalogSelect` se filtre sin querer a los otros dos usos del componente
+(registro y perfil de profesional).
 
-- **Contratos de producto cubiertos:** F-001, <otros>.
-- **Riesgo bloqueante:** <incertidumbre o "ninguna">.
+F-002 suma un cambio autocontenido en `LandingNavbar.vue`: reemplaza el botón que hacía scroll a
+`#profesionales` por un link directo, reusando `useProfessionalSession` — el mismo composable que
+`AppHeader.vue` ya usa hoy para la misma decisión (sesión de profesional sí/no). No introduce ningún
+concepto técnico nuevo.
 
-## Arquitectura: <cómo se divide la responsabilidad>
+- **Contratos de producto cubiertos:** F-001, F-002.
+- **Riesgo bloqueante:** ninguno.
 
-<!--
-La lógica de negocio se separa de la infraestructura: funciones puras en utils/ y server/utils/,
-reactividad en composables, acceso a datos en server/api/ con Drizzle. Incluye diagrama solo cuando tres o
-más partes interactúan.
--->
+## Arquitectura: un componente de buscador nuevo, sobre el mismo `CatalogSelect` que ya existe
 
-<Descripción del enfoque y por qué satisface los contratos con menor riesgo.>
+`LandingHero.vue` hoy mezcla texto, imagen y el buscador en un solo archivo. El buscador crece con esta
+misión (dos bloques responsive, estado de "listo", shake al tocar incompleto), así que se extrae a su
+propio componente — `LandingHero.vue` deja de conocer cómo funciona el buscador, solo lo renderiza.
 
-| Componente | Responsabilidad       | No debe decidir | Contratos |
-| ---------- | --------------------- | --------------- | --------- |
-| <nombre>   | <una responsabilidad> | <frontera>      | F-001     |
+`CatalogSelect` (y sus wrappers `CategoriaSelect`/`ComunaSelect`) ganan dos props opcionales,
+`placeholder` y `leadingIcon`, sin tocar su comportamiento de selección — mismo patrón de wrapper delgado
+que ya describe [T-003 de misión 03](../03-taxonomia-categorias-y-comunas/ingenieria.md#t-003): la
+implementación (fetch, filtrado, apertura de la lista) sigue escondida en `CatalogSelect`, y
+`LandingHeroSearch` solo le pasa su propio placeholder e ícono a través de `CategoriaSelect`/`ComunaSelect`.
+
+| Componente             | Responsabilidad                                                          | No debe decidir                          | Contratos |
+| ------------------------ | --------------------------------------------------------------------------- | ------------------------------------------- | --------- |
+| `LandingHero.vue`        | Headline, subheadline, imagen, trust items, monta `LandingHeroSearch`       | Cómo se abre o filtra un catálogo           | F-001     |
+| `LandingHeroSearch.vue`  | Los dos bloques responsive del buscador (mobile apilado, desktop en pill), estado "listo", shake al tocar incompleto, navegación a `/buscar` | El fetch o el filtrado de categorías/comunas | F-001     |
+| `CatalogSelect.vue`      | Selección, filtrado y apertura de la lista (sin cambios de comportamiento) — gana `placeholder`/`leadingIcon` opcionales | Qué placeholder o ícono usar cada consumidor | F-001     |
+| `CategoriaSelect.vue` / `ComunaSelect.vue` | Wrapper delgado: fija su composable de catálogo, pasa `placeholder`/`leadingIcon` si el consumidor los da | La lógica de selección (vive en `CatalogSelect`) | F-001     |
+| `LandingNavbar.vue`     | Nav de la landing: logo, Categorías, Buscar, y el link de profesionales (gana el criterio de sesión) | Cómo se resuelve la sesión (vive en `useProfessionalSession`) | F-002 |
 
 ## Contratos
 
-<!--
-Cada contrato especifica entrada, salida e invariantes al nivel en que se puede implementar sin reuniones
-de aclaración. Incluye los errores observables y el código HTTP cuando es un endpoint.
--->
+### TC-001 — `CatalogSelect`, `CategoriaSelect` y `ComunaSelect` aceptan `placeholder` y `leadingIcon` opcionales, sin cambiar su comportamiento por defecto
 
-### TC-001 — <contrato en una frase>
+- **Entrada:** dos props nuevas, ambas opcionales, declaradas explícitamente con `defineProps` en los
+  **tres** componentes (`CatalogSelect.vue`, y sus wrappers `CategoriaSelect.vue`/`ComunaSelect.vue` —
+  hoy estos dos solo declaran `defineModel`, así que sin un `defineProps` propio cualquier prop nuevo
+  llegaría por *attribute fallthrough* de Vue en vez de como prop tipada, que es justo lo que este
+  contrato evita):
+  - `placeholder?: string` — si no se pasa, usa el que ya trae cada wrapper hoy: "¿Qué necesitas?" en
+    `CategoriaSelect`, "¿Qué comuna buscas?" en `ComunaSelect`.
+  - `leadingIcon?: string` — nombre de ícono Iconify (mismo patrón que `trailing-icon="i-lucide-chevron-down"`
+    que `CatalogSelect.vue:136` ya usa, ej. `"i-lucide-wrench"` / `"i-lucide-map-pin"`), no un componente.
+    Si no se pasa, el campo no muestra ícono a la izquierda — comportamiento idéntico al actual.
+- **Salida:** `CategoriaSelect`/`ComunaSelect` reenvían ambos props tal cual a `CatalogSelect`, que le pasa
+  `leading-icon` al `UInput` interno solo cuando `leadingIcon` viene definido; el `placeholder` efectivo es
+  el prop nuevo si existe, o el que cada wrapper ya trae por defecto.
+- **Invariantes:** los tres usos actuales de `CategoriaSelect`/`ComunaSelect` (`LandingHero.vue`,
+  `profesional/registro.vue`, `profesional/perfil.vue`) se ven exactamente igual que hoy si no pasan estos
+  props — es un cambio aditivo, no una migración.
+- **Errores:** ninguno nuevo — la selección, el filtrado y los estados de carga/error de `CatalogSelect`
+  no cambian.
+- **Contrato de producto:** [F-001](./producto.md#f-001), [D-003](./producto.md#d-003).
 
-- **Entrada:** <datos y precondiciones, con tipos y forma concreta>.
-- **Salida:** <resultado y su forma concreta>.
-- **Invariantes:** <qué se cumple siempre: atomicidad, consistencia, idempotencia>.
-- **Errores:** <condición → código HTTP y cuerpo `{ error, code? }`, y qué puede hacer el llamador>.
-- **Contrato de producto:** [F-001](./producto.md#f-001).
+### TC-002 — El buscador del hero navega a `/buscar` con lo que esté elegido, y avisa con un shake si le falta algo
+
+- **Entrada:** `categoriaSlug: string | null`, `comunaCodigo: string | null` (estado local de
+  `LandingHeroSearch`), y el tap en el botón "Buscar".
+- **Salida:** `navigateTo({ path: '/buscar', query })`, donde `query` solo incluye `categoria`/`comuna` si
+  tienen valor — mismo comportamiento tolerante que existe hoy en `LandingHero.vue`.
+- **Invariantes:** tocar "Buscar" nunca lanza una excepción ni bloquea la navegación aunque falte un
+  campo. El shake es una animación puramente visual (una clase CSS que se agrega y se quita a los 200ms),
+  no cambia ningún estado de datos.
+- **Errores:** no aplica — no hay llamada a servidor en este contrato, solo navegación de cliente.
+- **Contrato de producto:** [F-001](./producto.md#f-001), [UX-002](./experiencia.md#ux-002).
+
+### TC-003 — `LandingNavbar` muestra "Publícate" o "Mi perfil" según la sesión de profesional, nunca ambos
+
+- **Entrada:** `professional` de `useProfessionalSession()` (el mismo composable que ya usa
+  `AppHeader.vue:25` — `const { professional } = await useProfessionalSession()`), sin parámetros nuevos.
+- **Salida:** si `professional` es `null`/`undefined`, el link muestra "Publícate" y navega a
+  `/profesional/registro`; si existe, muestra "Mi perfil" y navega a `/profesional/perfil`.
+- **Invariantes:** el link de Categorías, el CTA "Buscar" y el comportamiento de scroll (fondo/padding) del
+  nav no cambian. Nunca se muestran los dos textos a la vez. A diferencia de `AppHeader.vue` (que usa
+  `v-if="professional"` sin `v-else`, y queda vacío sin sesión porque ahí es un acceso secundario), acá el
+  link nunca queda vacío una vez que la sesión resuelve — necesita su propio `v-else`, no alcanza con
+  copiar el `v-if` de `AppHeader.vue`. Qué se muestra mientras la sesión todavía no resuelve (el `await`
+  inicial) no está definido por este contrato — ver [TR-002](#riesgos-y-experimentos-de-factibilidad).
+- **Errores:** ninguno nuevo — `useProfessionalSession` ya maneja su propio estado de error/ausencia de
+  sesión, sin cambios de esta misión.
+- **Contrato de producto:** [F-002](./producto.md#f-002), [D-004](./producto.md#d-004).
 
 ## Modelo de datos
 
-<!-- Entidades con significado, escritura y ciclo de vida. El schema completo vive en server/db/. -->
+No aplica. `LANDING_HERO`, `LANDING_SOLUTION` y `LANDING_FINAL_CTA` son constantes estáticas en
+`app/constants/landing.ts` (`as const`, sin tabla ni endpoint detrás) — el cambio es solo a sus valores de
+texto. Ningún dato de usuario ni de negocio se lee o escribe como parte de esta misión.
 
-| Entidad o campo | Significado             | Escritura          | Retención o historial |
-| --------------- | ----------------------- | ------------------ | --------------------- |
-| <dato>          | <semántica de producto> | <endpoint o acción>| <política>            |
+### Contenido final de `app/constants/landing.ts`
+
+<!-- Copy real, sin em dash — ver docs/design/README.md "Reglas de contenido". -->
+
+- `LANDING_HERO.headline`: "Deja de preguntarle al grupo del edificio"
+- `LANDING_HERO.headlineAccent`: "y encuentra a alguien que sí te va a resolver."
+- `LANDING_HERO.subheadline`: "Gasfiter, electricista, peluquera y más. Busca por categoría y comuna, no
+  por quién contesta primero en el chat del edificio."
+- `LANDING_HERO.trust`: `['Reseñas reales de tu zona', 'Ordenados por cercanía', 'Categorías claras']`
+- `LANDING_HERO.tagline`, `cta`, `heroImage`: sin cambios.
+- `LANDING_SOLUTION.subtitle`: "Eso es datealo. Un buscador de profesionales con reseñas reales, cerca de
+  ti." (sale "verificados").
+- `LANDING_SOLUTION.features[0]`: reemplaza el ítem de verificación completo (título, ícono y
+  descripción, no solo la palabra) porque describía un proceso que no existe — icon: `LayoutGrid`, title:
+  "Busca por categoría", description: "Gasfitería, electricidad, peluquería y más. Encuentra justo lo que
+  necesitas, no un hilo de mensajes mezclado." `features[1..3]` (reseñas, cercanía, contacto directo): sin
+  cambios.
+- `LANDING_FINAL_CTA.subheadline`: "Ya podés buscar profesionales de tu zona, con reseñas reales. Sin
+  registro, sin esperar." `headline`, `trust`, `cta`: sin cambios.
 
 ### Invariantes de datos
 
-- <unicidad, pertenencia, orden o consistencia temporal>.
-- <qué operación es atómica o qué dato tiene una única fuente de verdad>.
+- No aplica — no hay entidad persistida.
 
 ### Impacto en RLS
 
-<!--
-Obligatorio. Fuente de verdad: server/db/sql/rls.sql. Si el cambio no toca ownership ni relaciones usadas
-en policies, decirlo explícitamente con esa razón — no dejar la sección vacía.
--->
-
-| Tabla    | Cambio                 | Policy afectada | Acción                    |
-| -------- | ---------------------- | --------------- | ------------------------- |
-| <tabla>  | <nueva, ownership, FK> | <nombre>        | <crear, actualizar, nada> |
+| Tabla | Cambio | Policy afectada | Acción |
+| ----- | ------ | ---------------- | ------ |
+| — | ninguna tabla cambia | — | ninguna — el cambio no toca `server/db/` ni `server/db/sql/rls.sql` |
 
 ## Riesgos y experimentos de factibilidad
 
-<!--
-Un riesgo que podría cambiar el producto se enlaza como pregunta o decisión en producto.md. Un experimento
-tiene pregunta, límite de tiempo y resultado capaz de cerrar la incertidumbre.
--->
-
-| ID     | Riesgo o pregunta | Qué invalida        | Experimento o mitigación  | Criterio de salida      | Estado  |
-| ------ | ----------------- | ------------------- | ------------------------- | ----------------------- | ------- |
-| TR-001 | <incertidumbre>   | <alcance en riesgo> | <spike, prueba o recorte> | <resultado concluyente> | abierto |
+| ID     | Riesgo o pregunta | Qué invalida | Experimento o mitigación | Criterio de salida | Estado |
+| ------ | ------------------ | ------------- | -------------------------- | -------------------- | ------ |
+| TR-001 | El override de `placeholder`/`leadingIcon` de TC-001 podría filtrarse sin querer a `profesional/registro.vue` o `profesional/perfil.vue`, cambiando esas pantallas fuera del alcance de F-001 | El alcance ("no toca" otras pantallas) | Los props son opcionales con default `undefined`, y el mismo slice que los agrega verifica visualmente esas dos pantallas (`npm run dev`, 390px) sin pasar los props nuevos | Registro y perfil de profesional se ven idénticos a antes del cambio | abierto |
+| TR-002 | El comentario de pausa del [issue #155](https://github.com/PatricioTabilo/datealo/issues/155) nombra "el CTA 'Publícate' como texto" junto al bug de mobile, sin aislar si el bug era del buscador tras scroll (fuera de este alcance), del CTA, o de ambos. Tampoco está definido qué muestra el link mientras `useProfessionalSession()` resuelve (el `await` inicial) | El criterio de aceptación de S-003 ("sin cambios de scroll, se ve igual que antes salvo el link") | Verificación manual en mobile (390px) del link nuevo, con y sin sesión, antes de dar S-003 por aceptado — si aparece algo parecido al bug original, se investiga como parte del mismo slice, no se ignora asumiendo que ya estaba resuelto | El link se ve y navega bien en 390px, en los tres momentos: cargando, sin sesión, con sesión | abierto |
 
 ## Estrategia de pruebas
 
-<!-- Mapea los ejemplos verificables de producto.md a niveles de prueba. Qué demuestra cada una. -->
-
-| Contrato o riesgo | Nivel                          | Caso principal | Límite o falla |
-| ----------------- | ------------------------------ | -------------- | -------------- |
-| F-001, CL-001     | <unidad, contrato, integración>| <caso>         | <caso>         |
+| Contrato o riesgo | Nivel      | Caso principal                                                             | Límite o falla |
+| ------------------ | ---------- | ---------------------------------------------------------------------------- | ---------------- |
+| TC-001              | unidad     | `CatalogSelect` sin `placeholder`/`leadingIcon` se ve igual que hoy (snapshot de props por defecto) | con los props, el `UInput` recibe `leading-icon` y el `placeholder` pasado |
+| TC-002              | unidad     | categoría y comuna elegidas → `navigateTo` recibe `{ categoria, comuna }`    | solo categoría elegida → tocar "Buscar" no navega y dispara el shake |
+| CL-001 (producto.md) | manual    | copy revisado cabe en 390px sin desbordar (verificación visual, `npm run dev`) | — |
+| TR-001               | manual     | `profesional/registro.vue` y `profesional/perfil.vue` sin cambios visuales tras el slice | — |
+| TC-003               | unidad     | sin sesión → el link renderiza "Publícate" con `to="/profesional/registro"` | con sesión (`professional` mockeado) → renderiza "Mi perfil" con `to="/profesional/perfil"` |
+| TR-002               | manual     | link en mobile (390px) sin sesión y con sesión, sin el bug del issue #155 | mientras `useProfessionalSession()` resuelve, el link no queda roto ni salta de layout |
 
 ### Propiedades que deben probarse
 
-- <invariante bajo reintentos, concurrencia o distintas entradas>.
-- <ausencia de efectos parciales en falla>.
+- Tocar "Buscar" nunca lanza una excepción, con cero, uno o los dos campos elegidos.
+- El shake es puramente visual — no cambia `categoriaSlug` ni `comunaCodigo`, y no reintenta la navegación
+  solo.
 
 ## Plan de construcción
 
-<!--
-Se completa al final, cuando el gate de salida se cumple y ninguna pregunta bloqueante sigue abierta —
-cortar sobre decisiones abiertas produce issues que mueren. Cada slice es un cambio funcional atómico: un
-Issue, un PR, ejecutable sin haber leído la misión (el issue lleva su contrato inline) y con criterios
-pass/fail enumerables como tests. Guía completa en el skill discovery-engineering.
--->
-
-| ID    | Slice (una frase, sin "y") | Sustento      | Criterio de aceptación principal          | Depende de |
-| ----- | -------------------------- | ------------- | ----------------------------------------- | ---------- |
-| S-001 | <cambio atómico>           | TC-001, D-001 | <entrada concreta → resultado observable> | —          |
-
-## Secciones bajo demanda
-
-<!--
-Agregar solo cuando el riesgo lo justifique, con estos títulos:
-
-- "Migración y compatibilidad": cuando existan datos o consumidores que deben llegar al nuevo contrato.
-  Incluye rollback lógico si la migración física no puede revertirse.
-- "Rendimiento y observabilidad": cuando haya presupuesto de latencia o volumen que defender (búsqueda
-  geográfica y listados paginados son los candidatos naturales).
-- "SEO e indexación": cuando la superficie deba ser indexable (páginas por categoría + comuna, datos
-  estructurados).
-- "Entrega por etapas": cuando el cambio necesite despliegue incremental o feature flags.
--->
+| ID    | Slice (una frase, sin "y")                                        | Sustento                    | Criterio de aceptación principal | Depende de |
+| ----- | -------------------------------------------------------------------- | ------------------------------ | ------------------------------------ | ---------- |
+| S-001 | Reescribir el copy del hero, `LandingSolution` y `LandingFinalCta` sin "verificado" | D-001, D-002, C-001 a C-004, C-006 | El texto de `app/constants/landing.ts` queda como en "Contenido final" de arriba; ninguna cadena visible en la landing usa "verificado"/"verificados" para describir profesionales; `npx nuxi typecheck` y `npm run build` pasan | — |
+| S-002 | Rediseñar el buscador del hero como pill segmentada con íconos, siguiendo `CompactSearchBar` | D-003, UX-001, UX-002, TC-001, TC-002 | `placeholder`/`leadingIcon` quedan declarados con `defineProps` propio en `CategoriaSelect.vue`/`ComunaSelect.vue` (no por fallthrough), `leadingIcon` tipado `string` (nombre Iconify, no `Component`). Mobile: dos campos apilados con ícono + botón ancho abajo. Desktop: pill horizontal con los dos campos y el botón. Tocar "Buscar" con los dos campos elegidos navega a `/buscar` con la query; incompleto, hace shake y no navega. `profesional/registro.vue` y `profesional/perfil.vue` sin cambios visuales (TR-001). `npx nuxi typecheck` y `npm run build` pasan | S-001 (usa el copy ya actualizado en los placeholders de las pruebas manuales, aunque el componente en sí no depende del texto) |
+| S-003 | Reemplazar "Para profesionales" en `LandingNavbar` por "Publícate"/"Mi perfil" | D-004, TC-003 | Sin sesión, el link dice "Publícate" y navega a `/profesional/registro`; con sesión (`useProfessionalSession`), dice "Mi perfil" y navega a `/profesional/perfil`. Categorías, Buscar y el comportamiento de scroll del nav no cambian. Verificación manual en mobile (390px), en los tres momentos (cargando, sin sesión, con sesión), sin el bug de mobile que motivó pausar el issue #155 (TR-002). `npx nuxi typecheck` y `npm run build` pasan | — |
 
 ## Decisiones técnicas
 
 <a id="t-001"></a>
 
-### T-001 — <decisión en una frase>
+### T-001 — El buscador del hero se extrae a `LandingHeroSearch.vue`, `LandingHero.vue` se queda con texto e imagen
 
-- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
-- **Contratos:** F-001 y <regla relevante>.
-- **Alternativas descartadas:** <opciones y trade-offs, con el porqué del rechazo>.
-- **Decisión y consecuencias:** <enfoque elegido, beneficio, costo y trabajo futuro aceptado>.
-- **Reapertura:** <medición o cambio que justificaría revisar>.
+- **Estado:** aceptada. **Fecha:** 2026-09-04.
+- **Contratos:** F-001, [UX-001](./experiencia.md#ux-001).
+- **Alternativas descartadas:** dejar todo en `LandingHero.vue` — se descarta porque el buscador pasa de
+  un `<div>` con dos selects a dos bloques responsive completos con estado de "listo" y shake; mantenerlo
+  inline mezclaría la responsabilidad de "texto de marketing" con "lógica de un formulario de búsqueda" en
+  el mismo archivo.
+- **Decisión y consecuencias:** `LandingHeroSearch.vue` nuevo, montado por `LandingHero.vue` sin props más
+  allá de las que ya necesita el propio buscador (no recibe nada del padre). Costo: un archivo más; a
+  cambio, `LandingHero.vue` queda legible como texto puro.
+- **Reapertura:** —.
+
+<a id="t-002"></a>
+
+### T-002 — `CatalogSelect` gana `placeholder`/`leadingIcon` opcionales en vez de duplicar el componente para el hero
+
+- **Estado:** aceptada. **Fecha:** 2026-09-04.
+- **Contratos:** F-001, [D-003](./producto.md#d-003).
+- **Alternativas descartadas:** crear un `HeroCatalogSelect` aparte solo para el hero — se descarta porque
+  duplicaría la selección, el filtrado y los estados de carga/error que `CatalogSelect` ya resuelve bien
+  (ver el porqué de no unificar de más en
+  [T-003 de misión 03](../03-taxonomia-categorias-y-comunas/ingenieria.md#t-003), aplicado acá al revés: sí
+  es la misma regla, así que extender en vez de duplicar es lo correcto); hardcodear el placeholder e
+  ícono del hero dentro de `CatalogSelect` mismo — se descarta porque cambiaría el look de
+  `profesional/registro.vue` y `profesional/perfil.vue` sin que F-001 lo pida.
+- **Decisión y consecuencias:** dos props opcionales (`placeholder: string`, `leadingIcon: string` — nombre
+  Iconify, mismo patrón que `trailing-icon`), default `undefined`, declarados con `defineProps` propio en
+  los wrappers (no por fallthrough), sin cambiar ningún consumidor existente (TR-001 cubre el riesgo de que
+  se filtren igual). Corrección tras la auditoría independiente del 2026-09-04: la primera versión de este
+  documento no declaraba el contrato en los wrappers ni tipaba `leadingIcon` como `string` — ver TC-001.
+- **Reapertura:** —.
 
 ## Preguntas
 
-<!--
-Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
-Estado: abierta | resuelta AAAA-MM-DD | disuelta AAAA-MM-DD. Solo las abiertas llevan bloque de detalle.
--->
-
-<Una frase que responde "¿qué falta?": la pregunta que bloquea construcción y qué bloquea.>
-
-| ID     | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
-| ------ | ---------------------- | ------------------- | --------------------------------------------------------------- |
-| TQ-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
-| TQ-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |
+Ninguna abierta.

--- a/docs/missions/12-hero-y-copy-landing/investigacion.md
+++ b/docs/missions/12-hero-y-copy-landing/investigacion.md
@@ -2,7 +2,7 @@
 
 **Estado:** activo
 
-**Última actualización:** 2026-09-01
+**Última actualización:** 2026-09-04
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
@@ -61,6 +61,8 @@ una entrevista, la columna "límite" es lo que impide que se lea como dato duro.
 | E-003 | código + producto | `server/db/schema/*.ts`, `app/constants/landing.ts:5,47,51-52,104`, [D-001 de misión 07](../07-resenas-verificadas-por-contacto/producto.md#d-001) | No existe ningún campo de verificación en el schema de profesionales, ni ninguna misión que planifique construirlo. Pese a eso, `LandingSolution` ya afirma como hecho "Cada profesional pasa por un proceso de verificación" y el hero dice "profesionales verificados". Misión 07 ya resolvió esta misma tensión para las reseñas: nunca dice "verificada" a secas, siempre "verificada por contacto" — porque lo único que Datealo puede respaldar es que el contacto ocurrió. | Confirma que "verificado" no es una funcionalidad planeada en ningún horizonte visible, no solo que falta hoy. |
 | E-004 | análisis (JTBD) | skill `jobs-to-be-done` aplicado al trabajo que alguien contrata al buscar un profesional de servicios para el hogar | El trabajo tiene tres dimensiones: funcional (encontrar rápido a alguien confiable, cerca, disponible), emocional (dejar la ansiedad de "¿me va a estafar o no va a llegar?" — alivio), social (evitar la exposición de pedir ayuda o depender de la buena voluntad de un grupo). El copy actual del hero cubre la funcional y roza la social ("deja de buscar en grupos"), pero no nombra la emocional — que `LANDING_PROBLEM` ya identificó como consecuencia ("la ruleta de la confianza", "el maestro fantasma"). | Es una aplicación del framework sobre conocimiento de dominio ya documentado (`CLAUDE.md`, `LANDING_PROBLEM`), no entrevistas nuevas con usuarios de Datealo. |
 | E-005 | benchmark   | [listivo6.tangiblewp.com](https://listivo6.tangiblewp.com/) — referencia aportada por el dueño de producto | El buscador del hero de la referencia tiene inputs más grandes (con íconos por campo), más padding, y un botón de búsqueda con ícono + texto — se siente "más trabajado" que el buscador actual de Datealo, que no tiene íconos ni el mismo padding. | Es un theme genérico, sirve como referencia de tamaño/jerarquía visual, no de contenido — ver [misión 09](../09-layout-general/investigacion.md#c-003) para el análisis completo de esta referencia. |
+| E-006 | código      | `app/components/CompactSearchBar.vue`, usado en `app/components/AppHeader.vue` (solo en `/buscar`) | Datealo ya tiene un buscador de categoría+comuna con estilo pill redondeada, campos segmentados y botón de búsqueda circular — visualmente cercano al patrón de Airbnb que el dueño de producto usa como referencia. Hoy solo vive en el header de `/buscar`; el hero usa un componente distinto (`CategoriaSelect`/`ComunaSelect` en una caja blanca simple, botón `variant="link"`). | Confirma que el estándar deseado ya existe construido en el producto, no que `CompactSearchBar` sea reusable tal cual en el hero (está afinado para un header angosto, con panel propio para mobile) — la forma exacta de aplicarlo es un detalle de `experiencia.md`. |
+| E-007 | producto (decisión) | [Issue #155](https://github.com/PatricioTabilo/datealo/issues/155) de la misión 09, comentarios del dueño de producto del 2026-09-04 | El link "Para profesionales" del nav de la landing (`LandingNavbar.vue`) hace scroll a una sección de la misma página (`#profesionales`) — dos pasos para llegar a crear un perfil. El dueño de producto había diseñado un link directo ("Publícate"/"Mi perfil") para reemplazarlo en el issue #155, pero lo pausó citando textualmente que "el enfoque original (buscador completo tras scroll, CTA 'Publícate' como texto) tenía bugs reales (mobile se rompe)", además de mezclar una segunda decisión (si el nav necesita su propio buscador tras el scroll). | El comentario de pausa no aísla si el bug de mobile venía del buscador tras scroll, del CTA de texto, o de ambos juntos — así que retomar solo el CTA no garantiza estar libre de ese bug; se verifica en mobile (390px) antes de dar el slice por bueno, no se asume resuelto. |
 
 ## Conclusiones
 
@@ -131,6 +133,40 @@ una entrevista, la columna "límite" es lo que impide que se lea como dato duro.
   el dueño de producto).
 - **Confianza:** alta — confirmado directamente por el dueño de producto.
 
+<a id="c-006"></a>
+
+### C-006 — El estándar que el buscador del hero debe seguir ya existe construido en Datealo, no hay que inventarlo desde una referencia externa
+
+- **Sustento:** [E-006](#e-006).
+- **Razonamiento:** `CompactSearchBar` (usado hoy en `/buscar`) ya resuelve el mismo problema que
+  [C-005](#c-005) describe — campos grandes, jerarquía clara, botón de búsqueda trabajado — con un patrón
+  pill/segmentado cercano al de Airbnb. El buscador del hero usa hoy un componente distinto y visualmente
+  más simple. Seguir ese patrón ya construido, en vez de partir de la referencia externa de E-005, evita
+  que Datealo termine con dos estilos de buscador compitiendo por ser "el" estándar.
+- **Implicación:** la revisión visual del buscador del hero toma `CompactSearchBar` como referencia de
+  forma (pill, segmentado, botón circular), no solo el benchmark externo — el detalle de cómo se adapta al
+  tamaño del hero (que no es un header angosto) se resuelve en `experiencia.md`.
+- **Confianza:** alta — el componente de referencia ya existe y está en producción en `/buscar`.
+
+<a id="c-007"></a>
+
+### C-007 — El nav de la landing necesita el mismo CTA directo al lado profesional que ya usa el header general, sin pasar por un scroll intermedio
+
+- **Sustento:** [E-007](#e-007).
+- **Razonamiento:** la misión 09 ya estableció el patrón "Publícate" (sin sesión) / "Mi perfil" (con
+  sesión) como el acceso directo al lado profesional en el header general — un link a
+  `/profesional/registro` o `/profesional/perfil`. El nav de la landing es la única superficie que
+  todavía usa un patrón distinto (ancla de scroll a una sección de la misma página), inconsistente con
+  esa decisión ya vigente.
+- **Implicación:** reemplazar "Para profesionales" por el mismo patrón directo cierra esa inconsistencia,
+  reusando una decisión de nombres/destinos ya vigente (D-005 de misión 09) en vez de inventar un CTA
+  nuevo. La pregunta de si el nav necesita además su propio buscador tras el scroll (y si el hero seguiría
+  necesitando el suyo) queda fuera, sin resolver todavía.
+- **Confianza:** media — el destino y el naming ("Publícate"/"Mi perfil") ya están decididos, pero el
+  comentario de pausa del issue #155 nombra el "CTA 'Publícate' como texto" junto al bug de mobile sin
+  aislar si el bug era del buscador, del CTA, o de ambos — la implementación de F-002 verifica en mobile
+  antes de darse por resuelta ([TR-002](./ingenieria.md) en `ingenieria.md`).
+
 ## El ideal: el hero comunica en segundos qué es Datealo, por qué es mejor que preguntarle al vecino, y con un buscador que se ve tan cuidado como el resto de la sección
 
 <!--
@@ -153,7 +189,8 @@ tocarlo. Ningún trust item promete algo que Datealo no puede respaldar todavía
 | --------- | -------------------- | ------------------------------------- | --------------------------- |
 | Copy revisado | alguien llega a la landing por primera vez | entiende en segundos qué hace Datealo, sin repetir atributos de la alternativa que ya conoce | [C-001](#c-001), [C-002](#c-002), [C-004](#c-004) |
 | Mensaje de confianza honesto | cualquiera que lea el hero o la sección de soluciones | ningún texto afirma verificación que no existe; la confianza se apoya en reseñas reales | [C-003](#c-003) |
-| Buscador del hero pulido | alguien interactúa con el buscador del hero | campos grandes, con íconos, botón de búsqueda trabajado | [C-005](#c-005) |
+| Buscador del hero pulido | alguien interactúa con el buscador del hero | campos grandes, con íconos, botón de búsqueda trabajado, con el mismo lenguaje visual que el buscador de `/buscar` | [C-005](#c-005), [C-006](#c-006) |
+| CTA profesional directo en el nav | alguien que quiere ofrecer sus servicios ve el nav de la landing | encuentra un link directo a crear o ver su perfil, sin pasar por un scroll intermedio | [C-007](#c-007) |
 
 ### El ideal no significa
 

--- a/docs/missions/12-hero-y-copy-landing/producto.md
+++ b/docs/missions/12-hero-y-copy-landing/producto.md
@@ -1,8 +1,8 @@
 # Misión: hero y copy de la landing — Producto
 
-**Estado:** en revisión
+**Estado:** vigente — aprobado por Patricio el 2026-09-04, con F-002/D-004 sumadas y aceptadas el mismo día
 
-**Última actualización:** 2026-09-01
+**Última actualización:** 2026-09-04
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
@@ -31,13 +31,25 @@ la sección — sigue entregando el resultado central porque el problema de fond
 resuelve en su origen.
 
 **Restricciones aceptadas:** no cambia la estructura funcional del buscador del hero (categoría + comuna +
-CTA); no toca `LandingCategories`, `LandingForProfessionals` ni `LandingFinalCta`.
+CTA); no toca `LandingCategories` ni `LandingForProfessionals`. `LandingFinalCta` no se rediseña, pero su
+subheadline también dice "profesionales verificados" — D-002 no se acota al hero, así que ese mismo cambio
+de palabra entra en F-001 (ver regla actualizada más abajo); es una corrección de una frase, no un
+rediseño de la sección.
+
+**Ampliación de alcance (2026-09-04):** el dueño de producto sumó una segunda funcionalidad, F-002, sobre
+`LandingNavbar.vue` — reemplazar el link "Para profesionales" por el mismo CTA directo que ya usa el
+header general (misión 09, D-005). Nace de retomar el [issue #155](https://github.com/PatricioTabilo/datealo/issues/155)
+de la misión 09, que el dueño de producto pausó y derivó a esta misión (ver [C-007](./investigacion.md#c-007)).
+Explícitamente **no** incluye la otra mitad de ese issue: si el nav necesita `CompactSearchBar` en línea
+tras hacer scroll, y si el hero seguiría necesitando su propio buscador en ese caso — esa pregunta queda
+en "Fuera de alcance" hasta que se retome.
 
 ## Funcionalidades
 
 | ID    | Funcionalidad                  | Lado    | Sustento             | Éxito |
 | ----- | ------------------------------ | ------- | ---------------------- | ----- |
-| F-001 | Revisar hero y copy de la landing | buscador | C-001 a C-005, D-001, D-002 | M-001 |
+| F-001 | Revisar hero y copy de la landing | buscador | C-001 a C-006, D-001 a D-003 | M-001 |
+| F-002 | Reemplazar el CTA "Para profesionales" del nav de la landing | profesional | C-007, D-004 | M-002 |
 
 <a id="f-001"></a>
 
@@ -58,7 +70,8 @@ aunque el mensaje no debe prometer más cobertura, verificación o reseñas de l
 
 **Sustento:** [C-001](./investigacion.md#c-001), [C-002](./investigacion.md#c-002),
 [C-003](./investigacion.md#c-003), [C-004](./investigacion.md#c-004),
-[C-005](./investigacion.md#c-005) y [D-001](#d-001), [D-002](#d-002). **Éxito:** [M-001](#m-001).
+[C-005](./investigacion.md#c-005), [C-006](./investigacion.md#c-006) y [D-001](#d-001),
+[D-002](#d-002), [D-003](#d-003). **Éxito:** [M-001](#m-001).
 
 **Reglas:**
 
@@ -71,25 +84,69 @@ aunque el mensaje no debe prometer más cobertura, verificación o reseñas de l
 - El copy nunca usa "verificado"/"verificados" para describir profesionales — no existe esa funcionalidad
   ni está planificada ([D-002](#d-002)). El mensaje de confianza se apoya en reseñas reales y en los
   atributos de cercanía/categorización.
-- El buscador dentro del hero recibe inputs más grandes, con íconos por campo (categoría, comuna) y más
-  padding — hoy se ve "simplón" comparado con el resto de la sección. Sin fila de accesos rápidos por
-  categoría.
-- El botón de búsqueda del hero se rediseña como un botón trabajado (no un link de texto) — sin necesidad
-  de copiar exactamente ninguna referencia, solo más amigable que hoy.
+- El buscador del hero deja de usar la caja blanca con `<select>` planos que tiene hoy y sigue el mismo
+  lenguaje visual que `CompactSearchBar` (el buscador de `/buscar`): pill redondeada, campos segmentados
+  por categoría y comuna, botón de búsqueda circular — no un estilo inventado desde cero, y sin fila de
+  accesos rápidos por categoría ([D-003](#d-003)).
+- El botón de búsqueda del hero deja de ser un link de texto (`variant="link"`) y pasa a ser el botón
+  circular trabajado del mismo patrón — nunca un link disfrazado de CTA.
 - Si el copy revisado no cabe con el mismo tamaño de fuente en 390px que en desktop, Datealo prioriza
   claridad y legibilidad mobile sobre mantener idéntica proporción entre anchos.
-- Esta funcionalidad también corrige `LANDING_SOLUTION.features[0]` ("Profesionales verificados" / "Cada
-  profesional pasa por un proceso de verificación") — misma regla de no usar "verificado".
+- Esta funcionalidad corrige toda mención a "verificado"/"verificados" que describa profesionales fuera
+  del hero: `LANDING_SOLUTION.subtitle` ("Un buscador de profesionales verificados..."),
+  `LANDING_SOLUTION.features[0]` ("Profesionales verificados" / "Cada profesional pasa por un proceso de
+  verificación") y `LANDING_FINAL_CTA.subheadline` ("Ya podés buscar profesionales verificados..."). Ninguna
+  de esas tres secciones se rediseña — es la misma corrección de palabra que en el hero, no un rediseño.
 - Datealo nunca promete cobertura o volumen de profesionales que no existe todavía — el guardrail de "no
   copy agresivo o de urgencia artificial" sigue vigente.
 
 **Ejemplo verificable:** dado el hero actual, cuando se aplique la revisión de copy, entonces el headline
 y el subheadline resultantes pasan la prueba de lectura en voz alta del skill `ux-writing`, ninguna frase
-usa "verificado" o "verificados" para describir a los profesionales, y el buscador muestra íconos por
-campo con inputs más grandes que la versión actual.
+usa "verificado" o "verificados" para describir a los profesionales, y el buscador del hero se ve como una
+variante del mismo patrón pill/segmentado que ya usa `/buscar`, no como un componente aparte.
 
 **No incluye:** cambiar la estructura funcional del buscador del hero (categoría + comuna + CTA) — esa
 decisión ya está resuelta por la misión de búsqueda; esta funcionalidad es de mensaje y pulido visual.
+
+**Experiencia:** —. **Ingeniería:** —.
+
+<a id="f-002"></a>
+
+### F-002 — Reemplazar el CTA "Para profesionales" del nav de la landing
+
+Cuando alguien que ofrece un servicio (gasfitería, peluquería, etc.) llega a datealo.cl y quiere entender
+cómo aparecer en la plataforma,
+quiero encontrar en el nav un camino directo a crear o ver mi perfil,
+para no tener que hacer scroll hasta encontrar el botón real de esa sección — el nav ya me dice qué hacer.
+
+**Lado del marketplace:** profesional — es la entrada de captación del lado difícil del marketplace
+([cold-start-problem](../../../.claude/skills/cold-start-problem/)). **Qué necesita del otro lado:** nada
+— usa la sesión de profesional que ya existe (`useProfessionalSession`, ya construida y en uso en
+`AppHeader.vue`).
+
+**Sustento:** [C-007](./investigacion.md#c-007) y [D-004](#d-004). **Éxito:** [M-002](#m-002).
+
+**Reglas:**
+
+- El link "Para profesionales" (hoy hace scroll a `#profesionales` con `scrollToSection`) se reemplaza por
+  un link directo: "Publícate" → `/profesional/registro` si no hay sesión de profesional activa, o
+  "Mi perfil" → `/profesional/perfil` si la hay. Nunca los dos textos a la vez, y siempre uno de los dos
+  visible — reusa el naming y los destinos que ya fijó D-005 de la misión 09 para el header general, pero
+  no su comportamiento: `AppHeader.vue` solo muestra el link de perfil cuando hay sesión (`v-if`, sin
+  alternativa sin sesión) porque ahí es un acceso secundario; acá es la entrada principal de captación del
+  lado profesional en la landing, así que siempre muestra algo.
+- El link "Categorías" (ancla a `#categorias`) y el CTA "Buscar" (a `/buscar`) del nav no cambian — esta
+  funcionalidad es solo del acceso al lado profesional.
+- No se toca el comportamiento del nav al hacer scroll (el cambio de fondo/padding que ya existe) — eso
+  queda igual; lo que cambia es únicamente el texto y destino del link de profesionales.
+
+**Ejemplo verificable:** dado el nav de la landing sin sesión de profesional activa, cuando se aplique
+este cambio, entonces el link que antes decía "Para profesionales" dice "Publícate" y navega directo a
+`/profesional/registro`, sin hacer scroll. Con sesión activa, el mismo lugar dice "Mi perfil" y navega a
+`/profesional/perfil`.
+
+**No incluye:** si el nav necesita `CompactSearchBar` en línea tras hacer scroll, ni si el hero seguiría
+necesitando su propio buscador en ese caso — ver "Fuera de alcance".
 
 **Experiencia:** —. **Ingeniería:** —.
 
@@ -104,6 +161,7 @@ decisión ya está resuelta por la misión de búsqueda; esta funcionalidad es d
 | Capacidad o caso      | Estado    | Razón del recorte | Condición para reconsiderar |
 | ---------------------- | --------- | ------------------ | ---------------------------- |
 | Rediseño completo de `LandingSolution`, `LandingCategories`, `LandingForProfessionals` | postergada | Esta misión corrige la claim puntual de verificación; un rediseño de esas secciones es un problema aparte, sin evidencia todavía de que haga falta. | Evidencia de que esas secciones también tienen brechas de mensaje o visuales. |
+| `CompactSearchBar` en línea en el nav de la landing tras hacer scroll, y si el hero sigue necesitando su propio buscador en ese caso | postergada | Es la otra mitad del [issue #155](https://github.com/PatricioTabilo/datealo/issues/155) de la misión 09 — el dueño de producto pidió explícitamente resolver primero el CTA de profesionales solo (F-002), sin mezclarlo con esta pregunta más grande de dónde vive la búsqueda en la landing. | El dueño de producto decide retomarla, en esta misión o en una nueva. |
 
 ## Señales de éxito
 
@@ -122,13 +180,28 @@ decisión ya está resuelta por la misión de búsqueda; esta funcionalidad es d
 - **Guardrail:** el copy no cae en urgencia artificial ni promete algo que Datealo no tiene todavía (ver
   guardrails de producto en `CLAUDE.md`, y [D-002](#d-002) para las claims de verificación/reseñas).
 
+<a id="m-002"></a>
+
+### M-002 — El acceso al lado profesional desde el nav de la landing es directo, no un scroll
+
+- **Pregunta:** ¿alguien que quiere ofrecer sus servicios llega a `/profesional/registro` o
+  `/profesional/perfil` sin tener que encontrar primero la sección correcta de la página?
+- **Señal:** el dueño de producto confirma que el link del nav navega directo, sin pasar por
+  `scrollToSection`.
+- **Método y umbral:** revisión directa del comportamiento — es un cambio de destino de un link, no
+  necesita medición cuantitativa.
+- **Cuando exista tráfico:** reemplazar por la tasa de clic en ese link sobre visitas a `/` que vienen de
+  un profesional (o que no tienen sesión de cliente activa), separando lado profesional de lado buscador.
+- **Guardrail:** el link nunca muestra "Publícate" y "Mi perfil" a la vez — mismo guardrail que ya aplica
+  al header general (misión 09, D-005).
+
 ## Decisiones de producto
 
 <a id="d-001"></a>
 
 ### D-001 — El copy del hero se revisa como una iteración propia de esta misión, no se hereda tal cual del cambio funcional reciente
 
-- **Estado:** propuesta. **Fecha:** 2026-09-08.
+- **Estado:** aceptada. **Fecha:** 2026-09-04.
 - **Sustento:** [C-001](./investigacion.md#c-001).
 - **Tensión:** evitar re-litigar algo "que ya funciona" vs. la evidencia muestra que el copy actual nunca
   fue validado como mensaje, solo actualizado técnicamente al cambiar de lista de espera a buscador en
@@ -143,7 +216,7 @@ decisión ya está resuelta por la misión de búsqueda; esta funcionalidad es d
 
 ### D-002 — La palabra "verificado" sale del copy que describe profesionales; el mensaje de confianza se apoya en reseñas reales, no en una verificación que no existe ni está planificada
 
-- **Estado:** propuesta. **Fecha:** 2026-09-08.
+- **Estado:** aceptada. **Fecha:** 2026-09-04.
 - **Sustento:** [C-003](./investigacion.md#c-003).
 - **Tensión:** la confianza es la única palanca diferenciadora de Datealo frente al grupo de WhatsApp vs.
   no existe ninguna funcionalidad de verificación de profesionales, ni planificada.
@@ -153,9 +226,49 @@ decisión ya está resuelta por la misión de búsqueda; esta funcionalidad es d
   vecinos reales, ya con su propio estándar de honestidad en la misión 07) sí existe y sí debe
   comunicarse.
 - **Decisión y consecuencia:** F-001 retira "verificado"/"verificados" del copy que describe profesionales
-  (hero y `LandingSolution`). Afecta directamente a `LANDING_SOLUTION.features[0]`.
+  en toda la landing — no solo el hero. Afecta a `LANDING_HERO`, `LANDING_SOLUTION.subtitle`,
+  `LANDING_SOLUTION.features[0]` y `LANDING_FINAL_CTA.subheadline`.
 - **Reapertura:** si en algún momento el producto decide construir una verificación formal de
   profesionales, se reabre para volver a usar la palabra con respaldo real.
+
+<a id="d-003"></a>
+
+### D-003 — El buscador del hero se rediseña siguiendo el mismo lenguaje visual que `CompactSearchBar` (el buscador de `/buscar`), no un estilo nuevo
+
+- **Estado:** aceptada. **Fecha:** 2026-09-04.
+- **Sustento:** [C-006](./investigacion.md#c-006).
+- **Tensión:** el buscador del hero hoy se ve "feísimo" y no sigue el estándar del buscador que ya existe
+  en `/buscar` (bastante mejor) vs. el hero no es un header angosto — replicar el componente tal cual, sin
+  ajustar, podría no funcionar en un contenedor más ancho y con más espacio.
+- **Alternativas descartadas:** mantener los `<select>` planos actuales en una caja blanca simple — se
+  descarta porque es exactamente lo que el dueño de producto identificó como "feísimo" y sin estándar;
+  diseñar un estilo nuevo para el hero inspirado directamente en Airbnb sin pasar por el componente que ya
+  existe en el producto — se descarta porque crea una tercera variante visual de buscador conviviendo con
+  la de `/buscar`, cuando el objetivo explícito es que "pegue con la página".
+- **Decisión y consecuencia:** F-001 toma `CompactSearchBar` (pill redondeada, campos segmentados,
+  botón de búsqueda circular) como referencia de forma para el buscador del hero — con el mismo lenguaje
+  visual, tipo Airbnb. Cómo se adapta ese lenguaje al ancho y contexto del hero (mobile y desktop) se
+  resuelve en `experiencia.md`, no acá.
+- **Reapertura:** —.
+
+<a id="d-004"></a>
+
+### D-004 — El nav de la landing reemplaza "Para profesionales" por un link directo a registro o perfil, sin pasar por el scroll a la sección
+
+- **Estado:** aceptada. **Fecha:** 2026-09-04.
+- **Sustento:** [C-007](./investigacion.md#c-007).
+- **Tensión:** retomar la parte simple de un issue ya diseñado (misión 09, #155) vs. el riesgo de mezclar
+  otra vez la pregunta más grande que hizo pausar ese issue (buscador en el nav tras scroll).
+- **Alternativas descartadas:** mantener el link como ancla de scroll y solo cambiarle el texto a
+  "Publícate" — se descarta porque sigue siendo un paso indirecto (scroll → encontrar el botón real de la
+  sección) para algo que en el resto del producto ya es un solo link; resolver junto con la pregunta del
+  buscador en el nav tras scroll (la versión original del issue #155) — se descarta porque el dueño de
+  producto pidió explícitamente separar ambas cosas, dado que la segunda todavía no está lista.
+- **Decisión y consecuencia:** F-002 reemplaza el link por "Publícate" (`/profesional/registro`) o
+  "Mi perfil" (`/profesional/perfil`), con el mismo criterio de sesión que ya usa `AppHeader.vue`. El resto
+  del nav (Categorías, Buscar) no cambia.
+- **Reapertura:** si se retoma la pregunta del buscador en el nav tras scroll (ver "Fuera de alcance"), se
+  revisa si este link necesita moverse o reacomodarse junto a ese cambio.
 
 ## Preguntas
 

--- a/docs/missions/README.md
+++ b/docs/missions/README.md
@@ -20,7 +20,7 @@ abrieron y de dónde salió cada una.
 | 09  | [layout general (navbar, footer, TOS)](./09-layout-general/) | producto | 2026-08-31 | en construcción | — | — |
 | 10  | [vista de resultados de búsqueda](./10-vista-resultados-busqueda/) | producto | 2026-09-01 | lista para construir | — | — |
 | 11  | [vista de detalle de perfil](./11-perfil-profesional/) | producto | 2026-09-01 | exploración | — | — |
-| 12  | [hero y copy de la landing](./12-hero-y-copy-landing/) | producto | 2026-09-01 | definición | Producto | — |
+| 12  | [hero y copy de la landing](./12-hero-y-copy-landing/) | producto | 2026-09-01 | lista para construir | — | — |
 
 Misiones 02 a 07 son las seis que llevan al MVP (registrarse, mostrarse, buscar, reseñar), en el orden de
 dependencia definido en la conversación de roadmap del 2026-08-13 — el número no es prioridad, pero acá sí


### PR DESCRIPTION
## Resumen

Cierra el discovery de la misión 12 — `producto.md`, `experiencia.md` e `ingenieria.md` quedan vigentes:

- **F-001** — revisión del copy del hero (sin "verificado", D-002) y del buscador del hero, que pasa a
  seguir el mismo lenguaje visual que `CompactSearchBar` (pill segmentada, íconos por campo, botón
  circular — D-003) en vez de un estilo inventado desde cero.
- **F-002** (ampliación, sumada por Patricio el 2026-09-04) — retoma la mitad simple del
  [issue #155](https://github.com/PatricioTabilo/datealo/issues/155) de la misión 09: reemplaza "Para
  profesionales" del nav de la landing por un CTA directo, "Publícate"/"Mi perfil" según sesión (D-004),
  igual que ya hace `AppHeader.vue`.
- `ingenieria.md` corta el trabajo en 3 slices (S-001 copy, S-002 buscador del hero, S-003 CTA del nav),
  auditado en contexto separado dos veces.
- Suma la regla "sin em dash en copy real" a `docs/design/README.md` — se repitió sin documentar en las
  misiones 04, 09 y 12 porque solo vivía en memoria.
- Mueve la misión 12 a `lista para construir` en el registro.

Sin cambios de código — es solo el cierre del discovery. El plan de construcción queda listo para cortar
en issues.

## Test plan

- [x] `npx nuxi typecheck` — cero errores.
- [x] `npx vitest run` — 73 tests, todos pasan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)