### PR TITLE
docs(docs): abrir las misiones 13-14-15, cerrar el discovery de la 13

### DIFF
--- a/.claude/skills/write-code/SKILL.md
+++ b/.claude/skills/write-code/SKILL.md
@@ -41,6 +41,16 @@ que ya nos pidieron?".
 - Funciones: camelCase.
 - Named exports sobre default exports.
 
+## Tamaño de texto
+
+Piso tipográfico (misión 13, D-001/D-002): ningún texto de uso frecuente —el que alguien lee para decidir
+algo o que bloquea completar una tarea (nombre, precio, comuna, descripción, reseña, mensaje de error,
+botón de acción)— se escribe en `text-xs` (12px) ni en un `UButton`/`UInput` con `size` que rinda menos de
+16px. El texto principal de una pantalla o card va en `text-base` (16px); su secundario, en `text-sm`
+(14px) como mínimo. `text-xs` queda solo para lo que se lee una sola vez y no decide nada: un label de
+sección ("Categorías"), una fecha relativa, un badge. Ante la duda de si algo es "uso frecuente" o
+"se lee una vez", pensar si un error ahí bloquea una tarea o informa una decisión — si sí, sube.
+
 ## Componentes Vue, mínimo
 
 - Siempre `<script setup lang="ts">`.

--- a/docs/missions/13-tamano-de-fuente/README.md
+++ b/docs/missions/13-tamano-de-fuente/README.md
@@ -3,17 +3,21 @@
 **Tipo:** producto. **Carril:** Light Spec — cambio visual, sin RLS, sin dato de usuario, 100% reversible.
 **Abierta el** 2026-09-06. **Nace de:** ninguna.
 
-**Estado de la misión:** exploración
+**Estado de la misión:** lista para construir
 
-**En foco:** Investigación
+**En foco:** ninguno — discovery completo, falta abrir el PR
 
 **Última actualización:** 2026-09-06
 
 **Documentos:** [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-**Próximo hito:** completar `investigacion.md` con el problema concreto y benchmark de tamaños de fuente
-contra productos comparables — sin fecha límite todavía, recién se abre la misión.
+**Próximo hito:** los cuatro documentos están vigentes — aprobados por Patricio el 2026-09-06. Sigue
+abrir el PR de discovery con los tres documentos que requieren aprobación (producto/experiencia/ingeniería,
+más `README.md` y `design-mockups/`) sobre esta misma rama (`worktree-abrir-misiones-13-14-15`, donde ya
+vive el PR #213 abierto). Después: mergear → `ExitWorktree action: "remove"` → recién ahí crear los issues
+S-001 a S-003 en la raíz. [Q-001](./producto.md#q-001) sigue abierta sin bloquear — se resuelve con
+[TR-001](./ingenieria.md), revisando la captura real de cada slice antes de su PR.
 
 ## Brief
 

--- a/docs/missions/13-tamano-de-fuente/README.md
+++ b/docs/missions/13-tamano-de-fuente/README.md
@@ -1,0 +1,36 @@
+# Misión 13 — Tamaño de fuente
+
+**Tipo:** producto. **Carril:** Light Spec — cambio visual, sin RLS, sin dato de usuario, 100% reversible.
+**Abierta el** 2026-09-06. **Nace de:** ninguna.
+
+**Estado de la misión:** exploración
+
+**En foco:** Investigación
+
+**Última actualización:** 2026-09-06
+
+**Documentos:** [Investigación](./investigacion.md) · [Producto](./producto.md) ·
+[Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
+
+**Próximo hito:** completar `investigacion.md` con el problema concreto y benchmark de tamaños de fuente
+contra productos comparables — sin fecha límite todavía, recién se abre la misión.
+
+## Brief
+
+El dueño de producto siente que el tamaño de fuente en toda la app es chico — no es una pantalla puntual,
+es una sensación transversal. Antes de tocar cualquier tamaño, hace falta benchmark: cómo escalan la
+tipografía productos comparables (mobile-first, marketplaces de servicios, formularios densos) y qué dice
+la evidencia de accesibilidad/legibilidad para el público de Datealo (usuarios con poca familiaridad con
+apps, mayoría desde el celular).
+
+## Temas a explorar
+
+- **Dónde se siente chico.** ¿Es el body copy, los labels de formulario, las cards de resultado, todo por
+  igual? Necesita evidencia concreta (capturas, comparación lado a lado), no solo la sensación.
+- **Escala tipográfica actual.** Qué tamaños usa hoy la app (Tailwind `text-sm`/`text-base`/etc.) y de
+  dónde salieron — si fue una decisión a propósito o heredada de la migración a Nuxt UI (A-004).
+- **Benchmark externo.** Cómo escalan la tipografía Airbnb, Mercado Libre, Doctoralia u otros productos
+  mobile-first con el mismo perfil de usuario (poca familiaridad con apps).
+- **Legibilidad y accesibilidad.** Tamaño mínimo recomendado para mobile, contraste, y cómo afecta a un
+  público que puede incluir usuarios de mayor edad (profesionales de oficios, no necesariamente early
+  adopters de tecnología).

--- a/docs/missions/13-tamano-de-fuente/design-mockups/perfil-gestion.html
+++ b/docs/missions/13-tamano-de-fuente/design-mockups/perfil-gestion.html
@@ -1,0 +1,85 @@
+<!doctype html>
+<html lang="es-CL">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>V-003 Perfil de gestión — misión 13</title>
+
+    <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+    <link
+      href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&family=Plus+Jakarta+Sans:wght@600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../../design/datealo-mockup-kit.css" />
+    <style type="text/tailwindcss">
+      @theme {
+        --color-primary: var(--ui-primary);
+        --color-secondary: var(--ui-secondary);
+        --color-success: var(--ui-success);
+        --color-error: var(--ui-error);
+      }
+    </style>
+  </head>
+
+  <body>
+    <div class="frames">
+      <!-- ANTES -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-003 · perfil de gestión (privado)
+          <small>antes — text-sm/text-xs, código actual</small>
+        </div>
+        <div class="frame-viewport is-auto">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="px-5 pt-4" style="background: var(--color-datealo-bg, #fafafa)">
+            <h1 class="text-xl font-extrabold" style="color: var(--color-datealo-text)">María Fernanda Rojas Ilabaca</h1>
+            <p class="mt-0.5 text-sm" style="color: var(--color-datealo-muted)">Gasfitería · San José de Maipo</p>
+
+            <div class="mt-6">
+              <p class="text-sm font-semibold" style="color: var(--color-datealo-text)">Descripción</p>
+              <p class="mt-1 text-sm" style="color: var(--color-datealo-text)">
+                Gasfiter con 12 años de experiencia. Reparaciones, instalaciones y mantención.
+              </p>
+              <p class="mt-1 text-xs font-semibold text-primary underline">Editar</p>
+            </div>
+
+            <div class="mt-6">
+              <p class="text-sm font-semibold" style="color: var(--color-datealo-text)">Precio</p>
+              <p class="mt-1 text-sm" style="color: var(--color-datealo-text)">Desde $25.000</p>
+              <p class="mt-2 text-right text-xs font-semibold text-error">No se pudo guardar, toca para reintentar</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- DESPUÉS -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-003 · perfil de gestión (privado)
+          <small>después — D-001: descripción/precio en text-base, "Editar" y errores de validación en text-sm</small>
+        </div>
+        <div class="frame-viewport is-auto">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="px-5 pt-4" style="background: var(--color-datealo-bg, #fafafa)">
+            <h1 class="text-xl font-extrabold" style="color: var(--color-datealo-text)">María Fernanda Rojas Ilabaca</h1>
+            <p class="mt-0.5 text-sm" style="color: var(--color-datealo-muted)">Gasfitería · San José de Maipo</p>
+
+            <div class="mt-6">
+              <p class="text-base font-semibold" style="color: var(--color-datealo-text)">Descripción</p>
+              <p class="mt-1 text-base" style="color: var(--color-datealo-text)">
+                Gasfiter con 12 años de experiencia. Reparaciones, instalaciones y mantención.
+              </p>
+              <p class="mt-1 text-sm font-semibold text-primary underline">Editar</p>
+            </div>
+
+            <div class="mt-6">
+              <p class="text-base font-semibold" style="color: var(--color-datealo-text)">Precio</p>
+              <p class="mt-1 text-base" style="color: var(--color-datealo-text)">Desde $25.000</p>
+              <p class="mt-2 text-right text-sm font-semibold text-error">No se pudo guardar, toca para reintentar</p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  </body>
+</html>

--- a/docs/missions/13-tamano-de-fuente/design-mockups/perfil-publico.html
+++ b/docs/missions/13-tamano-de-fuente/design-mockups/perfil-publico.html
@@ -1,0 +1,105 @@
+<!doctype html>
+<html lang="es-CL">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>V-002 Perfil público — misión 13</title>
+
+    <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+    <link
+      href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&family=Plus+Jakarta+Sans:wght@600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../../design/datealo-mockup-kit.css" />
+    <style type="text/tailwindcss">
+      @theme {
+        --color-primary: var(--ui-primary);
+        --color-secondary: var(--ui-secondary);
+        --color-success: var(--ui-success);
+        --color-error: var(--ui-error);
+      }
+    </style>
+  </head>
+
+  <body>
+    <div class="frames">
+      <!-- ANTES -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-002 · perfil público
+          <small>antes — text-sm/text-xs, CTA en size="lg" (rinde 14px)</small>
+        </div>
+        <div class="frame-viewport is-auto">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div style="background: var(--color-datealo-bg, #fafafa)">
+            <div class="aspect-4/3 w-full" style="background: color-mix(in srgb, var(--color-primary) 15%, white)"></div>
+            <div class="px-5 pt-4 pb-4">
+              <h1 class="text-xl font-extrabold" style="color: var(--color-datealo-text)">María Fernanda Rojas Ilabaca</h1>
+              <p class="mt-0.5 text-sm" style="color: var(--color-datealo-muted)">Gasfitería · San José de Maipo</p>
+              <p class="mt-2 text-base font-bold" style="color: var(--color-datealo-text)">Desde $25.000</p>
+              <p class="mt-4 text-sm leading-relaxed" style="color: var(--color-datealo-text)">
+                Gasfiter con 12 años de experiencia. Reparaciones, instalaciones y mantención. Atiendo
+                domicilios en San José de Maipo y comunas vecinas, incluso fines de semana.
+              </p>
+            </div>
+            <div class="mt-6 border-t bg-white p-4" style="border-color: var(--color-datealo-surface)">
+              <div class="flex gap-2">
+                <div class="flex-1 rounded-md bg-primary py-2 text-center text-sm font-bold text-white">
+                  Escribir por WhatsApp
+                </div>
+                <div class="rounded-md border px-4 py-2" style="border-color: var(--color-datealo-surface)">☎</div>
+              </div>
+            </div>
+            <div class="px-5 pt-8 pb-6">
+              <h2 class="text-sm font-extrabold" style="color: var(--color-datealo-text)">Reseñas</h2>
+              <div class="mt-3 border-t pt-3" style="border-color: var(--color-datealo-surface)">
+                <span class="text-sm font-bold" style="color: var(--color-datealo-text)">Carla Muñoz</span>
+                <span class="ml-1" style="font-size: 0.6875rem; color: var(--color-datealo-muted)">hace 3 días</span>
+                <p class="mt-1 text-sm" style="color: var(--color-datealo-text)">Llegó puntual y dejó todo funcionando. Muy recomendado.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- DESPUÉS -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-002 · perfil público
+          <small>después — D-001/D-002: descripción en text-base, CTA en 16px real, "Reseñas" y su contenido en text-base</small>
+        </div>
+        <div class="frame-viewport is-auto">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div style="background: var(--color-datealo-bg, #fafafa)">
+            <div class="aspect-4/3 w-full" style="background: color-mix(in srgb, var(--color-primary) 15%, white)"></div>
+            <div class="px-5 pt-4 pb-4">
+              <h1 class="text-xl font-extrabold" style="color: var(--color-datealo-text)">María Fernanda Rojas Ilabaca</h1>
+              <p class="mt-0.5 text-sm" style="color: var(--color-datealo-muted)">Gasfitería · San José de Maipo</p>
+              <p class="mt-2 text-base font-bold" style="color: var(--color-datealo-text)">Desde $25.000</p>
+              <p class="mt-4 text-base leading-relaxed" style="color: var(--color-datealo-text)">
+                Gasfiter con 12 años de experiencia. Reparaciones, instalaciones y mantención. Atiendo
+                domicilios en San José de Maipo y comunas vecinas, incluso fines de semana.
+              </p>
+            </div>
+            <div class="mt-6 border-t bg-white p-4" style="border-color: var(--color-datealo-surface)">
+              <div class="flex gap-2">
+                <div class="flex-1 rounded-md bg-primary py-2.5 text-center text-base font-bold text-white">
+                  Escribir por WhatsApp
+                </div>
+                <div class="rounded-md border px-4 py-2.5" style="border-color: var(--color-datealo-surface)">☎</div>
+              </div>
+            </div>
+            <div class="px-5 pt-8 pb-6">
+              <h2 class="text-base font-extrabold" style="color: var(--color-datealo-text)">Reseñas</h2>
+              <div class="mt-3 border-t pt-3" style="border-color: var(--color-datealo-surface)">
+                <span class="text-base font-bold" style="color: var(--color-datealo-text)">Carla Muñoz</span>
+                <span class="ml-1" style="font-size: 0.6875rem; color: var(--color-datealo-muted)">hace 3 días</span>
+                <p class="mt-1 text-base" style="color: var(--color-datealo-text)">Llegó puntual y dejó todo funcionando. Muy recomendado.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  </body>
+</html>

--- a/docs/missions/13-tamano-de-fuente/design-mockups/resultados-busqueda.html
+++ b/docs/missions/13-tamano-de-fuente/design-mockups/resultados-busqueda.html
@@ -1,0 +1,195 @@
+<!doctype html>
+<html lang="es-CL">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>V-001 Resultados de búsqueda — misión 13</title>
+
+    <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+    <link
+      href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&family=Plus+Jakarta+Sans:wght@600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../../design/datealo-mockup-kit.css" />
+    <style type="text/tailwindcss">
+      @theme {
+        --color-primary: var(--ui-primary);
+        --color-secondary: var(--ui-secondary);
+        --color-success: var(--ui-success);
+        --color-error: var(--ui-error);
+      }
+    </style>
+  </head>
+
+  <body>
+    <div class="frames">
+      <!-- ANTES: tamaños actuales del código (text-sm / text-xs) -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-001 · buscador + card de resultados
+          <small>antes — text-sm / text-xs, código actual</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="p-4" style="background: var(--color-datealo-bg, #fafafa)">
+            <button
+              type="button"
+              class="flex w-full items-center gap-2.5 rounded-full border bg-white px-4.5 py-3.5 text-left shadow-[0_6px_16px_-8px_rgba(31,41,55,0.15)]"
+              style="border-color: var(--color-datealo-surface)"
+            >
+              <span class="truncate text-sm font-bold" style="color: var(--color-datealo-text)"
+                >Gasfitería en Ñuñoa</span
+              >
+            </button>
+
+            <p class="mt-4 px-0.5 text-xs" style="color: var(--color-datealo-muted)">2 resultados</p>
+
+            <div class="mt-2 grid grid-cols-2 gap-3">
+              <div class="flex flex-col overflow-hidden rounded-2xl border bg-white" style="border-color: var(--color-datealo-surface)">
+                <div class="flex aspect-4/3 w-full items-center justify-center" style="background: color-mix(in srgb, var(--color-primary) 10%, white)">
+                  <div class="flex h-16 w-16 items-center justify-center rounded-full bg-primary text-xl font-extrabold text-white">MF</div>
+                </div>
+                <div class="min-w-0 p-3.5">
+                  <p class="truncate text-sm font-bold" style="color: var(--color-datealo-text)">María Fernanda Rojas Ilabaca</p>
+                  <p class="truncate text-xs" style="color: var(--color-datealo-muted)">San José de Maipo</p>
+                  <div class="mt-1 flex items-center gap-1 text-xs">
+                    <span class="font-bold" style="color: var(--color-datealo-text)">★ 4,8</span>
+                    <span style="color: var(--color-datealo-muted)">· 23 reseñas</span>
+                  </div>
+                  <p class="mt-1 text-xs font-bold" style="color: var(--color-datealo-text)">Desde $25.000</p>
+                  <p class="mt-0.5" style="font-size: 0.6875rem; color: var(--color-datealo-muted)">En Datealo desde ago. 2026</p>
+                </div>
+              </div>
+
+              <div class="flex flex-col overflow-hidden rounded-2xl border bg-white" style="border-color: var(--color-datealo-surface)">
+                <div class="flex aspect-4/3 w-full items-center justify-center" style="background: color-mix(in srgb, var(--color-primary) 10%, white)">
+                  <div class="flex h-16 w-16 items-center justify-center rounded-full bg-primary text-xl font-extrabold text-white">JP</div>
+                </div>
+                <div class="min-w-0 p-3.5">
+                  <p class="truncate text-sm font-bold" style="color: var(--color-datealo-text)">Juan Pérez</p>
+                  <p class="truncate text-xs" style="color: var(--color-datealo-muted)">Ñuñoa</p>
+                  <div class="mt-1 flex items-center gap-1 text-xs">
+                    <span class="font-bold" style="color: var(--color-datealo-text)">★ 4,6</span>
+                    <span style="color: var(--color-datealo-muted)">· 8 reseñas</span>
+                  </div>
+                  <p class="mt-1 text-xs font-bold" style="color: var(--color-datealo-text)">Desde $18.000</p>
+                  <p class="mt-0.5" style="font-size: 0.6875rem; color: var(--color-datealo-muted)">En Datealo desde jul. 2026</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- DESPUÉS: D-001 aplicado (text-base / text-sm) -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-001 · buscador + card de resultados
+          <small>después — D-001: text-base / text-sm</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="p-4" style="background: var(--color-datealo-bg, #fafafa)">
+            <button
+              type="button"
+              class="flex w-full items-center gap-2.5 rounded-full border bg-white px-4.5 py-3.5 text-left shadow-[0_6px_16px_-8px_rgba(31,41,55,0.15)]"
+              style="border-color: var(--color-datealo-surface)"
+            >
+              <span class="truncate text-base font-bold" style="color: var(--color-datealo-text)"
+                >Gasfitería en Ñuñoa</span
+              >
+            </button>
+
+            <p class="mt-4 px-0.5 text-sm" style="color: var(--color-datealo-muted)">2 resultados</p>
+
+            <div class="mt-2 grid grid-cols-2 gap-3">
+              <div class="flex flex-col overflow-hidden rounded-2xl border bg-white" style="border-color: var(--color-datealo-surface)">
+                <div class="flex aspect-4/3 w-full items-center justify-center" style="background: color-mix(in srgb, var(--color-primary) 10%, white)">
+                  <div class="flex h-16 w-16 items-center justify-center rounded-full bg-primary text-xl font-extrabold text-white">MF</div>
+                </div>
+                <div class="min-w-0 p-3.5">
+                  <p class="truncate text-base font-bold" style="color: var(--color-datealo-text)">María Fernanda Rojas Ilabaca</p>
+                  <p class="truncate text-sm" style="color: var(--color-datealo-muted)">San José de Maipo</p>
+                  <div class="mt-1 flex items-center gap-1 text-sm">
+                    <span class="font-bold" style="color: var(--color-datealo-text)">★ 4,8</span>
+                    <span style="color: var(--color-datealo-muted)">· 23 reseñas</span>
+                  </div>
+                  <p class="mt-1 text-sm font-bold" style="color: var(--color-datealo-text)">Desde $25.000</p>
+                  <p class="mt-0.5 text-xs" style="color: var(--color-datealo-muted)">En Datealo desde ago. 2026</p>
+                </div>
+              </div>
+
+              <div class="flex flex-col overflow-hidden rounded-2xl border bg-white" style="border-color: var(--color-datealo-surface)">
+                <div class="flex aspect-4/3 w-full items-center justify-center" style="background: color-mix(in srgb, var(--color-primary) 10%, white)">
+                  <div class="flex h-16 w-16 items-center justify-center rounded-full bg-primary text-xl font-extrabold text-white">JP</div>
+                </div>
+                <div class="min-w-0 p-3.5">
+                  <p class="truncate text-base font-bold" style="color: var(--color-datealo-text)">Juan Pérez</p>
+                  <p class="truncate text-sm" style="color: var(--color-datealo-muted)">Ñuñoa</p>
+                  <div class="mt-1 flex items-center gap-1 text-sm">
+                    <span class="font-bold" style="color: var(--color-datealo-text)">★ 4,6</span>
+                    <span style="color: var(--color-datealo-muted)">· 8 reseñas</span>
+                  </div>
+                  <p class="mt-1 text-sm font-bold" style="color: var(--color-datealo-text)">Desde $18.000</p>
+                  <p class="mt-0.5 text-xs" style="color: var(--color-datealo-muted)">En Datealo desde jul. 2026</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ANTES: selector de categoría/comuna abierto (modo del buscador) -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-001 · buscador, selector abierto
+          <small>antes — lista en text-sm, botón "Buscar" en 15px (`text-[0.9375rem]`, ni siquiera un token)</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div style="background: var(--color-datealo-bg, #fafafa)">
+            <div class="flex items-center justify-between px-5 py-4">
+              <p class="font-heading text-base font-extrabold" style="color: var(--color-datealo-text)">¿Qué necesitas?</p>
+              <div class="flex h-9 w-9 items-center justify-center rounded-full border" style="border-color: var(--color-datealo-surface)">✕</div>
+            </div>
+            <div class="px-4">
+              <p class="px-1 pb-1" style="font-size: 0.6875rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em; color: var(--color-datealo-muted)">Categorías</p>
+              <div class="rounded-xl p-3 text-sm font-semibold" style="background: color-mix(in srgb, var(--color-primary) 8%, white); color: var(--color-datealo-text)">Gasfitería</div>
+              <div class="mt-1 rounded-xl p-3 text-sm font-semibold" style="color: var(--color-datealo-text)">Electricidad</div>
+              <div class="mt-1 rounded-xl p-3 text-sm font-semibold" style="color: var(--color-datealo-text)">Peluquería a domicilio</div>
+            </div>
+            <div class="mt-8 px-5 pb-5">
+              <div class="rounded-full bg-secondary py-4 text-center font-bold text-white" style="font-size: 0.9375rem">Buscar</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- DESPUÉS: mismo modo, tamaños D-001 -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-001 · buscador, selector abierto
+          <small>después — lista sin cambio (ya cumplía el piso bajo un título de 16px), botón "Buscar" en 16px real</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div style="background: var(--color-datealo-bg, #fafafa)">
+            <div class="flex items-center justify-between px-5 py-4">
+              <p class="font-heading text-base font-extrabold" style="color: var(--color-datealo-text)">¿Qué necesitas?</p>
+              <div class="flex h-9 w-9 items-center justify-center rounded-full border" style="border-color: var(--color-datealo-surface)">✕</div>
+            </div>
+            <div class="px-4">
+              <p class="px-1 pb-1" style="font-size: 0.6875rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em; color: var(--color-datealo-muted)">Categorías</p>
+              <div class="rounded-xl p-3 text-sm font-semibold" style="background: color-mix(in srgb, var(--color-primary) 8%, white); color: var(--color-datealo-text)">Gasfitería</div>
+              <div class="mt-1 rounded-xl p-3 text-sm font-semibold" style="color: var(--color-datealo-text)">Electricidad</div>
+              <div class="mt-1 rounded-xl p-3 text-sm font-semibold" style="color: var(--color-datealo-text)">Peluquería a domicilio</div>
+            </div>
+            <div class="mt-8 px-5 pb-5">
+              <div class="rounded-full bg-secondary py-4 text-center text-base font-bold text-white">Buscar</div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  </body>
+</html>

--- a/docs/missions/13-tamano-de-fuente/experiencia.md
+++ b/docs/missions/13-tamano-de-fuente/experiencia.md
@@ -1,0 +1,183 @@
+# Misión: <nombre> — Experiencia
+
+**Estado:** borrador
+
+**Última actualización:** AAAA-MM-DD
+
+[Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
+[Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
+
+<!--
+Fuente de verdad para flujos, estados, contenido e interacción. No redefine reglas de producto: si el
+diseño descubre una regla nueva o invalida una, abre o actualiza una decisión en producto.md.
+
+Núcleo obligatorio: vistas, mapa de estados, flujos críticos y estados por superficie. Las secciones bajo
+demanda (modelo mental, jerarquía de información, validación) se agregan solo cuando una decisión las
+necesita.
+
+Gate de salida — experiencia.md está lista para ingenieria.md cuando:
+- cada flujo crítico tiene secuencia, variantes, recuperación y criterio de término
+- cada estado tiene contenido concreto (texto real, información visible, acción disponible)
+- cada vista lista sus modos, y el mapa de estados cubre todas las transiciones entre ellos
+- cada modo tiene su indicador permanente de estado, y cada flujo tiene todas sus salidas documentadas
+- los casos límite de producto.md tienen flujo o estado mapeado
+- cada flujo crítico está mockeado en móvil (390px), y en desktop si también vive ahí
+- ninguna pantalla queda descrita como "similar a X" sin especificar qué cambia
+-->
+
+## Decisión de experiencia: <qué cambia para quien usa el producto>
+
+<Modelo de interacción elegido, flujo más importante y la incertidumbre que sigue abierta.>
+
+- **Funcionalidades cubiertas:** F-001, <otras>.
+- **Pendiente bloqueante:** <pregunta o "ninguna">.
+
+## Vistas
+
+<!--
+El listado de pantallas que define la experiencia — el mapa que se entrega antes de los flujos. Una línea
+por vista, sin tabla, con sus modos anidados debajo. Una vista es un destino: se llega a ella. Un modo es
+un estado de esa vista que cambia qué se puede hacer y qué se ve — se anida, nunca se lista como vista
+hermana.
+
+El porqué de cada vista, su trade-off o su justificación no van aquí: viven en su flujo (UXF) o en una
+decisión (UX-xxx). Regla de formato para todo el documento: las tablas se reservan para índices de celdas
+cortas; lo que lleva justificación extensa va en secciones con header + bullets, nunca en una celda.
+-->
+
+- **V-001 — <vista>** · móvil / desktop · resuelve F-001 · flujos UXF-001 · pendiente
+  - modo **<nombre>** — <qué lo distingue y qué se puede hacer en él>
+  - modo **<nombre>** — <ídem>
+
+## Mapa de estados
+
+<!--
+Vistas y flujos son listas, y una lista no muestra un camino. Esta tabla conecta los modos: qué acción
+lleva de uno a otro y qué pasa con el trabajo del usuario en cada salto. Cada fila que falte es una
+pregunta que ingeniería resuelve inventando.
+-->
+
+| Desde  | Acción             | Queda en | Qué pasa con el trabajo              |
+| ------ | ------------------ | -------- | ------------------------------------ |
+| <modo> | <acción concreta>  | <modo>   | <qué se aplicó, qué quedó pendiente> |
+| <modo> | <salir sin cerrar> | <modo>   | <qué se pierde o se conserva>        |
+
+## UXF-001 — <flujo principal en verbo>
+
+<!--
+Duplica por flujo crítico. Cada paso describe acción → respuesta al nivel de "el usuario toca X → Datealo
+muestra Y". Un mockup no reemplaza la secuencia porque no explica estados ni recuperación.
+-->
+
+**Objetivo:** <qué se completa o comprende>. **Contrato:** [F-001](./producto.md#f-001).
+
+**Punto de entrada:** <estado y superficie inicial, y qué acción trae al usuario hasta acá>.
+
+**Criterio de término:** <estado observable que confirma que el flujo terminó bien>.
+
+**Cómo sabe el usuario dónde está:** <el elemento concreto y permanente en pantalla que se lo dice, por
+cada modo que toca este flujo>.
+
+### Salidas
+
+<!--
+Todas las formas de irse, no solo terminar bien. El criterio de término cubre la salida buena; las otras
+son las que el usuario encuentra primero. Un modo del que no se sabe salir es un modo donde el usuario se
+pierde.
+-->
+
+| Salida                | Cómo se ejecuta       | Qué queda del trabajo           |
+| --------------------- | --------------------- | ------------------------------- |
+| <termina bien>        | <acción>              | <qué se aplicó y dónde>         |
+| <descarta>            | <acción, Esc, cerrar> | <nada, ni a medias>             |
+| <abandona sin cerrar> | <navega a otra parte> | <se conserva, se pierde, avisa> |
+
+### Secuencia principal
+
+| Paso | Acción            | Respuesta del sistema         | Información visible |
+| ---- | ----------------- | ----------------------------- | ------------------- |
+| 1    | <acción concreta> | <feedback o cambio de estado> | <dato y jerarquía>  |
+
+### Variantes y recuperación
+
+| Condición          | Qué cambia              | Cómo se entiende    | Cómo se recupera             |
+| ------------------ | ----------------------- | ------------------- | ---------------------------- |
+| <sin resultados>   | <estado>                | <mensaje concreto>  | <acción disponible>          |
+| <sin permiso de ubicación> | <comportamiento> | <indicador visible> | <alternativa manual>         |
+| <conexión lenta>   | <skeleton, no spinner>  | <qué se ve mientras>| <qué pasa si falla>          |
+
+### Decisiones que no deben quedar implícitas
+
+- <qué ocurre al cancelar, volver atrás, reintentar o confirmar>.
+- <qué cambio se guarda inmediato y cuál necesita confirmación>.
+
+## Estados por superficie
+
+<!--
+El contenido es concreto: texto real, no "mensaje apropiado". El estado vacío de un marketplace
+pre-lanzamiento no es un detalle: para muchas búsquedas será el estado principal durante meses.
+-->
+
+| Estado  | Qué se muestra (texto e información real) | Acción disponible                   |
+| ------- | ----------------------------------------- | ----------------------------------- |
+| inicial | <contenido>                               | <acción>                            |
+| vacío   | <por qué está vacío, con texto concreto>  | <cómo avanzar, o ninguna y por qué> |
+| carga   | <skeleton de qué forma>                   | <ninguna>                           |
+| error   | <causa útil y alcance>                    | <recuperación>                      |
+
+## Mockups
+
+<!--
+Los mockups viven en design-mockups/ como HTML (ver el skill discovery-ux y docs/design/README.md).
+Exploran o materializan una decisión; no son fuente de verdad de reglas de producto.
+-->
+
+| Mockup   | Cubre   | Estado                 | Ruta                              |
+| -------- | ------- | ---------------------- | --------------------------------- |
+| <nombre> | UXF-001 | exploración o validado | `./design-mockups/<archivo>.html` |
+
+## Cobertura
+
+<!-- Detecta huecos antes de construir. Una funcionalidad sin pantalla nueva igual tiene estados. -->
+
+| Funcionalidad | Flujo   | Estados cubiertos       | Estado    |
+| ------------- | ------- | ----------------------- | --------- |
+| F-001         | UXF-001 | principal, vacío, error | pendiente |
+
+## Secciones bajo demanda
+
+<!--
+Agregar solo cuando una decisión las necesite, con estos títulos:
+
+- "Modelo mental y lenguaje": cuando un concepto de producto pueda confundirse en la interfaz.
+- "Jerarquía de información": cuando una superficie densa exija decidir qué se ve primero (una card de
+  resultado con foto, rating, distancia, precio y disponibilidad es exactamente ese caso).
+- "Validación (UXV-xxx)": cuando una incertidumbre de diseño necesite prueba con usuarios.
+- "Accesibilidad y adaptación": cuando el contexto de uso cambie el flujo o la representación.
+-->
+
+## Decisiones de experiencia
+
+<a id="ux-001"></a>
+
+### UX-001 — <decisión en una frase>
+
+- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
+- **Sustento:** F-001 o <hallazgo>.
+- **Alternativas descartadas:** <opciones relevantes y trade-off, con el porqué del rechazo>.
+- **Decisión y consecuencia:** <qué flujo o superficie cambia>.
+- **Impacto en producto:** <ninguno o enlace a D-xxx/F-xxx actualizado>.
+
+## Preguntas
+
+<!--
+Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
+Estado: abierta | resuelta AAAA-MM-DD | disuelta AAAA-MM-DD. Solo las abiertas llevan bloque de detalle.
+-->
+
+<Una frase que responde "¿qué falta?": la pregunta que bloquea construcción y qué bloquea.>
+
+| ID      | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
+| ------- | ---------------------- | ------------------- | --------------------------------------------------------------- |
+| UXQ-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
+| UXQ-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |

--- a/docs/missions/13-tamano-de-fuente/experiencia.md
+++ b/docs/missions/13-tamano-de-fuente/experiencia.md
@@ -1,8 +1,8 @@
-# Misión: <nombre> — Experiencia
+# Misión 13: Tamaño de fuente — Experiencia
 
-**Estado:** borrador
+**Estado:** vigente — aprobado por Patricio el 2026-09-06
 
-**Última actualización:** AAAA-MM-DD
+**Última actualización:** 2026-09-06
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
@@ -25,12 +25,25 @@ Gate de salida — experiencia.md está lista para ingenieria.md cuando:
 - ninguna pantalla queda descrita como "similar a X" sin especificar qué cambia
 -->
 
-## Decisión de experiencia: <qué cambia para quien usa el producto>
+## Decisión de experiencia: subir el texto sin romper ni la jerarquía ni el layout de tres vistas existentes
 
-<Modelo de interacción elegido, flujo más importante y la incertidumbre que sigue abierta.>
+Esta misión no crea ninguna vista, modo ni flujo nuevo — sube el tamaño de texto (D-001) en tres vistas
+que ya existen (resultados de búsqueda, perfil público, perfil de gestión), y corrige el tamaño real del
+CTA de contacto y la regla de color (D-002). Por eso el foco de este documento no es diseñar un camino
+nuevo: es verificar, con mockups de las tres vistas en 390px y contenido realista (incluido el caso
+límite CL-001, un nombre y una comuna largos), que el texto más grande no rompe el truncado, no hace que
+la card crezca de forma rara y que la jerarquía entre texto principal y secundario se sigue notando solo
+con peso y color — la pregunta abierta en `producto.md` ([Q-001](./producto.md#q-001)).
 
-- **Funcionalidades cubiertas:** F-001, <otras>.
-- **Pendiente bloqueante:** <pregunta o "ninguna">.
+Los tres mockups (`design-mockups/resultados-busqueda.html`,
+`design-mockups/perfil-publico.html`, `design-mockups/perfil-gestion.html`) muestran que sí se sostiene:
+en las tres vistas el nombre en negrita se distingue de la comuna/metadata en gris incluso después de
+subir ambos un escalón. No encontré un caso donde la jerarquía se pierda con el tamaño nuevo — ver
+"Jerarquía de información" más abajo para el detalle.
+
+- **Funcionalidades cubiertas:** F-001.
+- **Pendiente bloqueante:** ninguno. Q-001 sigue formalmente abierta en `producto.md` (se resuelve ahí
+  con el PR ya implementado, no con este mockup estático), pero no bloquea pasar a `ingenieria.md`.
 
 ## Vistas
 
@@ -45,9 +58,15 @@ decisión (UX-xxx). Regla de formato para todo el documento: las tablas se reser
 cortas; lo que lleva justificación extensa va en secciones con header + bullets, nunca en una celda.
 -->
 
-- **V-001 — <vista>** · móvil / desktop · resuelve F-001 · flujos UXF-001 · pendiente
-  - modo **<nombre>** — <qué lo distingue y qué se puede hacer en él>
-  - modo **<nombre>** — <ídem>
+Las tres vistas ya existen (misiones 05, 06/10 y 04/11) y esta misión no les agrega ni les quita modos —
+solo cambia el tamaño de su texto. Se listan igual, por trazabilidad con F-001, con su nombre real en vez
+de un ID nuevo.
+
+- **V-001 — Resultados de búsqueda** (buscador + lista de cards) · móvil / desktop · resuelve F-001 ·
+  sin modos nuevos — ver el mapa de estados completo en la misión 06/10
+- **V-002 — Perfil público de profesional** · móvil / desktop · resuelve F-001 · sin modos nuevos — ver
+  la misión 05/11
+- **V-003 — Perfil de gestión (privado)** · móvil · resuelve F-001 · sin modos nuevos — ver la misión 04
 
 ## Mapa de estados
 
@@ -57,59 +76,21 @@ lleva de uno a otro y qué pasa con el trabajo del usuario en cada salto. Cada f
 pregunta que ingeniería resuelve inventando.
 -->
 
-| Desde  | Acción             | Queda en | Qué pasa con el trabajo              |
-| ------ | ------------------ | -------- | ------------------------------------ |
-| <modo> | <acción concreta>  | <modo>   | <qué se aplicó, qué quedó pendiente> |
-| <modo> | <salir sin cerrar> | <modo>   | <qué se pierde o se conserva>        |
+Sin modos nuevos, no hay transiciones nuevas que mapear: la navegación entre V-001, V-002 y V-003 es
+exactamente la que ya documentaron sus misiones de origen. Esta tabla queda vacía a propósito — llenarla
+con filas que no cambian sería inventar contenido para completar el molde, no información nueva.
 
-## UXF-001 — <flujo principal en verbo>
+## Sin flujo crítico nuevo
 
-<!--
-Duplica por flujo crítico. Cada paso describe acción → respuesta al nivel de "el usuario toca X → Datealo
-muestra Y". Un mockup no reemplaza la secuencia porque no explica estados ni recuperación.
--->
+Esta misión no agrega un `UXF-xxx`: no hay una secuencia de pasos, salidas ni recuperación que
+documentar, porque F-001 no cambia qué hace el usuario ni qué responde Datealo, solo qué tan grande se ve
+el texto que ya existía. La navegación de entrada y salida de V-001, V-002 y V-003 (cómo se llega, cómo se
+vuelve, qué pasa si el usuario se va a WhatsApp y vuelve) sigue siendo la que documentaron las misiones
+04, 05, 06, 10 y 11 — forzar un `UXF-001` acá sería completar el molde con una secuencia que no cambió.
 
-**Objetivo:** <qué se completa o comprende>. **Contrato:** [F-001](./producto.md#f-001).
-
-**Punto de entrada:** <estado y superficie inicial, y qué acción trae al usuario hasta acá>.
-
-**Criterio de término:** <estado observable que confirma que el flujo terminó bien>.
-
-**Cómo sabe el usuario dónde está:** <el elemento concreto y permanente en pantalla que se lo dice, por
-cada modo que toca este flujo>.
-
-### Salidas
-
-<!--
-Todas las formas de irse, no solo terminar bien. El criterio de término cubre la salida buena; las otras
-son las que el usuario encuentra primero. Un modo del que no se sabe salir es un modo donde el usuario se
-pierde.
--->
-
-| Salida                | Cómo se ejecuta       | Qué queda del trabajo           |
-| --------------------- | --------------------- | ------------------------------- |
-| <termina bien>        | <acción>              | <qué se aplicó y dónde>         |
-| <descarta>            | <acción, Esc, cerrar> | <nada, ni a medias>             |
-| <abandona sin cerrar> | <navega a otra parte> | <se conserva, se pierde, avisa> |
-
-### Secuencia principal
-
-| Paso | Acción            | Respuesta del sistema         | Información visible |
-| ---- | ----------------- | ----------------------------- | ------------------- |
-| 1    | <acción concreta> | <feedback o cambio de estado> | <dato y jerarquía>  |
-
-### Variantes y recuperación
-
-| Condición          | Qué cambia              | Cómo se entiende    | Cómo se recupera             |
-| ------------------ | ----------------------- | ------------------- | ---------------------------- |
-| <sin resultados>   | <estado>                | <mensaje concreto>  | <acción disponible>          |
-| <sin permiso de ubicación> | <comportamiento> | <indicador visible> | <alternativa manual>         |
-| <conexión lenta>   | <skeleton, no spinner>  | <qué se ve mientras>| <qué pasa si falla>          |
-
-### Decisiones que no deben quedar implícitas
-
-- <qué ocurre al cancelar, volver atrás, reintentar o confirmar>.
-- <qué cambio se guarda inmediato y cuál necesita confirmación>.
+La verificación real de esta misión (si el texto más grande sigue leyéndose con la jerarquía correcta, y
+si el caso límite CL-001 de nombre y comuna largos sigue truncando bien) vive en "Jerarquía de
+información" más abajo, con evidencia visual en los mockups.
 
 ## Estados por superficie
 
@@ -118,12 +99,22 @@ El contenido es concreto: texto real, no "mensaje apropiado". El estado vacío d
 pre-lanzamiento no es un detalle: para muchas búsquedas será el estado principal durante meses.
 -->
 
-| Estado  | Qué se muestra (texto e información real) | Acción disponible                   |
-| ------- | ----------------------------------------- | ----------------------------------- |
-| inicial | <contenido>                               | <acción>                            |
-| vacío   | <por qué está vacío, con texto concreto>  | <cómo avanzar, o ninguna y por qué> |
-| carga   | <skeleton de qué forma>                   | <ninguna>                           |
-| error   | <causa útil y alcance>                    | <recuperación>                      |
+Solo se documenta el estado que esta misión toca (con datos, texto en el tamaño nuevo) y el caso límite
+CL-001. Los estados vacío/carga/error de estas tres vistas no cambian de contenido y ya están
+documentados en sus misiones de origen — repetirlos acá sería duplicar texto que se desactualiza en un
+solo lado sin que nadie lo note.
+
+| Vista · estado                          | Qué se muestra (texto real, tamaño nuevo)                                                                                    | Acción disponible          |
+| ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| V-001 · con resultados                   | Contador "N resultados" en 14px (antes 12px, `buscar/index.vue`), nombre en 16px bold ("María Fernanda Rojas Ilabaca", truncado con `…`), comuna/rating/precio en 14px ("San José de Maipo", "★ 4,8 · 23 reseñas", "Desde $25.000"), "En Datealo desde…" sin cambio (11px) | Tocar la card → va al perfil |
+| V-001 · CL-001 (nombre y comuna largos)  | El nombre trunca antes que con el tamaño viejo (menos caracteres caben en 16px) pero sigue en una sola línea con `…`; la comuna hace lo mismo en su propia línea; la card no crece de ancho, solo puede crecer unos px de alto | Igual que el estado normal    |
+| V-001 · selector de categoría/comuna abierto | Lista de opciones sin cambio (14px, ya cumplía el piso bajo el título de 16px), botón "Buscar" pasa de 15px (`text-[0.9375rem]`, ni un token de la escala) a 16px real | Elegir una opción → confirma y busca |
+| V-002 · perfil con datos                 | Descripción y precio en 16px, categoría·comuna sin cambio (ya estaba en 14px), "En Datealo desde…" sin cambio (12px), CTA "Escribir por WhatsApp" en 16px real (antes rendía 14px pese a `size="lg"`) | Tocar el CTA → WhatsApp/llamar |
+| V-002 · con reseñas                      | Título "Reseñas" sube de 14px a 16px (mismo criterio que "Descripción"/"Precio" del perfil de gestión); nombre de quien reseña y comentario suben de 14px a 16px; fecha relativa y badge "verificado" sin cambio (11px) | Tocar "Escribir una reseña" → abre el formulario (fuera de alcance, ver producto.md) |
+| V-003 · perfil de gestión con datos      | "Descripción" y "Precio" (labels y valores) en 16px, "Editar" en 14px (antes 12px)                                              | Tocar "Editar" → modo edición |
+| V-003 · error de validación              | "No se pudo guardar, toca para reintentar" (texto real de `perfil.vue`) y errores equivalentes de `ProfessionalAvatar`/`ProfessionalPhotos`/`ProfessionalCatalogRow`/`ProfessionalDataRow` pasan de 12px a 14px — un error bloquea guardar, no es texto de una sola lectura | Tocar el error → reintenta guardar |
+| V-003 · cargando / error de carga        | "Cargando tu perfil…" y el mensaje de `loadError` pasan de 14px a 16px — no mockeado aparte: mismo patrón ya probado en el mensaje de comunas vecinas (único texto de la pantalla, sin título arriba) | ninguna, o recargar según el error |
+| V-002 · invitación a reseñar             | El `cardHeading` de la mini-card ("¿Cómo te fue con...?") pasa de 14px a 16px, mismo criterio que "Reseñas" — no mockeado aparte, mismo patrón que el encabezado "Reseñas" ya validado | Tocar el botón → abre el formulario (fuera de alcance) |
 
 ## Mockups
 
@@ -132,17 +123,19 @@ Los mockups viven en design-mockups/ como HTML (ver el skill discovery-ux y docs
 Exploran o materializan una decisión; no son fuente de verdad de reglas de producto.
 -->
 
-| Mockup   | Cubre   | Estado                 | Ruta                              |
-| -------- | ------- | ---------------------- | --------------------------------- |
-| <nombre> | UXF-001 | exploración o validado | `./design-mockups/<archivo>.html` |
+| Mockup                 | Cubre                                     | Estado    | Ruta                                             |
+| ------------------------ | -------------------------------------------- | ----------- | ---------------------------------------------------- |
+| Resultados de búsqueda | V-001, F-001, CL-001, selector abierto     | validado  | `./design-mockups/resultados-busqueda.html`      |
+| Perfil público         | V-002, F-001, reseñas                      | validado  | `./design-mockups/perfil-publico.html`           |
+| Perfil de gestión      | V-003, F-001, error de validación          | validado  | `./design-mockups/perfil-gestion.html`           |
 
 ## Cobertura
 
 <!-- Detecta huecos antes de construir. Una funcionalidad sin pantalla nueva igual tiene estados. -->
 
-| Funcionalidad | Flujo   | Estados cubiertos       | Estado    |
-| ------------- | ------- | ----------------------- | --------- |
-| F-001         | UXF-001 | principal, vacío, error | pendiente |
+| Funcionalidad | Flujo               | Estados cubiertos                                  | Estado   |
+| --------------- | ---------------------- | ----------------------------------------------------- | ---------- |
+| F-001         | sin flujo nuevo (ver arriba) | V-001 con resultados + CL-001 + selector abierto, V-002 con datos + reseñas, V-003 con datos + error de validación | validado |
 
 ## Secciones bajo demanda
 
@@ -156,17 +149,52 @@ Agregar solo cuando una decisión las necesite, con estos títulos:
 - "Accesibilidad y adaptación": cuando el contexto de uso cambie el flujo o la representación.
 -->
 
+## Jerarquía de información
+
+La duda de fondo de esta misión (Q-001 en `producto.md`) es de jerarquía: la diferencia en px entre
+principal y secundario no cambia (2px antes, 12 vs 14; 2px después, 14 vs 16), pero proporcionalmente es
+más chica (14% antes, 12,5% después) — ¿alcanza para que la diferencia se siga notando de un vistazo, o
+hace falta que peso/color compensen esa diferencia relativa más chica?
+
+Los tres mockups (ver "Mockups" arriba) muestran que no compiten, en las tres vistas, por el mismo motivo:
+la jerarquía nunca dependió solo del tamaño — depende del peso (`font-bold` en el principal, peso normal
+en el secundario) y del color (`text-datealo-text` oscuro contra `text-datealo-muted` gris). Esos dos ejes
+no cambian con esta misión, así que la separación visual se mantiene:
+
+- **V-001, card de resultados:** el nombre (16px, bold, oscuro) se lee primero; comuna, rating y precio
+  (14px, peso normal o bold puntual, mezcla de gris y oscuro) quedan claramente detrás incluso con el
+  nombre largo de CL-001 truncado.
+- **V-002, perfil público:** el precio en bold se distingue de la descripción en peso normal aunque ambos
+  compartan 16px — el peso hace el trabajo que antes hacía parcialmente el tamaño.
+- **V-003, perfil de gestión:** "Descripción"/"Precio" como labels en semibold quedan por encima de su
+  valor en peso normal, igual que antes de subir el tamaño.
+
+**Conclusión de esta misión:** con la evidencia de los tres mockups, subir el tamaño (D-001) alcanza sin
+tocar peso ni color — no encontré un caso donde la jerarquía se pierda. Esto no cierra
+[Q-001](./producto.md#q-001) de forma definitiva: esa pregunta se resuelve, según quedó escrito en
+`producto.md`, con el dueño de producto revisando el PR ya implementado (Nuxt UI real, no la aproximación
+de Tailwind puro del mockup) — pero le da a esa revisión una expectativa clara de qué debería ver.
+
 ## Decisiones de experiencia
 
 <a id="ux-001"></a>
 
-### UX-001 — <decisión en una frase>
+### UX-001 — La jerarquía se sostiene solo con peso y color; no hace falta rediseñarla para D-001
 
-- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
-- **Sustento:** F-001 o <hallazgo>.
-- **Alternativas descartadas:** <opciones relevantes y trade-off, con el porqué del rechazo>.
-- **Decisión y consecuencia:** <qué flujo o superficie cambia>.
-- **Impacto en producto:** <ninguno o enlace a D-xxx/F-xxx actualizado>.
+- **Estado:** aceptada — aprobado por Patricio el 2026-09-06. **Fecha:** 2026-09-06.
+- **Sustento:** F-001, evidencia de los tres mockups (ver "Jerarquía de información").
+- **Alternativas descartadas:**
+  - Bajar el peso o aclarar el color del texto secundario para separarlo más del principal ahora que
+    ambos son más grandes — descartada: los mockups no muestran pérdida de jerarquía, cambiar peso/color
+    sin evidencia de que haga falta sería resolver un problema que no apareció.
+  - Aumentar el contraste de tamaño entre principal y secundario más allá de D-001 (ej. principal en
+    18px) para asegurar la separación — descartada: `producto.md` (D-001) ya evaluó y descartó ir más
+    allá del piso de accesibilidad sin evidencia que lo pida; repetir esa discusión acá sería reabrir una
+    decisión ya tomada sin un hallazgo nuevo.
+- **Decisión y consecuencia:** F-001 se implementa solo cambiando tamaño (clases Tailwind) en las tres
+  vistas, sin tocar `font-weight` ni color. Si al implementarlo con Nuxt UI real (no la aproximación del
+  mockup) la jerarquía sí se siente débil, eso reabre esta UX-001, no se parcha en silencio.
+- **Impacto en producto:** ninguno — no cambia ni agrega ninguna `D-xxx`/`F-xxx` de `producto.md`.
 
 ## Preguntas
 
@@ -175,9 +203,7 @@ Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún I
 Estado: abierta | resuelta AAAA-MM-DD | disuelta AAAA-MM-DD. Solo las abiertas llevan bloque de detalle.
 -->
 
-<Una frase que responde "¿qué falta?": la pregunta que bloquea construcción y qué bloquea.>
-
-| ID      | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
-| ------- | ---------------------- | ------------------- | --------------------------------------------------------------- |
-| UXQ-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
-| UXQ-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |
+No hay ninguna pregunta abierta que bloquee el paso a `ingenieria.md`. La única incertidumbre real de esta
+misión (si la jerarquía se sostiene) quedó evaluada en "Jerarquía de información" y en
+[UX-001](#ux-001); lo que queda pendiente (Q-001 de `producto.md`) ya está registrado ahí, con su propio
+método y sin fecha límite, y no es una pregunta de experiencia.

--- a/docs/missions/13-tamano-de-fuente/ingenieria.md
+++ b/docs/missions/13-tamano-de-fuente/ingenieria.md
@@ -1,0 +1,162 @@
+# Misión: <nombre> — Ingeniería
+
+**Estado:** borrador
+
+**Última actualización:** AAAA-MM-DD
+
+[Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
+[Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
+
+<!--
+Fuente de verdad para arquitectura, datos, contratos, factibilidad y pruebas. Consume el comportamiento
+definido en producto. Una limitación técnica cambia el alcance solo mediante una decisión explícita en
+producto.md.
+
+Núcleo obligatorio: contratos, modelo de datos, RLS y riesgos de factibilidad. Las secciones bajo demanda
+(migración, rendimiento, entrega por etapas) se agregan solo cuando el riesgo lo justifica.
+
+Gate de salida — ingenieria.md está lista para construir cuando:
+- los contratos definen qué entra, qué sale y qué invariantes se mantienen, sin ambigüedad
+- el modelo de datos soporta los casos límite de producto.md sin workarounds
+- el impacto en RLS está resuelto: qué policy se crea o cambia, o por qué ninguna
+- la migración de datos existentes tiene estrategia o está explícitamente fuera del alcance
+- los escenarios verificables de producto están mapeados a pruebas
+- el plan de construcción corta el diseño en slices atómicos ordenados (un slice = un Issue = un PR)
+-->
+
+## Decisión técnica: <arquitectura y riesgo principal>
+
+<Dirección técnica, trade-off principal y el riesgo que todavía podría invalidarla.>
+
+- **Contratos de producto cubiertos:** F-001, <otros>.
+- **Riesgo bloqueante:** <incertidumbre o "ninguna">.
+
+## Arquitectura: <cómo se divide la responsabilidad>
+
+<!--
+La lógica de negocio se separa de la infraestructura: funciones puras en utils/ y server/utils/,
+reactividad en composables, acceso a datos en server/api/ con Drizzle. Incluye diagrama solo cuando tres o
+más partes interactúan.
+-->
+
+<Descripción del enfoque y por qué satisface los contratos con menor riesgo.>
+
+| Componente | Responsabilidad       | No debe decidir | Contratos |
+| ---------- | --------------------- | --------------- | --------- |
+| <nombre>   | <una responsabilidad> | <frontera>      | F-001     |
+
+## Contratos
+
+<!--
+Cada contrato especifica entrada, salida e invariantes al nivel en que se puede implementar sin reuniones
+de aclaración. Incluye los errores observables y el código HTTP cuando es un endpoint.
+-->
+
+### TC-001 — <contrato en una frase>
+
+- **Entrada:** <datos y precondiciones, con tipos y forma concreta>.
+- **Salida:** <resultado y su forma concreta>.
+- **Invariantes:** <qué se cumple siempre: atomicidad, consistencia, idempotencia>.
+- **Errores:** <condición → código HTTP y cuerpo `{ error, code? }`, y qué puede hacer el llamador>.
+- **Contrato de producto:** [F-001](./producto.md#f-001).
+
+## Modelo de datos
+
+<!-- Entidades con significado, escritura y ciclo de vida. El schema completo vive en server/db/. -->
+
+| Entidad o campo | Significado             | Escritura          | Retención o historial |
+| --------------- | ----------------------- | ------------------ | --------------------- |
+| <dato>          | <semántica de producto> | <endpoint o acción>| <política>            |
+
+### Invariantes de datos
+
+- <unicidad, pertenencia, orden o consistencia temporal>.
+- <qué operación es atómica o qué dato tiene una única fuente de verdad>.
+
+### Impacto en RLS
+
+<!--
+Obligatorio. Fuente de verdad: server/db/sql/rls.sql. Si el cambio no toca ownership ni relaciones usadas
+en policies, decirlo explícitamente con esa razón — no dejar la sección vacía.
+-->
+
+| Tabla    | Cambio                 | Policy afectada | Acción                    |
+| -------- | ---------------------- | --------------- | ------------------------- |
+| <tabla>  | <nueva, ownership, FK> | <nombre>        | <crear, actualizar, nada> |
+
+## Riesgos y experimentos de factibilidad
+
+<!--
+Un riesgo que podría cambiar el producto se enlaza como pregunta o decisión en producto.md. Un experimento
+tiene pregunta, límite de tiempo y resultado capaz de cerrar la incertidumbre.
+-->
+
+| ID     | Riesgo o pregunta | Qué invalida        | Experimento o mitigación  | Criterio de salida      | Estado  |
+| ------ | ----------------- | ------------------- | ------------------------- | ----------------------- | ------- |
+| TR-001 | <incertidumbre>   | <alcance en riesgo> | <spike, prueba o recorte> | <resultado concluyente> | abierto |
+
+## Estrategia de pruebas
+
+<!-- Mapea los ejemplos verificables de producto.md a niveles de prueba. Qué demuestra cada una. -->
+
+| Contrato o riesgo | Nivel                          | Caso principal | Límite o falla |
+| ----------------- | ------------------------------ | -------------- | -------------- |
+| F-001, CL-001     | <unidad, contrato, integración>| <caso>         | <caso>         |
+
+### Propiedades que deben probarse
+
+- <invariante bajo reintentos, concurrencia o distintas entradas>.
+- <ausencia de efectos parciales en falla>.
+
+## Plan de construcción
+
+<!--
+Se completa al final, cuando el gate de salida se cumple y ninguna pregunta bloqueante sigue abierta —
+cortar sobre decisiones abiertas produce issues que mueren. Cada slice es un cambio funcional atómico: un
+Issue, un PR, ejecutable sin haber leído la misión (el issue lleva su contrato inline) y con criterios
+pass/fail enumerables como tests. Guía completa en el skill discovery-engineering.
+-->
+
+| ID    | Slice (una frase, sin "y") | Sustento      | Criterio de aceptación principal          | Depende de |
+| ----- | -------------------------- | ------------- | ----------------------------------------- | ---------- |
+| S-001 | <cambio atómico>           | TC-001, D-001 | <entrada concreta → resultado observable> | —          |
+
+## Secciones bajo demanda
+
+<!--
+Agregar solo cuando el riesgo lo justifique, con estos títulos:
+
+- "Migración y compatibilidad": cuando existan datos o consumidores que deben llegar al nuevo contrato.
+  Incluye rollback lógico si la migración física no puede revertirse.
+- "Rendimiento y observabilidad": cuando haya presupuesto de latencia o volumen que defender (búsqueda
+  geográfica y listados paginados son los candidatos naturales).
+- "SEO e indexación": cuando la superficie deba ser indexable (páginas por categoría + comuna, datos
+  estructurados).
+- "Entrega por etapas": cuando el cambio necesite despliegue incremental o feature flags.
+-->
+
+## Decisiones técnicas
+
+<a id="t-001"></a>
+
+### T-001 — <decisión en una frase>
+
+- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
+- **Contratos:** F-001 y <regla relevante>.
+- **Alternativas descartadas:** <opciones y trade-offs, con el porqué del rechazo>.
+- **Decisión y consecuencias:** <enfoque elegido, beneficio, costo y trabajo futuro aceptado>.
+- **Reapertura:** <medición o cambio que justificaría revisar>.
+
+## Preguntas
+
+<!--
+Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
+Estado: abierta | resuelta AAAA-MM-DD | disuelta AAAA-MM-DD. Solo las abiertas llevan bloque de detalle.
+-->
+
+<Una frase que responde "¿qué falta?": la pregunta que bloquea construcción y qué bloquea.>
+
+| ID     | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
+| ------ | ---------------------- | ------------------- | --------------------------------------------------------------- |
+| TQ-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
+| TQ-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |

--- a/docs/missions/13-tamano-de-fuente/ingenieria.md
+++ b/docs/missions/13-tamano-de-fuente/ingenieria.md
@@ -1,8 +1,8 @@
-# Misión: <nombre> — Ingeniería
+# Misión 13: Tamaño de fuente — Ingeniería
 
-**Estado:** borrador
+**Estado:** vigente — aprobado por Patricio el 2026-09-06
 
-**Última actualización:** AAAA-MM-DD
+**Última actualización:** 2026-09-06
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
@@ -24,26 +24,30 @@ Gate de salida — ingenieria.md está lista para construir cuando:
 - el plan de construcción corta el diseño en slices atómicos ordenados (un slice = un Issue = un PR)
 -->
 
-## Decisión técnica: <arquitectura y riesgo principal>
+## Decisión técnica: cambiar clases y props de tamaño, archivo por archivo, sin config global
 
-<Dirección técnica, trade-off principal y el riesgo que todavía podría invalidarla.>
+F-001 se implementa cambiando clases Tailwind (`text-xs`→`text-sm`, `text-sm`→`text-base`) y props `size`
+de Nuxt UI (`UButton`, `UInput`) directo en cada uno de los 18 archivos que `producto.md` ya enumeró. El
+riesgo principal era el mecanismo de D-002 ("default a prueba de error"): la investigación de ingeniería
+encontró que un override global en `app.config.ts` del tema de `button` (ej. redefinir que `size="lg"`
+rinda 16px) tiene un radio de efecto que se sale del alcance de la misión — `size="lg"` también lo usan los
+botones "Reintentar" de `buscar/index.vue`/`[id].vue` (que esta misión decidió no tocar, ya cumplen el piso
+de 14px) y los `UButton` de `registro.vue`/`ingresar.vue` (explícitamente fuera de alcance). Cambiar el
+tema global subiría esas pantallas sin que nadie lo haya pedido ni revisado. Por eso D-002 se resuelve con
+cambios explícitos por instancia para el código que ya existe, y con el piso tipográfico agregado al skill
+`write-code` (invocado obligatoriamente antes de cualquier edición de `.vue`/`.ts`) para el texto que se
+escriba después — ver [T-001](#t-001).
 
-- **Contratos de producto cubiertos:** F-001, <otros>.
-- **Riesgo bloqueante:** <incertidumbre o "ninguna">.
+- **Contratos de producto cubiertos:** F-001.
+- **Riesgo bloqueante:** ninguno.
 
-## Arquitectura: <cómo se divide la responsabilidad>
+## Arquitectura: no hay una nueva — es un cambio de presentación sobre componentes existentes
 
-<!--
-La lógica de negocio se separa de la infraestructura: funciones puras en utils/ y server/utils/,
-reactividad en composables, acceso a datos en server/api/ con Drizzle. Incluye diagrama solo cuando tres o
-más partes interactúan.
--->
-
-<Descripción del enfoque y por qué satisface los contratos con menor riesgo.>
-
-| Componente | Responsabilidad       | No debe decidir | Contratos |
-| ---------- | --------------------- | --------------- | --------- |
-| <nombre>   | <una responsabilidad> | <frontera>      | F-001     |
+Esta misión no introduce lógica de negocio, funciones puras, composables ni endpoints — es cambiar el
+valor de una prop (`class`, `size`) en 18 archivos ya existentes. No hay responsabilidad nueva que dividir
+ni frontera nueva que trazar: forzar una tabla de "componente → responsabilidad" acá describiría una
+arquitectura que no existe. La única decisión de diseño real es T-001 (mecanismo de D-002), ya resuelta
+arriba.
 
 ## Contratos
 
@@ -52,26 +56,17 @@ Cada contrato especifica entrada, salida e invariantes al nivel en que se puede 
 de aclaración. Incluye los errores observables y el código HTTP cuando es un endpoint.
 -->
 
-### TC-001 — <contrato en una frase>
-
-- **Entrada:** <datos y precondiciones, con tipos y forma concreta>.
-- **Salida:** <resultado y su forma concreta>.
-- **Invariantes:** <qué se cumple siempre: atomicidad, consistencia, idempotencia>.
-- **Errores:** <condición → código HTTP y cuerpo `{ error, code? }`, y qué puede hacer el llamador>.
-- **Contrato de producto:** [F-001](./producto.md#f-001).
+Sin contratos nuevos ni modificados: F-001 no cambia qué datos entran o salen de ningún endpoint, ni las
+props públicas de ningún componente (`CategoriaSelect`/`ComunaSelect` siguen recibiendo `modelValue`/`size`
+igual que antes; `SearchResultCard` sigue recibiendo `professional`/`vecina`). Cambia únicamente el interior
+de sus templates.
 
 ## Modelo de datos
 
 <!-- Entidades con significado, escritura y ciclo de vida. El schema completo vive en server/db/. -->
 
-| Entidad o campo | Significado             | Escritura          | Retención o historial |
-| --------------- | ----------------------- | ------------------ | --------------------- |
-| <dato>          | <semántica de producto> | <endpoint o acción>| <política>            |
-
-### Invariantes de datos
-
-- <unicidad, pertenencia, orden o consistencia temporal>.
-- <qué operación es atómica o qué dato tiene una única fuente de verdad>.
+No aplica — F-001 no crea, modifica ni lee ninguna tabla, columna o entidad. No hay datos nuevos que
+tengan significado, escritura o retención que documentar.
 
 ### Impacto en RLS
 
@@ -80,9 +75,11 @@ Obligatorio. Fuente de verdad: server/db/sql/rls.sql. Si el cambio no toca owner
 en policies, decirlo explícitamente con esa razón — no dejar la sección vacía.
 -->
 
-| Tabla    | Cambio                 | Policy afectada | Acción                    |
-| -------- | ---------------------- | --------------- | ------------------------- |
-| <tabla>  | <nueva, ownership, FK> | <nombre>        | <crear, actualizar, nada> |
+Ninguno. Corrí el checklist de `seguridad-datos` contra este diseño: no hay tabla ni bucket nuevo o
+modificado, no cambia qué usa el cliente de Supabase del browser (`app/plugins/supabase.client.ts` sigue
+llamando exactamente a lo mismo), no hay función `SECURITY DEFINER` ni verificación de pertenencia que
+tocar — F-001 no le agrega ni le quita superficie a PostgREST/Storage. El checklist no aplica punto por
+punto porque su precondición (tocar datos) no se cumple.
 
 ## Riesgos y experimentos de factibilidad
 
@@ -91,22 +88,28 @@ Un riesgo que podría cambiar el producto se enlaza como pregunta o decisión en
 tiene pregunta, límite de tiempo y resultado capaz de cerrar la incertidumbre.
 -->
 
-| ID     | Riesgo o pregunta | Qué invalida        | Experimento o mitigación  | Criterio de salida      | Estado  |
-| ------ | ----------------- | ------------------- | ------------------------- | ----------------------- | ------- |
-| TR-001 | <incertidumbre>   | <alcance en riesgo> | <spike, prueba o recorte> | <resultado concluyente> | abierto |
+| ID     | Riesgo o pregunta                                                                 | Qué invalida | Experimento o mitigación | Criterio de salida | Estado |
+| ------ | ------------------------------------------------------------------------------------ | -------------- | --------------------------- | --------------------- | -------- |
+| TR-001 | Los mockups usan Tailwind puro (aproximación); Nuxt UI real puede espaciar distinto y romper algún layout que el mockup no capturó | UX-001 (jerarquía sin tocar peso/color) — no D-001/F-001 en sí | Captura con Playwright en 390px de cada slice ya implementado, antes de abrir su PR | El dueño de producto revisa la captura real y confirma que sostiene lo que muestra el mockup — esto es lo que cierra [Q-001](./producto.md#q-001) | abierto |
 
 ## Estrategia de pruebas
 
 <!-- Mapea los ejemplos verificables de producto.md a niveles de prueba. Qué demuestra cada una. -->
 
-| Contrato o riesgo | Nivel                          | Caso principal | Límite o falla |
-| ----------------- | ------------------------------ | -------------- | -------------- |
-| F-001, CL-001     | <unidad, contrato, integración>| <caso>         | <caso>         |
+No hay lógica pura ni contrato de API que probar con unidad/integración — F-001 es presentación. La
+verificación es la que ya define [M-001](./producto.md#m-001) en `producto.md`:
+
+| Contrato o riesgo | Nivel                                  | Caso principal                                                        | Límite o falla |
+| ------------------- | ------------------------------------------ | -------------------------------------------------------------------------- | ------------------ |
+| F-001              | estático (grep contra la lista de `producto.md`) | cero clases `text-xs`/`size="sm"` restantes en los elementos listados como "sube", por archivo | un elemento exento (ej. "En Datealo desde…") aparece en el grep y hay que confirmar a mano que sigue en la lista de exentos, no que se filtró |
+| F-001, CL-001      | visual (Playwright, 390px, por slice)   | captura de cada vista con datos reales (incluido el nombre largo de CL-001) sin overflow ni layout roto | TR-001: la captura no sostiene lo que muestra el mockup → vuelve a UX-001, no se parcha en el PR |
 
 ### Propiedades que deben probarse
 
-- <invariante bajo reintentos, concurrencia o distintas entradas>.
-- <ausencia de efectos parciales en falla>.
+- El truncado (`truncate`, `…`) sigue activo en nombre y comuna con el tamaño nuevo — CL-001 no depende
+  de un ancho fijo que el tamaño más grande pueda romper.
+- Ningún elemento de la lista "sube" de `producto.md` queda en 12px o en un `size` que rinda 12-14px por
+  debajo de lo que esa fila pide — verificable con el mismo grep que usa M-001.
 
 ## Plan de construcción
 
@@ -117,9 +120,16 @@ Issue, un PR, ejecutable sin haber leído la misión (el issue lleva su contrato
 pass/fail enumerables como tests. Guía completa en el skill discovery-engineering.
 -->
 
-| ID    | Slice (una frase, sin "y") | Sustento      | Criterio de aceptación principal          | Depende de |
-| ----- | -------------------------- | ------------- | ----------------------------------------- | ---------- |
-| S-001 | <cambio atómico>           | TC-001, D-001 | <entrada concreta → resultado observable> | —          |
+Eje de corte: por vista (V-001/V-002/V-003), no por tipo de cambio (ej. "todos los botones" separado de
+"todos los textos") — cada slice es revisable y verificable de forma aislada en una sola pantalla, sin
+esperar a que otro slice termine, y el riesgo es parejo entre los tres (ningún slice es más incierto que
+otro, así que no hay un eje de riesgo que priorizar por encima del de superficie).
+
+| ID    | Slice (una frase, sin "y")                                    | Sustento                        | Criterio de aceptación principal | Depende de |
+| ----- | ----------------------------------------------------------------- | ------------------------------------ | ------------------------------------- | ------------ |
+| S-001 | Subir el tamaño de texto del buscador y la card de resultados     | F-001, D-001, D-002, CL-001, [E-005](./investigacion.md#e-005) | Con "María Fernanda Rojas Ilabaca" en "San José de Maipo" y $25.000 en `/buscar` a 390px: el nombre se ve en 16px bold, comuna/rating/precio/contador en 14px, "En Datealo desde…" sin cambio, el botón "Buscar" del selector en 16px, y el nombre sigue truncando con `…` sin desbordar la card | — |
+| S-002 | Subir el tamaño de texto del perfil público y su CTA de contacto  | F-001, D-001, D-002                  | En `/profesionales/[id]` a 390px: descripción y precio en 16px, "Escribir por WhatsApp" en 16px real (no 14px pese a `size="lg"`), "Reseñas" y el contenido de cada reseña en 16px, "En Datealo desde…" y la fecha relativa sin cambio | — |
+| S-003 | Subir el tamaño de texto del perfil de gestión y sus componentes  | F-001, D-001, D-002                  | En `/profesional/perfil` a 390px: "Descripción"/"Precio" y sus valores en 16px, "Editar" y los mensajes de error de guardado en 14px, los inputs de precio y "Tus datos" en 16px (sin `size="sm"`), el botón "Reintentar" del selector de categoría/comuna en 14px (no 12px) | — |
 
 ## Secciones bajo demanda
 
@@ -139,13 +149,39 @@ Agregar solo cuando el riesgo lo justifique, con estos títulos:
 
 <a id="t-001"></a>
 
-### T-001 — <decisión en una frase>
+### T-001 — El código se corrige archivo por archivo; el piso a futuro se hace cumplir vía el skill `write-code`, no vía config ni lint
 
-- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
-- **Contratos:** F-001 y <regla relevante>.
-- **Alternativas descartadas:** <opciones y trade-offs, con el porqué del rechazo>.
-- **Decisión y consecuencias:** <enfoque elegido, beneficio, costo y trabajo futuro aceptado>.
-- **Reapertura:** <medición o cambio que justificaría revisar>.
+- **Estado:** aceptada — aprobado por Patricio el 2026-09-06. **Fecha:** 2026-09-06.
+- **Contratos:** F-001, [D-002](./producto.md#d-002).
+- **Alternativas descartadas:**
+  - Sobrescribir en `app.config.ts` el tamaño real de `size="lg"`/`"sm"` de `button`/`input` para que
+    "por default" rindan más grande — descartada: `size="lg"` lo usan también los botones "Reintentar" de
+    `buscar/index.vue`/`[id].vue`, que esta misión decidió dejar en 14px, y los `UButton` de
+    `registro.vue`/`ingresar.vue`, explícitamente fuera de alcance. Un override global los sube a todos
+    sin que nadie lo haya pedido — CL-002 de `producto.md` ya anticipaba este riesgo, y acá se confirma
+    que el radio de efecto es demasiado ancho para esta misión.
+  - Una regla de lint/CI que bloquee `text-xs`/`size="sm"` — descartada: para verificar si una instancia
+    puntual es "de uso frecuente" (sube) o "se lee una vez" (exenta) un lint necesitaría esa distinción
+    marcada en el código de alguna forma (un atributo, una convención de nombre) que hoy no existe;
+    construir esa marca solo para este chequeo es una abstracción a la medida de una herramienta, no del
+    problema.
+  - No decir nada y confiar en que el patrón ya escrito en `producto.md` se recuerde solo — descartada:
+    es exactamente lo que ya falló una vez en esta misión (los inputs con `size="sm"` que rompían un
+    supuesto que el propio documento daba por hecho); una regla que nadie vuelve a leer se repite.
+- **Decisión y consecuencias:** cada slice (S-001 a S-003) cambia las clases y props `size` directo en los
+  archivos que `producto.md` ya enumeró. Para el código que ya existe, esto cierra el problema. Para texto
+  nuevo que se escriba después de esta misión, el piso tipográfico (texto de uso frecuente nunca en 12px;
+  principal en 16px, secundario en 14px como mínimo) quedó agregado al skill `write-code`
+  (`.claude/skills/write-code/SKILL.md`), que el proyecto invoca **obligatoriamente** antes de escribir o
+  editar cualquier `.vue`/`.ts` (`write-code.global.md`) — no es una guía que alguien podría no leer, es
+  un paso del flujo de edición, igual que el `typecheck` antes de cerrar un cambio. Consecuencia aceptada:
+  esto depende de que el skill se siga invocando (una garantía de proceso, no una imposibilidad técnica
+  como sería un tipo de TypeScript) — más débil que un lint, pero cubre el caso real (un desarrollador o
+  un agente escribiendo código nuevo) sin la abstracción a medida que exigiría automatizarlo hoy.
+- **Reapertura:** si el piso documentado en `write-code` se salta más de una vez en la práctica (alguien
+  edita un `.vue` sin que el skill se haya invocado, o lo invoca y aun así reintroduce 12px), reconsiderar
+  el lint descartado arriba — a esa altura ya habría evidencia real de que la marca semántica que hace
+  falta vale la pena construirse.
 
 ## Preguntas
 
@@ -154,9 +190,6 @@ Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún I
 Estado: abierta | resuelta AAAA-MM-DD | disuelta AAAA-MM-DD. Solo las abiertas llevan bloque de detalle.
 -->
 
-<Una frase que responde "¿qué falta?": la pregunta que bloquea construcción y qué bloquea.>
-
-| ID     | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
-| ------ | ---------------------- | ------------------- | --------------------------------------------------------------- |
-| TQ-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
-| TQ-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |
+No hay ninguna pregunta abierta que bloquee la construcción. TR-001 (¿el layout real sostiene lo que
+muestra el mockup?) no bloquea empezar — se resuelve slice por slice, con la captura de cada PR, antes de
+mergearlo.

--- a/docs/missions/13-tamano-de-fuente/investigacion.md
+++ b/docs/missions/13-tamano-de-fuente/investigacion.md
@@ -1,0 +1,118 @@
+# Misión: <nombre> — Investigación
+
+**Estado:** activo
+
+**Última actualización:** AAAA-MM-DD
+
+[Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
+[Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
+
+<!--
+Este documento se acumula: la evidencia y las conclusiones no se borran cuando el alcance cambia, porque
+explican por qué el producto es como es. Lo que sí se actualiza es el ideal, que resume la dirección que
+la investigación sostiene hoy.
+
+Gate de salida — la investigación sostiene un producto.md cuando:
+- el problema tiene situación y consecuencia concretas, no una categoría abstracta
+- al menos una conclusión con confianza alta o media respalda la dirección
+- el ideal describe capacidades observables, no intenciones
+-->
+
+## El problema aparece cuando <historia concreta>
+
+<!--
+Una situación real o reconstruida con precisión. No abras con una categoría como "falta de confianza" —
+abre con quién estaba haciendo qué y qué salió mal. Nombra a la persona y el servicio concreto.
+-->
+
+**Situación:** <qué está ocurriendo antes del problema>.
+
+**Acción o necesidad:** <qué se intenta resolver o decidir>.
+
+**Respuesta actual:** <qué hace hoy la persona: grupo de WhatsApp, Google, recomendación de un vecino,
+Datealo si ya existe la superficie>.
+
+**Consecuencia:** <error, demora, riesgo o decisión que no puede tomarse>.
+
+## Preguntas que la investigación debe resolver
+
+<!--
+Solo preguntas capaces de cambiar el ideal o una decisión. Al resolver una, moverla a evidencia o
+conclusión. No es un backlog.
+-->
+
+- ¿<pregunta y decisión que depende de ella>?
+
+## Evidencia
+
+<!--
+Un hecho verificable con fuente y límite. Prioriza observación directa, entrevistas y comportamiento
+comprobado. Los benchmarks de otros productos también son evidencia: qué hacen, qué trade-off eligieron y
+qué no aplica a Datealo.
+
+Datealo no tiene datos de uso propios todavía. Cuando la única evidencia disponible sea un benchmark o
+una entrevista, la columna "límite" es lo que impide que se lea como dato duro.
+-->
+
+| ID    | Tipo                                              | Fuente                | Hecho verificable | Límite de la evidencia |
+| ----- | ------------------------------------------------- | --------------------- | ----------------- | ---------------------- |
+| E-001 | <entrevista, benchmark, uso, código, observación> | <enlace o referencia> | <hecho>           | <qué no demuestra>     |
+
+<a id="e-001"></a>
+
+### E-001 — <fuente o hecho en una frase>
+
+<!--
+Desarrollar solo cuando la tabla no alcanza para evaluar la calidad de la evidencia. Cierra con la
+consecuencia para la investigación.
+-->
+
+<Observación precisa y contexto necesario.>
+
+Esto permite afirmar <alcance>, pero no demuestra <límite>.
+
+## Conclusiones
+
+<!--
+Una conclusión interpreta evidencia; no es una preferencia ni una funcionalidad. El título expresa el
+hallazgo, no el tema.
+-->
+
+<a id="c-001"></a>
+
+### C-001 — <conclusión en una frase>
+
+- **Sustento:** [E-001](#e-001).
+- **Razonamiento:** <por qué la evidencia conduce a esta lectura y no a otra>.
+- **Implicación:** <qué deberá ser cierto en el producto o qué alternativa queda debilitada>.
+- **Confianza:** <alta, media o baja> porque <razón o validación pendiente>.
+
+## El ideal: <resultado completo, sin recortar>
+
+<!--
+El ideal es el producto de la investigación: la dirección que la evidencia sostiene, sin restricciones de
+implementación. El recorte a la primera entrega no vive aquí — vive en producto.md como decisión de
+alcance. Esta sección sí se reescribe cuando nueva evidencia cambia la dirección.
+-->
+
+### El resultado ideal se ve así
+
+<Narra de principio a fin una situación futura con datos concretos: nombres, comunas, oficios, horarios.
+Qué acción ocurre, qué responde Datealo, qué decisión puede tomar la persona. Evita "una experiencia
+simple" sin comportamiento observable.>
+
+### Capacidades del ideal
+
+| Capacidad | Acción habilitada    | Respuesta esperada              | Conclusión que la justifica |
+| --------- | -------------------- | ------------------------------- | --------------------------- |
+| <nombre>  | <qué se puede hacer> | <qué produce o explica Datealo> | [C-001](#c-001)             |
+
+### El ideal no significa <confusión probable>
+
+- <límite conceptual que evita una interpretación incorrecta>.
+
+## Referencias
+
+<!-- Fuentes primarias citadas por las evidencias. El enlace no sustituye el hecho y el límite en E-xxx. -->
+
+- [<título descriptivo>](URL): usado en E-001 para <afirmación concreta>.

--- a/docs/missions/13-tamano-de-fuente/investigacion.md
+++ b/docs/missions/13-tamano-de-fuente/investigacion.md
@@ -1,8 +1,8 @@
-# Misión: <nombre> — Investigación
+# Misión 13: Tamaño de fuente — Investigación
 
 **Estado:** activo
 
-**Última actualización:** AAAA-MM-DD
+**Última actualización:** 2026-09-06
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
@@ -18,21 +18,27 @@ Gate de salida — la investigación sostiene un producto.md cuando:
 - el ideal describe capacidades observables, no intenciones
 -->
 
-## El problema aparece cuando <historia concreta>
+## El problema aparece cuando Patricio compara Datealo con Airbnb en su propio celular
 
 <!--
 Una situación real o reconstruida con precisión. No abras con una categoría como "falta de confianza" —
 abre con quién estaba haciendo qué y qué salió mal. Nombra a la persona y el servicio concreto.
 -->
 
-**Situación:** <qué está ocurriendo antes del problema>.
+**Situación:** Patricio (dueño de producto) recorre el buscador, las cards de resultados y el perfil de
+profesional (el público y el de gestión) desde su celular, y los pone al lado de Airbnb en la misma
+pantalla. No hay todavía un usuario real reportando esto — Datealo sigue pre-lanzamiento.
 
-**Acción o necesidad:** <qué se intenta resolver o decidir>.
+**Acción o necesidad:** decidir si el texto de esas cuatro superficies es tan chico como se siente a
+simple vista, o si es una impresión que no aguanta la comparación con números reales.
 
-**Respuesta actual:** <qué hace hoy la persona: grupo de WhatsApp, Google, recomendación de un vecino,
-Datealo si ya existe la superficie>.
+**Respuesta actual:** ninguna medición hasta ahora. Cada componente quedó con el tamaño que trajo Tailwind
+o Nuxt UI por defecto al construirse (`text-xs`, `text-sm`, etc.), sin que nadie fijara una escala
+tipográfica a propósito — no es una decisión que se esté revirtiendo, es la primera vez que se mira.
 
-**Consecuencia:** <error, demora, riesgo o decisión que no puede tomarse>.
+**Consecuencia:** sin comparar tamaños reales (los de Datealo hoy, los de un benchmark, y el piso de
+legibilidad mobile) no se puede saber si achicar el texto fue un problema real o una sensación — y
+cualquier cambio a ciegas puede subir un componente y dejar intacto otro con el mismo patrón.
 
 ## Preguntas que la investigación debe resolver
 
@@ -41,7 +47,12 @@ Solo preguntas capaces de cambiar el ideal o una decisión. Al resolver una, mov
 conclusión. No es un backlog.
 -->
 
-- ¿<pregunta y decisión que depende de ella>?
+- ¿La brecha es de tamaño puro (subir un escalón alcanza) o de jerarquía visual (el texto secundario
+  necesita distinguirse del principal con peso/color en vez de con un tamaño que ya cruza el piso de
+  legibilidad)? Decide si el fix es una escala nueva o un rediseño de qué es "principal" y qué es
+  "secundario" en cada superficie.
+- ¿Cuál es el piso de legibilidad que Datealo se compromete a no cruzar, independiente de qué tamaño use
+  Airbnb? Decide si la meta es "igualar al benchmark" o "cumplir un mínimo propio de accesibilidad".
 
 ## Evidencia
 
@@ -54,22 +65,105 @@ Datealo no tiene datos de uso propios todavía. Cuando la única evidencia dispo
 una entrevista, la columna "límite" es lo que impide que se lea como dato duro.
 -->
 
-| ID    | Tipo                                              | Fuente                | Hecho verificable | Límite de la evidencia |
-| ----- | ------------------------------------------------- | --------------------- | ----------------- | ---------------------- |
-| E-001 | <entrevista, benchmark, uso, código, observación> | <enlace o referencia> | <hecho>           | <qué no demuestra>     |
+| ID    | Tipo        | Fuente                                                              | Hecho verificable | Límite de la evidencia |
+| ----- | ----------- | -------------------------------------------------------------------- | ------------------ | ----------------------- |
+| E-001 | código      | `SearchResultCard.vue`, `CompactSearchBar(Panel).vue`, `buscar/index.vue`, `perfil.vue`, `[id].vue` y los componentes que factorizan cada superficie (`ProfessionalAvatar`, `ProfessionalPhotos`, `ProfessionalCatalogRow`, `ProfessionalDataRow`, `ProfessionalPublicContactBar`, `ProfessionalPublicReviews(Card)`) | Datealo usa 12px (`text-xs`) para metadata, errores de validación, hints de acción y el contador "N resultados" de la lista, y 14px (`text-sm`) para el texto principal, en las cuatro superficies — el patrón no se limita a los 4 archivos de página, se repite en cada componente que factoriza contenido de esas superficies | describe qué se implementó, no cómo lo percibe un usuario real |
+| E-002 | benchmark   | [Superdesign — Airbnb design system breakdown (2026)](https://superdesign.dev/blog/airbnb-design-system) | Airbnb usa 16px/600 para el título de una card de listado y 14px/400 para su descripción, contra 14px/12px en el equivalente de Datealo | valores reconstruidos por un tercero ("community-observed, not Airbnb-published"), no la spec oficial de Airbnb, y Airbnb opera con otra escala de datos y de uso |
+| E-003 | accesibilidad | [The A11Y Collective — WCAG minimum font size](https://www.a11y-collective.com/blog/wcag-minimum-font-size/), [Recite Me — accessible font size](https://reciteme.com/news/accessible-font-size/) | 16px es el piso práctico aceptado para body text en mobile (18px si el público es 50+); 14px queda documentado como insuficiente para lectura cómoda en celular | agrega guías de terceros, no cita la norma WCAG primaria línea por línea; WCAG en sí no fija un mínimo en px |
+| E-004 | código      | `node_modules/@nuxt/ui` (theme de `button` e `input`), `ProfessionalPublicContactBar.vue`, `perfil.vue`, `ProfessionalDataRow.vue`, `CatalogSelect.vue` | El tamaño real de texto en Datealo no depende solo de las clases `text-*` que escribimos: el theme de Nuxt UI fija que un `UButton` en `size="sm"`/`"md"`/`"lg"` renderiza a 12-14px y solo `size="xl"` llega a 16px — el CTA "Escribir por WhatsApp" usa `size="lg"` (14px) y el botón "Reintentar" de `CatalogSelect.vue` usa `size="sm"` (12px). Los `UInput`/`UTextarea` sin `size` explícito rinden en 16px por defecto, pero dos instancias lo pisan con `size="sm"` (14px): el campo de precio de `perfil.vue` y el de `ProfessionalDataRow.vue` | describe el theme de la librería en esta versión, no una auditoría de cada componente Nuxt UI que Datealo usa |
+| E-005 | código + cálculo de contraste | `main.css` (`--color-datealo-muted: #6B7280`), `LandingForProfessionals.vue:86` | `text-datealo-muted` (#6B7280) sobre el fondo claro de Datealo (#FAFAFA/blanco) da un contraste de ~4.6-4.8:1 — pasa el mínimo AA de WCAG (4.5:1) para texto normal, pero con margen casi nulo. Un patrón puntual fuera de las cuatro superficies de esta misión (`text-datealo-text/50`, usado para atenuar color con opacidad en vez de un tono sólido) cae a ~3.06:1, por debajo del mínimo AA | cálculo propio con la fórmula estándar de contraste de WCAG, no una auditoría automatizada de cada color de la app; no mide percepción real de un usuario |
 
 <a id="e-001"></a>
 
-### E-001 — <fuente o hecho en una frase>
+### E-001 — El código de hoy repite el mismo patrón de dos escalones en las cuatro superficies
 
 <!--
 Desarrollar solo cuando la tabla no alcanza para evaluar la calidad de la evidencia. Cierra con la
 consecuencia para la investigación.
 -->
 
-<Observación precisa y contexto necesario.>
+En `SearchResultCard.vue`, el nombre del profesional es `text-sm` (14px) y todo lo demás — comuna,
+rating, precio desde — es `text-xs` (12px). En `CompactSearchBar.vue`, el resumen de la búsqueda es
+`text-sm` y las etiquetas "Categoría"/"Comuna" son `text-xs`. En `perfil.vue` (gestión) y en
+`[id].vue` (perfil público), el nombre sube a `text-xl`/`text-2xl` (20-24px), pero la descripción, el
+precio y las reseñas vuelven a `text-sm`, y los datos de apoyo ("En Datealo desde…", errores de
+validación) bajan a `text-xs`. No hay una escala tipográfica declarada en `main.css` — Tailwind v4 corre
+con sus tamaños por defecto (`text-xs`=12px, `text-sm`=14px, `text-base`=16px, sin overrides).
 
-Esto permite afirmar <alcance>, pero no demuestra <límite>.
+Esto permite afirmar que el patrón es sistemático, no un componente que se escapó — el mismo par
+12px/14px aparece en las cuatro superficies que Patricio señaló. No demuestra que ese patrón sea
+efectivamente ilegible para un usuario real: es una lectura del código, no de comportamiento.
+
+<a id="e-002"></a>
+
+### E-002 — Airbnb reserva 16px para lo que Datealo resuelve en 14px
+
+Según la reconstrucción de Superdesign (2026), Airbnb tipografía sus cards de listado con el título en
+16px/peso 600 y la descripción en 14px/peso 400, con el body/UI general en 14-16px y los títulos de
+sección en 22-28px. Comparado con Datealo — nombre del profesional en 14px, metadata en 12px — la brecha
+más clara es de un escalón completo (14 vs 16px) en el elemento más visible de la card, y de dos
+escalones (12 vs 14-16px) en la metadata de apoyo.
+
+Esto permite afirmar que la sensación de "chico" tiene un correlato numérico concreto contra al menos un
+producto de referencia. No demuestra que 16px sea el tamaño correcto para Datealo: la fuente es una
+reconstrucción de terceros sin acceso a la spec real de Airbnb, y Airbnb diseña para una escala de
+catálogo y de datos de uso que Datealo no tiene.
+
+<a id="e-003"></a>
+
+### E-003 — El texto secundario de Datealo (12px) ya está bajo el piso que la industria de accesibilidad considera aceptable en mobile
+
+Sin importar qué tamaño use Airbnb, la guía agregada de accesibilidad para mobile ubica el piso práctico
+de body text en 16px (18px si el público incluye personas de 50+ o baja visión), y señala 14px como
+insuficiente para lectura cómoda en celular — antes de llegar siquiera a los 12px que Datealo usa hoy
+para comuna, precio, rating y "En Datealo desde". El público de Datealo (profesionales de oficio,
+mayoría desde el celular, sin que se pueda asumir familiaridad alta con apps) es el perfil que esa guía
+identifica como el más afectado por texto chico. Un matiz técnico: iOS fuerza zoom automático en un
+`<input>` con `font-size` menor a 16px, pero el único `<input>` real que encontramos en el buscador
+(`UInput` de Nuxt UI en el panel de comuna, `CompactSearchBarPanel.vue:57`) usa `size="lg"`, no las
+clases chicas que sí aparecen en el resto del buscador — ese disparador puntual puede no aplicar hoy tal
+cual.
+
+Esto permite afirmar que hay un piso de legibilidad independiente del benchmark de Airbnb, y que Datealo
+ya lo cruza en su texto secundario. No demuestra que 16px o 18px sea el tamaño que Datealo debe adoptar
+en cada elemento — eso es una decisión de alcance, no un hecho.
+
+<a id="e-004"></a>
+
+### E-004 — El tamaño real no depende solo de qué clase escribimos: el theme de Nuxt UI tiene su propia escala
+
+Nuxt UI resuelve el tamaño de texto de sus componentes (`UButton`, `UInput`, `UTextarea`) con su propio
+theme, no con las clases `text-*` que Datealo escribe a mano. Revisando ese theme
+(`node_modules/@nuxt/ui/dist/shared/ui.*.mjs`): en `button`, `size="md"` y `size="lg"` renderizan a
+`text-sm` (14px) — solo `size="xl"` llega a `text-base` (16px). El CTA más importante del flujo core
+("Escribir por WhatsApp", `ProfessionalPublicContactBar.vue:30`) está en `size="lg"`, así que hoy
+renderiza a 14px pese a que "lg" sugiere que es grande. En cambio, `input` (y `textarea`, que hereda de
+`input`) ya rinde en `text-base` (16px) desde `size="md"` — pero eso es el default: dos instancias reales
+lo pisan a propósito con `size="sm"` (`perfil.vue:138`, el campo de precio; `ProfessionalDataRow.vue:46`,
+los campos de "Tus datos"), y ahí sí quedan en `text-sm` (14px), por debajo del piso de E-003.
+
+Esto permite afirmar que "subir los tamaños" no se resuelve completo tocando solo las clases `text-*` de
+los componentes propios de Datealo — un botón o un input pueden quedarse en 12-14px aunque nadie haya
+escrito esa clase en ningún lado, porque viene del `size` que Nuxt UI le asignó. No demuestra que todos
+los botones o inputs de la app tengan este problema — se verificó el CTA de contacto y los inputs de las
+cuatro superficies de esta misión, no cada `UButton`/`UInput` que existe en Datealo.
+
+<a id="e-005"></a>
+
+### E-005 — El contraste de color también puede convertir texto legible en texto chico en la práctica
+
+El color secundario de Datealo (`--color-datealo-muted: #6B7280`) da un contraste de ~4.6-4.8:1 contra el
+fondo claro de la app — pasa el mínimo AA de WCAG para texto normal (4.5:1), pero con un margen casi nulo:
+cualquier ajuste futuro del fondo o del tono podría hacerlo caer por debajo sin que nadie lo note a simple
+vista. Aparte, un patrón puntual fuera de las cuatro superficies de esta misión
+(`LandingForProfessionals.vue:86`, "+200 reseñas" en `text-datealo-text/50`) usa opacidad para simular un
+tono secundario en vez de un color sólido, y eso baja el contraste real a ~3.06:1 — por debajo del mínimo
+AA. Mismo síntoma que el tamaño (texto difícil de leer), causa distinta.
+
+Esto permite afirmar que el color no es un eje separado del tamaño para este problema: un texto en 16px
+con contraste insuficiente sigue siendo difícil de leer. No demuestra que todos los usos de color de la
+app tengan este problema — es un cálculo puntual sobre los tonos ya usados en las cuatro superficies y un
+ejemplo fuera de ellas, no una auditoría exhaustiva de cada color del sistema.
 
 ## Conclusiones
 
@@ -80,14 +174,57 @@ hallazgo, no el tema.
 
 <a id="c-001"></a>
 
-### C-001 — <conclusión en una frase>
+### C-001 — La sensación de "chico en toda la app" tiene una causa sistémica: dos escalones fijos (12px/14px) que se repiten en cada superficie
 
-- **Sustento:** [E-001](#e-001).
-- **Razonamiento:** <por qué la evidencia conduce a esta lectura y no a otra>.
-- **Implicación:** <qué deberá ser cierto en el producto o qué alternativa queda debilitada>.
-- **Confianza:** <alta, media o baja> porque <razón o validación pendiente>.
+- **Sustento:** [E-001](#e-001), [E-002](#e-002).
+- **Razonamiento:** el mismo par de tamaños aparece en el buscador, la card de resultados y los dos
+  perfiles, siempre con el mismo rol (texto principal en 14px, secundario en 12px). Si fuera un problema
+  puntual, un componente se vería distinto de los demás — no es lo que muestra el código. Comparado con
+  el benchmark de Airbnb, la brecha es de un escalón en el texto principal y dos en el secundario, lo que
+  explica por qué la sensación es transversal y no aparece en una sola pantalla.
+- **Implicación:** el fix no es ajustar un componente aislado (por ejemplo, solo agrandar el nombre en la
+  card de resultados) — necesita mover la escala base del sistema: lo que hoy es "secundario" (12px) pasa
+  a un tamaño que no cruce el piso de legibilidad, y lo que hoy es "principal" (14px) sube en consecuencia
+  para mantener la jerarquía entre ambos.
+- **Confianza:** alta porque está sustentada en código propio, no en benchmark ni intuición — el patrón
+  es un hecho verificable, no una interpretación.
 
-## El ideal: <resultado completo, sin recortar>
+<a id="c-002"></a>
+
+### C-002 — El texto secundario de Datealo (12px) no cumple un piso de legibilidad mobile que es independiente de cómo lo resuelva Airbnb
+
+- **Sustento:** [E-003](#e-003).
+- **Razonamiento:** aunque el benchmark de Airbnb (E-002) tiene confianza baja por venir de una
+  reconstrucción de terceros, el piso de accesibilidad no depende de qué haga un competidor puntual — es
+  una guía de legibilidad general, y el público de Datealo (profesionales de oficio, mayoría desde el
+  celular, sin asumir familiaridad alta con apps) es exactamente el perfil que esa guía identifica como
+  el más perjudicado por texto de 14px o menos.
+- **Implicación:** la meta de esta misión no debería fijarse solo como "igualar a Airbnb" — necesita un
+  piso propio de legibilidad (14px como mínimo absoluto en toda la app es la primera candidata, a
+  confirmar en `producto.md`) que se sostenga aunque el benchmark cambie.
+- **Confianza:** media — la fuente agrega guías de terceros en vez de citar la norma primaria línea por
+  línea, pero el hallazgo puntual (14px insuficiente en mobile) aparece consistente entre fuentes
+  independientes de accesibilidad, no en una sola.
+
+<a id="c-003"></a>
+
+### C-003 — El tamaño de las clases `text-*` no alcanza para arreglar el problema: hacen falta el tamaño real de los componentes de Nuxt UI y el contraste de color
+
+- **Sustento:** [E-004](#e-004), [E-005](#e-005).
+- **Razonamiento:** el mismo síntoma (texto difícil de leer) tiene dos causas más allá de las clases
+  `text-xs`/`text-sm` que Datealo escribe a mano: el tamaño real de un `UButton` depende del theme de
+  Nuxt UI (un botón "lg" puede seguir en 14px), y un texto en el tamaño correcto sigue siendo difícil de
+  leer si su contraste de color es insuficiente (opacidad usada como atajo para un tono secundario). Un
+  fix que solo cambie clases `text-xs`→`text-sm` en los archivos de F-001 deja ambos problemas intactos.
+- **Implicación:** la corrección tiene que ser sistémica, no archivo por archivo: cualquier botón con
+  texto de uso frecuente necesita el tamaño que realmente rinde en 16px (hoy, `size="xl"` en Nuxt UI, o
+  corregir el default en `app.config.ts` para que no dependa de que cada desarrollador lo recuerde), y
+  ningún texto secundario puede usar opacidad para simular su tono — solo colores sólidos con contraste
+  verificado.
+- **Confianza:** alta — ambos hallazgos son código propio y cálculo verificable, no benchmark ni
+  intuición.
+
+## El ideal: ningún texto de uso frecuente cruza el piso de legibilidad mobile, en ninguna superficie
 
 <!--
 El ideal es el producto de la investigación: la dirección que la evidencia sostiene, sin restricciones de
@@ -97,22 +234,35 @@ alcance. Esta sección sí se reescribe cuando nueva evidencia cambia la direcci
 
 ### El resultado ideal se ve así
 
-<Narra de principio a fin una situación futura con datos concretos: nombres, comunas, oficios, horarios.
-Qué acción ocurre, qué responde Datealo, qué decisión puede tomar la persona. Evita "una experiencia
-simple" sin comportamiento observable.>
+Doña Marcela, 58 años, gasfiter, abre Datealo en la calle con el sol pegándole a la pantalla para revisar
+si le llegó un mensaje. Lee su nombre, su comuna y su precio en la card de resultados sin acercar el
+celular ni entrecerrar los ojos. Un cliente que busca "electricista en Ñuñoa" ve la lista de resultados y
+distingue de un vistazo el nombre del profesional (texto principal, más grande y con más peso) de su
+comuna y su rating (texto secundario, más chico pero nunca ilegible) — la jerarquía se nota en el peso y
+el color, no en un tamaño que ya cuesta leer. Al entrar al perfil público, la descripción que el
+profesional escribió sobre su trabajo se lee tan cómoda como el precio o el nombre — ningún bloque de
+texto de uso frecuente obliga a hacer zoom con los dedos.
 
 ### Capacidades del ideal
 
-| Capacidad | Acción habilitada    | Respuesta esperada              | Conclusión que la justifica |
-| --------- | -------------------- | ------------------------------- | --------------------------- |
-| <nombre>  | <qué se puede hacer> | <qué produce o explica Datealo> | [C-001](#c-001)             |
+| Capacidad                          | Acción habilitada                                                                | Respuesta esperada                                                                                              | Conclusión que la justifica       |
+| ------------------------------------ | ----------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| Escala tipográfica única             | Leer cualquier texto del buscador, una card o un perfil sin acercar el celular    | Ningún texto de uso frecuente (nombre, precio, comuna, descripción, reseña, botón de contacto) baja del piso de legibilidad mobile | [C-001](#c-001), [C-002](#c-002) |
+| Jerarquía sin sacrificio de tamaño   | Distinguir el texto principal del secundario en una card o perfil de un vistazo  | La diferencia se expresa con peso y color sólido, no con un tamaño o una opacidad que cruza el piso de legibilidad | [C-001](#c-001), [C-003](#c-003) |
+| Default a prueba de error           | Agregar un componente nuevo sin tener que recordar "no uses `text-xs`/opacidad" | El tamaño y el color correctos salen por defecto del sistema (theme de Nuxt UI, tokens), no de que cada desarrollador se acuerde | [C-003](#c-003) |
 
-### El ideal no significa <confusión probable>
+### El ideal no significa que todo el texto mida lo mismo
 
-- <límite conceptual que evita una interpretación incorrecta>.
+- La jerarquía entre texto principal y secundario sigue existiendo — se logra con peso y color en vez de
+  con un tamaño que ya es difícil de leer.
+- No significa copiar el valor exacto que usa Airbnb: el benchmark (E-002) tiene confianza baja por ser
+  una reconstrucción de terceros. La escala final de Datealo es una decisión de `producto.md`, informada
+  por el benchmark y por el piso de accesibilidad (E-003), no una calca de ninguno de los dos.
 
 ## Referencias
 
 <!-- Fuentes primarias citadas por las evidencias. El enlace no sustituye el hecho y el límite en E-xxx. -->
 
-- [<título descriptivo>](URL): usado en E-001 para <afirmación concreta>.
+- [Superdesign — How Airbnb Designs Their UI: A Design System Breakdown (2026)](https://superdesign.dev/blog/airbnb-design-system): usado en E-002 para los tamaños de card de listado de Airbnb.
+- [The A11Y Collective — How to Pick the Perfect Font Size: A Guide to WCAG Accessibility](https://www.a11y-collective.com/blog/wcag-minimum-font-size/): usado en E-003 para el piso práctico de 16px en mobile.
+- [Recite Me — How to Pick an Accessible Font Size for your Website](https://reciteme.com/news/accessible-font-size/): usado en E-003 para la recomendación de 18px con público 50+ y el señalamiento de 14px como insuficiente.

--- a/docs/missions/13-tamano-de-fuente/producto.md
+++ b/docs/missions/13-tamano-de-fuente/producto.md
@@ -1,0 +1,149 @@
+# Misión: <nombre> — Producto
+
+**Estado:** borrador
+
+**Última actualización:** AAAA-MM-DD
+
+[Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
+[Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
+
+<!--
+Este documento es la spec viva del resultado: qué construimos ahora y bajo qué reglas. El porqué vive en
+investigacion.md — aquí solo se enlaza. Se reescribe cuando el alcance cambia; no acumula historia.
+
+Gate de salida — producto.md está listo para experiencia.md cuando:
+- cada funcionalidad tiene formato JTBD, reglas y al menos un caso límite con comportamiento definido
+- cada funcionalidad enlaza una conclusión de investigacion.md y una señal de éxito
+- cada funcionalidad declara a qué lado del marketplace sirve, y qué necesita del otro lado para funcionar
+- no hay decisiones de producto delegadas a diseño o ingeniería
+- las decisiones propuestas tienen fecha límite en el README
+-->
+
+## Qué construimos: <resultado en una frase>
+
+<!--
+El recorte vigente del ideal y por qué sigue entregando el resultado central. Máximo cuatro párrafos
+cortos. El ideal completo vive en investigacion.md.
+-->
+
+**Resultado:** <qué podrá lograr una persona al finalizar esta entrega>.
+
+**Recorte respecto del ideal:** <qué dimensión se reduce y por qué sigue siendo suficiente>
+(ver [el ideal](./investigacion.md)).
+
+**Restricciones aceptadas:** <plataforma, cobertura geográfica, categorías, volumen inicial de
+profesionales>.
+
+## Funcionalidades
+
+| ID    | Funcionalidad                  | Lado         | Sustento     | Éxito |
+| ----- | ------------------------------ | ------------ | ------------ | ----- |
+| F-001 | <verbo + resultado observable> | buscador     | C-001, D-001 | M-001 |
+
+<a id="f-001"></a>
+
+### F-001 — <verbo + resultado observable>
+
+<!--
+Duplica este bloque por funcionalidad. Se escribe desde el resultado del usuario (working backwards):
+primero el JTBD, después las reglas. Si la respuesta de Datealo no se puede describir sin hablar de tablas
+o componentes, falta cerrar la decisión de producto.
+-->
+
+Cuando <usuario en contexto concreto>,
+quiero <acción>,
+para <resultado observable>.
+
+**Lado del marketplace:** buscador, profesional o ambos. **Qué necesita del otro lado:** <volumen mínimo
+de perfiles, reseñas o cobertura sin el cual esta funcionalidad no entrega su resultado>.
+
+**Sustento:** [C-001](./investigacion.md#c-001) y [D-001](#d-001). **Éxito:** [M-001](#m-001).
+
+**Reglas:**
+
+- Si <condición>, Datealo <comportamiento esperado>.
+- Si <caso límite>, Datealo <comportamiento seguro y qué información muestra>.
+- Datealo nunca <comportamiento que rompería el significado o la confianza>.
+
+**Ejemplo verificable:** dado <estado con datos concretos>, cuando <acción>, entonces <resultado
+observable>.
+
+**No incluye:** <variante del ideal excluida de esta funcionalidad>.
+
+**Experiencia:** <enlace a UXF-xxx cuando exista>. **Ingeniería:** <enlace a T-xxx cuando exista>.
+
+## Casos límite que cruzan funcionalidades
+
+<!--
+Solo condiciones que afectan varias funcionalidades. Las propias de una viven en su bloque. Un caso
+retirado no se borra ni se reutiliza: conserva su fila, o se nombra con su motivo en una línea debajo.
+
+Los casos límite propios de un marketplace pre-lanzamiento aparecen acá: cero resultados en una comuna,
+un profesional sin reseñas, una categoría con un solo perfil, un perfil sin verificar.
+-->
+
+| ID     | Condición concreta     | Comportamiento esperado | Funcionalidades |
+| ------ | ---------------------- | ----------------------- | --------------- |
+| CL-001 | <estado o combinación> | <qué hace Datealo>      | F-001           |
+
+## Fuera de alcance
+
+<!-- Distingue postergado de descartado y qué condición justificaría reabrirlo. -->
+
+| Capacidad o caso      | Estado                  | Razón del recorte | Condición para reconsiderar |
+| --------------------- | ----------------------- | ----------------- | --------------------------- |
+| <capacidad del ideal> | postergada o descartada | <trade-off>       | <evidencia o hito>          |
+
+## Señales de éxito
+
+<a id="m-001"></a>
+
+### M-001 — <señal que demuestra el resultado>
+
+- **Pregunta:** ¿<qué queremos comprobar>?
+- **Señal:** <comportamiento o resultado observable>.
+- **Método y umbral:** <instrumentación o revisión, qué resultado, en qué población y ventana>.
+- **Guardrail:** <daño que no debe aumentar para conseguir la señal>.
+
+## Decisiones de producto
+
+<!--
+Solo decisiones con alternativas reales. No borres decisiones reemplazadas: explican por qué el producto
+es como es. Toda decisión propuesta se refleja en el README con fecha límite.
+-->
+
+<a id="d-001"></a>
+
+### D-001 — <decisión en una frase que se entiende sola>
+
+- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
+- **Sustento:** [C-001](./investigacion.md#c-001).
+- **Tensión:** <criterios que no podían maximizarse al mismo tiempo>.
+- **Alternativas descartadas:** <opciones y razón concreta del rechazo, en la misma línea>.
+- **Decisión y consecuencia:** <qué se hará y qué habilita, limita o exige revisar en UX e ingeniería>.
+- **Reapertura:** <evidencia o cambio que justificaría revisarla>.
+
+## Preguntas
+
+<!--
+Solo preguntas que pueden cambiar una decisión o funcionalidad. Lo demás va a un issue.
+Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
+Estado: abierta | resuelta AAAA-MM-DD (alguien la respondió) | disuelta AAAA-MM-DD (el producto cambió y la
+pregunta dejó de tener sentido). Solo las abiertas llevan bloque de detalle debajo de la tabla.
+-->
+
+<Una frase que responde "¿qué falta?": la pregunta que bloquea y qué bloquea.>
+
+| ID    | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
+| ----- | ---------------------- | ------------------- | --------------------------------------------------------------- |
+| Q-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
+| Q-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |
+
+<a id="q-001"></a>
+
+### Q-001 — <la pregunta en una frase que se entiende sola>
+
+- **La duda, con un ejemplo:** <el caso concreto que muestra por qué hay dos respuestas posibles>.
+- **Afecta a:** D-001 o F-001.
+- **Cómo se resolverá:** <quién y con qué método>.
+- **¿Bloquea algo?:** <qué bloquea y su fecha límite, o no>.

--- a/docs/missions/13-tamano-de-fuente/producto.md
+++ b/docs/missions/13-tamano-de-fuente/producto.md
@@ -1,8 +1,8 @@
-# Misión: <nombre> — Producto
+# Misión 13: Tamaño de fuente — Producto
 
-**Estado:** borrador
+**Estado:** vigente — aprobado por Patricio el 2026-09-06
 
-**Última actualización:** AAAA-MM-DD
+**Última actualización:** 2026-09-06
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
@@ -19,30 +19,44 @@ Gate de salida — producto.md está listo para experiencia.md cuando:
 - las decisiones propuestas tienen fecha límite en el README
 -->
 
-## Qué construimos: <resultado en una frase>
+## Qué construimos: subir un escalón la escala tipográfica en buscador, cards y perfiles
 
 <!--
 El recorte vigente del ideal y por qué sigue entregando el resultado central. Máximo cuatro párrafos
 cortos. El ideal completo vive en investigacion.md.
 -->
 
-**Resultado:** <qué podrá lograr una persona al finalizar esta entrega>.
+**Resultado:** cualquier persona lee el nombre, la comuna, el precio, el rating, la descripción y el botón
+de contacto de un profesional en el buscador, la card de resultados y ambos perfiles sin acercar el
+celular ni entrecerrar los ojos — el texto secundario deja de estar en 12px, el principal deja de estar en
+14px, y el tamaño y el color correctos quedan fijados como default del sistema, no como algo que dependa
+de que cada archivo se edite a mano.
 
-**Recorte respecto del ideal:** <qué dimensión se reduce y por qué sigue siendo suficiente>
-(ver [el ideal](./investigacion.md)).
+**Recorte respecto del ideal:** el ideal (ver [el ideal](./investigacion.md)) habla de una jerarquía que
+se distingue por peso y color en vez de por tamaño. Esta entrega solo sube el tamaño de los dos
+escalones actuales (12→14px, 14→16px); no rediseña la jerarquía visual (peso, color, espaciado) — eso
+queda condicionado a [Q-001](#q-001), abierta.
 
-**Restricciones aceptadas:** <plataforma, cobertura geográfica, categorías, volumen inicial de
-profesionales>.
+**Restricciones aceptadas:** solo las cuatro superficies donde el dueño de producto detectó el problema —
+buscador (`CompactSearchBar`, `CompactSearchBarPanel`), resultados de búsqueda (`buscar/index.vue`,
+`SearchResultCard`, `SearchEmptyState`), perfil público (`[id].vue`, `ProfessionalPublicContactBar`,
+`ProfessionalPublicReviews`, `ProfessionalPublicReviewCard`) y perfil de gestión (`perfil.vue`,
+`ProfessionalAvatar`, `ProfessionalPhotos`, `ProfessionalCatalogRow`, `ProfessionalDataRow`,
+`CatalogSelect`) — incluyendo todo texto de uso frecuente dentro de esos componentes, no solo el elemento
+puntual que motivó la misión. No toca el hero de la landing (`LandingHeroSearch`, componente distinto, con
+su tamaño ya cerrado en la misión 12), el formulario de reseña (`ProfessionalPublicReviewSheet`, es una
+tarea, no lectura), ni ningún tamaño que ya esté en 16px o más (los nombres de perfil, ya en 20-24px, y
+los inputs de estas superficies que no pisan el default de Nuxt UI — ver E-004).
 
 ## Funcionalidades
 
-| ID    | Funcionalidad                  | Lado         | Sustento     | Éxito |
-| ----- | ------------------------------ | ------------ | ------------ | ----- |
-| F-001 | <verbo + resultado observable> | buscador     | C-001, D-001 | M-001 |
+| ID    | Funcionalidad                                                    | Lado  | Sustento           | Éxito |
+| ----- | ------------------------------------------------------------------ | ----- | -------------------- | ----- |
+| F-001 | Subir un escalón el texto principal y secundario del buscador, la card de resultados y los dos perfiles | ambos | C-001, C-002, C-003, D-001, D-002 | M-001 |
 
 <a id="f-001"></a>
 
-### F-001 — <verbo + resultado observable>
+### F-001 — Subir un escalón el texto principal y secundario del buscador, la card de resultados y los dos perfiles
 
 <!--
 Duplica este bloque por funcionalidad. Se escribe desde el resultado del usuario (working backwards):
@@ -50,27 +64,97 @@ primero el JTBD, después las reglas. Si la respuesta de Datealo no se puede des
 o componentes, falta cerrar la decisión de producto.
 -->
 
-Cuando <usuario en contexto concreto>,
-quiero <acción>,
-para <resultado observable>.
+Cuando reviso resultados de búsqueda o el perfil de un profesional desde mi celular, en la calle o con
+poca luz,
+quiero leer el nombre, la comuna, el precio, el rating y la descripción sin acercar la pantalla,
+para decidir a quién contactar sin el esfuerzo extra de forzar la vista.
 
-**Lado del marketplace:** buscador, profesional o ambos. **Qué necesita del otro lado:** <volumen mínimo
-de perfiles, reseñas o cobertura sin el cual esta funcionalidad no entrega su resultado>.
+**Lado del marketplace:** ambos — el buscador lee resultados y perfiles, el profesional lee y edita su
+propio perfil de gestión con el mismo texto. **Qué necesita del otro lado:** nada — es un cambio de
+legibilidad, no depende del volumen de oferta ni de cuántos profesionales o reseñas existan hoy.
 
-**Sustento:** [C-001](./investigacion.md#c-001) y [D-001](#d-001). **Éxito:** [M-001](#m-001).
+**Sustento:** [C-001](./investigacion.md#c-001), [C-002](./investigacion.md#c-002),
+[C-003](./investigacion.md#c-003), [D-001](#d-001) y [D-002](#d-002). **Éxito:** [M-001](#m-001).
 
-**Reglas:**
+**Regla general (para que ningún componente de estas cuatro superficies quede afuera por accidente):** un
+texto en 12px se mantiene en 12px solo si es un label de sección o un dato que se lee una sola vez y no
+informa una decisión activa ni bloquea completar algo (ej. "En Datealo desde…", la fecha relativa de una
+reseña, un badge de "verificado", los labels "Categorías"/"Comunas"/"Cerca de tu comuna"). Cualquier otro
+texto de 12px en estas superficies —mensajes de error, hints de acción, nombres o comentarios de reseñas,
+botones— sube a 14px como mínimo, y el texto que ya cumplía el rol "principal" de cada pantalla sube a
+16px.
 
-- Si <condición>, Datealo <comportamiento esperado>.
-- Si <caso límite>, Datealo <comportamiento seguro y qué información muestra>.
-- Datealo nunca <comportamiento que rompería el significado o la confianza>.
+**Reglas por archivo:**
 
-**Ejemplo verificable:** dado <estado con datos concretos>, cuando <acción>, entonces <resultado
-observable>.
+- `CompactSearchBar.vue`: el resumen de búsqueda ("Gasfitería en Ñuñoa") y las opciones de
+  categoría/comuna del selector desktop pasan de `text-sm`/`text-xs` a `text-base`/`text-sm`. El botón
+  "Buscar" del panel mobile pasa de `text-[0.9375rem]` (15px, no era ni siquiera un tamaño de la escala)
+  a `text-base` (16px) — es un CTA, mismo criterio que el botón de contacto.
+- `CompactSearchBarPanel.vue`: los nombres de categoría/comuna en la lista (`text-sm`) ya cumplen el piso
+  de secundario y no suben — son contenido bajo el título de la pantalla ("¿Qué necesitas?"/"¿Dónde?", ya
+  en `text-base`). Los labels "Categorías"/"Comunas" (11px) son exentos, igual que "En Datealo desde…".
+- `AppHeader.vue:46`, las iniciales dentro del avatar circular de la nav (12px en un círculo de 36×36px),
+  es exento — no es texto que se lea para decidir algo, es un glifo dentro de un ícono, y su tamaño ya
+  escala con el del círculo que lo contiene, igual que las iniciales de los avatares más grandes
+  (`SearchResultCard`, sidebar de `[id].vue`).
+- `SearchResultCard.vue`: el nombre del profesional pasa de `text-sm` a `text-base`; comuna, rating y
+  precio pasan de `text-xs` a `text-sm`. "En Datealo desde…" (11px) es exento — no sube.
+- `buscar/index.vue`: el contador de resultados ("4 resultados") pasa de `text-xs` a `text-sm`. El
+  mensaje de comunas vecinas ("Todavía no hay profesionales de X en Y") pasa de `text-sm` a `text-base` —
+  es el título de facto de ese estado, no hay otro texto más grande arriba. El label "Cerca de tu comuna"
+  (11px) es exento.
+- `SearchEmptyState.vue`: ya cumple el patrón (título 16px, subtítulo 14px) — no cambia.
+- `[id].vue`: la descripción y el precio pasan de `text-sm` a `text-base`; "En Datealo desde…" (12px) es
+  exento — no sube, mismo criterio que en la card. El subtítulo de "no encontramos este perfil" ya cumple
+  el patrón título/subtítulo (18px/14px) — no cambia.
+- `ProfessionalPublicContactBar.vue`: el CTA "Escribir por WhatsApp"/"Llamar" deja de renderizar a 14px:
+  pasa al tamaño que realmente rinde 16px en Nuxt UI (hoy `size="xl"`, o el default corregido por
+  [D-002](#d-002)).
+- `ProfessionalPublicReviews.vue`: el título "Reseñas" (`text-sm` extrabold, 14px) y el `cardHeading` de
+  la invitación a reseñar ("¿Cómo te fue con...?") suben a `text-base` — mismo criterio que
+  "Descripción"/"Precio" en el perfil de gestión, son encabezados de sección, no cuerpo de texto. El botón
+  para abrir el formulario no cambia (ya está en 14px, cumple el piso); el formulario en sí queda fuera de
+  alcance (ver más abajo).
+- `ProfessionalPublicReviewCard.vue`: el nombre de quien reseña y el comentario pasan de `text-sm` a
+  `text-base` (esto es lo que ya cubría "las reseñas" en la redacción original de esta regla). El badge
+  "verificado" y la fecha relativa (11px) son exentos.
+- `perfil.vue`: "Descripción", "Precio", sus valores y "Tus datos" pasan de `text-sm` a `text-base`.
+  "Editar" y los mensajes de error de validación (`hasDescriptionError`, `hasPriceError`) pasan de
+  `text-xs` a `text-sm` — un error bloquea guardar, no es texto que se lee una sola vez. "Cargando tu
+  perfil…" y el error de carga (`loadError`, línea 69) pasan de `text-sm` a `text-base` — son el único
+  contenido de esos dos estados, no hay ningún título más grande arriba (mismo criterio que el mensaje de
+  comunas vecinas en `buscar/index.vue`).
+- `ProfessionalAvatar.vue`: todo su texto de apoyo pasa de `text-xs` a `text-sm` — el hint sin foto ("Para
+  que te reconozcan antes de escribirte. Opcional.", explica el porqué, no es decorativo), el hint con
+  foto ("Toca la foto para cambiarla"), el link "Quitar foto" y los errores de subida/eliminación.
+- `ProfessionalPhotos.vue`, `ProfessionalCatalogRow.vue`, `ProfessionalDataRow.vue`: sus mensajes de
+  error de carga/guardado pasan de `text-xs` a `text-sm`, mismo criterio que los errores de `perfil.vue` —
+  viven en la misma superficie de gestión, factorizados en componentes propios.
+- `perfil.vue:138` (campo de precio) y `ProfessionalDataRow.vue:46` (campos de "Tus datos") pisan a
+  propósito el default de `UInput` con `size="sm"` (14px) — pasan a `size="lg"` o `"xl"` para volver al
+  16px que ya tiene el resto de los inputs de la app sin necesidad de ese override.
+- `CatalogSelect.vue:174`, el botón "Reintentar" del selector de categoría/comuna, pasa de `size="sm"`
+  (12px) a `size="md"` (14px) — ningún botón de estas superficies queda en 12px, mismo criterio general.
+- Ningún texto de uso frecuente de estas superficies usa un modificador de opacidad (`text-datealo-text/50`,
+  `/75`, etc.) para lograr un tono secundario — el único tono aceptado es `text-datealo-muted`, que ya
+  cumple el contraste mínimo (E-005).
+- Si un nombre o una comuna no entran en el ancho disponible de la card en 390px, Datealo sigue
+  truncando con `…` — el tamaño más grande no cambia esa regla, solo cuánto texto entra antes de truncar.
 
-**No incluye:** <variante del ideal excluida de esta funcionalidad>.
+**Fuera de esta funcionalidad:** `ProfessionalPublicReviewSheet.vue` (el formulario para escribir una
+reseña) no está cubierto — es un flujo de completar una tarea, no de leer sin acercar la pantalla, y
+ninguna evidencia de `investigacion.md` lo señaló como chico. Ver "Fuera de alcance".
 
-**Experiencia:** <enlace a UXF-xxx cuando exista>. **Ingeniería:** <enlace a T-xxx cuando exista>.
+**Ejemplo verificable:** dado un profesional con nombre "María Fernanda Rojas Ilabaca" en la comuna
+"San José de Maipo" y precio "$25.000", cuando se abre la card de resultados en 390px de ancho, entonces
+el nombre se ve en 16px, la comuna y el precio en 14px, y ninguno de los tres corta de forma distinta a
+como corta hoy en 12/14px (mismo truncado, tamaño más grande).
+
+**No incluye:** el rediseño de qué distingue visualmente al texto principal del secundario más allá del
+tamaño (peso, color) — queda condicionado a [Q-001](#q-001). Tampoco incluye auditar cada `UButton` o
+color de la app fuera de las cuatro superficies — solo el CTA de contacto, que vive en el perfil público.
+
+**Experiencia:** pendiente. **Ingeniería:** pendiente.
 
 ## Casos límite que cruzan funcionalidades
 
@@ -82,28 +166,52 @@ Los casos límite propios de un marketplace pre-lanzamiento aparecen acá: cero 
 un profesional sin reseñas, una categoría con un solo perfil, un perfil sin verificar.
 -->
 
-| ID     | Condición concreta     | Comportamiento esperado | Funcionalidades |
-| ------ | ---------------------- | ----------------------- | --------------- |
-| CL-001 | <estado o combinación> | <qué hace Datealo>      | F-001           |
+| ID     | Condición concreta                                                                 | Comportamiento esperado                                                                 | Funcionalidades |
+| ------ | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------ | --------------- |
+| CL-001 | Nombre y comuna largos juntos en la card de resultados en 390px (ej. "María Fernanda Rojas Ilabaca" en "San José de Maipo"), con el texto más grande | Datealo sigue truncando cada línea con `…` por separado; la card puede crecer unos px de alto, pero nunca fuerza scroll horizontal ni corta a mitad de palabra sin `…` | F-001 |
+| CL-002 | Retirada — evaluaba qué pasaba si D-002 corregía el default de `UButton` en `app.config.ts` en vez de subir cada CTA puntualmente | Ingeniería.md descartó esa vía (ver [T-001](./ingenieria.md#t-001)): su radio de efecto tocaba botones fuera de las cuatro superficies (`registro.vue`/`ingresar.vue`, los "Reintentar" que esta misión no cambia). El caso límite que anticipaba no llega a ocurrir | F-001, D-002 |
 
 ## Fuera de alcance
 
 <!-- Distingue postergado de descartado y qué condición justificaría reabrirlo. -->
 
-| Capacidad o caso      | Estado                  | Razón del recorte | Condición para reconsiderar |
-| --------------------- | ----------------------- | ----------------- | --------------------------- |
-| <capacidad del ideal> | postergada o descartada | <trade-off>       | <evidencia o hito>          |
+| Capacidad o caso                                                                 | Estado      | Razón del recorte | Condición para reconsiderar |
+| ----------------------------------------------------------------------------------- | ----------- | -------------------- | ------------------------------- |
+| Rediseñar la jerarquía visual con peso/color en vez de solo tamaño                   | postergada  | Q-001 sigue abierta: no sabemos todavía si subir el tamaño alcanza o si además hace falta tocar peso/color. Forzar un rediseño ahora sería adelantarse a esa respuesta. | Q-001 se resuelve y muestra que el tamaño solo no basta |
+| Tocar el hero de la landing (`LandingHeroSearch`) o su CTA                           | descartada  | Es un componente distinto, con su tamaño ya cerrado como decisión vigente en la misión 12 (hero y copy de la landing) — no es parte de lo que Patricio señaló como chico | Evidencia nueva y específica sobre el hero, tratada como su propia misión |
+| Subir tamaños que ya están en 16px o más (nombre de perfil, en 20-24px)             | descartada  | No hay evidencia (E-001, E-002, E-003) de que esos tamaños crucen ningún piso de legibilidad ni se vean chicos frente al benchmark | Evidencia nueva que muestre que esos tamaños también son un problema |
+| Tamaños del formulario para escribir una reseña (`ProfessionalPublicReviewSheet`)   | descartada  | Es un flujo de completar una tarea, no de leer sin acercar la pantalla — investigacion.md nunca lo evidenció como parte de la sensación "chico" | Evidencia nueva y específica sobre ese formulario |
+| Corregir el contraste de `text-datealo-text/50` en `LandingForProfessionals.vue` ("+200 reseñas") | descartada de F-001 | Es un componente de la landing, fuera de las cuatro superficies que abrieron esta misión — aunque E-005 lo documenta como evidencia de que la opacidad reduce contraste por debajo de AA | Es un bug de un archivo, 100% reversible: puede ir directo a issue sin misión (ver "Carril según riesgo" en `docs/missions/README.md`), no necesita esperar a esta misión |
+| Auditar o cambiar el tamaño de cada `UButton`/color de la app fuera de las cuatro superficies | descartada de F-001 | El mecanismo de D-002 (si se implementa vía `app.config.ts`) puede afectarlos igual, pero revisar uno por uno que ningún layout se rompa es trabajo de ingeniería, no una funcionalidad nueva de esta misión | Ingeniería.md reporta una regresión real al implementar D-002 |
 
 ## Señales de éxito
 
 <a id="m-001"></a>
 
-### M-001 — <señal que demuestra el resultado>
+### M-001 — Ningún texto de uso frecuente queda por debajo del piso de legibilidad definido
 
-- **Pregunta:** ¿<qué queremos comprobar>?
-- **Señal:** <comportamiento o resultado observable>.
-- **Método y umbral:** <instrumentación o revisión, qué resultado, en qué población y ventana>.
-- **Guardrail:** <daño que no debe aumentar para conseguir la señal>.
+<!--
+Datealo sigue sin usuarios ni analítica de uso (pre-lanzamiento): no hay ratio de comportamiento que
+medir todavía. La señal disponible hoy es una verificación de diseño, no una métrica de producto — se
+reemplaza por una señal de comportamiento real ni bien haya tráfico (ver revisión pendiente en M-001).
+-->
+
+- **Pregunta:** ¿el buscador, la card de resultados, los dos perfiles y su CTA de contacto dejaron de
+  tener texto de uso frecuente en 12px, en 14px donde debía subir a 16px, o con opacidad reduciendo el
+  contraste por debajo de 4.5:1?
+- **Señal:** cero elementos de texto de uso frecuente (nombre, comuna, precio, rating, descripción,
+  reseña, CTA de contacto) en `text-xs`, en un tamaño renderizado real bajo 16px, o con un modificador de
+  opacidad sobre su color, en las cuatro superficies de F-001 — verificado contra las reglas de F-001.
+- **Método y umbral:** revisión de código (grep de las clases listadas en F-001, más el tamaño renderizado
+  real del CTA de contacto según el theme de Nuxt UI) más una captura en 390px de cada superficie,
+  comparada antes/después. Umbral: 100% de los elementos listados en las reglas de F-001 migrados, cero
+  regresiones en el resto de la app.
+- **Guardrail:** ninguna card de resultados fuerza scroll horizontal en 390px, y el layout de los
+  perfiles no rompe (validar con `npx playwright screenshot --viewport-size=390,844` por página tocada).
+
+**Revisión pendiente:** cuando Datealo tenga tráfico real, reemplazar o complementar esta señal por una de
+comportamiento (ej. tiempo en pantalla de resultados, tasa de contacto desde la card) — hoy no hay datos
+de uso que la sostengan.
 
 ## Decisiones de producto
 
@@ -114,14 +222,61 @@ es como es. Toda decisión propuesta se refleja en el README con fecha límite.
 
 <a id="d-001"></a>
 
-### D-001 — <decisión en una frase que se entiende sola>
+### D-001 — La escala tipográfica sube un escalón en cada rol: el secundario pasa de 12 a 14px, el principal de 14 a 16px
 
-- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
-- **Sustento:** [C-001](./investigacion.md#c-001).
-- **Tensión:** <criterios que no podían maximizarse al mismo tiempo>.
-- **Alternativas descartadas:** <opciones y razón concreta del rechazo, en la misma línea>.
-- **Decisión y consecuencia:** <qué se hará y qué habilita, limita o exige revisar en UX e ingeniería>.
-- **Reapertura:** <evidencia o cambio que justificaría revisarla>.
+- **Estado:** aceptada — aprobado por Patricio el 2026-09-06. **Fecha:** 2026-09-06.
+- **Sustento:** [C-001](./investigacion.md#c-001), [C-002](./investigacion.md#c-002).
+- **Tensión:** legibilidad/accesibilidad (subir el tamaño) contra densidad visual (una card o un bloque de
+  perfil ocupa más alto en pantalla, cabe menos contenido de un vistazo en 390px).
+- **Alternativas descartadas:**
+  - Mantener 12/14px y mejorar solo contraste o peso de fuente — descartada porque no resuelve el piso de
+    accesibilidad de E-003 (16px como estándar práctico de body text mobile); el texto seguiría siendo
+    chico, solo más oscuro.
+  - Subir solo el texto principal (14→16px) y dejar el secundario en 12px — descartada porque el
+    secundario (comuna, precio, rating) es justo el que C-002 identifica cruzando el piso de legibilidad;
+    dejarlo intacto no cierra el problema que abrió la misión.
+  - Saltar directo a valores mayores al benchmark de Airbnb (18px en el principal) — descartada por ahora:
+    no hay evidencia (E-002 es de confianza baja, E-003 no lo exige) que sostenga ir más allá del piso de
+    accesibilidad; sería sobre-corregir sin dato que lo respalde.
+- **Decisión y consecuencia:** el texto de uso frecuente en las cuatro superficies de F-001 sube un
+  escalón por rol: `text-xs`→`text-sm` en secundario, `text-sm`→`text-base` en principal. Esto exige que
+  `experiencia.md` revise si el espaciado y el alto de la card de resultados siguen viéndose bien con más
+  texto, y que ingeniería solo cambie clases Tailwind — no toca datos ni contratos.
+- **Reapertura:** si tras implementarlo alguien (dueño de producto, un tester real) sigue viendo el texto
+  chico, o si [Q-001](#q-001) concluye que hace falta un escalón más.
+
+<a id="d-002"></a>
+
+### D-002 — La corrección se fija como default del sistema, no como edición puntual de cada archivo
+
+- **Estado:** aceptada — aprobado por Patricio el 2026-09-06. **Fecha:** 2026-09-06.
+- **Sustento:** [C-003](./investigacion.md#c-003).
+- **Tensión:** consistencia a prueba de error (fijar un default global que ningún componente nuevo pueda
+  saltarse sin querer) contra flexibilidad puntual (poder ajustar un caso específico sin heredar ese
+  default).
+- **Alternativas descartadas:**
+  - Editar cada `UButton` o clase de color caso por caso, confiando en que quien agregue un componente
+    nuevo repita el patrón de memoria — descartada: es exactamente el riesgo que motivó esta decisión
+    ("sin espacios para errores"); un componente nuevo puede reintroducir 12px o una opacidad sin que
+    nadie lo note hasta que alguien vuelva a comparar con Airbnb.
+  - Agregar una regla de lint/CI que bloquee `text-xs` y modificadores de opacidad en texto — descartada
+    por ahora: exige mantener una lista de excepciones legítimas (ej. "En Datealo desde…" sí puede ser
+    `text-xs`) y hoy el código no distingue "texto de uso frecuente" de "texto que se lee una vez" de
+    forma que un lint pueda verificar solo; queda como opción a evaluar en `ingenieria.md` si el default
+    de configuración no alcanza.
+  - Documentar la regla en una guía de convenciones sin verificación técnica — descartada: una convención
+    que nadie verifica es el mismo espacio para el error que esta decisión busca cerrar.
+- **Decisión y consecuencia:** ingeniería.md evaluó el candidato de `app.config.ts` y lo descartó — su
+  radio de efecto se sale de las cuatro superficies de F-001 (ver [T-001](./ingenieria.md#t-001)). El
+  mecanismo real es distinto al que esta decisión imaginaba, pero cumple el mismo objetivo por otra vía:
+  el piso tipográfico quedó agregado al skill `write-code`, que el proyecto invoca obligatoriamente antes
+  de escribir o editar cualquier `.vue`/`.ts` — no es "una guía de convenciones sin verificación" (la
+  alternativa ya descartada arriba), porque leerlo no es opcional ni depende de la memoria de quien
+  escribe: es un paso del flujo, igual que `typecheck` antes de cerrar un cambio. Ningún componente propio
+  de Datealo usa un modificador de opacidad sobre color de texto — el único tono aceptado para texto
+  secundario es `text-datealo-muted`.
+- **Reapertura:** si ingeniería.md encuentra que el default global rompe otros usos de `UButton` que
+  dependían del tamaño chico a propósito (ej. un botón secundario de baja jerarquía visual).
 
 ## Preguntas
 
@@ -132,18 +287,24 @@ Estado: abierta | resuelta AAAA-MM-DD (alguien la respondió) | disuelta AAAA-MM
 pregunta dejó de tener sentido). Solo las abiertas llevan bloque de detalle debajo de la tabla.
 -->
 
-<Una frase que responde "¿qué falta?": la pregunta que bloquea y qué bloquea.>
+Falta saber si subir el tamaño alcanza o si además hace falta rediseñar la jerarquía visual — sin
+resolverla no se puede cerrar si `experiencia.md` solo ajusta números o también retoca peso/color.
 
-| ID    | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
-| ----- | ---------------------- | ------------------- | --------------------------------------------------------------- |
-| Q-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
-| Q-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |
+| ID    | La duda                                                                              | Estado  | Respuesta, o quién la resuelve                                                                          |
+| ----- | --------------------------------------------------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------- |
+| Q-001 | ¿Alcanza con subir el tamaño (D-001), o el texto secundario necesita además más peso o contraste para distinguirse del principal? | abierta | Dueño de producto, revisando una captura en 390px del antes/después de F-001 ya implementado. Bloquea si `experiencia.md` toca solo tamaños o también peso/color; sin fecha límite, se resuelve al revisar el primer PR de F-001. |
 
 <a id="q-001"></a>
 
-### Q-001 — <la pregunta en una frase que se entiende sola>
+### Q-001 — ¿Alcanza con subir el tamaño o hace falta además rediseñar la jerarquía visual?
 
-- **La duda, con un ejemplo:** <el caso concreto que muestra por qué hay dos respuestas posibles>.
-- **Afecta a:** D-001 o F-001.
-- **Cómo se resolverá:** <quién y con qué método>.
-- **¿Bloquea algo?:** <qué bloquea y su fecha límite, o no>.
+- **La duda, con un ejemplo:** en `SearchResultCard`, si el nombre pasa a 16px bold y la comuna/precio a
+  14px normal, ¿la diferencia se sigue notando de un vistazo, o el salto de un solo escalón (16 vs 14px)
+  hace que ambos textos "compitan" visualmente y haga falta bajarle el peso o el contraste de color al
+  secundario para que la jerarquía se mantenga clara?
+- **Afecta a:** [D-001](#d-001) y [F-001](#f-001).
+- **Cómo se resolverá:** el dueño de producto revisa una captura de F-001 ya implementado en 390px, antes
+  de aprobar `experiencia.md` como definitivo.
+- **¿Bloquea algo?:** no bloquea empezar `experiencia.md` ni la implementación de F-001 — bloquea
+  únicamente si `experiencia.md` necesita una segunda vuelta para ajustar peso/color además de tamaño. Sin
+  fecha límite.

--- a/docs/missions/14-multiples-categorias-profesional/README.md
+++ b/docs/missions/14-multiples-categorias-profesional/README.md
@@ -1,0 +1,41 @@
+# Misión 14 — Múltiples categorías por profesional
+
+**Tipo:** producto. **Carril:** Full Spec — toca el modelo de datos de `professionals` (hoy una sola
+categoría por profesional) y cómo `/api/search` filtra por categoría. **Abierta el** 2026-09-06.
+**Nace de:** ninguna.
+
+**Estado de la misión:** exploración
+
+**En foco:** Investigación
+
+**Última actualización:** 2026-09-06
+
+**Documentos:** [Investigación](./investigacion.md) · [Producto](./producto.md) ·
+[Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
+
+**Próximo hito:** completar `investigacion.md` con el problema concreto y evidencia de que un profesional
+real ofrece más de un oficio — sin fecha límite todavía, recién se abre la misión.
+
+## Brief
+
+Hoy un profesional declara una sola categoría (gasfitería, electricidad, etc.) en su perfil. En la
+práctica, muchos profesionales de oficios cubren más de un rubro relacionado — el ejemplo que dio el
+dueño de producto: alguien que es electricista y también gasfiter. Con una sola categoría, ese profesional
+solo aparece en las búsquedas de una de las dos, perdiendo la otra mitad de su demanda potencial — y
+Datealo pierde cobertura de oferta en la categoría donde ese profesional no quedó registrado.
+
+## Temas a explorar
+
+- **Cuántas categorías tiene sentido permitir.** ¿Sin límite, o un tope razonable (2-3) para que el perfil
+  siga siendo legible y no se use como spam de categorías para aparecer en todo?
+- **Cómo se ve en el perfil público y en las cards de resultado.** Hoy la categoría es un dato singular en
+  varios lugares (`categoriaNombre` en la card, en el perfil) — mostrar 2-3 categorías sin romper la
+  jerarquía visual existente.
+- **Cómo busca alguien.** Si el buscador sigue siendo "una categoría a la vez" (`/buscar?categoria=X`), un
+  profesional con 2 categorías debe aparecer en los resultados de cualquiera de las dos que tenga.
+- **Impacto en el modelo de datos.** Hoy `professionals` probablemente tiene la categoría como columna
+  simple — pasar a múltiples categorías es una tabla de relación nueva (`professional_categorias` o
+  similar), con su propia policy RLS y migración de los datos existentes (cada profesional actual conserva
+  su única categoría de hoy como la primera).
+- **Impacto en `/api/search`.** El filtro por categoría pasa de una comparación simple a un `EXISTS`/join
+  contra la tabla de relación — evaluar costo de query y si necesita índice nuevo.

--- a/docs/missions/14-multiples-categorias-profesional/experiencia.md
+++ b/docs/missions/14-multiples-categorias-profesional/experiencia.md
@@ -1,0 +1,183 @@
+# Misión: <nombre> — Experiencia
+
+**Estado:** borrador
+
+**Última actualización:** AAAA-MM-DD
+
+[Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
+[Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
+
+<!--
+Fuente de verdad para flujos, estados, contenido e interacción. No redefine reglas de producto: si el
+diseño descubre una regla nueva o invalida una, abre o actualiza una decisión en producto.md.
+
+Núcleo obligatorio: vistas, mapa de estados, flujos críticos y estados por superficie. Las secciones bajo
+demanda (modelo mental, jerarquía de información, validación) se agregan solo cuando una decisión las
+necesita.
+
+Gate de salida — experiencia.md está lista para ingenieria.md cuando:
+- cada flujo crítico tiene secuencia, variantes, recuperación y criterio de término
+- cada estado tiene contenido concreto (texto real, información visible, acción disponible)
+- cada vista lista sus modos, y el mapa de estados cubre todas las transiciones entre ellos
+- cada modo tiene su indicador permanente de estado, y cada flujo tiene todas sus salidas documentadas
+- los casos límite de producto.md tienen flujo o estado mapeado
+- cada flujo crítico está mockeado en móvil (390px), y en desktop si también vive ahí
+- ninguna pantalla queda descrita como "similar a X" sin especificar qué cambia
+-->
+
+## Decisión de experiencia: <qué cambia para quien usa el producto>
+
+<Modelo de interacción elegido, flujo más importante y la incertidumbre que sigue abierta.>
+
+- **Funcionalidades cubiertas:** F-001, <otras>.
+- **Pendiente bloqueante:** <pregunta o "ninguna">.
+
+## Vistas
+
+<!--
+El listado de pantallas que define la experiencia — el mapa que se entrega antes de los flujos. Una línea
+por vista, sin tabla, con sus modos anidados debajo. Una vista es un destino: se llega a ella. Un modo es
+un estado de esa vista que cambia qué se puede hacer y qué se ve — se anida, nunca se lista como vista
+hermana.
+
+El porqué de cada vista, su trade-off o su justificación no van aquí: viven en su flujo (UXF) o en una
+decisión (UX-xxx). Regla de formato para todo el documento: las tablas se reservan para índices de celdas
+cortas; lo que lleva justificación extensa va en secciones con header + bullets, nunca en una celda.
+-->
+
+- **V-001 — <vista>** · móvil / desktop · resuelve F-001 · flujos UXF-001 · pendiente
+  - modo **<nombre>** — <qué lo distingue y qué se puede hacer en él>
+  - modo **<nombre>** — <ídem>
+
+## Mapa de estados
+
+<!--
+Vistas y flujos son listas, y una lista no muestra un camino. Esta tabla conecta los modos: qué acción
+lleva de uno a otro y qué pasa con el trabajo del usuario en cada salto. Cada fila que falte es una
+pregunta que ingeniería resuelve inventando.
+-->
+
+| Desde  | Acción             | Queda en | Qué pasa con el trabajo              |
+| ------ | ------------------ | -------- | ------------------------------------ |
+| <modo> | <acción concreta>  | <modo>   | <qué se aplicó, qué quedó pendiente> |
+| <modo> | <salir sin cerrar> | <modo>   | <qué se pierde o se conserva>        |
+
+## UXF-001 — <flujo principal en verbo>
+
+<!--
+Duplica por flujo crítico. Cada paso describe acción → respuesta al nivel de "el usuario toca X → Datealo
+muestra Y". Un mockup no reemplaza la secuencia porque no explica estados ni recuperación.
+-->
+
+**Objetivo:** <qué se completa o comprende>. **Contrato:** [F-001](./producto.md#f-001).
+
+**Punto de entrada:** <estado y superficie inicial, y qué acción trae al usuario hasta acá>.
+
+**Criterio de término:** <estado observable que confirma que el flujo terminó bien>.
+
+**Cómo sabe el usuario dónde está:** <el elemento concreto y permanente en pantalla que se lo dice, por
+cada modo que toca este flujo>.
+
+### Salidas
+
+<!--
+Todas las formas de irse, no solo terminar bien. El criterio de término cubre la salida buena; las otras
+son las que el usuario encuentra primero. Un modo del que no se sabe salir es un modo donde el usuario se
+pierde.
+-->
+
+| Salida                | Cómo se ejecuta       | Qué queda del trabajo           |
+| --------------------- | --------------------- | ------------------------------- |
+| <termina bien>        | <acción>              | <qué se aplicó y dónde>         |
+| <descarta>            | <acción, Esc, cerrar> | <nada, ni a medias>             |
+| <abandona sin cerrar> | <navega a otra parte> | <se conserva, se pierde, avisa> |
+
+### Secuencia principal
+
+| Paso | Acción            | Respuesta del sistema         | Información visible |
+| ---- | ----------------- | ----------------------------- | ------------------- |
+| 1    | <acción concreta> | <feedback o cambio de estado> | <dato y jerarquía>  |
+
+### Variantes y recuperación
+
+| Condición          | Qué cambia              | Cómo se entiende    | Cómo se recupera             |
+| ------------------ | ----------------------- | ------------------- | ---------------------------- |
+| <sin resultados>   | <estado>                | <mensaje concreto>  | <acción disponible>          |
+| <sin permiso de ubicación> | <comportamiento> | <indicador visible> | <alternativa manual>         |
+| <conexión lenta>   | <skeleton, no spinner>  | <qué se ve mientras>| <qué pasa si falla>          |
+
+### Decisiones que no deben quedar implícitas
+
+- <qué ocurre al cancelar, volver atrás, reintentar o confirmar>.
+- <qué cambio se guarda inmediato y cuál necesita confirmación>.
+
+## Estados por superficie
+
+<!--
+El contenido es concreto: texto real, no "mensaje apropiado". El estado vacío de un marketplace
+pre-lanzamiento no es un detalle: para muchas búsquedas será el estado principal durante meses.
+-->
+
+| Estado  | Qué se muestra (texto e información real) | Acción disponible                   |
+| ------- | ----------------------------------------- | ----------------------------------- |
+| inicial | <contenido>                               | <acción>                            |
+| vacío   | <por qué está vacío, con texto concreto>  | <cómo avanzar, o ninguna y por qué> |
+| carga   | <skeleton de qué forma>                   | <ninguna>                           |
+| error   | <causa útil y alcance>                    | <recuperación>                      |
+
+## Mockups
+
+<!--
+Los mockups viven en design-mockups/ como HTML (ver el skill discovery-ux y docs/design/README.md).
+Exploran o materializan una decisión; no son fuente de verdad de reglas de producto.
+-->
+
+| Mockup   | Cubre   | Estado                 | Ruta                              |
+| -------- | ------- | ---------------------- | --------------------------------- |
+| <nombre> | UXF-001 | exploración o validado | `./design-mockups/<archivo>.html` |
+
+## Cobertura
+
+<!-- Detecta huecos antes de construir. Una funcionalidad sin pantalla nueva igual tiene estados. -->
+
+| Funcionalidad | Flujo   | Estados cubiertos       | Estado    |
+| ------------- | ------- | ----------------------- | --------- |
+| F-001         | UXF-001 | principal, vacío, error | pendiente |
+
+## Secciones bajo demanda
+
+<!--
+Agregar solo cuando una decisión las necesite, con estos títulos:
+
+- "Modelo mental y lenguaje": cuando un concepto de producto pueda confundirse en la interfaz.
+- "Jerarquía de información": cuando una superficie densa exija decidir qué se ve primero (una card de
+  resultado con foto, rating, distancia, precio y disponibilidad es exactamente ese caso).
+- "Validación (UXV-xxx)": cuando una incertidumbre de diseño necesite prueba con usuarios.
+- "Accesibilidad y adaptación": cuando el contexto de uso cambie el flujo o la representación.
+-->
+
+## Decisiones de experiencia
+
+<a id="ux-001"></a>
+
+### UX-001 — <decisión en una frase>
+
+- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
+- **Sustento:** F-001 o <hallazgo>.
+- **Alternativas descartadas:** <opciones relevantes y trade-off, con el porqué del rechazo>.
+- **Decisión y consecuencia:** <qué flujo o superficie cambia>.
+- **Impacto en producto:** <ninguno o enlace a D-xxx/F-xxx actualizado>.
+
+## Preguntas
+
+<!--
+Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
+Estado: abierta | resuelta AAAA-MM-DD | disuelta AAAA-MM-DD. Solo las abiertas llevan bloque de detalle.
+-->
+
+<Una frase que responde "¿qué falta?": la pregunta que bloquea construcción y qué bloquea.>
+
+| ID      | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
+| ------- | ---------------------- | ------------------- | --------------------------------------------------------------- |
+| UXQ-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
+| UXQ-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |

--- a/docs/missions/14-multiples-categorias-profesional/ingenieria.md
+++ b/docs/missions/14-multiples-categorias-profesional/ingenieria.md
@@ -1,0 +1,162 @@
+# Misión: <nombre> — Ingeniería
+
+**Estado:** borrador
+
+**Última actualización:** AAAA-MM-DD
+
+[Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
+[Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
+
+<!--
+Fuente de verdad para arquitectura, datos, contratos, factibilidad y pruebas. Consume el comportamiento
+definido en producto. Una limitación técnica cambia el alcance solo mediante una decisión explícita en
+producto.md.
+
+Núcleo obligatorio: contratos, modelo de datos, RLS y riesgos de factibilidad. Las secciones bajo demanda
+(migración, rendimiento, entrega por etapas) se agregan solo cuando el riesgo lo justifica.
+
+Gate de salida — ingenieria.md está lista para construir cuando:
+- los contratos definen qué entra, qué sale y qué invariantes se mantienen, sin ambigüedad
+- el modelo de datos soporta los casos límite de producto.md sin workarounds
+- el impacto en RLS está resuelto: qué policy se crea o cambia, o por qué ninguna
+- la migración de datos existentes tiene estrategia o está explícitamente fuera del alcance
+- los escenarios verificables de producto están mapeados a pruebas
+- el plan de construcción corta el diseño en slices atómicos ordenados (un slice = un Issue = un PR)
+-->
+
+## Decisión técnica: <arquitectura y riesgo principal>
+
+<Dirección técnica, trade-off principal y el riesgo que todavía podría invalidarla.>
+
+- **Contratos de producto cubiertos:** F-001, <otros>.
+- **Riesgo bloqueante:** <incertidumbre o "ninguna">.
+
+## Arquitectura: <cómo se divide la responsabilidad>
+
+<!--
+La lógica de negocio se separa de la infraestructura: funciones puras en utils/ y server/utils/,
+reactividad en composables, acceso a datos en server/api/ con Drizzle. Incluye diagrama solo cuando tres o
+más partes interactúan.
+-->
+
+<Descripción del enfoque y por qué satisface los contratos con menor riesgo.>
+
+| Componente | Responsabilidad       | No debe decidir | Contratos |
+| ---------- | --------------------- | --------------- | --------- |
+| <nombre>   | <una responsabilidad> | <frontera>      | F-001     |
+
+## Contratos
+
+<!--
+Cada contrato especifica entrada, salida e invariantes al nivel en que se puede implementar sin reuniones
+de aclaración. Incluye los errores observables y el código HTTP cuando es un endpoint.
+-->
+
+### TC-001 — <contrato en una frase>
+
+- **Entrada:** <datos y precondiciones, con tipos y forma concreta>.
+- **Salida:** <resultado y su forma concreta>.
+- **Invariantes:** <qué se cumple siempre: atomicidad, consistencia, idempotencia>.
+- **Errores:** <condición → código HTTP y cuerpo `{ error, code? }`, y qué puede hacer el llamador>.
+- **Contrato de producto:** [F-001](./producto.md#f-001).
+
+## Modelo de datos
+
+<!-- Entidades con significado, escritura y ciclo de vida. El schema completo vive en server/db/. -->
+
+| Entidad o campo | Significado             | Escritura          | Retención o historial |
+| --------------- | ----------------------- | ------------------ | --------------------- |
+| <dato>          | <semántica de producto> | <endpoint o acción>| <política>            |
+
+### Invariantes de datos
+
+- <unicidad, pertenencia, orden o consistencia temporal>.
+- <qué operación es atómica o qué dato tiene una única fuente de verdad>.
+
+### Impacto en RLS
+
+<!--
+Obligatorio. Fuente de verdad: server/db/sql/rls.sql. Si el cambio no toca ownership ni relaciones usadas
+en policies, decirlo explícitamente con esa razón — no dejar la sección vacía.
+-->
+
+| Tabla    | Cambio                 | Policy afectada | Acción                    |
+| -------- | ---------------------- | --------------- | ------------------------- |
+| <tabla>  | <nueva, ownership, FK> | <nombre>        | <crear, actualizar, nada> |
+
+## Riesgos y experimentos de factibilidad
+
+<!--
+Un riesgo que podría cambiar el producto se enlaza como pregunta o decisión en producto.md. Un experimento
+tiene pregunta, límite de tiempo y resultado capaz de cerrar la incertidumbre.
+-->
+
+| ID     | Riesgo o pregunta | Qué invalida        | Experimento o mitigación  | Criterio de salida      | Estado  |
+| ------ | ----------------- | ------------------- | ------------------------- | ----------------------- | ------- |
+| TR-001 | <incertidumbre>   | <alcance en riesgo> | <spike, prueba o recorte> | <resultado concluyente> | abierto |
+
+## Estrategia de pruebas
+
+<!-- Mapea los ejemplos verificables de producto.md a niveles de prueba. Qué demuestra cada una. -->
+
+| Contrato o riesgo | Nivel                          | Caso principal | Límite o falla |
+| ----------------- | ------------------------------ | -------------- | -------------- |
+| F-001, CL-001     | <unidad, contrato, integración>| <caso>         | <caso>         |
+
+### Propiedades que deben probarse
+
+- <invariante bajo reintentos, concurrencia o distintas entradas>.
+- <ausencia de efectos parciales en falla>.
+
+## Plan de construcción
+
+<!--
+Se completa al final, cuando el gate de salida se cumple y ninguna pregunta bloqueante sigue abierta —
+cortar sobre decisiones abiertas produce issues que mueren. Cada slice es un cambio funcional atómico: un
+Issue, un PR, ejecutable sin haber leído la misión (el issue lleva su contrato inline) y con criterios
+pass/fail enumerables como tests. Guía completa en el skill discovery-engineering.
+-->
+
+| ID    | Slice (una frase, sin "y") | Sustento      | Criterio de aceptación principal          | Depende de |
+| ----- | -------------------------- | ------------- | ----------------------------------------- | ---------- |
+| S-001 | <cambio atómico>           | TC-001, D-001 | <entrada concreta → resultado observable> | —          |
+
+## Secciones bajo demanda
+
+<!--
+Agregar solo cuando el riesgo lo justifique, con estos títulos:
+
+- "Migración y compatibilidad": cuando existan datos o consumidores que deben llegar al nuevo contrato.
+  Incluye rollback lógico si la migración física no puede revertirse.
+- "Rendimiento y observabilidad": cuando haya presupuesto de latencia o volumen que defender (búsqueda
+  geográfica y listados paginados son los candidatos naturales).
+- "SEO e indexación": cuando la superficie deba ser indexable (páginas por categoría + comuna, datos
+  estructurados).
+- "Entrega por etapas": cuando el cambio necesite despliegue incremental o feature flags.
+-->
+
+## Decisiones técnicas
+
+<a id="t-001"></a>
+
+### T-001 — <decisión en una frase>
+
+- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
+- **Contratos:** F-001 y <regla relevante>.
+- **Alternativas descartadas:** <opciones y trade-offs, con el porqué del rechazo>.
+- **Decisión y consecuencias:** <enfoque elegido, beneficio, costo y trabajo futuro aceptado>.
+- **Reapertura:** <medición o cambio que justificaría revisar>.
+
+## Preguntas
+
+<!--
+Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
+Estado: abierta | resuelta AAAA-MM-DD | disuelta AAAA-MM-DD. Solo las abiertas llevan bloque de detalle.
+-->
+
+<Una frase que responde "¿qué falta?": la pregunta que bloquea construcción y qué bloquea.>
+
+| ID     | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
+| ------ | ---------------------- | ------------------- | --------------------------------------------------------------- |
+| TQ-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
+| TQ-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |

--- a/docs/missions/14-multiples-categorias-profesional/investigacion.md
+++ b/docs/missions/14-multiples-categorias-profesional/investigacion.md
@@ -1,0 +1,118 @@
+# Misión: <nombre> — Investigación
+
+**Estado:** activo
+
+**Última actualización:** AAAA-MM-DD
+
+[Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
+[Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
+
+<!--
+Este documento se acumula: la evidencia y las conclusiones no se borran cuando el alcance cambia, porque
+explican por qué el producto es como es. Lo que sí se actualiza es el ideal, que resume la dirección que
+la investigación sostiene hoy.
+
+Gate de salida — la investigación sostiene un producto.md cuando:
+- el problema tiene situación y consecuencia concretas, no una categoría abstracta
+- al menos una conclusión con confianza alta o media respalda la dirección
+- el ideal describe capacidades observables, no intenciones
+-->
+
+## El problema aparece cuando <historia concreta>
+
+<!--
+Una situación real o reconstruida con precisión. No abras con una categoría como "falta de confianza" —
+abre con quién estaba haciendo qué y qué salió mal. Nombra a la persona y el servicio concreto.
+-->
+
+**Situación:** <qué está ocurriendo antes del problema>.
+
+**Acción o necesidad:** <qué se intenta resolver o decidir>.
+
+**Respuesta actual:** <qué hace hoy la persona: grupo de WhatsApp, Google, recomendación de un vecino,
+Datealo si ya existe la superficie>.
+
+**Consecuencia:** <error, demora, riesgo o decisión que no puede tomarse>.
+
+## Preguntas que la investigación debe resolver
+
+<!--
+Solo preguntas capaces de cambiar el ideal o una decisión. Al resolver una, moverla a evidencia o
+conclusión. No es un backlog.
+-->
+
+- ¿<pregunta y decisión que depende de ella>?
+
+## Evidencia
+
+<!--
+Un hecho verificable con fuente y límite. Prioriza observación directa, entrevistas y comportamiento
+comprobado. Los benchmarks de otros productos también son evidencia: qué hacen, qué trade-off eligieron y
+qué no aplica a Datealo.
+
+Datealo no tiene datos de uso propios todavía. Cuando la única evidencia disponible sea un benchmark o
+una entrevista, la columna "límite" es lo que impide que se lea como dato duro.
+-->
+
+| ID    | Tipo                                              | Fuente                | Hecho verificable | Límite de la evidencia |
+| ----- | ------------------------------------------------- | --------------------- | ----------------- | ---------------------- |
+| E-001 | <entrevista, benchmark, uso, código, observación> | <enlace o referencia> | <hecho>           | <qué no demuestra>     |
+
+<a id="e-001"></a>
+
+### E-001 — <fuente o hecho en una frase>
+
+<!--
+Desarrollar solo cuando la tabla no alcanza para evaluar la calidad de la evidencia. Cierra con la
+consecuencia para la investigación.
+-->
+
+<Observación precisa y contexto necesario.>
+
+Esto permite afirmar <alcance>, pero no demuestra <límite>.
+
+## Conclusiones
+
+<!--
+Una conclusión interpreta evidencia; no es una preferencia ni una funcionalidad. El título expresa el
+hallazgo, no el tema.
+-->
+
+<a id="c-001"></a>
+
+### C-001 — <conclusión en una frase>
+
+- **Sustento:** [E-001](#e-001).
+- **Razonamiento:** <por qué la evidencia conduce a esta lectura y no a otra>.
+- **Implicación:** <qué deberá ser cierto en el producto o qué alternativa queda debilitada>.
+- **Confianza:** <alta, media o baja> porque <razón o validación pendiente>.
+
+## El ideal: <resultado completo, sin recortar>
+
+<!--
+El ideal es el producto de la investigación: la dirección que la evidencia sostiene, sin restricciones de
+implementación. El recorte a la primera entrega no vive aquí — vive en producto.md como decisión de
+alcance. Esta sección sí se reescribe cuando nueva evidencia cambia la dirección.
+-->
+
+### El resultado ideal se ve así
+
+<Narra de principio a fin una situación futura con datos concretos: nombres, comunas, oficios, horarios.
+Qué acción ocurre, qué responde Datealo, qué decisión puede tomar la persona. Evita "una experiencia
+simple" sin comportamiento observable.>
+
+### Capacidades del ideal
+
+| Capacidad | Acción habilitada    | Respuesta esperada              | Conclusión que la justifica |
+| --------- | -------------------- | ------------------------------- | --------------------------- |
+| <nombre>  | <qué se puede hacer> | <qué produce o explica Datealo> | [C-001](#c-001)             |
+
+### El ideal no significa <confusión probable>
+
+- <límite conceptual que evita una interpretación incorrecta>.
+
+## Referencias
+
+<!-- Fuentes primarias citadas por las evidencias. El enlace no sustituye el hecho y el límite en E-xxx. -->
+
+- [<título descriptivo>](URL): usado en E-001 para <afirmación concreta>.

--- a/docs/missions/14-multiples-categorias-profesional/producto.md
+++ b/docs/missions/14-multiples-categorias-profesional/producto.md
@@ -1,0 +1,149 @@
+# Misión: <nombre> — Producto
+
+**Estado:** borrador
+
+**Última actualización:** AAAA-MM-DD
+
+[Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
+[Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
+
+<!--
+Este documento es la spec viva del resultado: qué construimos ahora y bajo qué reglas. El porqué vive en
+investigacion.md — aquí solo se enlaza. Se reescribe cuando el alcance cambia; no acumula historia.
+
+Gate de salida — producto.md está listo para experiencia.md cuando:
+- cada funcionalidad tiene formato JTBD, reglas y al menos un caso límite con comportamiento definido
+- cada funcionalidad enlaza una conclusión de investigacion.md y una señal de éxito
+- cada funcionalidad declara a qué lado del marketplace sirve, y qué necesita del otro lado para funcionar
+- no hay decisiones de producto delegadas a diseño o ingeniería
+- las decisiones propuestas tienen fecha límite en el README
+-->
+
+## Qué construimos: <resultado en una frase>
+
+<!--
+El recorte vigente del ideal y por qué sigue entregando el resultado central. Máximo cuatro párrafos
+cortos. El ideal completo vive en investigacion.md.
+-->
+
+**Resultado:** <qué podrá lograr una persona al finalizar esta entrega>.
+
+**Recorte respecto del ideal:** <qué dimensión se reduce y por qué sigue siendo suficiente>
+(ver [el ideal](./investigacion.md)).
+
+**Restricciones aceptadas:** <plataforma, cobertura geográfica, categorías, volumen inicial de
+profesionales>.
+
+## Funcionalidades
+
+| ID    | Funcionalidad                  | Lado         | Sustento     | Éxito |
+| ----- | ------------------------------ | ------------ | ------------ | ----- |
+| F-001 | <verbo + resultado observable> | buscador     | C-001, D-001 | M-001 |
+
+<a id="f-001"></a>
+
+### F-001 — <verbo + resultado observable>
+
+<!--
+Duplica este bloque por funcionalidad. Se escribe desde el resultado del usuario (working backwards):
+primero el JTBD, después las reglas. Si la respuesta de Datealo no se puede describir sin hablar de tablas
+o componentes, falta cerrar la decisión de producto.
+-->
+
+Cuando <usuario en contexto concreto>,
+quiero <acción>,
+para <resultado observable>.
+
+**Lado del marketplace:** buscador, profesional o ambos. **Qué necesita del otro lado:** <volumen mínimo
+de perfiles, reseñas o cobertura sin el cual esta funcionalidad no entrega su resultado>.
+
+**Sustento:** [C-001](./investigacion.md#c-001) y [D-001](#d-001). **Éxito:** [M-001](#m-001).
+
+**Reglas:**
+
+- Si <condición>, Datealo <comportamiento esperado>.
+- Si <caso límite>, Datealo <comportamiento seguro y qué información muestra>.
+- Datealo nunca <comportamiento que rompería el significado o la confianza>.
+
+**Ejemplo verificable:** dado <estado con datos concretos>, cuando <acción>, entonces <resultado
+observable>.
+
+**No incluye:** <variante del ideal excluida de esta funcionalidad>.
+
+**Experiencia:** <enlace a UXF-xxx cuando exista>. **Ingeniería:** <enlace a T-xxx cuando exista>.
+
+## Casos límite que cruzan funcionalidades
+
+<!--
+Solo condiciones que afectan varias funcionalidades. Las propias de una viven en su bloque. Un caso
+retirado no se borra ni se reutiliza: conserva su fila, o se nombra con su motivo en una línea debajo.
+
+Los casos límite propios de un marketplace pre-lanzamiento aparecen acá: cero resultados en una comuna,
+un profesional sin reseñas, una categoría con un solo perfil, un perfil sin verificar.
+-->
+
+| ID     | Condición concreta     | Comportamiento esperado | Funcionalidades |
+| ------ | ---------------------- | ----------------------- | --------------- |
+| CL-001 | <estado o combinación> | <qué hace Datealo>      | F-001           |
+
+## Fuera de alcance
+
+<!-- Distingue postergado de descartado y qué condición justificaría reabrirlo. -->
+
+| Capacidad o caso      | Estado                  | Razón del recorte | Condición para reconsiderar |
+| --------------------- | ----------------------- | ----------------- | --------------------------- |
+| <capacidad del ideal> | postergada o descartada | <trade-off>       | <evidencia o hito>          |
+
+## Señales de éxito
+
+<a id="m-001"></a>
+
+### M-001 — <señal que demuestra el resultado>
+
+- **Pregunta:** ¿<qué queremos comprobar>?
+- **Señal:** <comportamiento o resultado observable>.
+- **Método y umbral:** <instrumentación o revisión, qué resultado, en qué población y ventana>.
+- **Guardrail:** <daño que no debe aumentar para conseguir la señal>.
+
+## Decisiones de producto
+
+<!--
+Solo decisiones con alternativas reales. No borres decisiones reemplazadas: explican por qué el producto
+es como es. Toda decisión propuesta se refleja en el README con fecha límite.
+-->
+
+<a id="d-001"></a>
+
+### D-001 — <decisión en una frase que se entiende sola>
+
+- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
+- **Sustento:** [C-001](./investigacion.md#c-001).
+- **Tensión:** <criterios que no podían maximizarse al mismo tiempo>.
+- **Alternativas descartadas:** <opciones y razón concreta del rechazo, en la misma línea>.
+- **Decisión y consecuencia:** <qué se hará y qué habilita, limita o exige revisar en UX e ingeniería>.
+- **Reapertura:** <evidencia o cambio que justificaría revisarla>.
+
+## Preguntas
+
+<!--
+Solo preguntas que pueden cambiar una decisión o funcionalidad. Lo demás va a un issue.
+Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
+Estado: abierta | resuelta AAAA-MM-DD (alguien la respondió) | disuelta AAAA-MM-DD (el producto cambió y la
+pregunta dejó de tener sentido). Solo las abiertas llevan bloque de detalle debajo de la tabla.
+-->
+
+<Una frase que responde "¿qué falta?": la pregunta que bloquea y qué bloquea.>
+
+| ID    | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
+| ----- | ---------------------- | ------------------- | --------------------------------------------------------------- |
+| Q-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
+| Q-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |
+
+<a id="q-001"></a>
+
+### Q-001 — <la pregunta en una frase que se entiende sola>
+
+- **La duda, con un ejemplo:** <el caso concreto que muestra por qué hay dos respuestas posibles>.
+- **Afecta a:** D-001 o F-001.
+- **Cómo se resolverá:** <quién y con qué método>.
+- **¿Bloquea algo?:** <qué bloquea y su fecha límite, o no>.

--- a/docs/missions/15-multiples-comunas-profesional/README.md
+++ b/docs/missions/15-multiples-comunas-profesional/README.md
@@ -1,0 +1,47 @@
+# Misión 15 — Múltiples comunas por profesional
+
+**Tipo:** producto. **Carril:** Full Spec — toca el modelo de datos de `professionals` (hoy una sola
+comuna por profesional) y cómo `/api/search` filtra por comuna. **Abierta el** 2026-09-06.
+**Nace de:** ninguna.
+
+**Estado de la misión:** exploración
+
+**En foco:** Investigación
+
+**Última actualización:** 2026-09-06
+
+**Documentos:** [Investigación](./investigacion.md) · [Producto](./producto.md) ·
+[Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
+
+**Próximo hito:** completar `investigacion.md` con el problema concreto y evidencia de que un profesional
+real atiende más de una comuna — sin fecha límite todavía, recién se abre la misión.
+
+## Brief
+
+Hoy un profesional declara una sola comuna en su perfil. En zonas menos densas que Santiago, un mismo
+profesional suele cubrir varias comunas vecinas — el ejemplo que dio el dueño de producto: alguien en la
+Región de los Lagos puede atender tanto en Llanquihue como en Frutillar o Puerto Varas. Con una sola
+comuna, ese profesional solo aparece en las búsquedas de una, perdiendo cobertura real en las otras dos
+donde también trabaja.
+
+Esta misión es independiente de la [14](../14-multiples-categorias-profesional/) (múltiples categorías) —
+resuelve el mismo tipo de limitación (un solo valor donde la realidad tiene varios) pero en el eje
+geográfico, no el de oficio. Ya existe una noción de "comunas vecinas" en el producto (búsqueda de
+resultados, misión 06) para cuando una comuna no tiene profesionales — esta misión es distinta: no es una
+sugerencia de fallback, es que el profesional declare explícitamente en cuáles trabaja.
+
+## Temas a explorar
+
+- **Relación con "comunas vecinas" (misión 06).** Esa función ya existe para *ampliar* una búsqueda sin
+  resultados hacia comunas cercanas. Esta misión deja que el profesional declare sus comunas reales —
+  evaluar si ambas conviven o si una vuelve redundante a la otra en ciertos casos.
+- **Cuántas comunas tiene sentido permitir.** Sin límite, o un tope razonable — y si el tope debería ser
+  distinto según la densidad de la zona (Santiago vs. regiones).
+- **Cómo se ve en el perfil público y en las cards de resultado.** Mostrar varias comunas sin que la card
+  se sienta sobrecargada — hoy `comunaNombre` es un dato singular.
+- **Cómo busca alguien.** El buscador filtra por una comuna a la vez (`/buscar?comuna=X`) — un profesional
+  con varias comunas debe aparecer en los resultados de cualquiera de las que atienda.
+- **Impacto en el modelo de datos.** Pasar de una columna simple a una tabla de relación
+  (`professional_comunas` o similar), con su policy RLS y migración de los datos existentes.
+- **Impacto en `/api/search`.** El filtro por comuna pasa a un `EXISTS`/join — mismo tipo de evaluación de
+  costo que la misión 14, posiblemente compartiendo el mismo patrón de solución.

--- a/docs/missions/15-multiples-comunas-profesional/experiencia.md
+++ b/docs/missions/15-multiples-comunas-profesional/experiencia.md
@@ -1,0 +1,183 @@
+# Misión: <nombre> — Experiencia
+
+**Estado:** borrador
+
+**Última actualización:** AAAA-MM-DD
+
+[Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
+[Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
+
+<!--
+Fuente de verdad para flujos, estados, contenido e interacción. No redefine reglas de producto: si el
+diseño descubre una regla nueva o invalida una, abre o actualiza una decisión en producto.md.
+
+Núcleo obligatorio: vistas, mapa de estados, flujos críticos y estados por superficie. Las secciones bajo
+demanda (modelo mental, jerarquía de información, validación) se agregan solo cuando una decisión las
+necesita.
+
+Gate de salida — experiencia.md está lista para ingenieria.md cuando:
+- cada flujo crítico tiene secuencia, variantes, recuperación y criterio de término
+- cada estado tiene contenido concreto (texto real, información visible, acción disponible)
+- cada vista lista sus modos, y el mapa de estados cubre todas las transiciones entre ellos
+- cada modo tiene su indicador permanente de estado, y cada flujo tiene todas sus salidas documentadas
+- los casos límite de producto.md tienen flujo o estado mapeado
+- cada flujo crítico está mockeado en móvil (390px), y en desktop si también vive ahí
+- ninguna pantalla queda descrita como "similar a X" sin especificar qué cambia
+-->
+
+## Decisión de experiencia: <qué cambia para quien usa el producto>
+
+<Modelo de interacción elegido, flujo más importante y la incertidumbre que sigue abierta.>
+
+- **Funcionalidades cubiertas:** F-001, <otras>.
+- **Pendiente bloqueante:** <pregunta o "ninguna">.
+
+## Vistas
+
+<!--
+El listado de pantallas que define la experiencia — el mapa que se entrega antes de los flujos. Una línea
+por vista, sin tabla, con sus modos anidados debajo. Una vista es un destino: se llega a ella. Un modo es
+un estado de esa vista que cambia qué se puede hacer y qué se ve — se anida, nunca se lista como vista
+hermana.
+
+El porqué de cada vista, su trade-off o su justificación no van aquí: viven en su flujo (UXF) o en una
+decisión (UX-xxx). Regla de formato para todo el documento: las tablas se reservan para índices de celdas
+cortas; lo que lleva justificación extensa va en secciones con header + bullets, nunca en una celda.
+-->
+
+- **V-001 — <vista>** · móvil / desktop · resuelve F-001 · flujos UXF-001 · pendiente
+  - modo **<nombre>** — <qué lo distingue y qué se puede hacer en él>
+  - modo **<nombre>** — <ídem>
+
+## Mapa de estados
+
+<!--
+Vistas y flujos son listas, y una lista no muestra un camino. Esta tabla conecta los modos: qué acción
+lleva de uno a otro y qué pasa con el trabajo del usuario en cada salto. Cada fila que falte es una
+pregunta que ingeniería resuelve inventando.
+-->
+
+| Desde  | Acción             | Queda en | Qué pasa con el trabajo              |
+| ------ | ------------------ | -------- | ------------------------------------ |
+| <modo> | <acción concreta>  | <modo>   | <qué se aplicó, qué quedó pendiente> |
+| <modo> | <salir sin cerrar> | <modo>   | <qué se pierde o se conserva>        |
+
+## UXF-001 — <flujo principal en verbo>
+
+<!--
+Duplica por flujo crítico. Cada paso describe acción → respuesta al nivel de "el usuario toca X → Datealo
+muestra Y". Un mockup no reemplaza la secuencia porque no explica estados ni recuperación.
+-->
+
+**Objetivo:** <qué se completa o comprende>. **Contrato:** [F-001](./producto.md#f-001).
+
+**Punto de entrada:** <estado y superficie inicial, y qué acción trae al usuario hasta acá>.
+
+**Criterio de término:** <estado observable que confirma que el flujo terminó bien>.
+
+**Cómo sabe el usuario dónde está:** <el elemento concreto y permanente en pantalla que se lo dice, por
+cada modo que toca este flujo>.
+
+### Salidas
+
+<!--
+Todas las formas de irse, no solo terminar bien. El criterio de término cubre la salida buena; las otras
+son las que el usuario encuentra primero. Un modo del que no se sabe salir es un modo donde el usuario se
+pierde.
+-->
+
+| Salida                | Cómo se ejecuta       | Qué queda del trabajo           |
+| --------------------- | --------------------- | ------------------------------- |
+| <termina bien>        | <acción>              | <qué se aplicó y dónde>         |
+| <descarta>            | <acción, Esc, cerrar> | <nada, ni a medias>             |
+| <abandona sin cerrar> | <navega a otra parte> | <se conserva, se pierde, avisa> |
+
+### Secuencia principal
+
+| Paso | Acción            | Respuesta del sistema         | Información visible |
+| ---- | ----------------- | ----------------------------- | ------------------- |
+| 1    | <acción concreta> | <feedback o cambio de estado> | <dato y jerarquía>  |
+
+### Variantes y recuperación
+
+| Condición          | Qué cambia              | Cómo se entiende    | Cómo se recupera             |
+| ------------------ | ----------------------- | ------------------- | ---------------------------- |
+| <sin resultados>   | <estado>                | <mensaje concreto>  | <acción disponible>          |
+| <sin permiso de ubicación> | <comportamiento> | <indicador visible> | <alternativa manual>         |
+| <conexión lenta>   | <skeleton, no spinner>  | <qué se ve mientras>| <qué pasa si falla>          |
+
+### Decisiones que no deben quedar implícitas
+
+- <qué ocurre al cancelar, volver atrás, reintentar o confirmar>.
+- <qué cambio se guarda inmediato y cuál necesita confirmación>.
+
+## Estados por superficie
+
+<!--
+El contenido es concreto: texto real, no "mensaje apropiado". El estado vacío de un marketplace
+pre-lanzamiento no es un detalle: para muchas búsquedas será el estado principal durante meses.
+-->
+
+| Estado  | Qué se muestra (texto e información real) | Acción disponible                   |
+| ------- | ----------------------------------------- | ----------------------------------- |
+| inicial | <contenido>                               | <acción>                            |
+| vacío   | <por qué está vacío, con texto concreto>  | <cómo avanzar, o ninguna y por qué> |
+| carga   | <skeleton de qué forma>                   | <ninguna>                           |
+| error   | <causa útil y alcance>                    | <recuperación>                      |
+
+## Mockups
+
+<!--
+Los mockups viven en design-mockups/ como HTML (ver el skill discovery-ux y docs/design/README.md).
+Exploran o materializan una decisión; no son fuente de verdad de reglas de producto.
+-->
+
+| Mockup   | Cubre   | Estado                 | Ruta                              |
+| -------- | ------- | ---------------------- | --------------------------------- |
+| <nombre> | UXF-001 | exploración o validado | `./design-mockups/<archivo>.html` |
+
+## Cobertura
+
+<!-- Detecta huecos antes de construir. Una funcionalidad sin pantalla nueva igual tiene estados. -->
+
+| Funcionalidad | Flujo   | Estados cubiertos       | Estado    |
+| ------------- | ------- | ----------------------- | --------- |
+| F-001         | UXF-001 | principal, vacío, error | pendiente |
+
+## Secciones bajo demanda
+
+<!--
+Agregar solo cuando una decisión las necesite, con estos títulos:
+
+- "Modelo mental y lenguaje": cuando un concepto de producto pueda confundirse en la interfaz.
+- "Jerarquía de información": cuando una superficie densa exija decidir qué se ve primero (una card de
+  resultado con foto, rating, distancia, precio y disponibilidad es exactamente ese caso).
+- "Validación (UXV-xxx)": cuando una incertidumbre de diseño necesite prueba con usuarios.
+- "Accesibilidad y adaptación": cuando el contexto de uso cambie el flujo o la representación.
+-->
+
+## Decisiones de experiencia
+
+<a id="ux-001"></a>
+
+### UX-001 — <decisión en una frase>
+
+- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
+- **Sustento:** F-001 o <hallazgo>.
+- **Alternativas descartadas:** <opciones relevantes y trade-off, con el porqué del rechazo>.
+- **Decisión y consecuencia:** <qué flujo o superficie cambia>.
+- **Impacto en producto:** <ninguno o enlace a D-xxx/F-xxx actualizado>.
+
+## Preguntas
+
+<!--
+Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
+Estado: abierta | resuelta AAAA-MM-DD | disuelta AAAA-MM-DD. Solo las abiertas llevan bloque de detalle.
+-->
+
+<Una frase que responde "¿qué falta?": la pregunta que bloquea construcción y qué bloquea.>
+
+| ID      | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
+| ------- | ---------------------- | ------------------- | --------------------------------------------------------------- |
+| UXQ-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
+| UXQ-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |

--- a/docs/missions/15-multiples-comunas-profesional/ingenieria.md
+++ b/docs/missions/15-multiples-comunas-profesional/ingenieria.md
@@ -1,0 +1,162 @@
+# Misión: <nombre> — Ingeniería
+
+**Estado:** borrador
+
+**Última actualización:** AAAA-MM-DD
+
+[Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
+[Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
+
+<!--
+Fuente de verdad para arquitectura, datos, contratos, factibilidad y pruebas. Consume el comportamiento
+definido en producto. Una limitación técnica cambia el alcance solo mediante una decisión explícita en
+producto.md.
+
+Núcleo obligatorio: contratos, modelo de datos, RLS y riesgos de factibilidad. Las secciones bajo demanda
+(migración, rendimiento, entrega por etapas) se agregan solo cuando el riesgo lo justifica.
+
+Gate de salida — ingenieria.md está lista para construir cuando:
+- los contratos definen qué entra, qué sale y qué invariantes se mantienen, sin ambigüedad
+- el modelo de datos soporta los casos límite de producto.md sin workarounds
+- el impacto en RLS está resuelto: qué policy se crea o cambia, o por qué ninguna
+- la migración de datos existentes tiene estrategia o está explícitamente fuera del alcance
+- los escenarios verificables de producto están mapeados a pruebas
+- el plan de construcción corta el diseño en slices atómicos ordenados (un slice = un Issue = un PR)
+-->
+
+## Decisión técnica: <arquitectura y riesgo principal>
+
+<Dirección técnica, trade-off principal y el riesgo que todavía podría invalidarla.>
+
+- **Contratos de producto cubiertos:** F-001, <otros>.
+- **Riesgo bloqueante:** <incertidumbre o "ninguna">.
+
+## Arquitectura: <cómo se divide la responsabilidad>
+
+<!--
+La lógica de negocio se separa de la infraestructura: funciones puras en utils/ y server/utils/,
+reactividad en composables, acceso a datos en server/api/ con Drizzle. Incluye diagrama solo cuando tres o
+más partes interactúan.
+-->
+
+<Descripción del enfoque y por qué satisface los contratos con menor riesgo.>
+
+| Componente | Responsabilidad       | No debe decidir | Contratos |
+| ---------- | --------------------- | --------------- | --------- |
+| <nombre>   | <una responsabilidad> | <frontera>      | F-001     |
+
+## Contratos
+
+<!--
+Cada contrato especifica entrada, salida e invariantes al nivel en que se puede implementar sin reuniones
+de aclaración. Incluye los errores observables y el código HTTP cuando es un endpoint.
+-->
+
+### TC-001 — <contrato en una frase>
+
+- **Entrada:** <datos y precondiciones, con tipos y forma concreta>.
+- **Salida:** <resultado y su forma concreta>.
+- **Invariantes:** <qué se cumple siempre: atomicidad, consistencia, idempotencia>.
+- **Errores:** <condición → código HTTP y cuerpo `{ error, code? }`, y qué puede hacer el llamador>.
+- **Contrato de producto:** [F-001](./producto.md#f-001).
+
+## Modelo de datos
+
+<!-- Entidades con significado, escritura y ciclo de vida. El schema completo vive en server/db/. -->
+
+| Entidad o campo | Significado             | Escritura          | Retención o historial |
+| --------------- | ----------------------- | ------------------ | --------------------- |
+| <dato>          | <semántica de producto> | <endpoint o acción>| <política>            |
+
+### Invariantes de datos
+
+- <unicidad, pertenencia, orden o consistencia temporal>.
+- <qué operación es atómica o qué dato tiene una única fuente de verdad>.
+
+### Impacto en RLS
+
+<!--
+Obligatorio. Fuente de verdad: server/db/sql/rls.sql. Si el cambio no toca ownership ni relaciones usadas
+en policies, decirlo explícitamente con esa razón — no dejar la sección vacía.
+-->
+
+| Tabla    | Cambio                 | Policy afectada | Acción                    |
+| -------- | ---------------------- | --------------- | ------------------------- |
+| <tabla>  | <nueva, ownership, FK> | <nombre>        | <crear, actualizar, nada> |
+
+## Riesgos y experimentos de factibilidad
+
+<!--
+Un riesgo que podría cambiar el producto se enlaza como pregunta o decisión en producto.md. Un experimento
+tiene pregunta, límite de tiempo y resultado capaz de cerrar la incertidumbre.
+-->
+
+| ID     | Riesgo o pregunta | Qué invalida        | Experimento o mitigación  | Criterio de salida      | Estado  |
+| ------ | ----------------- | ------------------- | ------------------------- | ----------------------- | ------- |
+| TR-001 | <incertidumbre>   | <alcance en riesgo> | <spike, prueba o recorte> | <resultado concluyente> | abierto |
+
+## Estrategia de pruebas
+
+<!-- Mapea los ejemplos verificables de producto.md a niveles de prueba. Qué demuestra cada una. -->
+
+| Contrato o riesgo | Nivel                          | Caso principal | Límite o falla |
+| ----------------- | ------------------------------ | -------------- | -------------- |
+| F-001, CL-001     | <unidad, contrato, integración>| <caso>         | <caso>         |
+
+### Propiedades que deben probarse
+
+- <invariante bajo reintentos, concurrencia o distintas entradas>.
+- <ausencia de efectos parciales en falla>.
+
+## Plan de construcción
+
+<!--
+Se completa al final, cuando el gate de salida se cumple y ninguna pregunta bloqueante sigue abierta —
+cortar sobre decisiones abiertas produce issues que mueren. Cada slice es un cambio funcional atómico: un
+Issue, un PR, ejecutable sin haber leído la misión (el issue lleva su contrato inline) y con criterios
+pass/fail enumerables como tests. Guía completa en el skill discovery-engineering.
+-->
+
+| ID    | Slice (una frase, sin "y") | Sustento      | Criterio de aceptación principal          | Depende de |
+| ----- | -------------------------- | ------------- | ----------------------------------------- | ---------- |
+| S-001 | <cambio atómico>           | TC-001, D-001 | <entrada concreta → resultado observable> | —          |
+
+## Secciones bajo demanda
+
+<!--
+Agregar solo cuando el riesgo lo justifique, con estos títulos:
+
+- "Migración y compatibilidad": cuando existan datos o consumidores que deben llegar al nuevo contrato.
+  Incluye rollback lógico si la migración física no puede revertirse.
+- "Rendimiento y observabilidad": cuando haya presupuesto de latencia o volumen que defender (búsqueda
+  geográfica y listados paginados son los candidatos naturales).
+- "SEO e indexación": cuando la superficie deba ser indexable (páginas por categoría + comuna, datos
+  estructurados).
+- "Entrega por etapas": cuando el cambio necesite despliegue incremental o feature flags.
+-->
+
+## Decisiones técnicas
+
+<a id="t-001"></a>
+
+### T-001 — <decisión en una frase>
+
+- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
+- **Contratos:** F-001 y <regla relevante>.
+- **Alternativas descartadas:** <opciones y trade-offs, con el porqué del rechazo>.
+- **Decisión y consecuencias:** <enfoque elegido, beneficio, costo y trabajo futuro aceptado>.
+- **Reapertura:** <medición o cambio que justificaría revisar>.
+
+## Preguntas
+
+<!--
+Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
+Estado: abierta | resuelta AAAA-MM-DD | disuelta AAAA-MM-DD. Solo las abiertas llevan bloque de detalle.
+-->
+
+<Una frase que responde "¿qué falta?": la pregunta que bloquea construcción y qué bloquea.>
+
+| ID     | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
+| ------ | ---------------------- | ------------------- | --------------------------------------------------------------- |
+| TQ-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
+| TQ-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |

--- a/docs/missions/15-multiples-comunas-profesional/investigacion.md
+++ b/docs/missions/15-multiples-comunas-profesional/investigacion.md
@@ -1,0 +1,118 @@
+# Misión: <nombre> — Investigación
+
+**Estado:** activo
+
+**Última actualización:** AAAA-MM-DD
+
+[Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
+[Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
+
+<!--
+Este documento se acumula: la evidencia y las conclusiones no se borran cuando el alcance cambia, porque
+explican por qué el producto es como es. Lo que sí se actualiza es el ideal, que resume la dirección que
+la investigación sostiene hoy.
+
+Gate de salida — la investigación sostiene un producto.md cuando:
+- el problema tiene situación y consecuencia concretas, no una categoría abstracta
+- al menos una conclusión con confianza alta o media respalda la dirección
+- el ideal describe capacidades observables, no intenciones
+-->
+
+## El problema aparece cuando <historia concreta>
+
+<!--
+Una situación real o reconstruida con precisión. No abras con una categoría como "falta de confianza" —
+abre con quién estaba haciendo qué y qué salió mal. Nombra a la persona y el servicio concreto.
+-->
+
+**Situación:** <qué está ocurriendo antes del problema>.
+
+**Acción o necesidad:** <qué se intenta resolver o decidir>.
+
+**Respuesta actual:** <qué hace hoy la persona: grupo de WhatsApp, Google, recomendación de un vecino,
+Datealo si ya existe la superficie>.
+
+**Consecuencia:** <error, demora, riesgo o decisión que no puede tomarse>.
+
+## Preguntas que la investigación debe resolver
+
+<!--
+Solo preguntas capaces de cambiar el ideal o una decisión. Al resolver una, moverla a evidencia o
+conclusión. No es un backlog.
+-->
+
+- ¿<pregunta y decisión que depende de ella>?
+
+## Evidencia
+
+<!--
+Un hecho verificable con fuente y límite. Prioriza observación directa, entrevistas y comportamiento
+comprobado. Los benchmarks de otros productos también son evidencia: qué hacen, qué trade-off eligieron y
+qué no aplica a Datealo.
+
+Datealo no tiene datos de uso propios todavía. Cuando la única evidencia disponible sea un benchmark o
+una entrevista, la columna "límite" es lo que impide que se lea como dato duro.
+-->
+
+| ID    | Tipo                                              | Fuente                | Hecho verificable | Límite de la evidencia |
+| ----- | ------------------------------------------------- | --------------------- | ----------------- | ---------------------- |
+| E-001 | <entrevista, benchmark, uso, código, observación> | <enlace o referencia> | <hecho>           | <qué no demuestra>     |
+
+<a id="e-001"></a>
+
+### E-001 — <fuente o hecho en una frase>
+
+<!--
+Desarrollar solo cuando la tabla no alcanza para evaluar la calidad de la evidencia. Cierra con la
+consecuencia para la investigación.
+-->
+
+<Observación precisa y contexto necesario.>
+
+Esto permite afirmar <alcance>, pero no demuestra <límite>.
+
+## Conclusiones
+
+<!--
+Una conclusión interpreta evidencia; no es una preferencia ni una funcionalidad. El título expresa el
+hallazgo, no el tema.
+-->
+
+<a id="c-001"></a>
+
+### C-001 — <conclusión en una frase>
+
+- **Sustento:** [E-001](#e-001).
+- **Razonamiento:** <por qué la evidencia conduce a esta lectura y no a otra>.
+- **Implicación:** <qué deberá ser cierto en el producto o qué alternativa queda debilitada>.
+- **Confianza:** <alta, media o baja> porque <razón o validación pendiente>.
+
+## El ideal: <resultado completo, sin recortar>
+
+<!--
+El ideal es el producto de la investigación: la dirección que la evidencia sostiene, sin restricciones de
+implementación. El recorte a la primera entrega no vive aquí — vive en producto.md como decisión de
+alcance. Esta sección sí se reescribe cuando nueva evidencia cambia la dirección.
+-->
+
+### El resultado ideal se ve así
+
+<Narra de principio a fin una situación futura con datos concretos: nombres, comunas, oficios, horarios.
+Qué acción ocurre, qué responde Datealo, qué decisión puede tomar la persona. Evita "una experiencia
+simple" sin comportamiento observable.>
+
+### Capacidades del ideal
+
+| Capacidad | Acción habilitada    | Respuesta esperada              | Conclusión que la justifica |
+| --------- | -------------------- | ------------------------------- | --------------------------- |
+| <nombre>  | <qué se puede hacer> | <qué produce o explica Datealo> | [C-001](#c-001)             |
+
+### El ideal no significa <confusión probable>
+
+- <límite conceptual que evita una interpretación incorrecta>.
+
+## Referencias
+
+<!-- Fuentes primarias citadas por las evidencias. El enlace no sustituye el hecho y el límite en E-xxx. -->
+
+- [<título descriptivo>](URL): usado en E-001 para <afirmación concreta>.

--- a/docs/missions/15-multiples-comunas-profesional/producto.md
+++ b/docs/missions/15-multiples-comunas-profesional/producto.md
@@ -1,0 +1,149 @@
+# Misión: <nombre> — Producto
+
+**Estado:** borrador
+
+**Última actualización:** AAAA-MM-DD
+
+[Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
+[Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
+
+<!--
+Este documento es la spec viva del resultado: qué construimos ahora y bajo qué reglas. El porqué vive en
+investigacion.md — aquí solo se enlaza. Se reescribe cuando el alcance cambia; no acumula historia.
+
+Gate de salida — producto.md está listo para experiencia.md cuando:
+- cada funcionalidad tiene formato JTBD, reglas y al menos un caso límite con comportamiento definido
+- cada funcionalidad enlaza una conclusión de investigacion.md y una señal de éxito
+- cada funcionalidad declara a qué lado del marketplace sirve, y qué necesita del otro lado para funcionar
+- no hay decisiones de producto delegadas a diseño o ingeniería
+- las decisiones propuestas tienen fecha límite en el README
+-->
+
+## Qué construimos: <resultado en una frase>
+
+<!--
+El recorte vigente del ideal y por qué sigue entregando el resultado central. Máximo cuatro párrafos
+cortos. El ideal completo vive en investigacion.md.
+-->
+
+**Resultado:** <qué podrá lograr una persona al finalizar esta entrega>.
+
+**Recorte respecto del ideal:** <qué dimensión se reduce y por qué sigue siendo suficiente>
+(ver [el ideal](./investigacion.md)).
+
+**Restricciones aceptadas:** <plataforma, cobertura geográfica, categorías, volumen inicial de
+profesionales>.
+
+## Funcionalidades
+
+| ID    | Funcionalidad                  | Lado         | Sustento     | Éxito |
+| ----- | ------------------------------ | ------------ | ------------ | ----- |
+| F-001 | <verbo + resultado observable> | buscador     | C-001, D-001 | M-001 |
+
+<a id="f-001"></a>
+
+### F-001 — <verbo + resultado observable>
+
+<!--
+Duplica este bloque por funcionalidad. Se escribe desde el resultado del usuario (working backwards):
+primero el JTBD, después las reglas. Si la respuesta de Datealo no se puede describir sin hablar de tablas
+o componentes, falta cerrar la decisión de producto.
+-->
+
+Cuando <usuario en contexto concreto>,
+quiero <acción>,
+para <resultado observable>.
+
+**Lado del marketplace:** buscador, profesional o ambos. **Qué necesita del otro lado:** <volumen mínimo
+de perfiles, reseñas o cobertura sin el cual esta funcionalidad no entrega su resultado>.
+
+**Sustento:** [C-001](./investigacion.md#c-001) y [D-001](#d-001). **Éxito:** [M-001](#m-001).
+
+**Reglas:**
+
+- Si <condición>, Datealo <comportamiento esperado>.
+- Si <caso límite>, Datealo <comportamiento seguro y qué información muestra>.
+- Datealo nunca <comportamiento que rompería el significado o la confianza>.
+
+**Ejemplo verificable:** dado <estado con datos concretos>, cuando <acción>, entonces <resultado
+observable>.
+
+**No incluye:** <variante del ideal excluida de esta funcionalidad>.
+
+**Experiencia:** <enlace a UXF-xxx cuando exista>. **Ingeniería:** <enlace a T-xxx cuando exista>.
+
+## Casos límite que cruzan funcionalidades
+
+<!--
+Solo condiciones que afectan varias funcionalidades. Las propias de una viven en su bloque. Un caso
+retirado no se borra ni se reutiliza: conserva su fila, o se nombra con su motivo en una línea debajo.
+
+Los casos límite propios de un marketplace pre-lanzamiento aparecen acá: cero resultados en una comuna,
+un profesional sin reseñas, una categoría con un solo perfil, un perfil sin verificar.
+-->
+
+| ID     | Condición concreta     | Comportamiento esperado | Funcionalidades |
+| ------ | ---------------------- | ----------------------- | --------------- |
+| CL-001 | <estado o combinación> | <qué hace Datealo>      | F-001           |
+
+## Fuera de alcance
+
+<!-- Distingue postergado de descartado y qué condición justificaría reabrirlo. -->
+
+| Capacidad o caso      | Estado                  | Razón del recorte | Condición para reconsiderar |
+| --------------------- | ----------------------- | ----------------- | --------------------------- |
+| <capacidad del ideal> | postergada o descartada | <trade-off>       | <evidencia o hito>          |
+
+## Señales de éxito
+
+<a id="m-001"></a>
+
+### M-001 — <señal que demuestra el resultado>
+
+- **Pregunta:** ¿<qué queremos comprobar>?
+- **Señal:** <comportamiento o resultado observable>.
+- **Método y umbral:** <instrumentación o revisión, qué resultado, en qué población y ventana>.
+- **Guardrail:** <daño que no debe aumentar para conseguir la señal>.
+
+## Decisiones de producto
+
+<!--
+Solo decisiones con alternativas reales. No borres decisiones reemplazadas: explican por qué el producto
+es como es. Toda decisión propuesta se refleja en el README con fecha límite.
+-->
+
+<a id="d-001"></a>
+
+### D-001 — <decisión en una frase que se entiende sola>
+
+- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
+- **Sustento:** [C-001](./investigacion.md#c-001).
+- **Tensión:** <criterios que no podían maximizarse al mismo tiempo>.
+- **Alternativas descartadas:** <opciones y razón concreta del rechazo, en la misma línea>.
+- **Decisión y consecuencia:** <qué se hará y qué habilita, limita o exige revisar en UX e ingeniería>.
+- **Reapertura:** <evidencia o cambio que justificaría revisarla>.
+
+## Preguntas
+
+<!--
+Solo preguntas que pueden cambiar una decisión o funcionalidad. Lo demás va a un issue.
+Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
+Estado: abierta | resuelta AAAA-MM-DD (alguien la respondió) | disuelta AAAA-MM-DD (el producto cambió y la
+pregunta dejó de tener sentido). Solo las abiertas llevan bloque de detalle debajo de la tabla.
+-->
+
+<Una frase que responde "¿qué falta?": la pregunta que bloquea y qué bloquea.>
+
+| ID    | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
+| ----- | ---------------------- | ------------------- | --------------------------------------------------------------- |
+| Q-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
+| Q-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |
+
+<a id="q-001"></a>
+
+### Q-001 — <la pregunta en una frase que se entiende sola>
+
+- **La duda, con un ejemplo:** <el caso concreto que muestra por qué hay dos respuestas posibles>.
+- **Afecta a:** D-001 o F-001.
+- **Cómo se resolverá:** <quién y con qué método>.
+- **¿Bloquea algo?:** <qué bloquea y su fecha límite, o no>.

--- a/docs/missions/README.md
+++ b/docs/missions/README.md
@@ -21,7 +21,7 @@ abrieron y de dónde salió cada una.
 | 10  | [vista de resultados de búsqueda](./10-vista-resultados-busqueda/) | producto | 2026-09-01 | cerrada 2026-09-04 | — | — |
 | 11  | [vista de detalle de perfil](./11-perfil-profesional/) | producto | 2026-09-01 | cerrada 2026-09-04 | — | — |
 | 12  | [hero y copy de la landing](./12-hero-y-copy-landing/) | producto | 2026-09-01 | cerrada 2026-09-06 | — | — |
-| 13  | [tamaño de fuente](./13-tamano-de-fuente/) | producto | 2026-09-06 | exploración | Investigación | — |
+| 13  | [tamaño de fuente](./13-tamano-de-fuente/) | producto | 2026-09-06 | lista para construir | — | — |
 | 14  | [múltiples categorías por profesional](./14-multiples-categorias-profesional/) | producto | 2026-09-06 | exploración | Investigación | — |
 | 15  | [múltiples comunas por profesional](./15-multiples-comunas-profesional/) | producto | 2026-09-06 | exploración | Investigación | — |
 

--- a/docs/missions/README.md
+++ b/docs/missions/README.md
@@ -21,6 +21,9 @@ abrieron y de dónde salió cada una.
 | 10  | [vista de resultados de búsqueda](./10-vista-resultados-busqueda/) | producto | 2026-09-01 | cerrada 2026-09-04 | — | — |
 | 11  | [vista de detalle de perfil](./11-perfil-profesional/) | producto | 2026-09-01 | cerrada 2026-09-04 | — | — |
 | 12  | [hero y copy de la landing](./12-hero-y-copy-landing/) | producto | 2026-09-01 | cerrada 2026-09-06 | — | — |
+| 13  | [tamaño de fuente](./13-tamano-de-fuente/) | producto | 2026-09-06 | exploración | Investigación | — |
+| 14  | [múltiples categorías por profesional](./14-multiples-categorias-profesional/) | producto | 2026-09-06 | exploración | Investigación | — |
+| 15  | [múltiples comunas por profesional](./15-multiples-comunas-profesional/) | producto | 2026-09-06 | exploración | Investigación | — |
 
 Misiones 02 a 07 son las seis que llevan al MVP (registrarse, mostrarse, buscar, reseñar), en el orden de
 dependencia definido en la conversación de roadmap del 2026-08-13 — el número no es prioridad, pero acá sí


### PR DESCRIPTION
## Resumen

Abre tres misiones nuevas y cierra el discovery completo de una de ellas:

- **13 — tamaño de fuente**: **discovery completo, lista para construir.** Sube el texto de uso
  frecuente del buscador, resultados de búsqueda, perfil público y perfil de gestión (12→14px,
  14→16px), corrige botones/inputs de Nuxt UI que rendían por debajo del piso pese a su `size`
  (el CTA "Escribir por WhatsApp", el botón "Buscar" del selector, dos inputs de edición), y agrega
  el piso tipográfico al skill `write-code` para que el texto que se escriba después lo siga sin
  depender de que alguien se acuerde. Investigación, producto, experiencia e ingeniería vigentes,
  aprobados por Patricio el 2026-09-06. Plan de construcción cortado en 3 slices por vista
  (S-001 buscador+resultados, S-002 perfil público, S-003 perfil de gestión) — se crean como issues
  después de mergear este PR.
- **14 — múltiples categorías por profesional**: queda en `exploración`, con solo el brief y los
  temas a explorar en su README.
- **15 — múltiples comunas por profesional**: queda en `exploración`, con solo el brief y los temas
  a explorar en su README.

## Test plan

- [x] `investigacion.md`, `producto.md`, `experiencia.md` e `ingenieria.md` de la misión 13 siguen el
  formato de sus skills de discovery correspondientes.
- [x] Los tres mockups (`design-mockups/`) verificados con Playwright headless en 390px — jerarquía y
  truncado se sostienen con los tamaños nuevos.
- [x] Sin cambios de código de la app en este PR — es documentación de discovery más una entrada de
  skill; `npx nuxi typecheck`/`npm run build` no aplican.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018N9djwyFLp8JRjCVCcD59z