### PR TITLE
docs(docs): cerrar la misión 13 (tamaño de fuente)

### DIFF
--- a/docs/missions/13-tamano-de-fuente/README.md
+++ b/docs/missions/13-tamano-de-fuente/README.md
@@ -3,21 +3,20 @@
 **Tipo:** producto. **Carril:** Light Spec — cambio visual, sin RLS, sin dato de usuario, 100% reversible.
 **Abierta el** 2026-09-06. **Nace de:** ninguna.
 
-**Estado de la misión:** lista para construir
+**Estado de la misión:** cerrada 2026-09-06
 
-**En foco:** ninguno — discovery completo, falta abrir el PR
+**En foco:** ninguno — misión cerrada
 
 **Última actualización:** 2026-09-06
 
 **Documentos:** [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-**Próximo hito:** los cuatro documentos están vigentes — aprobados por Patricio el 2026-09-06. Sigue
-abrir el PR de discovery con los tres documentos que requieren aprobación (producto/experiencia/ingeniería,
-más `README.md` y `design-mockups/`) sobre esta misma rama (`worktree-abrir-misiones-13-14-15`, donde ya
-vive el PR #213 abierto). Después: mergear → `ExitWorktree action: "remove"` → recién ahí crear los issues
-S-001 a S-003 en la raíz. [Q-001](./producto.md#q-001) sigue abierta sin bloquear — se resuelve con
-[TR-001](./ingenieria.md), revisando la captura real de cada slice antes de su PR.
+**Cierre:** los tres slices del plan de construcción se implementaron y mergearon: S-001 (#217, issue
+#214), S-002 (#218, issue #215) y S-003 (#219, issue #216). [Q-001](./producto.md#q-001) se resolvió
+revisando la captura real de S-001 en 390px — la jerarquía nombre 16px bold / secundario 14px normal se
+sostiene sola, sin ajuste de peso o contraste. [TR-001](./ingenieria.md) cerrado con el mismo criterio
+para los tres slices.
 
 ## Brief
 

--- a/docs/missions/13-tamano-de-fuente/ingenieria.md
+++ b/docs/missions/13-tamano-de-fuente/ingenieria.md
@@ -90,7 +90,7 @@ tiene pregunta, límite de tiempo y resultado capaz de cerrar la incertidumbre.
 
 | ID     | Riesgo o pregunta                                                                 | Qué invalida | Experimento o mitigación | Criterio de salida | Estado |
 | ------ | ------------------------------------------------------------------------------------ | -------------- | --------------------------- | --------------------- | -------- |
-| TR-001 | Los mockups usan Tailwind puro (aproximación); Nuxt UI real puede espaciar distinto y romper algún layout que el mockup no capturó | UX-001 (jerarquía sin tocar peso/color) — no D-001/F-001 en sí | Captura con Playwright en 390px de cada slice ya implementado, antes de abrir su PR | El dueño de producto revisa la captura real y confirma que sostiene lo que muestra el mockup — esto es lo que cierra [Q-001](./producto.md#q-001) | abierto |
+| TR-001 | Los mockups usan Tailwind puro (aproximación); Nuxt UI real puede espaciar distinto y romper algún layout que el mockup no capturó | UX-001 (jerarquía sin tocar peso/color) — no D-001/F-001 en sí | Captura con Playwright en 390px de cada slice ya implementado, antes de abrir su PR | El dueño de producto revisa la captura real y confirma que sostiene lo que muestra el mockup — esto es lo que cierra [Q-001](./producto.md#q-001) | cerrado 2026-09-06 — capturas de los tres slices revisadas, layout y jerarquía sostenidos sin ajustes |
 
 ## Estrategia de pruebas
 

--- a/docs/missions/13-tamano-de-fuente/producto.md
+++ b/docs/missions/13-tamano-de-fuente/producto.md
@@ -292,7 +292,7 @@ resolverla no se puede cerrar si `experiencia.md` solo ajusta números o tambié
 
 | ID    | La duda                                                                              | Estado  | Respuesta, o quién la resuelve                                                                          |
 | ----- | --------------------------------------------------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------- |
-| Q-001 | ¿Alcanza con subir el tamaño (D-001), o el texto secundario necesita además más peso o contraste para distinguirse del principal? | abierta | Dueño de producto, revisando una captura en 390px del antes/después de F-001 ya implementado. Bloquea si `experiencia.md` toca solo tamaños o también peso/color; sin fecha límite, se resuelve al revisar el primer PR de F-001. |
+| Q-001 | ¿Alcanza con subir el tamaño (D-001), o el texto secundario necesita además más peso o contraste para distinguirse del principal? | resuelta 2026-09-06 | Dueño de producto, revisando la captura real en 390px de `SearchResultCard` (S-001 ya implementado): la jerarquía nombre 16px bold / secundario 14px normal se sostiene sola, sin necesidad de ajustar peso o contraste. |
 
 <a id="q-001"></a>
 
@@ -303,8 +303,7 @@ resolverla no se puede cerrar si `experiencia.md` solo ajusta números o tambié
   hace que ambos textos "compitan" visualmente y haga falta bajarle el peso o el contraste de color al
   secundario para que la jerarquía se mantenga clara?
 - **Afecta a:** [D-001](#d-001) y [F-001](#f-001).
-- **Cómo se resolverá:** el dueño de producto revisa una captura de F-001 ya implementado en 390px, antes
-  de aprobar `experiencia.md` como definitivo.
-- **¿Bloquea algo?:** no bloquea empezar `experiencia.md` ni la implementación de F-001 — bloquea
-  únicamente si `experiencia.md` necesita una segunda vuelta para ajustar peso/color además de tamaño. Sin
-  fecha límite.
+- **Cómo se resolvió:** el dueño de producto revisó la captura real de S-001 en 390px (PR #217, ya
+  mergeado) y confirmó que la jerarquía se sostiene sola, sin ajuste de peso o contraste.
+- **Resolución:** 2026-09-06 — no bloqueó nada; los tres slices (S-001 a S-003) se implementaron y
+  mergearon con el criterio de `experiencia.md` sin cambios.

--- a/docs/missions/README.md
+++ b/docs/missions/README.md
@@ -21,7 +21,7 @@ abrieron y de dónde salió cada una.
 | 10  | [vista de resultados de búsqueda](./10-vista-resultados-busqueda/) | producto | 2026-09-01 | cerrada 2026-09-04 | — | — |
 | 11  | [vista de detalle de perfil](./11-perfil-profesional/) | producto | 2026-09-01 | cerrada 2026-09-04 | — | — |
 | 12  | [hero y copy de la landing](./12-hero-y-copy-landing/) | producto | 2026-09-01 | cerrada 2026-09-06 | — | — |
-| 13  | [tamaño de fuente](./13-tamano-de-fuente/) | producto | 2026-09-06 | lista para construir | — | — |
+| 13  | [tamaño de fuente](./13-tamano-de-fuente/) | producto | 2026-09-06 | cerrada 2026-09-06 | — | — |
 | 14  | [múltiples categorías por profesional](./14-multiples-categorias-profesional/) | producto | 2026-09-06 | exploración | Investigación | — |
 | 15  | [múltiples comunas por profesional](./15-multiples-comunas-profesional/) | producto | 2026-09-06 | exploración | Investigación | — |
 


### PR DESCRIPTION
## Resumen

Cierra la misión 13 (tamaño de fuente): los tres slices del plan de construcción están mergeados
(S-001 #217, S-002 #218, S-003 #219 — issues #214/#215/#216 cerrados).

- `Q-001` (`producto.md`) resuelta: revisada la captura real de S-001 en 390px, la jerarquía nombre
  16px bold / secundario 14px normal se sostiene sola, sin ajuste de peso o contraste.
- `TR-001` (`ingenieria.md`) cerrado con el mismo criterio.
- Estado de la misión actualizado a `cerrada 2026-09-06` en su README y en el registro de
  `docs/missions/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EEGPAjtMS5Wu74BsRzQpUW