### PR TITLE
feat(app): subir tamaño de texto del perfil de gestión y sus componentes

### DIFF
--- a/app/components/CatalogSelect.vue
+++ b/app/components/CatalogSelect.vue
@@ -171,7 +171,7 @@ defineExpose({ focus: () => uInputRef.value?.inputRef?.focus() })
       <template v-if="error">
         <div class="flex flex-col items-center gap-2 px-2 py-3 text-center">
           <p class="text-sm" style="color: var(--ui-text-muted)">{{ errorMessage }}</p>
-          <UButton size="sm" data-testid="retry-button" @click="retry">Reintentar</UButton>
+          <UButton size="md" data-testid="retry-button" @click="retry">Reintentar</UButton>
         </div>
       </template>
       <template v-else-if="pending">

--- a/app/components/professional/ProfessionalAvatar.vue
+++ b/app/components/professional/ProfessionalAvatar.vue
@@ -40,14 +40,14 @@ function onFileSelected(event: Event) {
         </div>
       </button>
 
-      <p v-if="!hasAvatar" class="text-xs text-datealo-muted">
+      <p v-if="!hasAvatar" class="text-sm text-datealo-muted">
         Para que te reconozcan antes de escribirte. Opcional.
       </p>
       <div v-else>
-        <p class="text-xs font-semibold text-datealo-text">Toca la foto para cambiarla</p>
+        <p class="text-sm font-semibold text-datealo-text">Toca la foto para cambiarla</p>
         <button
           type="button"
-          class="-m-2 mt-1 inline-block p-2 text-xs font-semibold text-error underline disabled:opacity-50"
+          class="-m-2 mt-1 inline-block p-2 text-sm font-semibold text-error underline disabled:opacity-50"
           :disabled="removing"
           @click="remove"
         >
@@ -58,7 +58,7 @@ function onFileSelected(event: Event) {
 
     <input ref="fileInput" type="file" accept="image/*" class="hidden" @change="onFileSelected">
 
-    <p v-if="uploadError" class="mt-2 text-xs font-semibold text-error" aria-live="polite">{{ uploadError }}</p>
-    <p v-if="removeError" class="mt-2 text-xs font-semibold text-error" aria-live="polite">{{ removeError }}</p>
+    <p v-if="uploadError" class="mt-2 text-sm font-semibold text-error" aria-live="polite">{{ uploadError }}</p>
+    <p v-if="removeError" class="mt-2 text-sm font-semibold text-error" aria-live="polite">{{ removeError }}</p>
   </div>
 </template>

--- a/app/components/professional/ProfessionalCatalogRow.vue
+++ b/app/components/professional/ProfessionalCatalogRow.vue
@@ -42,7 +42,7 @@ function onSelect(newValue: string | null | undefined) {
         <slot name="select" :model-value="draft" :update="onSelect" />
       </div>
     </div>
-    <p v-if="hasSaveError" class="mt-1 text-right text-xs font-semibold text-error" aria-live="polite">
+    <p v-if="hasSaveError" class="mt-1 text-right text-sm font-semibold text-error" aria-live="polite">
       No se pudo guardar, toca para reintentar
     </p>
   </div>

--- a/app/components/professional/ProfessionalDataRow.vue
+++ b/app/components/professional/ProfessionalDataRow.vue
@@ -43,7 +43,7 @@ function commit() {
         v-else
         v-model="draft"
         :type="type === 'tel' ? 'tel' : 'text'"
-        size="sm"
+        size="lg"
         class="w-40"
         autofocus
         :color="fieldError ? 'error' : 'primary'"
@@ -52,10 +52,10 @@ function commit() {
         @keyup.enter="commit"
       />
     </div>
-    <p v-if="isEditing && fieldError" class="mt-1 text-right text-xs font-semibold text-error" aria-live="polite">
+    <p v-if="isEditing && fieldError" class="mt-1 text-right text-sm font-semibold text-error" aria-live="polite">
       {{ fieldError }}
     </p>
-    <p v-if="hasSaveError" class="mt-1 text-right text-xs font-semibold text-error" aria-live="polite">
+    <p v-if="hasSaveError" class="mt-1 text-right text-sm font-semibold text-error" aria-live="polite">
       No se pudo guardar, toca para reintentar
     </p>
   </div>

--- a/app/components/professional/ProfessionalPhotos.vue
+++ b/app/components/professional/ProfessionalPhotos.vue
@@ -56,7 +56,7 @@ function onFileSelected(event: Event) {
 
     <input ref="fileInput" type="file" accept="image/*" class="hidden" @change="onFileSelected">
 
-    <p v-if="uploadError" class="mt-2 text-xs font-semibold text-error" aria-live="polite">{{ uploadError }}</p>
-    <p v-if="deleteError" class="mt-2 text-xs font-semibold text-error" aria-live="polite">{{ deleteError }}</p>
+    <p v-if="uploadError" class="mt-2 text-sm font-semibold text-error" aria-live="polite">{{ uploadError }}</p>
+    <p v-if="deleteError" class="mt-2 text-sm font-semibold text-error" aria-live="polite">{{ deleteError }}</p>
   </div>
 </template>

--- a/app/pages/profesional/perfil.vue
+++ b/app/pages/profesional/perfil.vue
@@ -64,9 +64,9 @@ function commitPrice() {
 
 <template>
   <div class="mx-auto min-h-screen max-w-md px-5 py-8 pb-16">
-    <p v-if="pending" class="text-sm text-datealo-muted">Cargando tu perfil…</p>
+    <p v-if="pending" class="text-base text-datealo-muted">Cargando tu perfil…</p>
 
-    <p v-else-if="loadError" class="text-sm text-error">{{ loadError }}</p>
+    <p v-else-if="loadError" class="text-base text-error">{{ loadError }}</p>
 
     <template v-else-if="professional">
       <h1 class="text-xl font-extrabold text-datealo-text">{{ professional.displayName }}</h1>
@@ -78,17 +78,17 @@ function commitPrice() {
 
       <div class="mt-3 rounded-2xl border border-datealo-surface p-4">
         <div class="flex items-center justify-between">
-          <p class="text-sm font-semibold text-datealo-text">Descripción</p>
+          <p class="text-base font-semibold text-datealo-text">Descripción</p>
           <Loader2 v-if="isSavingDescription" class="h-3.5 w-3.5 animate-spin text-primary" />
         </div>
 
-        <p v-if="!isEditingDescription && professional.description" class="mt-1 text-sm text-datealo-text">
+        <p v-if="!isEditingDescription && professional.description" class="mt-1 text-base text-datealo-text">
           {{ professional.description }}
         </p>
         <button
           v-else-if="!isEditingDescription"
           type="button"
-          class="mt-1 text-left text-sm italic text-datealo-muted"
+          class="mt-1 text-left text-base italic text-datealo-muted"
           @click="editDescription"
         >
           Ej: "Electricista con 10 años de experiencia en Ñuñoa"
@@ -104,23 +104,23 @@ function commitPrice() {
         <button
           v-if="!isEditingDescription && professional.description"
           type="button"
-          class="mt-1 text-xs font-semibold text-primary underline"
+          class="mt-1 text-sm font-semibold text-primary underline"
           @click="editDescription"
         >
           Editar
         </button>
-        <p v-if="hasDescriptionError" class="mt-2 text-xs font-semibold text-error" aria-live="polite">
+        <p v-if="hasDescriptionError" class="mt-2 text-sm font-semibold text-error" aria-live="polite">
           No se pudo guardar, toca para reintentar
         </p>
       </div>
 
       <div class="mt-3 rounded-2xl border border-datealo-surface p-4">
         <div class="flex items-center justify-between">
-          <p class="text-sm font-semibold text-datealo-text">Precio</p>
+          <p class="text-base font-semibold text-datealo-text">Precio</p>
           <Loader2 v-if="isSavingPrice" class="h-3.5 w-3.5 animate-spin text-primary" />
         </div>
 
-        <button v-if="!isEditingPrice" type="button" class="mt-1 block text-left text-sm" @click="editPrice">
+        <button v-if="!isEditingPrice" type="button" class="mt-1 block text-left text-base" @click="editPrice">
           <template v-if="professional.priceFrom">
             <span class="text-datealo-text">Desde ${{ formatPriceFrom(professional.priceFrom) }}</span>
           </template>
@@ -130,24 +130,24 @@ function commitPrice() {
           </template>
         </button>
         <div v-else class="mt-2 flex items-center gap-2">
-          <span class="text-sm text-datealo-muted">Desde $</span>
+          <span class="text-base text-datealo-muted">Desde $</span>
           <UInput
             v-model="priceDraft"
             inputmode="numeric"
             autofocus
-            size="sm"
+            size="lg"
             class="w-32"
             @blur="commitPrice"
             @keyup.enter="commitPrice"
           />
         </div>
-        <p v-if="hasPriceError" class="mt-2 text-xs font-semibold text-error" aria-live="polite">
+        <p v-if="hasPriceError" class="mt-2 text-sm font-semibold text-error" aria-live="polite">
           No se pudo guardar, toca para reintentar
         </p>
       </div>
 
       <div class="mt-3 rounded-2xl border border-datealo-surface p-4">
-        <p class="mb-1 text-sm font-semibold text-datealo-text">Tus datos</p>
+        <p class="mb-1 text-base font-semibold text-datealo-text">Tus datos</p>
 
         <ProfessionalDataRow label="Nombre" field="displayName" :value="professional.displayName" />
         <ProfessionalCatalogRow


### PR DESCRIPTION
## Resumen

Misión 13 (tamaño de fuente), slice S-003. Sube el piso tipográfico en el perfil de gestión de
profesional:

- `perfil.vue`: "Descripción", "Precio", sus valores y "Tus datos" suben a 16px. "Editar" y los
  mensajes de error de guardado suben a 14px. "Cargando tu perfil…" y el error de carga suben a
  16px (único contenido de esos estados). El input de precio pasa de `size="sm"` a `size="lg"`.
- `ProfessionalAvatar.vue`: todo su texto de apoyo (hints, "Quitar foto", errores de subida/borrado)
  sube de 12px a 14px.
- `ProfessionalPhotos.vue`, `ProfessionalCatalogRow.vue`, `ProfessionalDataRow.vue`: sus mensajes de
  error de carga/guardado suben de 12px a 14px. `ProfessionalDataRow.vue` pasa su input de
  `size="sm"` a `size="lg"`.
- `CatalogSelect.vue`: el botón "Reintentar" del selector de categoría/comuna pasa de `size="sm"`
  (12px) a `size="md"` (14px).

Sustento: F-001, D-001, D-002 — ver `docs/missions/13-tamano-de-fuente/ingenieria.md`.

Closes #216

## Test plan

- [x] `npx nuxi typecheck` sin errores.
- [x] `npm run build` compila sin errores.
- [x] Verificación visual en Playwright headless a 390px, con datos mockeados (`/profesional/perfil`
  requiere sesión — se usó una página temporal, no incluida en este PR, que precarga el estado del
  composable y renderiza los mismos componentes reales): "Descripción"/"Precio"/"Tus datos" en 16px,
  "Editar" en 14px, input de precio en 16px real.
- [x] Grep de IDs de decisión en comentarios nuevos: sin coincidencias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EEGPAjtMS5Wu74BsRzQpUW