### PR TITLE
feat(app): subir tamaño de texto del perfil público y su CTA de contacto

### DIFF
--- a/app/components/professional-public/ProfessionalPublicContactBar.vue
+++ b/app/components/professional-public/ProfessionalPublicContactBar.vue
@@ -27,13 +27,13 @@ function registerContact() {
 
 <template>
   <div class="flex gap-2">
-    <UButton :to="whatsappUrl" size="lg" class="flex-1 justify-center font-bold" @click="registerContact">
+    <UButton :to="whatsappUrl" size="xl" class="flex-1 justify-center font-bold" @click="registerContact">
       <MessageCircle class="h-5 w-5" />
       Escribir por WhatsApp
     </UButton>
     <UButton
       :to="telUrl"
-      size="lg"
+      size="xl"
       variant="outline"
       color="neutral"
       class="px-4"

--- a/app/components/professional-public/ProfessionalPublicReviewCard.vue
+++ b/app/components/professional-public/ProfessionalPublicReviewCard.vue
@@ -12,7 +12,7 @@ const relativeDate = computed(() => formatRelativeDate(props.review.updatedAt))
 <template>
   <div class="rounded-2xl border border-datealo-surface bg-white p-4">
     <div class="flex items-center justify-between gap-2">
-      <span class="text-sm font-bold text-datealo-text">{{ review.name }}</span>
+      <span class="text-base font-bold text-datealo-text">{{ review.name }}</span>
       <span
         class="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2 py-0.5 text-[0.6875rem] font-semibold text-emerald-700"
       >
@@ -26,6 +26,6 @@ const relativeDate = computed(() => formatRelativeDate(props.review.updatedAt))
       <span class="ml-1 text-[0.6875rem] text-datealo-muted">{{ relativeDate }}</span>
     </div>
 
-    <p v-if="review.comment" class="mt-2 text-sm text-datealo-text">{{ review.comment }}</p>
+    <p v-if="review.comment" class="mt-2 text-base text-datealo-text">{{ review.comment }}</p>
   </div>
 </template>

--- a/app/components/professional-public/ProfessionalPublicReviews.vue
+++ b/app/components/professional-public/ProfessionalPublicReviews.vue
@@ -47,13 +47,13 @@ async function handleSubmit() {
 
 <template>
   <div v-if="reviews.length > 0 || hasToken">
-    <h2 class="text-sm font-extrabold text-datealo-text">Reseñas</h2>
+    <h2 class="text-base font-extrabold text-datealo-text">Reseñas</h2>
 
     <div
       v-if="hasToken"
       class="mt-3 rounded-2xl border-[1.5px] border-dashed border-datealo-surface bg-datealo-surface/40 p-4"
     >
-      <p class="text-sm font-bold text-datealo-text">{{ cardHeading }}</p>
+      <p class="text-base font-bold text-datealo-text">{{ cardHeading }}</p>
       <UButton class="mt-2.5 w-full justify-center" @click="sheet.open()">
         {{ cardButtonLabel }}
       </UButton>

--- a/app/pages/profesionales/[id].vue
+++ b/app/pages/profesionales/[id].vue
@@ -77,7 +77,7 @@ useSeoMeta({
             Desde ${{ formatPriceFrom(professional.priceFrom) }}
           </p>
 
-          <p v-if="professional.description" class="mt-4 text-sm leading-relaxed text-datealo-text">
+          <p v-if="professional.description" class="mt-4 text-base leading-relaxed text-datealo-text">
             {{ professional.description }}
           </p>
         </div>


### PR DESCRIPTION
## Resumen

Misión 13 (tamaño de fuente), slice S-002. Sube el piso tipográfico en el perfil público de
profesional y su CTA de contacto:

- `[id].vue`: la descripción del profesional sube a 16px. El precio ya estaba en 16px.
- `ProfessionalPublicContactBar.vue`: "Escribir por WhatsApp" y "Llamar" pasan de `size="lg"` a
  `size="xl"` — `size="lg"` rendía 14px real en Nuxt UI pese a lo que sugiere su nombre.
- `ProfessionalPublicReviews.vue`: el título "Reseñas" y el heading de invitación a reseñar
  ("¿Cómo te fue con…?") suben a 16px. El botón para abrir el formulario no cambia (ya cumplía el
  piso de 14px).
- `ProfessionalPublicReviewCard.vue`: el nombre de quien reseña y el comentario suben a 16px. El
  badge "verificada por contacto" y la fecha relativa quedan exentos.

Sustento: F-001, D-001, D-002 — ver `docs/missions/13-tamano-de-fuente/ingenieria.md`.

Closes #215

## Test plan

- [x] `npx nuxi typecheck` sin errores.
- [x] `npm run build` compila sin errores.
- [x] Verificación visual en Playwright headless a 390px, con datos mockeados (descripción larga,
  una reseña real): descripción y precio en 16px, "Reseñas" y la reseña en 16px, CTA de WhatsApp ya
  no se ve en 14px, "En Datealo desde…" y la fecha relativa sin cambio.
- [x] Grep de IDs de decisión en comentarios nuevos: sin coincidencias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EEGPAjtMS5Wu74BsRzQpUW