### PR TITLE
docs(docs): registrar D-005, dropdown del hero con ícono por opción

### DIFF
--- a/docs/missions/12-hero-y-copy-landing/README.md
+++ b/docs/missions/12-hero-y-copy-landing/README.md
@@ -20,6 +20,12 @@ S-002 buscador del hero, S-003 CTA de profesionales del nav), auditado en contex
 09 ya cerró, así que deja de bloquear el único cupo de misión `en construcción` a la vez. TR-002 sigue
 abierto: verificar en mobile que el CTA del nav no repite el bug que pausó el issue #155.
 
+**Corrección durante delivery (2026-09-06):** al ver S-002 implementado en vivo, Patricio pidió que el
+dropdown de categoría del buscador del hero muestre ícono por opción, igual que el panel de `/buscar`
+(`CompactSearchBarPanel`) — D-003 original solo pedía texto plano, igual que el resto de la app. Se
+registró como [D-005](./producto.md#d-005) y [TC-004](./ingenieria.md#tc-004) antes de seguir con el
+código, según el loop de vuelta de `discovery-product`.
+
 ## Brief
 
 Nace de la misma investigación que arrancó como parte de la misión 09 ("mejoras de UI/UX") — al dividir

--- a/docs/missions/12-hero-y-copy-landing/experiencia.md
+++ b/docs/missions/12-hero-y-copy-landing/experiencia.md
@@ -1,8 +1,9 @@
 # Misión: hero y copy de la landing — Experiencia
 
-**Estado:** vigente — aprobado por Patricio el 2026-09-04, con F-002 sumada y aceptada el mismo día
+**Estado:** vigente — aprobado por Patricio el 2026-09-04, con F-002 sumada el mismo día y UX-001 revisada
+el 2026-09-06 (ícono por opción en el dropdown, D-005)
 
-**Última actualización:** 2026-09-04
+**Última actualización:** 2026-09-06
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
@@ -84,9 +85,9 @@ buscar o todavía le falta un campo.
 
 | Paso | Acción                                    | Respuesta del sistema                                                                                   | Información visible                                        |
 | ---- | ------------------------------------------ | --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
-| 1    | Toca el campo "¿Qué servicio buscas?"      | Se abre debajo el dropdown de categorías (mismo `CatalogSelect` que usa el resto de la app)               | Lista de categorías por nombre                              |
+| 1    | Toca el campo "¿Qué servicio buscas?"      | Se abre debajo el dropdown de categorías (mismo `CatalogSelect` que usa el resto de la app, con ícono y círculo de color por categoría — igual que `CompactSearchBarPanel` de `/buscar`, [D-005](./producto.md#d-005)) | Lista de categorías con ícono y nombre                       |
 | 2    | Elige "Gasfitería"                         | El campo pasa de mostrar el placeholder a mostrar "Gasfitería" en negrita; el dropdown se cierra          | El valor elegido reemplaza el placeholder                   |
-| 3    | Toca el campo "¿Qué comuna buscas?"        | Se abre el dropdown de comunas, con buscador de texto (catálogo grande)                                   | Lista de comunas frecuentes, o resultados al escribir        |
+| 3    | Toca el campo "¿Qué comuna buscas?"        | Se abre el dropdown de comunas, con buscador de texto (catálogo grande), con el mismo ícono de pin en cada opción | Lista de comunas frecuentes, o resultados al escribir        |
 | 4    | Elige "Ñuñoa"                              | El campo muestra "Ñuñoa"; con los dos campos llenos, el botón "Buscar" pasa de atenuado a su color sólido | El botón cambia de color — señal de que ya puede tocarlo    |
 | 5    | Toca "Buscar"                              | Navega a `/buscar?categoria=gasfiteria&comuna=nunoa`                                                       | Vista de resultados (fuera del alcance de esta misión)      |
 
@@ -172,6 +173,9 @@ en producción (`LandingNavbar.vue`), con el mismo criterio de sesión que `AppH
   dropdown en el lugar (reusa `CatalogSelect`, sin sheet ni `Teleport`), con un botón "Buscar" (ícono +
   texto) al final de la pill.
 - **Impacto en producto:** ninguno — mismo nivel de detalle que ya fija [D-003](./producto.md#d-003).
+- **Revisión (2026-09-06):** el dropdown que abre cada campo pasa a mostrar ícono y círculo de color por
+  opción, igual que `CompactSearchBarPanel` de `/buscar` — ver [D-005](./producto.md#d-005). No cambia el
+  resto de la decisión: sigue siendo `CatalogSelect` en el lugar, sin sheet ni panel aparte.
 
 <a id="ux-002"></a>
 

--- a/docs/missions/12-hero-y-copy-landing/ingenieria.md
+++ b/docs/missions/12-hero-y-copy-landing/ingenieria.md
@@ -1,6 +1,7 @@
 # Misión: hero y copy de la landing — Ingeniería
 
-**Estado:** vigente — aprobado por Patricio el 2026-09-06
+**Estado:** vigente — aprobado por Patricio el 2026-09-06, con TC-004 sumado y aceptado el mismo día
+(ícono por opción en el dropdown, [D-005](./producto.md#d-005))
 
 **Última actualización:** 2026-09-06
 
@@ -102,6 +103,22 @@ implementación (fetch, filtrado, apertura de la lista) sigue escondida en `Cata
   sesión, sin cambios de esta misión.
 - **Contrato de producto:** [F-002](./producto.md#f-002), [D-004](./producto.md#d-004).
 
+### TC-004 — `CatalogSelect` acepta un mapeo opcional de ícono por opción, sin cambiar su comportamiento por defecto
+
+- **Entrada:** un prop nuevo, opcional, en `CatalogSelect.vue`: `itemIcon?: (value: string) => Component`.
+  Sin valor, la lista se ve igual que hoy (texto plano) — mismo criterio aditivo que TC-001.
+  `CategoriaSelect.vue` lo reenvía como `itemIcon={(slug) => CATEGORIA_ICONS[slug] ?? Wrench}` (la misma
+  fuente que ya usa `CompactSearchBarPanel.vue`); `ComunaSelect.vue` lo reenvía como una función constante
+  que siempre devuelve `MapPin`.
+- **Salida:** cuando `itemIcon` viene definido, cada opción de la lista renderiza el resultado de
+  `itemIcon(item.value)` dentro de un círculo `bg-datealo-surface text-primary` (mismo estilo que
+  `CompactSearchBarPanel.vue`), antes del label. Sin `itemIcon`, la opción renderiza solo el label, igual
+  que hoy.
+- **Invariantes:** `profesional/registro.vue` y `profesional/perfil.vue`, que no pasan `itemIcon`, se ven
+  idénticos a antes del cambio. La selección, el filtrado y los estados de carga/error no cambian.
+- **Errores:** ninguno nuevo.
+- **Contrato de producto:** [D-005](./producto.md#d-005).
+
 ## Modelo de datos
 
 No aplica. `LANDING_HERO`, `LANDING_SOLUTION` y `LANDING_FINAL_CTA` son constantes estáticas en
@@ -142,7 +159,7 @@ texto. Ningún dato de usuario ni de negocio se lee o escribe como parte de esta
 
 | ID     | Riesgo o pregunta | Qué invalida | Experimento o mitigación | Criterio de salida | Estado |
 | ------ | ------------------ | ------------- | -------------------------- | -------------------- | ------ |
-| TR-001 | El override de `placeholder`/`leadingIcon` de TC-001 podría filtrarse sin querer a `profesional/registro.vue` o `profesional/perfil.vue`, cambiando esas pantallas fuera del alcance de F-001 | El alcance ("no toca" otras pantallas) | Los props son opcionales con default `undefined`, y el mismo slice que los agrega verifica visualmente esas dos pantallas (`npm run dev`, 390px) sin pasar los props nuevos | Registro y perfil de profesional se ven idénticos a antes del cambio | abierto |
+| TR-001 | El override de `placeholder`/`leadingIcon`/`itemIcon` (TC-001, TC-004) podría filtrarse sin querer a `profesional/registro.vue` o `profesional/perfil.vue`, cambiando esas pantallas fuera del alcance de F-001 | El alcance ("no toca" otras pantallas) | Los props son opcionales con default `undefined`, y el mismo slice que los agrega verifica visualmente esas dos pantallas (`npm run dev`, 390px) sin pasar los props nuevos | Registro y perfil de profesional se ven idénticos a antes del cambio | abierto |
 | TR-002 | El comentario de pausa del [issue #155](https://github.com/PatricioTabilo/datealo/issues/155) nombra "el CTA 'Publícate' como texto" junto al bug de mobile, sin aislar si el bug era del buscador tras scroll (fuera de este alcance), del CTA, o de ambos. Tampoco está definido qué muestra el link mientras `useProfessionalSession()` resuelve (el `await` inicial) | El criterio de aceptación de S-003 ("sin cambios de scroll, se ve igual que antes salvo el link") | Verificación manual en mobile (390px) del link nuevo, con y sin sesión, antes de dar S-003 por aceptado — si aparece algo parecido al bug original, se investiga como parte del mismo slice, no se ignora asumiendo que ya estaba resuelto | El link se ve y navega bien en 390px, en los tres momentos: cargando, sin sesión, con sesión | abierto |
 
 ## Estrategia de pruebas
@@ -167,7 +184,7 @@ texto. Ningún dato de usuario ni de negocio se lee o escribe como parte de esta
 | ID    | Slice (una frase, sin "y")                                        | Sustento                    | Criterio de aceptación principal | Depende de |
 | ----- | -------------------------------------------------------------------- | ------------------------------ | ------------------------------------ | ---------- |
 | S-001 | Reescribir el copy del hero, `LandingSolution` y `LandingFinalCta` sin "verificado" | D-001, D-002, C-001 a C-004, C-006 | El texto de `app/constants/landing.ts` queda como en "Contenido final" de arriba; ninguna cadena visible en la landing usa "verificado"/"verificados" para describir profesionales; `npx nuxi typecheck` y `npm run build` pasan | — |
-| S-002 | Rediseñar el buscador del hero como pill segmentada con íconos, siguiendo `CompactSearchBar` | D-003, UX-001, UX-002, TC-001, TC-002 | `placeholder`/`leadingIcon` quedan declarados con `defineProps` propio en `CategoriaSelect.vue`/`ComunaSelect.vue` (no por fallthrough), `leadingIcon` tipado `string` (nombre Iconify, no `Component`). Mobile: dos campos apilados con ícono + botón ancho abajo. Desktop: pill horizontal con los dos campos y el botón. Tocar "Buscar" con los dos campos elegidos navega a `/buscar` con la query; incompleto, hace shake y no navega. `profesional/registro.vue` y `profesional/perfil.vue` sin cambios visuales (TR-001). `npx nuxi typecheck` y `npm run build` pasan | S-001 (usa el copy ya actualizado en los placeholders de las pruebas manuales, aunque el componente en sí no depende del texto) |
+| S-002 | Rediseñar el buscador del hero como pill segmentada con íconos, siguiendo `CompactSearchBar` | D-003, D-005, UX-001, UX-002, TC-001, TC-002, TC-004 | `placeholder`/`leadingIcon` quedan declarados con `defineProps` propio en `CategoriaSelect.vue`/`ComunaSelect.vue` (no por fallthrough), `leadingIcon` tipado `string` (nombre Iconify, no `Component`). Mobile: dos campos apilados con ícono + botón ancho abajo. Desktop: pill horizontal con los dos campos y el botón. El dropdown de categoría muestra ícono por opción (`CATEGORIA_ICONS`), el de comuna muestra `MapPin` en todas (TC-004). Tocar "Buscar" con los dos campos elegidos navega a `/buscar` con la query; incompleto, hace shake y no navega. `profesional/registro.vue` y `profesional/perfil.vue` sin cambios visuales (TR-001). `npx nuxi typecheck` y `npm run build` pasan | S-001 (usa el copy ya actualizado en los placeholders de las pruebas manuales, aunque el componente en sí no depende del texto) |
 | S-003 | Reemplazar "Para profesionales" en `LandingNavbar` por "Publícate"/"Mi perfil" | D-004, TC-003 | Sin sesión, el link dice "Publícate" y navega a `/profesional/registro`; con sesión (`useProfessionalSession`), dice "Mi perfil" y navega a `/profesional/perfil`. Categorías, Buscar y el comportamiento de scroll del nav no cambian. Verificación manual en mobile (390px), en los tres momentos (cargando, sin sesión, con sesión), sin el bug de mobile que motivó pausar el issue #155 (TR-002). `npx nuxi typecheck` y `npm run build` pasan | — |
 
 ## Decisiones técnicas

--- a/docs/missions/12-hero-y-copy-landing/producto.md
+++ b/docs/missions/12-hero-y-copy-landing/producto.md
@@ -1,8 +1,9 @@
 # Misión: hero y copy de la landing — Producto
 
-**Estado:** vigente — aprobado por Patricio el 2026-09-04, con F-002/D-004 sumadas y aceptadas el mismo día
+**Estado:** vigente — aprobado por Patricio el 2026-09-04, con F-002/D-004 sumadas el mismo día y D-005
+sumada y aceptada el 2026-09-06
 
-**Última actualización:** 2026-09-04
+**Última actualización:** 2026-09-06
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
@@ -48,7 +49,7 @@ en "Fuera de alcance" hasta que se retome.
 
 | ID    | Funcionalidad                  | Lado    | Sustento             | Éxito |
 | ----- | ------------------------------ | ------- | ---------------------- | ----- |
-| F-001 | Revisar hero y copy de la landing | buscador | C-001 a C-006, D-001 a D-003 | M-001 |
+| F-001 | Revisar hero y copy de la landing | buscador | C-001 a C-006, D-001 a D-003, D-005 | M-001 |
 | F-002 | Reemplazar el CTA "Para profesionales" del nav de la landing | profesional | C-007, D-004 | M-002 |
 
 <a id="f-001"></a>
@@ -269,6 +270,28 @@ necesitando su propio buscador en ese caso — ver "Fuera de alcance".
   del nav (Categorías, Buscar) no cambia.
 - **Reapertura:** si se retoma la pregunta del buscador en el nav tras scroll (ver "Fuera de alcance"), se
   revisa si este link necesita moverse o reacomodarse junto a ese cambio.
+
+<a id="d-005"></a>
+
+### D-005 — El dropdown de categoría del buscador del hero muestra ícono y círculo de color por categoría, igual que el panel de `/buscar`
+
+- **Estado:** aceptada. **Fecha:** 2026-09-06.
+- **Sustento:** revisión en vivo del dueño de producto sobre la implementación de S-002 (D-003).
+- **Tensión:** D-003 dice que el hero reusa `CatalogSelect` tal cual (lista en texto plano, igual que
+  registro y perfil de profesional) vs. al ver el resultado en vivo, el dueño de producto lo comparó con
+  el dropdown real de `/buscar` (`CompactSearchBarPanel`, que sí muestra ícono por categoría) y lo pidió
+  explícitamente ahí.
+- **Alternativas descartadas:** dejar el dropdown en texto plano, tal como quedó definido en D-003 — se
+  descarta porque el dueño de producto, viéndolo al lado del de `/buscar`, lo pidió explícitamente distinto
+  al aprobado originalmente; reemplazar `CatalogSelect` por `CompactSearchBarPanel` en el hero — se
+  descarta porque reintroduce el sheet/panel que UX-001 ya rechazó para el hero (los dos campos deben
+  seguir siempre visibles, sin abrir un panel aparte); esto es solo la lista interna de opciones, no el
+  mecanismo de apertura.
+- **Decisión y consecuencia:** `CatalogSelect` gana un prop opcional para mapear cada opción a un ícono
+  (reusando `CATEGORIA_ICONS`, la misma fuente que ya usa `CompactSearchBarPanel`) — sin ese prop, se ve
+  igual que hoy (registro y perfil de profesional no cambian). El campo de comuna del hero usa el mismo
+  ícono de pin para todas las opciones, igual que `CompactSearchBarPanel`.
+- **Reapertura:** —.
 
 ## Preguntas
 


### PR DESCRIPTION
## Resumen

Durante la revisión en vivo de S-002 (buscador del hero, PR #206), Patricio pidió que el dropdown de
categoría muestre ícono y círculo de color por opción, igual que `CompactSearchBarPanel` de `/buscar` —
D-003 original solo pedía texto plano, igual que el resto de la app.

Registra la decisión antes de tocar código, según el loop de vuelta de `discovery-product`:

- **D-005** en `producto.md` — la decisión de producto.
- **Revisión de UX-001** en `experiencia.md` — el dropdown pasa a mostrar ícono por opción.
- **TC-004** en `ingenieria.md` — `CatalogSelect` gana un prop opcional `itemIcon`, reusando
  `CATEGORIA_ICONS` (la misma fuente que ya usa `CompactSearchBarPanel`).

Sin cambios de código — eso sigue en PR #206.

🤖 Generated with [Claude Code](https://claude.com/claude-code)