### PR TITLE
feat(app): rediseñar el buscador del hero como pill segmentada con íconos

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -112,3 +112,16 @@
     transform: translateY(0);
   }
 }
+
+@utility animate-shake {
+  animation: shake 0.2s ease-in-out;
+}
+
+@keyframes shake {
+  25% {
+    transform: translateX(-4px);
+  }
+  75% {
+    transform: translateX(4px);
+  }
+}

--- a/app/components/CatalogSelect.vue
+++ b/app/components/CatalogSelect.vue
@@ -8,6 +8,7 @@
 // ref/computed importados explícitos (no solo auto-import de Nuxt): así el componente se puede montar
 // en un test con Vitest + Vue Test Utils plano, sin levantar un contexto de Nuxt completo.
 import { computed, ref, watch } from 'vue'
+import type { Component } from 'vue'
 
 export type CatalogOption = { value: string, label: string }
 
@@ -18,6 +19,10 @@ const props = defineProps<{
   error: boolean
   placeholder: string
   errorMessage: string
+  // Mapea el value de una opción a su ícono — sin valor, la lista se ve igual que hoy (solo texto).
+  // Un consumidor (el buscador del hero) lo usa para mostrar el mismo ícono por categoría que ya muestra
+  // CompactSearchBarPanel; ninguno de los otros usos de este componente lo necesita.
+  itemIcon?: (value: string) => Component
   // Nombre de ícono Iconify (ej. "i-lucide-wrench"), reenviado tal cual al `leading-icon` de `UInput`.
   // Sin valor, el campo se ve igual que hoy — es un override por consumidor, no un default nuevo.
   leadingIcon?: string
@@ -180,9 +185,12 @@ defineExpose({ focus: () => uInputRef.value?.inputRef?.focus() })
           :key="item.value"
           type="button"
           :data-testid="`option-${item.value}`"
-          class="catalog-option flex w-full cursor-pointer items-center rounded-md px-2 py-1.5 text-left text-sm"
+          class="catalog-option flex w-full cursor-pointer items-center gap-3 rounded-md px-2 py-1.5 text-left text-sm"
           @click="selectItem(item)"
         >
+          <span v-if="itemIcon" class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-datealo-surface text-primary">
+            <component :is="itemIcon(item.value)" class="h-4 w-4" />
+          </span>
           {{ item.label }}
         </button>
       </template>

--- a/app/components/CatalogSelect.vue
+++ b/app/components/CatalogSelect.vue
@@ -21,6 +21,13 @@ const props = defineProps<{
   // Nombre de ícono Iconify (ej. "i-lucide-wrench"), reenviado tal cual al `leading-icon` de `UInput`.
   // Sin valor, el campo se ve igual que hoy — es un override por consumidor, no un default nuevo.
   leadingIcon?: string
+  // `variant`/`size` de UInput y clases extra para el input real — todos opcionales, sin valor el campo
+  // se ve exactamente igual que hoy. Existen porque un consumidor (el buscador del hero) necesita verse
+  // como un segmento sin borde dentro de su propia pill, no como el input con anillo que usa el resto de
+  // la app — ninguno de esos dos casos debe imponerle su estilo al otro.
+  variant?: 'outline' | 'ghost'
+  size?: 'md' | 'lg' | 'xl'
+  inputClass?: string
   // Catálogo chico (categorías): mostrar todo al enfocar no cuesta nada. Catálogo grande (comunas):
   // esperar a que se escriba, el patrón ya validado de Mercado Libre — mostrar todas las opciones de
   // entrada es más ruido que ayuda.
@@ -137,8 +144,11 @@ defineExpose({ focus: () => uInputRef.value?.inputRef?.focus() })
       :placeholder="placeholder"
       :readonly="error"
       :leading-icon="leadingIcon"
+      :variant="variant"
+      :size="size"
       trailing-icon="i-lucide-chevron-down"
       class="w-full"
+      :class="inputClass"
       @update:model-value="handleInput"
     />
 

--- a/app/components/CatalogSelect.vue
+++ b/app/components/CatalogSelect.vue
@@ -34,6 +34,10 @@ const props = defineProps<{
   variant?: 'outline' | 'ghost'
   size?: 'md' | 'lg' | 'xl'
   ui?: { base?: string, leading?: string, leadingIcon?: string, trailing?: string, trailingIcon?: string }
+  // Clases extra para el panel del dropdown — sin valor, mide lo mismo que el campo (comportamiento de
+  // hoy). El buscador del hero lo usa para que el panel no quede angosto pegado al ancho de un solo
+  // segmento de la pill, igual de generoso que el panel de `/buscar`.
+  panelClass?: string
   // Catálogo chico (categorías): mostrar todo al enfocar no cuesta nada. Catálogo grande (comunas):
   // esperar a que se escriba, el patrón ya validado de Mercado Libre — mostrar todas las opciones de
   // entrada es más ruido que ayuda.
@@ -161,6 +165,7 @@ defineExpose({ focus: () => uInputRef.value?.inputRef?.focus() })
     <div
       v-if="isOpen"
       class="absolute inset-x-0 top-full z-10 mt-2 max-h-72 overflow-auto rounded-md border p-1 shadow-lg"
+      :class="panelClass"
       style="background: var(--ui-bg); border-color: var(--ui-border)"
     >
       <template v-if="error">

--- a/app/components/CatalogSelect.vue
+++ b/app/components/CatalogSelect.vue
@@ -21,13 +21,14 @@ const props = defineProps<{
   // Nombre de ícono Iconify (ej. "i-lucide-wrench"), reenviado tal cual al `leading-icon` de `UInput`.
   // Sin valor, el campo se ve igual que hoy — es un override por consumidor, no un default nuevo.
   leadingIcon?: string
-  // `variant`/`size` de UInput y clases extra para el input real — todos opcionales, sin valor el campo
-  // se ve exactamente igual que hoy. Existen porque un consumidor (el buscador del hero) necesita verse
-  // como un segmento sin borde dentro de su propia pill, no como el input con anillo que usa el resto de
-  // la app — ninguno de esos dos casos debe imponerle su estilo al otro.
+  // `variant`/`size`/`ui` de UInput, reenviados tal cual — todos opcionales, sin valor el campo se ve
+  // exactamente igual que hoy. Existen porque un consumidor (el buscador del hero) necesita verse como un
+  // segmento sin borde dentro de su propia pill, con un ícono más chico y menos espacio reservado para él
+  // que el que UInput calcula por defecto en tamaño xl — ninguno de esos ajustes debe imponerse al input
+  // con anillo que usa el resto de la app.
   variant?: 'outline' | 'ghost'
   size?: 'md' | 'lg' | 'xl'
-  inputClass?: string
+  ui?: { base?: string, leading?: string, leadingIcon?: string, trailing?: string, trailingIcon?: string }
   // Catálogo chico (categorías): mostrar todo al enfocar no cuesta nada. Catálogo grande (comunas):
   // esperar a que se escriba, el patrón ya validado de Mercado Libre — mostrar todas las opciones de
   // entrada es más ruido que ayuda.
@@ -148,7 +149,7 @@ defineExpose({ focus: () => uInputRef.value?.inputRef?.focus() })
       :size="size"
       trailing-icon="i-lucide-chevron-down"
       class="w-full"
-      :class="inputClass"
+      :ui="ui"
       @update:model-value="handleInput"
     />
 

--- a/app/components/CatalogSelect.vue
+++ b/app/components/CatalogSelect.vue
@@ -18,6 +18,9 @@ const props = defineProps<{
   error: boolean
   placeholder: string
   errorMessage: string
+  // Nombre de ícono Iconify (ej. "i-lucide-wrench"), reenviado tal cual al `leading-icon` de `UInput`.
+  // Sin valor, el campo se ve igual que hoy — es un override por consumidor, no un default nuevo.
+  leadingIcon?: string
   // Catálogo chico (categorías): mostrar todo al enfocar no cuesta nada. Catálogo grande (comunas):
   // esperar a que se escriba, el patrón ya validado de Mercado Libre — mostrar todas las opciones de
   // entrada es más ruido que ayuda.
@@ -133,6 +136,7 @@ defineExpose({ focus: () => uInputRef.value?.inputRef?.focus() })
       :model-value="searchTerm"
       :placeholder="placeholder"
       :readonly="error"
+      :leading-icon="leadingIcon"
       trailing-icon="i-lucide-chevron-down"
       class="w-full"
       @update:model-value="handleInput"

--- a/app/components/CategoriaSelect.vue
+++ b/app/components/CategoriaSelect.vue
@@ -1,16 +1,20 @@
 <script setup lang="ts">
+import type { Component } from 'vue'
+
 const {
   placeholder = '¿Qué necesitas?',
   leadingIcon,
   variant,
   size,
   ui,
+  itemIcon,
 } = defineProps<{
   placeholder?: string
   leadingIcon?: string
   variant?: 'outline' | 'ghost'
   size?: 'md' | 'lg' | 'xl'
   ui?: { base?: string, leading?: string, leadingIcon?: string, trailing?: string, trailingIcon?: string }
+  itemIcon?: (value: string) => Component
 }>()
 const modelValue = defineModel<string | null>()
 const { items, pending, error, refresh } = useCategoriasCatalog()
@@ -27,6 +31,7 @@ const { items, pending, error, refresh } = useCategoriasCatalog()
     :variant
     :size
     :ui
+    :item-icon="itemIcon"
     error-message="No pudimos cargar las categorías."
     :show-all-on-focus="true"
     @retry="refresh"

--- a/app/components/CategoriaSelect.vue
+++ b/app/components/CategoriaSelect.vue
@@ -1,5 +1,17 @@
 <script setup lang="ts">
-const { placeholder = '¿Qué necesitas?', leadingIcon } = defineProps<{ placeholder?: string, leadingIcon?: string }>()
+const {
+  placeholder = '¿Qué necesitas?',
+  leadingIcon,
+  variant,
+  size,
+  inputClass,
+} = defineProps<{
+  placeholder?: string
+  leadingIcon?: string
+  variant?: 'outline' | 'ghost'
+  size?: 'md' | 'lg' | 'xl'
+  inputClass?: string
+}>()
 const modelValue = defineModel<string | null>()
 const { items, pending, error, refresh } = useCategoriasCatalog()
 </script>
@@ -12,6 +24,9 @@ const { items, pending, error, refresh } = useCategoriasCatalog()
     :error
     :placeholder
     :leading-icon="leadingIcon"
+    :variant
+    :size
+    :input-class="inputClass"
     error-message="No pudimos cargar las categorías."
     :show-all-on-focus="true"
     @retry="refresh"

--- a/app/components/CategoriaSelect.vue
+++ b/app/components/CategoriaSelect.vue
@@ -8,6 +8,7 @@ const {
   size,
   ui,
   itemIcon,
+  panelClass,
 } = defineProps<{
   placeholder?: string
   leadingIcon?: string
@@ -15,6 +16,7 @@ const {
   size?: 'md' | 'lg' | 'xl'
   ui?: { base?: string, leading?: string, leadingIcon?: string, trailing?: string, trailingIcon?: string }
   itemIcon?: (value: string) => Component
+  panelClass?: string
 }>()
 const modelValue = defineModel<string | null>()
 const { items, pending, error, refresh } = useCategoriasCatalog()
@@ -32,6 +34,7 @@ const { items, pending, error, refresh } = useCategoriasCatalog()
     :size
     :ui
     :item-icon="itemIcon"
+    :panel-class="panelClass"
     error-message="No pudimos cargar las categorías."
     :show-all-on-focus="true"
     @retry="refresh"

--- a/app/components/CategoriaSelect.vue
+++ b/app/components/CategoriaSelect.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+const { placeholder = '¿Qué necesitas?', leadingIcon } = defineProps<{ placeholder?: string, leadingIcon?: string }>()
 const modelValue = defineModel<string | null>()
 const { items, pending, error, refresh } = useCategoriasCatalog()
 </script>
@@ -9,7 +10,8 @@ const { items, pending, error, refresh } = useCategoriasCatalog()
     :items
     :pending
     :error
-    placeholder="¿Qué necesitas?"
+    :placeholder
+    :leading-icon="leadingIcon"
     error-message="No pudimos cargar las categorías."
     :show-all-on-focus="true"
     @retry="refresh"

--- a/app/components/CategoriaSelect.vue
+++ b/app/components/CategoriaSelect.vue
@@ -4,13 +4,13 @@ const {
   leadingIcon,
   variant,
   size,
-  inputClass,
+  ui,
 } = defineProps<{
   placeholder?: string
   leadingIcon?: string
   variant?: 'outline' | 'ghost'
   size?: 'md' | 'lg' | 'xl'
-  inputClass?: string
+  ui?: { base?: string, leading?: string, leadingIcon?: string, trailing?: string, trailingIcon?: string }
 }>()
 const modelValue = defineModel<string | null>()
 const { items, pending, error, refresh } = useCategoriasCatalog()
@@ -26,7 +26,7 @@ const { items, pending, error, refresh } = useCategoriasCatalog()
     :leading-icon="leadingIcon"
     :variant
     :size
-    :input-class="inputClass"
+    :ui
     error-message="No pudimos cargar las categorías."
     :show-all-on-focus="true"
     @retry="refresh"

--- a/app/components/ComunaSelect.vue
+++ b/app/components/ComunaSelect.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+const { placeholder = '¿Qué comuna buscas?', leadingIcon } = defineProps<{ placeholder?: string, leadingIcon?: string }>()
 const modelValue = defineModel<string | null>()
 const { items, pending, error, refresh } = useComunasCatalog()
 const catalogSelect = useTemplateRef('catalogSelect')
@@ -13,7 +14,8 @@ defineExpose({ focus: () => catalogSelect.value?.focus() })
     :items
     :pending
     :error
-    placeholder="¿Qué comuna buscas?"
+    :placeholder
+    :leading-icon="leadingIcon"
     error-message="No pudimos cargar las comunas."
     @retry="refresh"
   />

--- a/app/components/ComunaSelect.vue
+++ b/app/components/ComunaSelect.vue
@@ -1,5 +1,17 @@
 <script setup lang="ts">
-const { placeholder = '¿Qué comuna buscas?', leadingIcon } = defineProps<{ placeholder?: string, leadingIcon?: string }>()
+const {
+  placeholder = '¿Qué comuna buscas?',
+  leadingIcon,
+  variant,
+  size,
+  inputClass,
+} = defineProps<{
+  placeholder?: string
+  leadingIcon?: string
+  variant?: 'outline' | 'ghost'
+  size?: 'md' | 'lg' | 'xl'
+  inputClass?: string
+}>()
 const modelValue = defineModel<string | null>()
 const { items, pending, error, refresh } = useComunasCatalog()
 const catalogSelect = useTemplateRef('catalogSelect')
@@ -16,6 +28,9 @@ defineExpose({ focus: () => catalogSelect.value?.focus() })
     :error
     :placeholder
     :leading-icon="leadingIcon"
+    :variant
+    :size
+    :input-class="inputClass"
     error-message="No pudimos cargar las comunas."
     @retry="refresh"
   />

--- a/app/components/ComunaSelect.vue
+++ b/app/components/ComunaSelect.vue
@@ -8,6 +8,7 @@ const {
   size,
   ui,
   itemIcon,
+  panelClass,
 } = defineProps<{
   placeholder?: string
   leadingIcon?: string
@@ -15,6 +16,7 @@ const {
   size?: 'md' | 'lg' | 'xl'
   ui?: { base?: string, leading?: string, leadingIcon?: string, trailing?: string, trailingIcon?: string }
   itemIcon?: (value: string) => Component
+  panelClass?: string
 }>()
 const modelValue = defineModel<string | null>()
 const { items, pending, error, refresh } = useComunasCatalog()
@@ -36,6 +38,7 @@ defineExpose({ focus: () => catalogSelect.value?.focus() })
     :size
     :ui
     :item-icon="itemIcon"
+    :panel-class="panelClass"
     error-message="No pudimos cargar las comunas."
     @retry="refresh"
   />

--- a/app/components/ComunaSelect.vue
+++ b/app/components/ComunaSelect.vue
@@ -4,13 +4,13 @@ const {
   leadingIcon,
   variant,
   size,
-  inputClass,
+  ui,
 } = defineProps<{
   placeholder?: string
   leadingIcon?: string
   variant?: 'outline' | 'ghost'
   size?: 'md' | 'lg' | 'xl'
-  inputClass?: string
+  ui?: { base?: string, leading?: string, leadingIcon?: string, trailing?: string, trailingIcon?: string }
 }>()
 const modelValue = defineModel<string | null>()
 const { items, pending, error, refresh } = useComunasCatalog()
@@ -30,7 +30,7 @@ defineExpose({ focus: () => catalogSelect.value?.focus() })
     :leading-icon="leadingIcon"
     :variant
     :size
-    :input-class="inputClass"
+    :ui
     error-message="No pudimos cargar las comunas."
     @retry="refresh"
   />

--- a/app/components/ComunaSelect.vue
+++ b/app/components/ComunaSelect.vue
@@ -1,16 +1,20 @@
 <script setup lang="ts">
+import type { Component } from 'vue'
+
 const {
   placeholder = '¿Qué comuna buscas?',
   leadingIcon,
   variant,
   size,
   ui,
+  itemIcon,
 } = defineProps<{
   placeholder?: string
   leadingIcon?: string
   variant?: 'outline' | 'ghost'
   size?: 'md' | 'lg' | 'xl'
   ui?: { base?: string, leading?: string, leadingIcon?: string, trailing?: string, trailingIcon?: string }
+  itemIcon?: (value: string) => Component
 }>()
 const modelValue = defineModel<string | null>()
 const { items, pending, error, refresh } = useComunasCatalog()
@@ -31,6 +35,7 @@ defineExpose({ focus: () => catalogSelect.value?.focus() })
     :variant
     :size
     :ui
+    :item-icon="itemIcon"
     error-message="No pudimos cargar las comunas."
     @retry="refresh"
   />

--- a/app/components/landing/LandingHero.vue
+++ b/app/components/landing/LandingHero.vue
@@ -4,7 +4,7 @@ import { LANDING_HERO } from '~/constants/landing'
 </script>
 
 <template>
-  <section class="hero-section relative overflow-hidden bg-primary pt-32 pb-20 lg:pt-40 lg:pb-32">
+  <section class="hero-section relative bg-primary pt-32 pb-20 lg:pt-40 lg:pb-32">
     <!-- Decorative background elements -->
     <div class="absolute top-0 left-0 w-full h-full overflow-hidden pointer-events-none">
       <div class="absolute -top-[20%] -right-[10%] w-[70%] h-[70%] rounded-full bg-white/5 blur-3xl" />
@@ -14,9 +14,9 @@ import { LANDING_HERO } from '~/constants/landing'
     </div>
 
     <div class="container relative z-10 mx-auto px-5 sm:px-8">
-      <div class="grid lg:grid-cols-2 gap-12 lg:gap-16 items-center">
+      <div class="grid lg:grid-cols-[55fr_45fr] gap-12 lg:gap-16 items-center">
         <!-- Text Content -->
-        <div class="max-w-2xl">
+        <div>
           <h1 class="text-4xl sm:text-5xl lg:text-[4rem] font-extrabold leading-[1.1] text-white mb-6 tracking-tight">
             {{ LANDING_HERO.headline }}
             <span class="text-secondary block mt-2">{{ LANDING_HERO.headlineAccent }}</span>

--- a/app/components/landing/LandingHero.vue
+++ b/app/components/landing/LandingHero.vue
@@ -1,16 +1,6 @@
 <script setup lang="ts">
 import { CheckCircle, Star } from '@lucide/vue'
 import { LANDING_HERO } from '~/constants/landing'
-
-const categoriaSlug = ref<string | null>(null)
-const comunaCodigo = ref<string | null>(null)
-
-const searchQuery = computed(() => {
-  const query: Record<string, string> = {}
-  if (categoriaSlug.value) query.categoria = categoriaSlug.value
-  if (comunaCodigo.value) query.comuna = comunaCodigo.value
-  return query
-})
 </script>
 
 <template>
@@ -36,27 +26,7 @@ const searchQuery = computed(() => {
             {{ LANDING_HERO.subheadline }}
           </p>
 
-          <!-- Buscador -->
-          <div class="bg-white p-3 rounded-2xl shadow-2xl shadow-black/20 max-w-xl relative z-20">
-            <div class="flex flex-col gap-3 sm:flex-row sm:items-center">
-              <div class="flex-1">
-                <label for="hero-categoria" class="sr-only">Categoría</label>
-                <CategoriaSelect id="hero-categoria" v-model="categoriaSlug" />
-              </div>
-              <div class="flex-1">
-                <label for="hero-comuna" class="sr-only">Comuna</label>
-                <ComunaSelect id="hero-comuna" v-model="comunaCodigo" />
-              </div>
-              <UButton
-                :to="{ path: '/buscar', query: searchQuery }"
-                variant="link"
-                color="neutral"
-                class="h-14 rounded-xl px-7 text-sm font-bold bg-secondary text-white hover:bg-secondary/90 hover:text-white active:text-white hover:scale-[1.02] shadow-lg shadow-secondary/20 transition-all"
-              >
-                {{ LANDING_HERO.cta }}
-              </UButton>
-            </div>
-          </div>
+          <LandingHeroSearch />
 
           <ul class="flex flex-wrap items-center gap-x-6 gap-y-3 mt-8 text-sm text-white/80 font-semibold">
             <li v-for="item in LANDING_HERO.trust" :key="item" class="flex items-center gap-2">

--- a/app/components/landing/LandingHeroSearch.vue
+++ b/app/components/landing/LandingHeroSearch.vue
@@ -33,7 +33,7 @@ function handleSubmit() {
     <!-- Mobile: cada campo es su propia tarjeta blanca con borde, separadas por espacio (no una línea
          divisora) — así se ve en el mockup validado, distinto del desktop porque ahí las dos van sueltas
          en columna, no lado a lado compartiendo una sola pill. -->
-    <div class="flex flex-col gap-2 rounded-3xl bg-white p-2 shadow-2xl shadow-black/20 lg:hidden" :class="{ 'animate-shake': shaking }">
+    <div class="flex flex-col gap-2 rounded-[24px] bg-white p-2 shadow-2xl shadow-black/20 lg:hidden" :class="{ 'animate-shake': shaking }">
       <label for="hero-categoria-mobile" class="sr-only">Categoría</label>
       <CategoriaSelect
         id="hero-categoria-mobile"
@@ -42,7 +42,7 @@ function handleSubmit() {
         leading-icon="i-lucide-wrench"
         variant="outline"
         size="xl"
-        :ui="{ base: 'rounded-2xl py-3.5 ps-11', leadingIcon: 'size-4 text-primary' }"
+        :ui="{ base: 'rounded-[16px] py-3.5 ps-11 ring-[var(--ui-border)]', leadingIcon: 'size-4 text-primary' }"
         :item-icon="categoriaIcon"
       />
 
@@ -54,13 +54,13 @@ function handleSubmit() {
         leading-icon="i-lucide-map-pin"
         variant="outline"
         size="xl"
-        :ui="{ base: 'rounded-2xl py-3.5 ps-11', leadingIcon: 'size-4 text-primary' }"
+        :ui="{ base: 'rounded-[16px] py-3.5 ps-11 ring-[var(--ui-border)]', leadingIcon: 'size-4 text-primary' }"
         :item-icon="() => MapPin"
       />
 
       <button
         type="button"
-        class="flex w-full items-center justify-center gap-2 rounded-2xl px-5 py-3.5 text-[0.9375rem] font-bold text-white transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-secondary"
+        class="flex w-full items-center justify-center gap-2 rounded-[16px] px-5 py-3.5 text-[0.9375rem] font-bold text-white transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-secondary"
         :class="ready ? 'bg-secondary shadow-lg shadow-secondary/30' : 'bg-secondary/50'"
         @click="handleSubmit"
       >
@@ -69,8 +69,9 @@ function handleSubmit() {
       </button>
     </div>
 
-    <!-- Desktop: campos y botón en una fila, divisor vertical, placeholder corto para que quepa en una línea -->
-    <div class="hidden items-center gap-1 rounded-full bg-white p-1.5 shadow-2xl shadow-black/20 lg:flex" :class="{ 'animate-shake': shaking }">
+    <!-- Desktop: campos y botón en una sola fila continua, sin divisor — el hover de cada campo ya
+         distingue dónde empieza y termina, un divisor de línea partía visualmente la pill al medio. -->
+    <div class="hidden items-center gap-0.5 rounded-full bg-white p-2 shadow-2xl shadow-black/20 lg:flex" :class="{ 'animate-shake': shaking }">
       <div class="flex-1">
         <label for="hero-categoria-desktop" class="sr-only">Categoría</label>
         <CategoriaSelect
@@ -80,12 +81,11 @@ function handleSubmit() {
           leading-icon="i-lucide-wrench"
           variant="ghost"
           size="xl"
-          :ui="{ base: 'rounded-full py-3.5', leadingIcon: 'size-4 text-primary' }"
+          :ui="{ base: 'rounded-full py-4 font-semibold text-datealo-text', leadingIcon: 'size-4 text-primary' }"
           :item-icon="categoriaIcon"
+          panel-class="min-w-80"
         />
       </div>
-
-      <div class="h-8 w-px shrink-0 bg-datealo-surface" />
 
       <div class="flex-1">
         <label for="hero-comuna-desktop" class="sr-only">Comuna</label>
@@ -96,15 +96,16 @@ function handleSubmit() {
           leading-icon="i-lucide-map-pin"
           variant="ghost"
           size="xl"
-          :ui="{ base: 'rounded-full py-3.5', leadingIcon: 'size-4 text-primary' }"
+          :ui="{ base: 'rounded-full py-4 font-semibold text-datealo-text', leadingIcon: 'size-4 text-primary' }"
           :item-icon="() => MapPin"
+          panel-class="min-w-80"
         />
       </div>
 
       <button
         type="button"
         aria-label="Buscar"
-        class="flex shrink-0 items-center gap-2 rounded-full px-7 py-3.5 text-sm font-bold text-white transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-secondary"
+        class="flex shrink-0 items-center gap-2 rounded-full px-7 py-4 text-sm font-bold text-white transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-secondary"
         :class="ready ? 'bg-secondary shadow-lg shadow-secondary/30 hover:bg-secondary/90' : 'bg-secondary/50'"
         @click="handleSubmit"
       >

--- a/app/components/landing/LandingHeroSearch.vue
+++ b/app/components/landing/LandingHeroSearch.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+import { Search } from '@lucide/vue'
+
+const categoriaSlug = ref<string | null>(null)
+const comunaCodigo = ref<string | null>(null)
+const shaking = ref(false)
+
+const ready = computed(() => Boolean(categoriaSlug.value && comunaCodigo.value))
+
+// El botón nunca bloquea el tap: navega con lo que esté elegido, igual que hoy. El shake es solo la señal
+// del momento del tap cuando falta un campo — el color atenuado ya es la señal permanente por sí sola.
+function handleSubmit() {
+  if (!ready.value) {
+    shaking.value = true
+    setTimeout(() => { shaking.value = false }, 200)
+  }
+
+  const query: Record<string, string> = {}
+  if (categoriaSlug.value) query.categoria = categoriaSlug.value
+  if (comunaCodigo.value) query.comuna = comunaCodigo.value
+  navigateTo({ path: '/buscar', query })
+}
+</script>
+
+<template>
+  <div class="relative z-20 max-w-xl">
+    <!-- Mobile: campos apilados con divisor horizontal, botón ancho abajo -->
+    <div class="rounded-3xl bg-white p-2 shadow-2xl shadow-black/20 lg:hidden" :class="{ 'animate-shake': shaking }">
+      <label for="hero-categoria-mobile" class="sr-only">Categoría</label>
+      <CategoriaSelect id="hero-categoria-mobile" v-model="categoriaSlug" placeholder="¿Qué servicio buscas?" leading-icon="i-lucide-wrench" />
+
+      <div class="mx-2 my-1 h-px bg-datealo-surface" />
+
+      <label for="hero-comuna-mobile" class="sr-only">Comuna</label>
+      <ComunaSelect id="hero-comuna-mobile" v-model="comunaCodigo" placeholder="¿Qué comuna buscas?" leading-icon="i-lucide-map-pin" />
+
+      <button
+        type="button"
+        class="mt-1 flex w-full items-center justify-center gap-2 rounded-2xl px-5 py-3.5 text-[0.9375rem] font-bold text-white transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-secondary"
+        :class="ready ? 'bg-secondary shadow-lg shadow-secondary/30' : 'bg-secondary/50'"
+        @click="handleSubmit"
+      >
+        <Search class="h-[18px] w-[18px]" :stroke-width="2.5" />
+        Buscar
+      </button>
+    </div>
+
+    <!-- Desktop: campos y botón en una fila, divisor vertical, placeholder corto para que quepa en una línea -->
+    <div class="hidden items-center gap-1 rounded-full bg-white p-1.5 shadow-2xl shadow-black/20 lg:flex" :class="{ 'animate-shake': shaking }">
+      <div class="flex-1">
+        <label for="hero-categoria-desktop" class="sr-only">Categoría</label>
+        <CategoriaSelect id="hero-categoria-desktop" v-model="categoriaSlug" placeholder="Elige categoría" leading-icon="i-lucide-wrench" />
+      </div>
+
+      <div class="h-8 w-px shrink-0 bg-datealo-surface" />
+
+      <div class="flex-1">
+        <label for="hero-comuna-desktop" class="sr-only">Comuna</label>
+        <ComunaSelect id="hero-comuna-desktop" v-model="comunaCodigo" placeholder="Elige comuna" leading-icon="i-lucide-map-pin" />
+      </div>
+
+      <button
+        type="button"
+        aria-label="Buscar"
+        class="flex shrink-0 items-center gap-2 rounded-full px-7 py-3.5 text-sm font-bold text-white transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-secondary"
+        :class="ready ? 'bg-secondary shadow-lg shadow-secondary/30 hover:bg-secondary/90' : 'bg-secondary/50'"
+        @click="handleSubmit"
+      >
+        <Search class="h-4 w-4" :stroke-width="2.5" />
+        Buscar
+      </button>
+    </div>
+  </div>
+</template>

--- a/app/components/landing/LandingHeroSearch.vue
+++ b/app/components/landing/LandingHeroSearch.vue
@@ -29,7 +29,7 @@ function handleSubmit() {
 </script>
 
 <template>
-  <div class="relative z-20 max-w-xl">
+  <div class="relative z-20 max-w-2xl">
     <!-- Mobile: cada campo es su propia tarjeta blanca con borde, separadas por espacio (no una línea
          divisora) — así se ve en el mockup validado, distinto del desktop porque ahí las dos van sueltas
          en columna, no lado a lado compartiendo una sola pill. -->

--- a/app/components/landing/LandingHeroSearch.vue
+++ b/app/components/landing/LandingHeroSearch.vue
@@ -24,20 +24,20 @@ function handleSubmit() {
 
 <template>
   <div class="relative z-20 max-w-xl">
-    <!-- Mobile: campos apilados con divisor horizontal, botón ancho abajo -->
-    <div class="rounded-3xl bg-white p-2 shadow-2xl shadow-black/20 lg:hidden" :class="{ 'animate-shake': shaking }">
+    <!-- Mobile: cada campo es su propia tarjeta blanca con borde, separadas por espacio (no una línea
+         divisora) — así se ve en el mockup validado, distinto del desktop porque ahí las dos van sueltas
+         en columna, no lado a lado compartiendo una sola pill. -->
+    <div class="flex flex-col gap-2 rounded-3xl bg-white p-2 shadow-2xl shadow-black/20 lg:hidden" :class="{ 'animate-shake': shaking }">
       <label for="hero-categoria-mobile" class="sr-only">Categoría</label>
       <CategoriaSelect
         id="hero-categoria-mobile"
         v-model="categoriaSlug"
         placeholder="¿Qué servicio buscas?"
         leading-icon="i-lucide-wrench"
-        variant="ghost"
+        variant="outline"
         size="xl"
         input-class="rounded-2xl py-3.5"
       />
-
-      <div class="mx-2 my-1 h-px bg-datealo-surface" />
 
       <label for="hero-comuna-mobile" class="sr-only">Comuna</label>
       <ComunaSelect
@@ -45,14 +45,14 @@ function handleSubmit() {
         v-model="comunaCodigo"
         placeholder="¿Qué comuna buscas?"
         leading-icon="i-lucide-map-pin"
-        variant="ghost"
+        variant="outline"
         size="xl"
         input-class="rounded-2xl py-3.5"
       />
 
       <button
         type="button"
-        class="mt-1 flex w-full items-center justify-center gap-2 rounded-2xl px-5 py-3.5 text-[0.9375rem] font-bold text-white transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-secondary"
+        class="flex w-full items-center justify-center gap-2 rounded-2xl px-5 py-3.5 text-[0.9375rem] font-bold text-white transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-secondary"
         :class="ready ? 'bg-secondary shadow-lg shadow-secondary/30' : 'bg-secondary/50'"
         @click="handleSubmit"
       >

--- a/app/components/landing/LandingHeroSearch.vue
+++ b/app/components/landing/LandingHeroSearch.vue
@@ -27,12 +27,28 @@ function handleSubmit() {
     <!-- Mobile: campos apilados con divisor horizontal, botón ancho abajo -->
     <div class="rounded-3xl bg-white p-2 shadow-2xl shadow-black/20 lg:hidden" :class="{ 'animate-shake': shaking }">
       <label for="hero-categoria-mobile" class="sr-only">Categoría</label>
-      <CategoriaSelect id="hero-categoria-mobile" v-model="categoriaSlug" placeholder="¿Qué servicio buscas?" leading-icon="i-lucide-wrench" />
+      <CategoriaSelect
+        id="hero-categoria-mobile"
+        v-model="categoriaSlug"
+        placeholder="¿Qué servicio buscas?"
+        leading-icon="i-lucide-wrench"
+        variant="ghost"
+        size="xl"
+        input-class="rounded-2xl py-3.5"
+      />
 
       <div class="mx-2 my-1 h-px bg-datealo-surface" />
 
       <label for="hero-comuna-mobile" class="sr-only">Comuna</label>
-      <ComunaSelect id="hero-comuna-mobile" v-model="comunaCodigo" placeholder="¿Qué comuna buscas?" leading-icon="i-lucide-map-pin" />
+      <ComunaSelect
+        id="hero-comuna-mobile"
+        v-model="comunaCodigo"
+        placeholder="¿Qué comuna buscas?"
+        leading-icon="i-lucide-map-pin"
+        variant="ghost"
+        size="xl"
+        input-class="rounded-2xl py-3.5"
+      />
 
       <button
         type="button"
@@ -49,14 +65,30 @@ function handleSubmit() {
     <div class="hidden items-center gap-1 rounded-full bg-white p-1.5 shadow-2xl shadow-black/20 lg:flex" :class="{ 'animate-shake': shaking }">
       <div class="flex-1">
         <label for="hero-categoria-desktop" class="sr-only">Categoría</label>
-        <CategoriaSelect id="hero-categoria-desktop" v-model="categoriaSlug" placeholder="Elige categoría" leading-icon="i-lucide-wrench" />
+        <CategoriaSelect
+          id="hero-categoria-desktop"
+          v-model="categoriaSlug"
+          placeholder="Elige categoría"
+          leading-icon="i-lucide-wrench"
+          variant="ghost"
+          size="xl"
+          input-class="rounded-full py-3.5"
+        />
       </div>
 
       <div class="h-8 w-px shrink-0 bg-datealo-surface" />
 
       <div class="flex-1">
         <label for="hero-comuna-desktop" class="sr-only">Comuna</label>
-        <ComunaSelect id="hero-comuna-desktop" v-model="comunaCodigo" placeholder="Elige comuna" leading-icon="i-lucide-map-pin" />
+        <ComunaSelect
+          id="hero-comuna-desktop"
+          v-model="comunaCodigo"
+          placeholder="Elige comuna"
+          leading-icon="i-lucide-map-pin"
+          variant="ghost"
+          size="xl"
+          input-class="rounded-full py-3.5"
+        />
       </div>
 
       <button

--- a/app/components/landing/LandingHeroSearch.vue
+++ b/app/components/landing/LandingHeroSearch.vue
@@ -36,7 +36,7 @@ function handleSubmit() {
         leading-icon="i-lucide-wrench"
         variant="outline"
         size="xl"
-        input-class="rounded-2xl py-3.5"
+        :ui="{ base: 'rounded-2xl py-3.5 ps-11', leadingIcon: 'size-4 text-primary' }"
       />
 
       <label for="hero-comuna-mobile" class="sr-only">Comuna</label>
@@ -47,7 +47,7 @@ function handleSubmit() {
         leading-icon="i-lucide-map-pin"
         variant="outline"
         size="xl"
-        input-class="rounded-2xl py-3.5"
+        :ui="{ base: 'rounded-2xl py-3.5 ps-11', leadingIcon: 'size-4 text-primary' }"
       />
 
       <button
@@ -72,7 +72,7 @@ function handleSubmit() {
           leading-icon="i-lucide-wrench"
           variant="ghost"
           size="xl"
-          input-class="rounded-full py-3.5"
+          :ui="{ base: 'rounded-full py-3.5', leadingIcon: 'size-4 text-primary' }"
         />
       </div>
 
@@ -87,7 +87,7 @@ function handleSubmit() {
           leading-icon="i-lucide-map-pin"
           variant="ghost"
           size="xl"
-          input-class="rounded-full py-3.5"
+          :ui="{ base: 'rounded-full py-3.5', leadingIcon: 'size-4 text-primary' }"
         />
       </div>
 

--- a/app/components/landing/LandingHeroSearch.vue
+++ b/app/components/landing/LandingHeroSearch.vue
@@ -1,5 +1,11 @@
 <script setup lang="ts">
-import { Search } from '@lucide/vue'
+import { MapPin, Search, Wrench } from '@lucide/vue'
+import { CATEGORIA_ICONS } from '~/constants/categoria-icons'
+
+// Mismo mapeo que usa CompactSearchBarPanel para su propio dropdown de categorías.
+function categoriaIcon(slug: string) {
+  return CATEGORIA_ICONS[slug as keyof typeof CATEGORIA_ICONS] ?? Wrench
+}
 
 const categoriaSlug = ref<string | null>(null)
 const comunaCodigo = ref<string | null>(null)
@@ -37,6 +43,7 @@ function handleSubmit() {
         variant="outline"
         size="xl"
         :ui="{ base: 'rounded-2xl py-3.5 ps-11', leadingIcon: 'size-4 text-primary' }"
+        :item-icon="categoriaIcon"
       />
 
       <label for="hero-comuna-mobile" class="sr-only">Comuna</label>
@@ -48,6 +55,7 @@ function handleSubmit() {
         variant="outline"
         size="xl"
         :ui="{ base: 'rounded-2xl py-3.5 ps-11', leadingIcon: 'size-4 text-primary' }"
+        :item-icon="() => MapPin"
       />
 
       <button
@@ -73,6 +81,7 @@ function handleSubmit() {
           variant="ghost"
           size="xl"
           :ui="{ base: 'rounded-full py-3.5', leadingIcon: 'size-4 text-primary' }"
+          :item-icon="categoriaIcon"
         />
       </div>
 
@@ -88,6 +97,7 @@ function handleSubmit() {
           variant="ghost"
           size="xl"
           :ui="{ base: 'rounded-full py-3.5', leadingIcon: 'size-4 text-primary' }"
+          :item-icon="() => MapPin"
         />
       </div>
 

--- a/app/constants/landing.ts
+++ b/app/constants/landing.ts
@@ -3,7 +3,6 @@ export const LANDING_HERO = {
   headline: 'Deja de preguntarle al grupo del edificio',
   headlineAccent: 'y encuentra a alguien que sí te va a resolver.',
   subheadline: 'Gasfiter, electricista, peluquera y más. Busca por categoría y comuna, no por quién contesta primero en el chat del edificio.',
-  cta: 'Buscar',
   trust: ['Reseñas reales de tu zona', 'Ordenados por cercanía', 'Categorías claras'],
   heroImage: {
     src: 'https://images.pexels.com/photos/5493672/pexels-photo-5493672.jpeg?auto=compress&cs=tinysrgb&w=1600&h=1100&fit=crop',


### PR DESCRIPTION
Closes #203

## Resumen

D-003 (misión 12): el buscador del hero pasa de una caja blanca con selects planos al mismo lenguaje
visual que `CompactSearchBar` — pill redondeada, campos segmentados, botón de búsqueda con ícono.

- Extrae `LandingHeroSearch.vue` de `LandingHero.vue`: este último queda solo con headline, subheadline,
  imagen y trust items, sin pasarle props.
- `CatalogSelect` gana un prop opcional `leadingIcon` (nombre Iconify), reenviado al `leading-icon` de
  `UInput` solo cuando viene definido. `CategoriaSelect`/`ComunaSelect` declaran su propio `placeholder` y
  `leadingIcon` con `defineProps` (no por attribute fallthrough), con default igual al hardcodeado de
  antes — `profesional/registro.vue` y `profesional/perfil.vue`, que no pasan estos props, quedan
  visualmente idénticos.
- Mobile: campos apilados con ícono (llave, pin) y placeholder largo ("¿Qué servicio buscas?"). Desktop:
  pill horizontal con placeholder corto ("Elige categoría") — con el placeholder largo, el texto se
  quebraba a dos líneas y dejaba el botón desproporcionado.
- El botón "Buscar" nunca bloquea el tap: navega con lo que esté elegido, igual que hoy. Si falta un
  campo, además hace un shake breve (200ms) al tocarlo.

**Nota sobre una inconsistencia en `ingenieria.md`:** el contrato TC-002 dice en sus invariantes que tocar
"Buscar" "nunca... bloquea la navegación aunque falte un campo", pero la fila de "Estrategia de pruebas" del
mismo TC-002 y la fila del "Plan de construcción" dicen lo contrario ("no navega y dispara el shake"). Implementé
según UX-002 de `experiencia.md` (la decisión más detallada, ajustada explícitamente tras la evaluación
heurística independiente): el botón siempre navega con lo que esté elegido, y el shake es una señal
adicional simultánea, no un bloqueo. Verificado con Playwright: tocar "Buscar" vacío navega a `/buscar`
sin query, con los dos campos navega con `?categoria=...&comuna=...`, y el shake se dispara en ambos casos
si falta algo.

## Test plan

- [x] `npx nuxi typecheck` — cero errores.
- [x] `npx vitest run` — 73 tests, todos pasan.
- [x] `npm run build` — compila.
- [x] Verificado con Playwright: selección de categoría/comuna, botón cambia de atenuado a sólido, navega
  con la query correcta, shake se dispara al tocar incompleto.
- [x] Mobile (390px) y desktop (1280px) verificados visualmente contra el mockup `hero.html` de la misión.
- [x] `profesional/registro.vue` y `profesional/perfil.vue` no pasan `placeholder`/`leadingIcon` — quedan
  con su comportamiento exacto de antes (TR-001).

🤖 Generated with [Claude Code](https://claude.com/claude-code)