### PR TITLE
fix(app): permitir seleccionar categoría/comuna al tocar en mobile

### DIFF
--- a/app/components/CatalogSelect.test.ts
+++ b/app/components/CatalogSelect.test.ts
@@ -208,4 +208,18 @@ describe('CatalogSelect', () => {
 
     expect(wrapper.emitted('update:modelValue')?.[0]).toEqual(['gasfiteria'])
   })
+
+  it('el mousedown sobre una opción previene su default, para no perder el foco del input en touch', async () => {
+    const wrapper = mountCatalogSelect()
+    await wrapper.find('input').trigger('focusin')
+    await wrapper.find('input').setValue('gasfi')
+
+    // dispatchEvent nativo en vez de wrapper.trigger: necesitamos el objeto Event de vuelta para leer
+    // defaultPrevented, que trigger() de vue-test-utils no expone.
+    const option = wrapper.find('[data-testid="option-gasfiteria"]').element
+    const mousedown = new MouseEvent('mousedown', { bubbles: true, cancelable: true })
+    option.dispatchEvent(mousedown)
+
+    expect(mousedown.defaultPrevented).toBe(true)
+  })
 })

--- a/app/components/CatalogSelect.vue
+++ b/app/components/CatalogSelect.vue
@@ -112,9 +112,10 @@ function handleFocusIn() {
 
 // focusout (no blur) a nivel del contenedor: permite distinguir "el foco se fue a otra opción de la
 // misma lista" (relatedTarget adentro del contenedor, no hacer nada) de "el foco se fue afuera de
-// verdad" (ahí sí cerrar). Sin esto, tocar una opción dispara blur del input antes que su propio
-// click, y la selección se pierde — el mismo problema de fondo que forzó a abandonar el combobox de
-// Reka, resuelto acá con un patrón estándar en vez de pelear contra una librería.
+// verdad" (ahí sí cerrar). Cubre el mouse, donde relatedTarget apunta al botón clickeado. En touch
+// (iOS/Android) el input pierde el foco antes de que relatedTarget llegue a apuntar al botón, así que
+// cada opción previene su propio mousedown (ver el botón más abajo) para que el input no pierda el
+// foco y la lista no se desmonte antes de que el click corra.
 function handleFocusOut(event: FocusEvent) {
   const related = event.relatedTarget
   if (containerRef.value && related instanceof Node && containerRef.value.contains(related)) {
@@ -191,6 +192,7 @@ defineExpose({ focus: () => uInputRef.value?.inputRef?.focus() })
           type="button"
           :data-testid="`option-${item.value}`"
           class="catalog-option flex w-full cursor-pointer items-center gap-3 rounded-md px-2 py-1.5 text-left text-sm"
+          @mousedown.prevent
           @click="selectItem(item)"
         >
           <span v-if="itemIcon" class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-datealo-surface text-primary">


### PR DESCRIPTION
Closes #221

## Problema

En mobile (reportado en iPhone Chrome), el dropdown del buscador de categoría (y comuna) de la landing se abría al tocar el campo, pero tocar una opción no la seleccionaba — el dropdown se cerraba sin elegir nada. En desktop funcionaba bien.

## Causa raíz

`CatalogSelect.vue` cierra el dropdown en `focusout` del contenedor, distinguiendo "el foco se fue a otra opción de la lista" (no cerrar) de "el foco se fue afuera de verdad" (cerrar) leyendo `event.relatedTarget`. Con mouse, `relatedTarget` apunta de forma confiable al botón clickeado. En touch, el input pierde el foco antes de que `relatedTarget` llegue a apuntar al botón — la lista se desmonta (`v-if="isOpen"`) antes de que el click en la opción se procese.

## Fix

`@mousedown.prevent` en cada botón de opción: previene que el navegador le saque el foco al input al tocar, así la lista sigue montada hasta que el click corre y `selectItem` se ejecuta.

## Verificación

- `npx vitest run app/components/CatalogSelect.test.ts` — 18/18 tests, incluyendo uno nuevo que verifica que el `mousedown` sobre una opción llega con `defaultPrevented`.
- `npx nuxi typecheck` — sin errores.
- `npm run build` — compila.
- Playwright headless con emulación de `iPhone 13` (touch): el `tap()` sobre una opción selecciona la categoría y cierra el dropdown correctamente con el fix aplicado.

**Limitación de la verificación**: el `tap()` sintético de Playwright sobre Chromium headless no reprodujo la pérdida de foco previa al click (la carrera de eventos específica de WebKit/iOS al cerrar el teclado virtual) ni con el fix ni sin él — es una limitación conocida de la emulación táctil headless, que no levanta un teclado virtual real. La causa raíz identificada por lectura de código (el mismo patrón `relatedTarget`-en-`focusout` que rompe con foco perdido sin `relatedTarget` seteado) y el fix (`mousedown.prevent` para evitar el blur) son el patrón estándar de la industria para este bug exacto en comboboxes custom — recomiendo confirmar en un dispositivo real antes de mergear.