### PR TITLE
feat(app): CTA directo de profesionales en el nav de la landing

### DIFF
--- a/app/components/landing/LandingNavbar.vue
+++ b/app/components/landing/LandingNavbar.vue
@@ -22,6 +22,8 @@ const scrollToSection = (selector: string) => {
 const goToTop = () => {
   window.scrollTo({ top: 0, behavior: 'auto' })
 }
+
+const { professional } = await useProfessionalSession()
 </script>
 
 <template>
@@ -52,12 +54,12 @@ const goToTop = () => {
           Categorías
         </UButton>
         <UButton
+          :to="professional ? '/profesional/perfil' : '/profesional/registro'"
           variant="link"
           color="neutral"
           class="nav-link hidden sm:inline-flex items-center px-3.5 py-2 text-sm font-semibold text-white/80 hover:text-white active:text-white rounded-lg hover:bg-white/10 transition-all duration-200"
-          @click="scrollToSection('#profesionales')"
         >
-          Para profesionales
+          {{ professional ? 'Mi perfil' : 'Publícate' }}
         </UButton>
 
         <!-- CTA -->

--- a/app/components/landing/LandingNavbar.vue
+++ b/app/components/landing/LandingNavbar.vue
@@ -57,7 +57,7 @@ const { professional } = await useProfessionalSession()
           :to="professional ? '/profesional/perfil' : '/profesional/registro'"
           variant="link"
           color="neutral"
-          class="hidden sm:inline-flex items-center h-10 px-5 rounded-xl text-sm font-bold text-white bg-secondary hover:bg-secondary active:text-white shadow-md hover:shadow-lg hover:scale-105 transition-all duration-200 cursor-pointer"
+          class="hidden sm:inline-flex items-center h-10 px-5 rounded-xl text-sm font-bold text-primary bg-secondary hover:bg-secondary active:text-primary shadow-md hover:shadow-lg hover:scale-105 transition-all duration-200 cursor-pointer"
         >
           {{ professional ? 'Mi perfil' : 'Publícate' }}
         </UButton>

--- a/app/components/landing/LandingNavbar.vue
+++ b/app/components/landing/LandingNavbar.vue
@@ -57,7 +57,7 @@ const { professional } = await useProfessionalSession()
           :to="professional ? '/profesional/perfil' : '/profesional/registro'"
           variant="link"
           color="neutral"
-          class="nav-link hidden sm:inline-flex items-center px-3.5 py-2 text-sm font-semibold text-white/80 hover:text-white active:text-white rounded-lg hover:bg-white/10 transition-all duration-200"
+          class="hidden sm:inline-flex items-center h-10 px-5 rounded-xl text-sm font-bold text-white bg-secondary hover:bg-secondary active:text-white shadow-md hover:shadow-lg hover:scale-105 transition-all duration-200 cursor-pointer"
         >
           {{ professional ? 'Mi perfil' : 'Publícate' }}
         </UButton>


### PR DESCRIPTION
Closes #204

## Resumen

D-004 (misión 12): retoma la mitad simple del [issue #155](https://github.com/PatricioTabilo/datealo/issues/155)
de la misión 09. "Para profesionales" hacía scroll a una sección de la misma página; pasa a ser un link
directo, mismo criterio de sesión que ya usa `AppHeader.vue` (`useProfessionalSession`):

- Sin sesión: "Publícate" → `/profesional/registro`.
- Con sesión: "Mi perfil" → `/profesional/perfil`.

A diferencia de `AppHeader.vue` (`v-if` sin `v-else`, queda vacío sin sesión porque ahí es un acceso
secundario), acá el texto sale de un ternario que siempre resuelve a algo — nunca queda vacío (TC-003).

Categorías, el CTA "Buscar" y el comportamiento de scroll del nav no cambian. La visibilidad del link
(`hidden sm:inline-flex`) tampoco cambia, así que no repite el bug de mobile que pausó el issue #155 (TR-002)
— ese bug era del buscador tras scroll, fuera de este alcance.

## Test plan

- [x] `npx nuxi typecheck` — cero errores.
- [x] `npx vitest run` — 73 tests, todos pasan.
- [x] `npm run build` — compila.
- [x] Verificado sin sesión: el link dice "Publícate" y navega a `/profesional/registro`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)