### PR TITLE
feat(app): reescribir el copy del hero sin la palabra verificado

### DIFF
--- a/app/components/landing/LandingHero.vue
+++ b/app/components/landing/LandingHero.vue
@@ -82,7 +82,7 @@ const searchQuery = computed(() => {
               <Star class="w-6 h-6 fill-current" />
             </div>
             <div>
-              <p class="text-sm font-extrabold text-datealo-text leading-tight">Profesionales<br>verificados</p>
+              <p class="text-sm font-extrabold text-datealo-text leading-tight">Reseñas<br>reales</p>
             </div>
           </div>
         </div>

--- a/app/components/landing/LandingSolution.vue
+++ b/app/components/landing/LandingSolution.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import { ShieldCheck, Star, MapPin, MessageCircle } from '@lucide/vue'
+import { LayoutGrid, Star, MapPin, MessageCircle } from '@lucide/vue'
 import { LANDING_SOLUTION } from '~/constants/landing'
 
-const iconMap = { ShieldCheck, Star, MapPin, MessageCircle } as const
+const iconMap = { LayoutGrid, Star, MapPin, MessageCircle } as const
 </script>
 
 <template>

--- a/app/constants/landing.ts
+++ b/app/constants/landing.ts
@@ -1,10 +1,10 @@
 export const LANDING_HERO = {
   tagline: 'lo bueno se recomienda',
-  headline: 'Deja de buscar en grupos de Facebook.',
-  headlineAccent: 'Encuentra profesionales reales, cerca de ti.',
-  subheadline: 'datealo conecta a personas con profesionales verificados de su zona. Gasfiter, electricista, peluquera — a un click.',
+  headline: 'Deja de preguntarle al grupo del edificio',
+  headlineAccent: 'y encuentra a alguien que sí te va a resolver.',
+  subheadline: 'Gasfiter, electricista, peluquera y más. Busca por categoría y comuna, no por quién contesta primero en el chat del edificio.',
   cta: 'Buscar',
-  trust: ['Gratis', 'Sin registro', 'Contacto directo'],
+  trust: ['Reseñas reales de tu zona', 'Ordenados por cercanía', 'Categorías claras'],
   heroImage: {
     src: 'https://images.pexels.com/photos/5493672/pexels-photo-5493672.jpeg?auto=compress&cs=tinysrgb&w=1600&h=1100&fit=crop',
     alt: 'Trabajador sonriendo mientras usa un taladro en renovación de hogar',
@@ -44,12 +44,12 @@ export const LANDING_PROBLEM = {
 
 export const LANDING_SOLUTION = {
   title: 'Imagina un lugar donde encontrar al profesional correcto es fácil',
-  subtitle: 'Eso es datealo. Un buscador de profesionales verificados, con reseñas reales, cerca de ti.',
+  subtitle: 'Eso es datealo. Un buscador de profesionales con reseñas reales, cerca de ti.',
   features: [
     {
-      icon: 'ShieldCheck' as const,
-      title: 'Profesionales verificados',
-      description: 'Cada profesional pasa por un proceso de verificación. Sabes que es real antes de contactarlo.',
+      icon: 'LayoutGrid' as const,
+      title: 'Busca por categoría',
+      description: 'Gasfitería, electricidad, peluquería y más. Encuentra justo lo que necesitas, no un hilo de mensajes mezclado.',
     },
     {
       icon: 'Star' as const,
@@ -101,7 +101,7 @@ export const LANDING_FOR_PROFESSIONALS = {
 export const LANDING_FINAL_CTA = {
   headline: 'No te lo cuenten —',
   headlineAccent: 'datealo',
-  subheadline: 'Ya podés buscar profesionales verificados en tu zona. Sin registro, sin esperar.',
+  subheadline: 'Ya podés buscar profesionales de tu zona, con reseñas reales. Sin registro, sin esperar.',
   cta: 'Buscar profesionales',
   trust: ['Gratis', 'Sin registro', 'Contacto directo'],
 } as const

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 useSeoMeta({
   title: 'datealo — Encuentra al profesional que necesitas, cerca de ti',
-  description: 'Conectamos personas con profesionales verificados de su zona. Gasfitería, electricidad, peluquería, limpieza y más. Regístrate para acceso anticipado.',
-  ogTitle: 'datealo — Profesionales verificados cerca de ti',
+  description: 'Conectamos personas con profesionales de su zona, con reseñas reales. Gasfitería, electricidad, peluquería, limpieza y más. Regístrate para acceso anticipado.',
+  ogTitle: 'datealo — Profesionales cerca de ti, con reseñas reales',
   ogDescription: 'Busca, compara y contacta profesionales de confianza en tu zona. Estamos por lanzar — únete a la lista de espera.',
   ogType: 'website',
   ogLocale: 'es_CL',
@@ -18,7 +18,7 @@ useHead({
         '@type': 'WebSite',
         name: 'datealo',
         url: 'https://datealo.cl',
-        description: 'Buscador de profesionales verificados para el hogar y la vida diaria.',
+        description: 'Buscador de profesionales con reseñas reales para el hogar y la vida diaria.',
         potentialAction: {
           '@type': 'SearchAction',
           target: 'https://datealo.cl/buscar?categoria={search_term_string}',


### PR DESCRIPTION
Closes #202

## Resumen

D-002 (misión 12) retira "verificado"/"verificados" del copy que describe profesionales — no existe esa
funcionalidad ni está planificada; la confianza se apoya en reseñas reales.

- `app/constants/landing.ts`: `LANDING_HERO`, `LANDING_SOLUTION` y `LANDING_FINAL_CTA` con el contenido
  final definido en `ingenieria.md` de la misión 12.
- Dos lugares que `ingenieria.md` no había listado pero tienen la misma claim, encontrados al revisar el
  criterio de aceptación ("ninguna cadena visible... usa verificado"):
  - El badge flotante sobre la foto del hero (`LandingHero.vue`): "Profesionales verificados" → "Reseñas
    reales".
  - El meta SEO de la landing (`app/pages/index.vue`): title, description y JSON-LD.
- `LandingSolution.vue` cambia el ícono `ShieldCheck` por `LayoutGrid` en el primer feature, que ahora es
  "Busca por categoría" en vez de verificación.

## Test plan

- [x] `npx nuxi typecheck` — cero errores.
- [x] `npx vitest run` — 73 tests, todos pasan.
- [x] `npm run build` — compila.
- [x] Verificado visualmente en 1280px y 390px — el copy nuevo cabe sin desbordes, sin ninguna mención a
  "verificado"/"verificados".

🤖 Generated with [Claude Code](https://claude.com/claude-code)