### PR TITLE
feat(docs): carriles de misión según riesgo y comando /mision-estado

### DIFF
--- a/.claude/rules/arquitectura.global.md
+++ b/.claude/rules/arquitectura.global.md
@@ -1,0 +1,24 @@
+---
+paths:
+  - "server/api/**"
+  - "server/db/**"
+  - "server/utils/**"
+  - "server/routes/**"
+  - "app/plugins/**"
+  - "app/middleware/**"
+  - "app/composables/useProfessionalSession.ts"
+  - "nuxt.config.ts"
+---
+# Arquitectura
+
+- Antes de crear un endpoint, tocar la base de datos, escribir o revisar políticas RLS, conectar
+  Supabase/Drizzle, manejar secretos o cambiar configuración de despliegue, invocar el skill `arquitectura`
+  — no asumir dónde va cada cosa ni qué ya está decidido de memoria.
+- Si el archivo está en `server/api/**`, invocar también `nuxt-server-endpoints` para el patrón de
+  implementación con Drizzle antes de escribir el endpoint.
+- Si el archivo está en `server/db/schema/**`, `server/db/migrations/**` o es `server/db/sql/rls.sql`,
+  invocar también `supabase-postgres-best-practices`.
+- Si el cambio crea una tabla con datos de usuario, cambia el ownership (`user_id`) o las relaciones que
+  usan las policies (`EXISTS`/FKs) — en el schema o en `server/db/sql/rls.sql` — invocar `seguridad-datos`
+  y correr su checklist antes de cerrar el edit: "hay una policy" no es lo mismo que "esa policy es la que
+  protege" (A-002 del skill `arquitectura`).

--- a/.claude/rules/discovery-engineering.global.md
+++ b/.claude/rules/discovery-engineering.global.md
@@ -1,0 +1,31 @@
+---
+paths:
+  - "docs/missions/*/ingenieria.md"
+---
+# Discovery de ingeniería
+
+- Antes de escribir o editar cualquier contenido en este archivo, invocar el skill `discovery-engineering`
+  — no asumir su gate de salida ni el método de slicing de memoria.
+- Según la sección que se esté trabajando, invocar también: `clean-architecture` (Dependency Rule y
+  acoplamiento entre capas) y `domain-driven-design` (lenguaje ubicuo, build-vs-buy) al definir la
+  arquitectura; `supabase-postgres-best-practices` al tocar schema, RLS, índices o migraciones.
+- Antes de marcar el impacto en RLS como resuelto, invocar `seguridad-datos` y correr su checklist —
+  "hay una policy" no es lo mismo que "esa policy es la que protege".
+- **Antes de proponer `en revisión`, revisar el Carril de la misión** (`**Carril:**` en el README de la
+  misión, o Full Spec automático si este documento terminó tocando RLS/Auth/pagos/datos de usuario, sin
+  importar lo que decía antes). Si es Light Spec, el paso siguiente es opcional. Si es Full Spec, es
+  obligatorio, y va antes de proponer `en revisión`, no antes, porque el diseño tiene que estar cerrado y
+  cortado en slices: lanzar la auditoría en contexto separado que exige el gate. Es una acción, no una
+  mención: usar `Agent` con un `subagent_type` que no sea `fork` (hereda el sesgo de esta conversación),
+  pasándole solo `ingenieria.md` terminado, `producto.md`/`experiencia.md` si existen y el código existente
+  relevante — nunca el razonamiento de esta conversación — y pidiéndole invocar `clean-architecture`,
+  `domain-driven-design` y `supabase-postgres-best-practices` según corresponda, citando qué dijo cada uno,
+  e intentar tumbar al menos una decisión ya tomada. No proponer `en revisión` sin haberla corrido y sin
+  resolver sus hallazgos bloqueantes.
+- **Cuando el dueño de producto marque este documento `vigente`, el siguiente paso nunca es crear los
+  issues directo.** La secuencia es: abrir el PR con los documentos de la misión (los que existan según su
+  Tipo — los tres en una misión de producto, solo `ingenieria.md` en una técnica) → esperar a que se
+  mergee → `ExitWorktree action: "remove"` → recién ahí, ya en la raíz del repo, cortar el plan de
+  construcción en issues. Ofrecer "crear los issues" como alternativa a "revisar con más calma" sin
+  mencionar el PR y el cierre del worktree es la misma pregunta mal planteada que ya pasó una vez — el PR y
+  el worktree no son opcionales ni se sobreentienden.

--- a/.claude/rules/discovery-product.global.md
+++ b/.claude/rules/discovery-product.global.md
@@ -1,0 +1,27 @@
+---
+paths:
+  - "docs/missions/*/investigacion.md"
+  - "docs/missions/*/producto.md"
+---
+# Discovery de producto
+
+- Antes de escribir o editar cualquier contenido en estos archivos, invocar el skill `discovery-product` —
+  no asumir su gate ni su formato JTBD de memoria.
+- Según lo que se esté trabajando, invocar también los skills que `discovery-product` cita como propios de
+  esta fase: `mom-test` (diseño de entrevistas sin sesgo), `jobs-to-be-done` (formato JTBD de una
+  funcionalidad), `cold-start-problem` (arranque en frío de un lado del marketplace), `lean-analytics`
+  (definir una señal `M-xxx` sin caer en vanity metric), `obviously-awesome` (positioning frente a
+  alternativas).
+- **Antes de proponer `en revisión`, revisar el Carril de la misión** (`**Carril:**` en el README de la
+  misión). Si es Light Spec, el paso siguiente es opcional — proponer `en revisión` sin correrlo es válido.
+  Si es Full Spec — o si esta conversación descubre que la misión toca algo que debería subirla a Full Spec
+  — es obligatorio, y va antes de proponer `en revisión`, no antes, porque el documento tiene que estar
+  terminado: lanzar la evaluación en contexto separado que exige el gate. Es una acción, no una mención:
+  usar `Agent` con un
+  `subagent_type` que no sea `fork` (un fork hereda el sesgo de esta conversación), pasándole solo
+  `producto.md` terminado, `investigacion.md` y las guardrails de producto del `CLAUDE.md` raíz — nunca el
+  razonamiento de esta conversación — y pidiéndole invocar `jobs-to-be-done`, `cold-start-problem`,
+  `lean-analytics`, `obviously-awesome` (y `mom-test` si hay entrevistas que auditar) según corresponda,
+  citando qué dijo cada uno, confirmando que ninguna guardrail fue violada, e intentando tumbar al menos
+  una decisión ya tomada. No proponer `en revisión` sin haberla corrido y sin resolver sus hallazgos
+  bloqueantes.

--- a/.claude/rules/discovery-ux.global.md
+++ b/.claude/rules/discovery-ux.global.md
@@ -1,0 +1,19 @@
+---
+paths:
+  - "docs/missions/*/experiencia.md"
+---
+# Discovery de experiencia
+
+- Antes de escribir o editar cualquier contenido en este archivo, invocar el skill `discovery-ux` — no
+  asumir su gate ni su formato de vistas/flujos/estados de memoria.
+- Al redactar o revisar cualquier texto de interfaz (labels, errores, empty states, CTAs, microcopy),
+  invocar también `ux-writing` antes de darlo por definitivo.
+- **Antes de proponer `en revisión`, revisar el Carril de la misión** (`**Carril:**` en el README de la
+  misión). Si es Light Spec, el paso siguiente es opcional. Si es Full Spec, es obligatorio, y va antes de
+  proponer `en revisión`, no antes, porque el documento tiene que estar terminado: lanzar la evaluación en
+  contexto separado que exige el gate. Es una acción, no una mención: usar `Agent` con un
+  `subagent_type` que no sea `fork` (un fork hereda el sesgo de esta conversación), pasándole solo
+  `experiencia.md` terminado, `producto.md` y los mockups — nunca el razonamiento de cómo se llegó ahí — y
+  pidiéndole invocar `ui-ux-pro-max` y `web-design-guidelines` para el juicio de usabilidad y
+  `frontend-design` para la propuesta visual, citando qué dijo cada uno. No proponer `en revisión` sin
+  haberla corrido y sin resolver sus hallazgos bloqueantes.

--- a/.claude/skills/discovery-engineering/SKILL.md
+++ b/.claude/skills/discovery-engineering/SKILL.md
@@ -73,10 +73,14 @@ en revisión se paga dos veces.
 - los escenarios críticos tienen criterio de prueba antes de considerar el feature listo
 - el diseño está cortado en slices (ver [Slicing](#slicing-del-diseño-a-tareas-atómicas)) y el plan de
   construcción vive en la sección homónima de `ingenieria.md`
-- el diseño pasó una auditoría en un contexto separado (ver "Evaluar antes de cerrar, en un contexto
-  separado" más abajo) y sus hallazgos bloqueantes están resueltos
+- si el **Carril** de la misión (ver `docs/missions/README.md#carril-según-riesgo`) es Full Spec, el diseño
+  pasó una auditoría en un contexto separado (ver "Evaluar antes de cerrar, en un contexto separado" más
+  abajo) y sus hallazgos bloqueantes están resueltos. En Light Spec el paso es opcional y no bloquea el
+  gate — pero si `ingenieria.md` termina tocando RLS, Auth, pagos o datos de usuario, la misión ya debería
+  haber subido a Full Spec por el criterio del carril, y este paso vuelve a ser obligatorio.
 
-**Evaluar antes de cerrar, en un contexto separado:** mismo problema que en `discovery-ux` — la
+**Evaluar antes de cerrar, en un contexto separado** (obligatorio en Full Spec, opcional en Light Spec):
+mismo problema que en `discovery-ux` — la
 conversación que diseñó `ingenieria.md` ya se convenció a sí misma de por qué cada capa, cada contrato y
 cada policy tienen sentido; juzgar el propio diseño en la misma pasada no encuentra lo que ese diseño no vio.
 

--- a/.claude/skills/discovery-product/SKILL.md
+++ b/.claude/skills/discovery-product/SKILL.md
@@ -112,6 +112,34 @@ observables. El único documento que el dueño de producto aprueba es `producto.
 - toda `D-xxx` con tensión real trae al menos una alternativa genuina en "Alternativas descartadas", no
   solo el statu quo
 - las decisiones propuestas tienen fecha límite en el README de la misión
+- si el **Carril** de la misión (ver `docs/missions/README.md#carril-según-riesgo`) es Full Spec,
+  `producto.md` pasó una evaluación en un contexto separado (ver "Evaluar antes de cerrar, en un contexto
+  separado" más abajo) y sus hallazgos bloqueantes están resueltos, incluyendo que ninguna guardrail de
+  producto del `CLAUDE.md` raíz fue violada. En Light Spec el paso es opcional y no bloquea el gate.
+
+**Evaluar antes de cerrar, en un contexto separado** (obligatorio en Full Spec, opcional en Light Spec):
+mismo problema que en `discovery-ux` y
+`discovery-engineering` — la conversación que escribió `producto.md` ya se convenció a sí misma de por qué
+cada JTBD, cada señal y cada decisión tienen sentido; juzgar el propio documento en la misma pasada no
+encuentra lo que esa conversación no vio.
+
+- **La evaluación corre en un agente sin memoria de haber escrito el documento** — recibe solo
+  `producto.md` terminado, `investigacion.md`, las guardrails de producto del `CLAUDE.md` raíz, y la lista
+  de skills a aplicar; nunca el razonamiento de esta conversación. Un fork **no sirve para esto**: hereda
+  toda la conversación, incluida la justificación de cada decisión, así que carga el mismo sesgo que se
+  busca evitar. Un agente nuevo (`Agent` con un `subagent_type` que no sea `fork`, o una sesión distinta)
+  sí aísla el sesgo.
+- **Cada skill se invoca de verdad**, con la tool `Skill`, uno por uno, según lo que `producto.md` haya
+  usado: `jobs-to-be-done`, `cold-start-problem`, `lean-analytics`, `obviously-awesome`, y `mom-test` si hay
+  evidencia de entrevistas que auditar. Un hallazgo que no cita qué dijo el skill invocado es una
+  aplicación de memoria, no una evaluación — no cuenta para el gate.
+- **La evaluación confirma explícitamente que ninguna guardrail de producto del `CLAUDE.md` fue violada**
+  (subastas o bidding, pago obligatorio para contactar, dashboards complejos, copy agresivo o de urgencia
+  artificial, pasos extra al flujo buscar → perfil → contactar). Es el único punto de control real que
+  existe para esas guardrails — si esta evaluación no las revisa, nada más lo hace.
+- **La evaluación cuestiona decisiones, no solo redacción.** Antes de cerrar, tiene que intentar tumbar al
+  menos una `D-xxx` o un `F-xxx` ya tomado citando por qué — si ninguno sobrevive el intento, recién ahí se
+  confirma el documento; si nunca se intenta, la evaluación fue cosmética.
 
 **Aprobación:** Claude propone y marca `en revisión`; `vigente` lo otorga solo el dueño de producto. Toda
 decisión `propuesta` lleva fecha límite — sin deadline es pocket veto.

--- a/.claude/skills/discovery-ux/SKILL.md
+++ b/.claude/skills/discovery-ux/SKILL.md
@@ -107,13 +107,15 @@ desde producto — no en paralelo a una revisión de `producto.md` "para mantene
 - cada flujo crítico está mockeado en móvil, y en desktop si también vive ahí
 - no quedan pantallas descritas como "similar a X" sin especificar qué cambia
 - cada `UXF-xxx` no trivial pasó por "Divergencia antes de converger" antes de fijar su enfoque
-- los flujos críticos pasaron una evaluación heurística en un contexto separado (ver "Evaluar antes de
-  cerrar, en un contexto separado" más abajo) y sus hallazgos bloqueantes están resueltos, y todo hallazgo
-  de enfoque volvió a divergencia en vez de parcharse
+- si el **Carril** de la misión (ver `docs/missions/README.md#carril-según-riesgo`) es Full Spec, los
+  flujos críticos pasaron una evaluación heurística en un contexto separado (ver "Evaluar antes de cerrar,
+  en un contexto separado" más abajo) y sus hallazgos bloqueantes están resueltos, y todo hallazgo de
+  enfoque volvió a divergencia en vez de parcharse. En Light Spec el paso es opcional y no bloquea el gate.
 - cada string de contenido (Estados por superficie, columnas "Información visible" de las secuencias,
   mockups) pasó el "Barrido de copy" contra `ux-writing` — la evaluación heurística general no lo reemplaza
 
-**Evaluar antes de cerrar, en un contexto separado:** proponer y juzgar son actos distintos, y hacerlos en
+**Evaluar antes de cerrar, en un contexto separado** (obligatorio en Full Spec, opcional en Light Spec):
+proponer y juzgar son actos distintos, y hacerlos en
 la misma pasada produce ceguera — el flujo recién escrito parece bueno porque uno acaba de convencerse a sí
 mismo de por qué cada decisión tiene sentido. Esa ceguera no se resuelve "prestando más atención": la
 conversación que escribió el flujo ya tiene la narrativa de por qué está bien, y esa narrativa contamina

--- a/.claude/skills/mision-estado/SKILL.md
+++ b/.claude/skills/mision-estado/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: mision-estado
+description: Comando — dado un número/slug de misión (o inferido del worktree/rama actual si no se da), revisa el estado real (worktree, PR, documentos, issues) contra la secuencia canónica de docs/missions/README.md y dice explícitamente cuál es el único paso siguiente válido. Se invoca como `/mision-estado <misión>` o sin argumento para inferir la misión activa. Usar antes de retomar el trabajo de una misión, antes de abrir un PR o crear issues, o cuando no esté claro qué sigue.
+---
+
+# `/mision-estado` — dónde está una misión en su secuencia
+
+Este comando existe para no reconstruir de memoria en qué paso de la secuencia está una misión — es
+exactamente lo que falló cuando se ofreció "crear los issues de los 3 slices" saltándose el PR de discovery
+y el cierre del worktree. La secuencia completa, numerada, vive en
+[`docs/missions/README.md`](../../../docs/missions/README.md#secuencia-completa-de-una-misión) — este
+comando no la repite de memoria, la lee.
+
+## Paso 1 — Resolver el target
+
+Si el argumento nombra una misión ("misión 12", "12", un slug, o parte de uno), resolverla contra la tabla
+de `docs/missions/README.md` — no adivinar el número, leer la tabla. Si no matchea ninguna fila, decirlo y
+detenerse.
+
+Si no hay argumento — incluido "no me acuerdo en qué misión estoy" — inferir en este orden, sin adivinar:
+
+1. `git worktree list` y la rama actual: ¿hay un worktree `NN-slug`, o la rama sigue el patrón
+   `feat/s-NNN-*`/`fix/s-NNN-*`? Si hay una sola candidata clara, es esa.
+2. Si no hay señal de git (ej. estás en `main` sin cambios), leer la tabla "Registro" de
+   `docs/missions/README.md` y filtrar las filas con Estado distinto de `cerrada` y `pausada`. Como solo
+   una misión puede estar `en construcción` a la vez, si hay una es casi seguro esa.
+3. Si ninguna está `en construcción` pero hay varias en discovery en paralelo (cada una en su worktree),
+   listarlas con su columna "En foco" y **preguntar cuál** — nunca elegir una por las dudas cuando hay más
+   de una candidata igual de válida.
+
+## Paso 2 — Reunir el estado real
+
+No preguntarle a la memoria de la conversación — todo esto se verifica en el momento:
+
+- **El tipo de misión** (columna "Tipo" de la tabla en `docs/missions/README.md`: `producto` o `técnica`)
+  — determina qué documentos existen antes de buscarlos. Una misión técnica no tiene `investigacion.md`,
+  `producto.md` ni `experiencia.md`; buscarlos ahí es ruido, no una señal de que faltan.
+- `git worktree list` — ¿existe un worktree para esta misión? ¿en qué rama y con qué cambios sin commitear?
+  **De paso, revisar todos los demás worktrees que aparezcan en esa misma lista** (no solo el de la misión
+  consultada) contra el estado de su misión en la tabla de `docs/missions/README.md`: cualquiera cuya misión
+  ya diga `cerrada` es huérfano — nombrarlo en el reporte con el `ExitWorktree action: "remove"` pendiente,
+  sin esperar a que alguien pregunte por esa otra misión.
+- El header `Estado:` de cada documento que sí exista para este tipo de misión — leerlos, no asumir por la
+  fecha de la última edición.
+- `gh pr list --state all --search "<slug o número de misión>"` — ¿hay un PR de discovery abierto,
+  mergeado, o no existe todavía?
+- Si `ingenieria.md` tiene "Plan de construcción": `gh issue list --state all --search "<label o texto de
+  los slices>"` — cuántos de los issues del plan existen, cuántos están cerrados, cuántos abiertos.
+- El estado de la misión en la tabla de `docs/missions/README.md` y en el README de la misión.
+
+## Paso 3 — Ubicar la misión en la secuencia canónica
+
+Comparar lo reunido contra los 11 pasos de la secuencia — **si la misión es técnica, los pasos 2 a 4 no
+existen**: tratar "los tres documentos" de las reglas de abajo como solo `ingenieria.md` para ese caso.
+Reglas de precedencia — de la señal más avanzada hacia atrás, la primera que sea cierta gana:
+
+- Todos los issues del Plan de construcción cerrados y el estado de la misión ya dice `cerrada` → misión
+  completa, no hay paso siguiente de esta lista.
+- Hay issues del plan todavía abiertos, o algunos cerrados y otros ni creados → **paso 10**: seguir el
+  loop de issues, uno a la vez, en la raíz.
+- El worktree ya se cerró (no aparece en `git worktree list`) pero no hay ningún issue del plan creado →
+  **paso 9**: crear los issues.
+- El PR de discovery está mergeado pero el worktree todavía existe → **inconsistencia**, no un paso
+  siguiente normal: el paso 8 se saltó. Reportarlo así, no seguir a crear issues sin resolverlo primero.
+- Los documentos que corresponden a este tipo de misión están todos `vigente` pero no hay PR de discovery
+  (ni abierto ni mergeado) → **paso 6**: abrir el PR.
+- Están todos `vigente` y hay un PR de discovery abierto sin mergear → **paso 7**: esperar o gestionar el
+  merge, no adelantarse a crear issues ni a cerrar el worktree todavía.
+- Alguno de esos documentos no está `vigente` → **el paso que le corresponda** (3, 4, o 5 en una misión de
+  producto; directo el 5 en una técnica) — seguir el discovery ahí, en el worktree.
+- Misión de producto, no existe worktree ni ningún documento más allá de `investigacion.md` → **paso 1 o
+  2**: abrir worktree o seguir en investigación. Misión técnica sin worktree ni `ingenieria.md` → **paso
+  1**: abrir worktree.
+
+## Paso 4 — Reportar
+
+Decir explícitamente, sin rodeos: "esta misión está en el paso N de la secuencia. El paso siguiente válido
+es: <texto exacto de ese paso, tal como está en `docs/missions/README.md`>."
+
+Si el Paso 3 encontró una inconsistencia (un paso saltado), decirlo primero y como bloqueante — no ofrecer
+el paso siguiente "normal" como si nada, resolver la inconsistencia es lo que sigue.
+
+Si el Paso 2 encontró worktrees huérfanos de otras misiones, listarlos aparte (no son parte de la secuencia
+de la misión consultada) y ofrecer cerrarlos ahí mismo — no dejarlo para que el usuario lo note por su
+cuenta como pasó con las misiones 09 y 10.
+
+No terminar el reporte sugiriendo una acción distinta a la que dice la secuencia, aunque parezca más rápida
+en el momento — ese atajo es exactamente el que este comando existe para prevenir.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,10 +46,10 @@ trabajos, también desde el celular.
 ## Stack técnico
 
 - **Frontend**: Nuxt 4, Vue 3, TypeScript strict
-- **Estilos**: Tailwind CSS v4, DaisyUI v5 (tema `datealo`), tipografías Plus Jakarta Sans + DM Sans
-  — la migración a Nuxt UI v4 está decidida y pendiente (A-004 del skill `arquitectura`). Nuxt UI trae
+- **Estilos**: Tailwind CSS v4 + Nuxt UI v4, tipografías Plus Jakarta Sans + DM Sans. Nuxt UI trae
   `@nuxt/fonts`, que auto-hospeda las tipografías en vez de cargarlas por `<link>` a Google Fonts — ojo con
-  esto al tocar `nuxt.config.ts` o `app.head` una vez que la migración aterrice.
+  esto al tocar `nuxt.config.ts` o `app.head`. El motor de interfaz y su historia (por qué Nuxt UI y no
+  DaisyUI) están en A-004 del skill `arquitectura` — no se repiten acá para no divergir cuando cambien.
 - **Iconos**: `@lucide/vue` (paquete renombrado desde `lucide-vue-next` en su v1, 2026-03)
 - **Auth/DB**: Supabase (PostgreSQL + Auth + RLS)
 - **ORM**: Drizzle
@@ -150,12 +150,22 @@ Cada cambio de schema debe evaluar si RLS necesita actualización antes de cerra
 
 ## Flujo de trabajo: misión → issue atómico → PR
 
+**No todo necesita una misión.** Un bug de un archivo o un ajuste de copy/UI 100% reversible, sin decisión
+de producto involucrada, va directo a issue + rama + PR + verificación — sin carpeta de misión. Forzar eso
+al framework completo es ceremonia sin valor (ver "Carril según riesgo" en `docs/missions/README.md`). Ante
+la duda de si algo entra en esta categoría o necesita misión, preguntar antes de elegir por las dudas el
+camino largo.
+
 El discovery de una feature vive en `docs/missions/`. El tracking de ejecución vive en **GitHub Issues**.
 
 **Una misión** documenta el discovery de una feature en cuatro documentos con fuentes de verdad separadas
 (`investigacion.md` → `producto.md` → `experiencia.md` → `ingenieria.md`). Cómo se escribe cada uno está en
-los skills `discovery-product`, `discovery-ux` y `discovery-engineering`. El registro de misiones y la
-convención de carpetas están en [`docs/missions/README.md`](docs/missions/README.md).
+los skills `discovery-product`, `discovery-ux` y `discovery-engineering`. El registro de misiones, la
+convención de carpetas y la secuencia completa numerada de una misión están en
+[`docs/missions/README.md`](docs/missions/README.md).
+
+**Al retomar una misión que ya existe** (no una recién abierta) — otra sesión, otro día, o después de un
+`/clear` — correr `/mision-estado <misión>` antes de seguir. No reconstruir de memoria en qué paso quedó.
 
 ### Discovery: siempre en worktree
 
@@ -167,6 +177,11 @@ dueño de producto) están completos y a punto de pasar a `vigente`, abrir el PR
 misión. Una vez aprobado y mergeado, cerrar el worktree con `ExitWorktree action: "remove"`.
 
 ### Delivery: siempre en la raíz, una misión a la vez
+
+Antes de crear el primer issue de esta fase, confirmar que el worktree de discovery de la misión ya se
+cerró (`ExitWorktree action: "remove"`). Es la última oportunidad de acordarse: una vez que arranca la
+construcción la atención se va a los issues, y el worktree queda huérfano — ya pasó con las misiones 09 y
+10, ambas con el worktree vivo semanas después de mergeado su PR de discovery.
 
 La ejecución (issues y PRs de código de una misión ya aprobada) se trabaja siempre en la raíz del repo,
 nunca en un worktree. Por foco, solo una misión puede estar en delivery (estado `en construcción`) a la
@@ -226,6 +241,7 @@ Skills propios del repo, escritos para las convenciones de Datealo:
 | `supabase-functions-logic`   | Lógica de negocio en Supabase Edge Functions (`supabase/functions/**`) |
 | `seguridad-datos`            | Auditar RLS/Storage/claves de un `ingenieria.md` o un cambio de schema real, antes de aprobarlo |
 | `audit-security`             | Comando `/audit-security <misión>` — corre `seguridad-datos` más una auditoría del slicing        |
+| `mision-estado`              | Comando `/mision-estado <misión>` — dice en qué paso de la secuencia está una misión y cuál sigue |
 
 Skills de terceros, pre-instalados y trackeados en `skills-lock.json` (con su fuente exacta): `nuxt`,
 `vue`, `drizzle-orm`, `frontend-design`, `ui-ux-pro-max`, `web-design-guidelines`, `marketing-psychology`,
@@ -253,8 +269,8 @@ Ante duda entre investigar y preguntar, investiga primero (cuesta cero):
 | Decisión de negocio que solo el usuario conoce (prioridad, alcance)      | Pregunta al usuario                   |
 | Bloqueo real (herramienta caída, credencial faltante)                    | Reporta el bloqueo y detente          |
 
-- Al implementar con versiones recientes (Nuxt 4, Tailwind v4, DaisyUI v5, Drizzle), verifica la API
-  contra la documentación oficial en vez de asumir por memoria — las tres cambiaron de forma en su
+- Al implementar con versiones recientes (Nuxt 4, Tailwind v4, Nuxt UI v4, Drizzle), verifica la API
+  contra la documentación oficial en vez de asumir por memoria — las cuatro cambiaron de forma en su
   última mayor.
 - Lee un archivo completo antes de editarlo. Un edit sobre contexto parcial pisa código que no viste.
 - Si encuentras algo roto y el fix es claro, arréglalo.

--- a/docs/missions/12-hero-y-copy-landing/README.md
+++ b/docs/missions/12-hero-y-copy-landing/README.md
@@ -1,6 +1,7 @@
 # Misión 12 — Hero y copy de la landing
 
-**Tipo:** producto. **Abierta el** 2026-09-01. **Nace de:** división de la misión 09 (ver su
+**Tipo:** producto. **Carril:** Light Spec — copy y hero de landing, sin RLS, sin dato de usuario, 100%
+reversible. **Abierta el** 2026-09-01. **Nace de:** división de la misión 09 (ver su
 [README](../09-layout-general/README.md)) — investigación ya hecha, movida acá con su contenido.
 
 **Estado de la misión:** lista para construir

--- a/docs/missions/README.md
+++ b/docs/missions/README.md
@@ -69,6 +69,30 @@ registro no se llene de intenciones:
   que sí cambia algo visible para el usuario, deja de ser técnica: se completa con `producto.md` y
   `experiencia.md` desde ese punto.
 
+## Carril según riesgo
+
+"Tipo" decide qué documentos existen. **"Carril" decide cuánto rigor de verificación pesa sobre esos
+documentos**, y aplica el mismo criterio anti-molde de arriba a la profundidad del proceso: forzar el
+proceso completo en un cambio reversible y de bajo riesgo es ceremonia sin valor — spec-driven development
+funciona para cambios cross-team y de seguridad crítica, y se rompe rápido en desarrollo exploratorio, que
+es la mayoría de los casos de un producto pre-lanzamiento como Datealo.
+
+- **Sin misión** — bugs de un archivo, ajustes de copy o UI 100% reversibles, sin decisión de producto
+  involucrada: issue directo + rama + PR + verificación, sin carpeta ni número de misión. Ya se usa así en
+  la práctica (ver issue #199, el fix de los dots del carrusel) — esto solo lo hace explícito.
+- **Light Spec** — la misión completa, con los documentos que le correspondan según su Tipo, pero **la
+  evaluación en un contexto separado de cada gate es opcional**, no bloqueante. Aplica cuando la misión no
+  crea ni cambia una tabla con datos de usuario, no toca RLS, Auth o pagos, y una decisión equivocada es
+  barata de revertir.
+- **Full Spec** — el proceso completo: evaluación en un contexto separado **obligatoria** en los tres gates
+  que la tengan. Aplica cuando la misión toca modelo de datos con datos de usuario, RLS, Auth, pagos, o
+  cualquier decisión cara de revertir (migración de datos, un contrato que otros PRs van a asumir como
+  cierto).
+
+El carril se declara en el README de la misión (`**Carril:**`) al abrirla. Puede subir a Full Spec a mitad
+de camino si el diseño revela que sí toca algo de la lista — nunca bajar sin verificar antes que lo que ya
+se saltó no hacía falta.
+
 ## Convención
 
 - Carpeta `NN-slug/`. `NN` es el orden en que se abrió la misión: nunca se reusa, nunca se reordena, y una
@@ -81,11 +105,40 @@ registro no se llene de intenciones:
 - Si una misión nace de una decisión de otra, el "nace de" apunta a esa `D-xxx`. Las misiones se
   ramifican; sin ese campo, en tres meses nadie reconstruye por qué existe la número 04.
 
-## Cómo se conecta con la ejecución
+## Secuencia completa de una misión
 
-El discovery termina en el "Plan de construcción" de `ingenieria.md`: una lista ordenada de slices donde
-cada slice es un Issue y un PR. Los issues llevan la etiqueta de la decisión que los sustenta (`D-xxx`,
-`TC-xxx`), para que cuando una decisión cambie se pueda encontrar exactamente qué tareas reescribir.
+Cada paso ya está definido en otro lado (`CLAUDE.md`, los skills de discovery, `discovery-engineering`) —
+esta lista solo fija el **orden**, para no reconstruirlo de memoria cada vez. `/mision-estado` la lee para
+decir en qué paso está una misión y cuál sigue.
 
-El método de corte está en el skill `discovery-engineering`
-([`references/slicing.md`](../../.claude/skills/discovery-engineering/references/slicing.md)).
+**Esta secuencia es la de una misión de producto** (ver "Tipos de misión" arriba). Una misión **técnica**
+salta los pasos 2 a 4 completos: no tiene `investigacion.md`, `producto.md` ni `experiencia.md` — va directo
+del paso 1 (worktree) al paso 5 (`ingenieria.md`, citando el `A-xxx` que la sustenta en vez de un `F-xxx`).
+Todo lo demás (6 en adelante) es igual para las dos.
+
+1. **Abrir el worktree** (`EnterWorktree`, nombrado `NN-slug`) y copiar `template/` con el número siguiente.
+2. **`investigacion.md`** — acumulativo, sin gate, no se aprueba. *(solo misión de producto)*
+3. **`producto.md`** — gate de `discovery-product`, evaluación en un contexto separado, aprobación del
+   dueño de producto (`vigente`). *(solo misión de producto)*
+4. **`experiencia.md`** — gate de `discovery-ux`, evaluación en un contexto separado, aprobación. *(solo
+   misión de producto)*
+5. **`ingenieria.md`** — gate de `discovery-engineering` (incluye `seguridad-datos` si hay RLS), evaluación
+   en un contexto separado, aprobación. Termina con el "Plan de construcción" cortado en slices — el método
+   de corte está en [`references/slicing.md`](../../.claude/skills/discovery-engineering/references/slicing.md).
+   Los issues del plan llevan la etiqueta de la decisión que los sustenta (`D-xxx`, `TC-xxx`), para que
+   cuando esa decisión cambie se pueda encontrar exactamente qué tareas reescribir.
+6. **Abrir el PR con los tres documentos** (`producto.md`, `experiencia.md`, `ingenieria.md`) — no antes de
+   que los tres estén `vigente`.
+7. **Mergear el PR de discovery.**
+8. **Cerrar el worktree** (`ExitWorktree action: "remove"`) — antes de crear el primer issue, nunca después.
+9. **Crear los issues** en GitHub desde el "Plan de construcción", uno por slice, con su label
+   `type:`/`scope:` y la decisión que lo sustenta citada en el cuerpo.
+10. **Por cada issue, en la raíz** (nunca en worktree): rama desde `main` → implementar → verificar
+    (typecheck, build) → abrir PR citando `Closes #NNN` → **detenerse** — el checkpoint de revisión humana
+    no es opcional. No arrancar el siguiente issue hasta que el PR actual esté mergeado o el dueño de
+    producto pida explícitamente saltar al siguiente.
+11. **Cuando todos los issues del plan estén mergeados**, cerrar la misión: actualizar el estado acá y en
+    el README de la misión.
+
+Saltarse el paso 6, 7 u 8 — ir de "`ingenieria.md` aprobado" directo al paso 9 — ya pasó una vez. No es
+hipotético.

--- a/docs/missions/template/README.md
+++ b/docs/missions/template/README.md
@@ -48,6 +48,9 @@ importancia de la columna "límite de la evidencia".
 **Misión NN** — abierta el AAAA-MM-DD. Nace de: `<D-xxx de la misión NN>` o "ninguna". Ver el
 [registro de misiones](../README.md).
 
+**Carril:** Light Spec | Full Spec — ver [criterio](../README.md#carril-según-riesgo). Declarar al abrir la
+misión, no al final.
+
 **Estado de la misión:** exploración · definición · lista para construir · en construcción ·
 en validación · cerrada · pausada
 


### PR DESCRIPTION
## Resumen

- Formaliza tres carriles de rigor (Sin misión / Light Spec / Full Spec) para que el proceso de misión
  escale con el riesgo real en vez de aplicar el mismo peso máximo a cualquier cambio — ver "Carril según
  riesgo" en `docs/missions/README.md`.
- El paso de evaluación en contexto separado en `discovery-product`/`discovery-ux`/`discovery-engineering`
  pasa a ser obligatorio solo en Full Spec (RLS, Auth, pagos, dato de usuario, decisión cara de revertir);
  opcional en Light Spec.
- Agrega el comando `/mision-estado`: dado el estado real (worktree, PR, documentos, issues), dice
  explícitamente en qué paso de la secuencia está una misión y cuál sigue — incluyendo detectar worktrees
  huérfanos de otras misiones de paso.
- Corrige al `CLAUDE.md` una afirmación desactualizada sobre el estado de la migración a Nuxt UI (ya estaba
  implementada, el texto decía "pendiente").
- Declara `**Carril:** Light Spec` en la misión 12 (copy/hero de landing) para que quede consistente con el
  campo nuevo del template.

## Test plan

- [x] Revisión manual de consistencia entre `docs/missions/README.md`, el template, y los tres skills de
      discovery — el Carril y la secuencia de pasos se citan igual en los tres lugares.
- No aplica typecheck/build — son solo cambios de `.md` (`CLAUDE.md`, skills, docs de misiones).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151N13nQEUK8Nf4N4b5Vy3f