### PR TITLE
feat(app): subir tamaño de texto del buscador y la card de resultados

### DIFF
--- a/app/components/CompactSearchBar.vue
+++ b/app/components/CompactSearchBar.vue
@@ -39,8 +39,8 @@ const summary = computed(() => {
       @click="open()"
     >
       <Search class="h-4 w-4 shrink-0 text-primary" :stroke-width="2.5" />
-      <span v-if="summary" class="truncate text-sm font-bold text-datealo-text">{{ summary }}</span>
-      <span v-else class="text-sm font-medium text-datealo-muted">¿Qué profesional buscas?</span>
+      <span v-if="summary" class="truncate text-base font-bold text-datealo-text">{{ summary }}</span>
+      <span v-else class="text-base font-medium text-datealo-muted">¿Qué profesional buscas?</span>
     </button>
 
     <div
@@ -53,8 +53,8 @@ const summary = computed(() => {
         :class="dense ? 'min-w-28 px-5 py-2' : 'min-w-48 px-6 py-3'"
         @click="open('categoria')"
       >
-        <span v-if="!dense" class="text-xs font-bold uppercase tracking-wide text-datealo-muted">Categoría</span>
-        <span class="text-sm font-bold" :class="categoriaLabel ? 'text-datealo-text' : 'font-medium text-datealo-muted'">
+        <span v-if="!dense" class="text-sm font-bold uppercase tracking-wide text-datealo-muted">Categoría</span>
+        <span class="text-base font-bold" :class="categoriaLabel ? 'text-datealo-text' : 'font-medium text-datealo-muted'">
           {{ categoriaLabel ?? 'Elige categoría' }}
         </span>
       </button>
@@ -65,8 +65,8 @@ const summary = computed(() => {
         :class="dense ? 'min-w-28 px-5 py-2' : 'min-w-48 px-6 py-3'"
         @click="open('comuna')"
       >
-        <span v-if="!dense" class="text-xs font-bold uppercase tracking-wide text-datealo-muted">Comuna</span>
-        <span class="text-sm font-bold" :class="comunaLabel ? 'text-datealo-text' : 'font-medium text-datealo-muted'">
+        <span v-if="!dense" class="text-sm font-bold uppercase tracking-wide text-datealo-muted">Comuna</span>
+        <span class="text-base font-bold" :class="comunaLabel ? 'text-datealo-text' : 'font-medium text-datealo-muted'">
           {{ comunaLabel ?? 'Elige comuna' }}
         </span>
       </button>
@@ -104,7 +104,7 @@ const summary = computed(() => {
           <button
             type="button"
             :disabled="!ready"
-            class="w-full rounded-full py-4 text-center text-[0.9375rem] font-bold disabled:cursor-not-allowed"
+            class="w-full rounded-full py-4 text-center text-base font-bold disabled:cursor-not-allowed"
             :class="ready ? 'bg-secondary text-white shadow-[0_10px_24px_-8px_rgba(62,203,215,0.5)]' : 'bg-datealo-surface text-datealo-muted'"
             @click="confirm"
           >

--- a/app/components/search/SearchResultCard.vue
+++ b/app/components/search/SearchResultCard.vue
@@ -40,18 +40,18 @@ const memberSince = computed(() => formatMemberSince(props.professional.createdA
     </div>
 
     <div class="min-w-0 p-3.5">
-      <p class="truncate text-sm font-bold text-datealo-text">{{ professional.displayName }}</p>
+      <p class="truncate text-base font-bold text-datealo-text">{{ professional.displayName }}</p>
       <!-- en negrita en modo vecina: el peso visual, no solo el texto, tiene que avisar que esta comuna
            no es la que se pidió — así el fallback nunca se lee como un resultado real de la exacta -->
-      <p class="truncate text-xs" :class="vecina ? 'font-bold text-datealo-text' : 'text-datealo-muted'">
+      <p class="truncate text-sm" :class="vecina ? 'font-bold text-datealo-text' : 'text-datealo-muted'">
         {{ professional.comunaNombre }}
       </p>
-      <div v-if="professional.ratingAverage !== null" class="mt-1 flex items-center gap-1 text-xs">
+      <div v-if="professional.ratingAverage !== null" class="mt-1 flex items-center gap-1 text-sm">
         <Star class="h-3.5 w-3.5 fill-amber-400 text-amber-400" />
         <span class="font-bold text-datealo-text">{{ professional.ratingAverage.toFixed(1).replace('.', ',') }}</span>
         <span class="text-datealo-muted">· {{ professional.reviewCount }} reseñas</span>
       </div>
-      <p v-if="professional.priceFrom" class="mt-1 text-xs font-bold text-datealo-text">
+      <p v-if="professional.priceFrom" class="mt-1 text-sm font-bold text-datealo-text">
         Desde ${{ formatPriceFrom(professional.priceFrom) }}
       </p>
       <p class="mt-0.5 text-[0.6875rem] text-datealo-muted">En Datealo desde {{ memberSince }}</p>

--- a/app/pages/buscar/index.vue
+++ b/app/pages/buscar/index.vue
@@ -90,14 +90,14 @@ useSeoMeta({
       <!-- con resultados / comunas vecinas -->
       <div v-else-if="matchType === 'exacta' || matchType === 'vecina'" class="flex flex-col gap-3 p-4 lg:p-8">
         <template v-if="matchType === 'vecina'">
-          <div class="rounded-xl bg-datealo-surface p-3.5 text-sm text-datealo-text">
+          <div class="rounded-xl bg-datealo-surface p-3.5 text-base text-datealo-text">
             Todavía no hay profesionales de {{ categoriaNombre }} en {{ comunaNombre }}.
           </div>
           <p class="px-0.5 text-[0.6875rem] font-bold uppercase tracking-wide text-datealo-muted">
             Cerca de {{ comunaNombre }}
           </p>
         </template>
-        <p v-else class="px-0.5 text-xs text-datealo-muted">
+        <p v-else class="px-0.5 text-sm text-datealo-muted">
           {{ results.length }} {{ results.length === 1 ? 'resultado' : 'resultados' }}
         </p>
 


### PR DESCRIPTION
## Resumen

Misión 13 (tamaño de fuente), slice S-001. Sube el piso tipográfico en el buscador del hero y la
card de resultados de búsqueda:

- `CompactSearchBar.vue`: el resumen de búsqueda ("Gasfitería en Ñuñoa"), las opciones de
  categoría/comuna del selector desktop y el botón "Buscar" del panel mobile suben a 16px.
- `SearchResultCard.vue`: el nombre del profesional sube a 16px bold; comuna, rating y precio suben
  a 14px. "En Datealo desde…" (11px) queda exento.
- `buscar/index.vue`: el contador de resultados sube a 14px; el mensaje de comunas vecinas
  (título de facto de ese estado) sube a 16px. El label "Cerca de tu comuna" queda exento.

Sustento: F-001, D-001, D-002, CL-001, [E-005](docs/missions/13-tamano-de-fuente/investigacion.md#e-005)
— ver `docs/missions/13-tamano-de-fuente/ingenieria.md`.

Closes #214

## Test plan

- [x] `npx nuxi typecheck` sin errores.
- [x] `npm run build` compila sin errores.
- [x] Verificación visual en Playwright headless a 390px, con datos mockeados (nombre largo de
  CL-001, "María Fernanda Rojas Ilabaca" en "San José de Maipo", $25.000): nombre en 16px bold,
  comuna/rating/precio/contador en 14px, "En Datealo desde…" sin cambio, sin overflow ni truncado
  roto.
- [x] Grep de IDs de decisión en comentarios nuevos: sin coincidencias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EEGPAjtMS5Wu74BsRzQpUW