### PR TITLE
fix(infra): forzar modo claro, el primary cambiaba de tono con el sistema

### DIFF
--- a/.claude/skills/arquitectura/references/recetas.md
+++ b/.claude/skills/arquitectura/references/recetas.md
@@ -416,6 +416,13 @@ export default defineAppConfig({
 Antes de crear una escala custom para un gris o un color de estado (éxito, error), comprobar si ya coincide
 con un color nativo de Tailwind — ahorra los 11 tonos.
 
+**Nuxt UI instala modo oscuro por defecto** (`@nuxtjs/color-mode`, activado con `ui.colorMode: true` de
+forma implícita) y cambia el tono que resuelve `primary` según la preferencia de sistema del visitante —
+el `500` de arriba en modo claro, el `400` en modo oscuro. Datealo no diseñó ni activó un modo oscuro
+propio, así que ese cambio automático solo desvía la marca del hex exacto sin ningún propósito — detectado
+comparando el sitio en dos navegadores con preferencia de sistema distinta. `ui: { colorMode: false }` en
+`nuxt.config.ts` (no en `app.config.ts` — ese es el módulo, no el theming) lo desactiva.
+
 **El radio base se overridea como variable CSS, no en `app.config.ts`:**
 
 ```css

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -4,6 +4,11 @@ export default defineNuxtConfig({
 
   modules: ['@nuxt/ui'],
 
+  // Sin modo oscuro propio (ningún mockup ni componente lo diseña): sin esto, Nuxt UI instala
+  // @nuxtjs/color-mode y cambia el tono de `primary` según la preferencia de sistema del visitante,
+  // desviando la marca del hex exacto sin ningún propósito.
+  ui: { colorMode: false },
+
   devtools: { enabled: true },
 
   devServer: { port: 3001 },


### PR DESCRIPTION
Closes #210

## Resumen

Nuxt UI instala `@nuxtjs/color-mode` por defecto (`ui.colorMode: true` implícito) y cambia el tono que
resuelve `primary` según la preferencia de sistema del visitante — el `500` (`#423ED0`, el indigo de marca)
en modo claro, el `400` (`#726FDC`, más lavanda) en modo oscuro.

Datealo no diseñó ni activó un modo oscuro propio (ningún mockup, ningún toggle en la UI, ningún doc lo
menciona), así que ese cambio automático solo desvía la marca sin ningún propósito — encontrado comparando
el sitio en dos navegadores con preferencia de sistema distinta, lado a lado.

`ui: { colorMode: false }` en `nuxt.config.ts` lo desactiva. Agrega también la nota a la receta de
"Colores de marca" del skill `arquitectura`, para que la próxima vez no haga falta redescubrirlo.

## Test plan

- [x] Verificado con Playwright emulando `colorScheme: 'dark'` — `--ui-primary` se mantiene en `#423ED0`
  en vez de desviarse a `#726FDC`.
- [x] `npx nuxi typecheck`, `npx vitest run` (73 tests), `npm run build` — todos pasan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)