### PR TITLE
docs(docs): cerrar el discovery de la misión 15 (múltiples comunas por profesional)

### DIFF
--- a/docs/missions/15-multiples-comunas-profesional/README.md
+++ b/docs/missions/15-multiples-comunas-profesional/README.md
@@ -4,17 +4,24 @@
 comuna por profesional) y cómo `/api/search` filtra por comuna. **Abierta el** 2026-09-06.
 **Nace de:** ninguna.
 
-**Estado de la misión:** exploración
+**Estado de la misión:** definición
 
-**En foco:** Investigación
+**En foco:** ninguno — discovery completo, los tres documentos (`producto.md`, `experiencia.md`,
+`ingenieria.md`) están vigentes
 
-**Última actualización:** 2026-09-06
+**Última actualización:** 2026-09-07
 
 **Documentos:** [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-**Próximo hito:** completar `investigacion.md` con el problema concreto y evidencia de que un profesional
-real atiende más de una comuna — sin fecha límite todavía, recién se abre la misión.
+**Próximo hito:** abrir el PR de discovery con los tres documentos vigentes (paso 6 de la secuencia,
+`docs/missions/README.md`) — todavía no abierto. Recién después de mergeado, cerrar el worktree
+(`ExitWorktree action: "remove"`) y, ya en la raíz, cortar el Plan de construcción de `ingenieria.md`
+(S-001 a S-010) en issues. `ingenieria.md` diseña `professional_comunas` (tabla de relación que reemplaza a
+`professionals.comuna_codigo`), 4 contratos (TC-001 a TC-004), su RLS (auditada contra el checklist de
+`seguridad-datos`), y 5 decisiones técnicas (T-001 a T-005) — incluida una ventana de migración entre
+slices y un consumidor de `comunaCodigo` que la auditoría del Carril Full Spec encontró y ya quedó
+corregido en el propio documento.
 
 ## Brief
 

--- a/docs/missions/15-multiples-comunas-profesional/design-mockups/card-resultados.html
+++ b/docs/missions/15-multiples-comunas-profesional/design-mockups/card-resultados.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<html lang="es-CL">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>V-005 Card de resultados — misión 15</title>
+
+    <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+    <link
+      href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&family=Plus+Jakarta+Sans:wght@600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../../design/datealo-mockup-kit.css" />
+    <style type="text/tailwindcss">
+      @theme {
+        --color-primary: var(--ui-primary);
+        --color-secondary: var(--ui-secondary);
+        --color-success: var(--ui-success);
+        --color-error: var(--ui-error);
+      }
+    </style>
+  </head>
+
+  <body>
+    <div class="frames">
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-005 · búsqueda "gasfitería" en Puerto Varas · coincidencia exacta
+          <small>ronda 1 — Rudiberto declaró Puerto Varas; la card sigue mostrando solo la comuna buscada (UX-005)</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="p-4">
+            <div class="overflow-hidden rounded-2xl border" style="border-color: var(--color-datealo-surface)">
+              <div class="aspect-4/3 w-full" style="background: color-mix(in oklab, var(--ui-primary) 10%, white)"></div>
+              <div class="p-3.5">
+                <p class="text-base font-bold text-datealo-text">Rudiberto Soto</p>
+                <p class="text-sm text-datealo-muted">Puerto Varas</p>
+                <p class="mt-1 text-sm font-bold text-datealo-text">Desde $15.000</p>
+                <p class="mt-0.5 text-[0.6875rem] text-datealo-muted">En Datealo desde ago. 2026</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-005 · búsqueda "gasfitería" en Puerto Octay · coincidencia vecina
+          <small>ronda 1 — Puerto Octay no tiene profesionales; Rudiberto aparece por ser vecina de Llanquihue, una de sus comunas declaradas</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="p-4">
+            <div class="overflow-hidden rounded-2xl border" style="border-color: var(--color-datealo-surface)">
+              <div class="aspect-4/3 w-full" style="background: color-mix(in oklab, var(--ui-primary) 10%, white)"></div>
+              <div class="p-3.5">
+                <p class="text-base font-bold text-datealo-text">Rudiberto Soto</p>
+                <p class="text-sm font-bold text-datealo-text">Llanquihue</p>
+                <p class="mt-1 text-sm font-bold text-datealo-text">Desde $15.000</p>
+                <p class="mt-0.5 text-[0.6875rem] text-datealo-muted">En Datealo desde ago. 2026</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  </body>
+</html>

--- a/docs/missions/15-multiples-comunas-profesional/design-mockups/perfil-publico.html
+++ b/docs/missions/15-multiples-comunas-profesional/design-mockups/perfil-publico.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<html lang="es-CL">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>V-004 Perfil público — misión 15</title>
+
+    <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+    <link
+      href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&family=Plus+Jakarta+Sans:wght@600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../../design/datealo-mockup-kit.css" />
+    <style type="text/tailwindcss">
+      @theme {
+        --color-primary: var(--ui-primary);
+        --color-secondary: var(--ui-secondary);
+        --color-success: var(--ui-success);
+        --color-error: var(--ui-error);
+      }
+    </style>
+  </head>
+
+  <body>
+    <div class="frames">
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-004 · perfil público · subtítulo con 3 comunas
+          <small>ronda 1 — Rudiberto, sin truncar (UX-004)</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="aspect-4/3 w-full" style="background: color-mix(in oklab, var(--ui-primary) 10%, white)"></div>
+          <div class="px-5 pt-4">
+            <p class="text-xl font-extrabold text-datealo-text">Rudiberto Soto</p>
+            <p class="mt-0.5 text-sm text-datealo-muted">Gasfitería · Llanquihue, Frutillar y Puerto Varas</p>
+            <p class="mt-2 text-base font-bold text-datealo-text">Desde $15.000</p>
+            <p class="mt-4 text-base leading-relaxed text-datealo-text">
+              Gasfitero con 12 años de experiencia en la zona del lago Llanquihue. Reparaciones, instalaciones y mantención.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-004 · perfil público · subtítulo con 1 comuna
+          <small>ronda 1 — caso mayoritario hoy, sin cambio visual respecto de la versión actual</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="aspect-4/3 w-full" style="background: color-mix(in oklab, var(--ui-primary) 10%, white)"></div>
+          <div class="px-5 pt-4">
+            <p class="text-xl font-extrabold text-datealo-text">Marcela Fuentes</p>
+            <p class="mt-0.5 text-sm text-datealo-muted">Peluquería a domicilio · Ñuñoa</p>
+            <p class="mt-2 text-base font-bold text-datealo-text">Desde $10.000</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-004 · perfil público · subtítulo con 6 comunas
+          <small>ronda 2 — Camila Reyes, Santiago Oriente: sin truncar, hace wrap a dos líneas (UX-004)</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="aspect-4/3 w-full" style="background: color-mix(in oklab, var(--ui-secondary) 10%, white)"></div>
+          <div class="px-5 pt-4">
+            <p class="text-xl font-extrabold text-datealo-text">Camila Reyes</p>
+            <p class="mt-0.5 text-sm text-datealo-muted">Electricidad · La Reina, Las Condes, Lo Barnechea, Ñuñoa, Providencia y Vitacura</p>
+            <p class="mt-2 text-base font-bold text-datealo-text">Desde $18.000</p>
+            <p class="mt-4 text-base leading-relaxed text-datealo-text">
+              Electricista certificada SEC, especializada en instalaciones residenciales en el sector oriente.
+            </p>
+          </div>
+        </div>
+      </section>
+    </div>
+  </body>
+</html>

--- a/docs/missions/15-multiples-comunas-profesional/design-mockups/registro-perfil.html
+++ b/docs/missions/15-multiples-comunas-profesional/design-mockups/registro-perfil.html
@@ -1,0 +1,182 @@
+<!doctype html>
+<html lang="es-CL">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>V-002/V-003 Registro y perfil — misión 15</title>
+
+    <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+    <link
+      href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&family=Plus+Jakarta+Sans:wght@600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../../design/datealo-mockup-kit.css" />
+    <style type="text/tailwindcss">
+      @theme {
+        --color-primary: var(--ui-primary);
+        --color-secondary: var(--ui-secondary);
+        --color-success: var(--ui-success);
+        --color-error: var(--ui-error);
+      }
+    </style>
+  </head>
+
+  <body>
+    <div class="frames">
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-002 · registro · modo campo vacío
+          <small>ronda 1 — antes de tocar "Tus comunas" por primera vez</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="px-6 py-6">
+            <p class="text-2xl font-extrabold text-datealo-text">Crea tu perfil</p>
+            <div class="mt-4 flex gap-1.5">
+              <div class="h-1.5 flex-1 rounded-full bg-primary"></div>
+              <div class="h-1.5 flex-1 rounded-full bg-primary"></div>
+              <div class="h-1.5 flex-1 rounded-full" style="background: var(--ui-bg-elevated)"></div>
+              <div class="h-1.5 flex-1 rounded-full" style="background: var(--ui-bg-elevated)"></div>
+            </div>
+
+            <p class="mb-2 mt-5 text-sm font-semibold text-datealo-text">Tu categoría</p>
+            <div class="rounded-xl border px-4 py-3 text-sm text-datealo-text" style="border-color: var(--ui-border)">Gasfitería</div>
+
+            <p class="mb-2 mt-5 text-sm font-semibold text-datealo-text">Tus comunas</p>
+            <div class="flex items-center justify-between rounded-xl border px-4 py-3" style="border-color: var(--ui-border)">
+              <span class="text-sm text-datealo-muted">¿Dónde atiendes?</span>
+              <span class="text-datealo-muted">▾</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-002 · registro · modo campo con selección
+          <small>ronda 1 — después de marcar y tocar "Listo" en el sheet</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="px-6 py-6">
+            <p class="text-2xl font-extrabold text-datealo-text">Crea tu perfil</p>
+            <div class="mt-4 flex gap-1.5">
+              <div class="h-1.5 flex-1 rounded-full bg-primary"></div>
+              <div class="h-1.5 flex-1 rounded-full bg-primary"></div>
+              <div class="h-1.5 flex-1 rounded-full bg-primary"></div>
+              <div class="h-1.5 flex-1 rounded-full" style="background: var(--ui-bg-elevated)"></div>
+            </div>
+
+            <p class="mb-2 mt-5 text-sm font-semibold text-datealo-text">Tu categoría</p>
+            <div class="rounded-xl border px-4 py-3 text-sm text-datealo-text" style="border-color: var(--ui-border)">Gasfitería</div>
+
+            <p class="mb-2 mt-5 text-sm font-semibold text-datealo-text">Tus comunas</p>
+            <div class="flex items-center justify-between rounded-xl border px-4 py-3" style="border-color: var(--ui-border)">
+              <span class="truncate text-sm text-datealo-text">Llanquihue, Frutillar y Puerto Varas</span>
+              <span class="ml-2 shrink-0 text-datealo-muted">▾</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-003 · perfil editable · fila "Comunas"
+          <small>ronda 1 — reemplaza la fila "Comuna" de hoy; siempre con selección (D-003)</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="px-5 py-6">
+            <p class="text-xl font-extrabold text-datealo-text">Rudiberto Soto</p>
+            <p class="mt-0.5 text-sm text-datealo-muted">Gasfitería · Llanquihue, Frutillar y Puerto Varas</p>
+
+            <div class="mt-5 rounded-2xl border p-4" style="border-color: var(--color-datealo-surface)">
+              <p class="mb-1 text-base font-semibold text-datealo-text">Tus datos</p>
+
+              <div class="flex items-center justify-between border-b py-3 text-sm" style="border-color: var(--color-datealo-surface)">
+                <span class="text-datealo-muted">Nombre</span>
+                <span class="text-datealo-text">Rudiberto Soto</span>
+              </div>
+              <div class="flex items-center justify-between border-b py-3 text-sm" style="border-color: var(--color-datealo-surface)">
+                <span class="text-datealo-muted">Categoría</span>
+                <span class="text-datealo-text">Gasfitería</span>
+              </div>
+              <div class="flex items-center justify-between gap-3 border-b py-3 text-sm" style="border-color: var(--color-datealo-surface)">
+                <span class="shrink-0 text-datealo-muted">Comunas</span>
+                <span class="min-w-0 truncate text-right text-datealo-text">Llanquihue, Frutillar y Puerto Varas</span>
+              </div>
+              <div class="flex items-center justify-between py-3 text-sm">
+                <span class="text-datealo-muted">Contacto</span>
+                <span class="text-datealo-text">+56 9 8765 4321</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-002 · registro · modo campo con muchas comunas
+          <small>ronda 2 — Camila Reyes, electricista de Santiago Oriente, 6 comunas: no caben en una línea (UX-004)</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="px-6 py-6">
+            <p class="text-2xl font-extrabold text-datealo-text">Crea tu perfil</p>
+            <div class="mt-4 flex gap-1.5">
+              <div class="h-1.5 flex-1 rounded-full bg-primary"></div>
+              <div class="h-1.5 flex-1 rounded-full bg-primary"></div>
+              <div class="h-1.5 flex-1 rounded-full bg-primary"></div>
+              <div class="h-1.5 flex-1 rounded-full" style="background: var(--ui-bg-elevated)"></div>
+            </div>
+
+            <p class="mb-2 mt-5 text-sm font-semibold text-datealo-text">Tu categoría</p>
+            <div class="rounded-xl border px-4 py-3 text-sm text-datealo-text" style="border-color: var(--ui-border)">Electricidad</div>
+
+            <p class="mb-2 mt-5 text-sm font-semibold text-datealo-text">Tus comunas</p>
+            <div class="flex items-center justify-between gap-2 rounded-xl border px-4 py-3" style="border-color: var(--ui-border)">
+              <span class="min-w-0 truncate text-sm text-datealo-text">La Reina, Las Condes, Lo Barnechea, Ñuñoa, Providencia y Vitacura</span>
+              <span class="shrink-0 text-datealo-muted">▾</span>
+            </div>
+            <p class="mt-2 text-xs text-datealo-muted">Trunca con elipsis: es un control de una sola línea, igual que Categoría. Tocarlo reabre el sheet con las 6 ya marcadas.</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-003 · perfil editable · fila "Comunas" con muchas comunas
+          <small>ronda 2 — mismo criterio de truncado que el campo de registro (UX-004)</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="px-5 py-6">
+            <p class="text-xl font-extrabold text-datealo-text">Camila Reyes</p>
+            <p class="mt-0.5 text-sm text-datealo-muted">Electricidad · La Reina, Las Condes, Lo Barnechea, Ñuñoa, Providencia y Vitacura</p>
+
+            <div class="mt-5 rounded-2xl border p-4" style="border-color: var(--color-datealo-surface)">
+              <p class="mb-1 text-base font-semibold text-datealo-text">Tus datos</p>
+
+              <div class="flex items-center justify-between border-b py-3 text-sm" style="border-color: var(--color-datealo-surface)">
+                <span class="text-datealo-muted">Nombre</span>
+                <span class="text-datealo-text">Camila Reyes</span>
+              </div>
+              <div class="flex items-center justify-between border-b py-3 text-sm" style="border-color: var(--color-datealo-surface)">
+                <span class="text-datealo-muted">Categoría</span>
+                <span class="text-datealo-text">Electricidad</span>
+              </div>
+              <div class="flex items-center justify-between gap-3 border-b py-3 text-sm" style="border-color: var(--color-datealo-surface)">
+                <span class="shrink-0 text-datealo-muted">Comunas</span>
+                <span class="min-w-0 truncate text-right text-datealo-text">La Reina, Las Condes, Lo Barnechea, Ñuñoa, Providencia y Vitacura</span>
+              </div>
+              <div class="flex items-center justify-between py-3 text-sm">
+                <span class="text-datealo-muted">Contacto</span>
+                <span class="text-datealo-text">+56 9 2345 6789</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  </body>
+</html>

--- a/docs/missions/15-multiples-comunas-profesional/design-mockups/selector-comunas.html
+++ b/docs/missions/15-multiples-comunas-profesional/design-mockups/selector-comunas.html
@@ -1,0 +1,259 @@
+<!doctype html>
+<html lang="es-CL">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>V-001 Selector de comunas — misión 15</title>
+
+    <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+    <link
+      href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&family=Plus+Jakarta+Sans:wght@600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../../design/datealo-mockup-kit.css" />
+    <style type="text/tailwindcss">
+      @theme {
+        --color-primary: var(--ui-primary);
+        --color-secondary: var(--ui-secondary);
+        --color-success: var(--ui-success);
+        --color-error: var(--ui-error);
+      }
+    </style>
+    <style>
+      .sheet-backdrop {
+        position: absolute;
+        inset: 0;
+        background: rgb(31 41 55 / 0.4);
+      }
+      .sheet {
+        position: absolute;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        max-height: 78%;
+        display: flex;
+        flex-direction: column;
+        background: var(--ui-bg);
+        border-radius: 1.25rem 1.25rem 0 0;
+        box-shadow: 0 -8px 30px -8px rgb(31 41 55 / 0.3);
+      }
+      .sheet-handle {
+        width: 2.5rem;
+        height: 0.25rem;
+        border-radius: 999px;
+        background: var(--ui-border-accented);
+        margin: 0.625rem auto 0;
+      }
+      .comuna-row {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        padding: 0.75rem 1.25rem;
+      }
+      .checkbox {
+        width: 1.25rem;
+        height: 1.25rem;
+        border-radius: 0.375rem;
+        border: 1.5px solid var(--ui-border-accented);
+        flex-shrink: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .checkbox.checked {
+        background: var(--ui-primary);
+        border-color: var(--ui-primary);
+        color: white;
+        font-size: 0.75rem;
+        font-weight: 700;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div class="frames">
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-001 · modo lista
+          <small>ronda 1 — Rudiberto ya llega con Llanquihue, Frutillar y Puerto Varas marcadas</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div style="padding: 1rem 1.25rem">
+            <p class="text-sm font-semibold text-datealo-text">Tus comunas</p>
+            <div class="mt-2 flex items-center justify-between rounded-xl border px-4 py-3" style="border-color: var(--ui-border)">
+              <span class="text-sm text-datealo-text">Llanquihue, Frutillar y Puerto Varas</span>
+              <span class="text-datealo-muted">▾</span>
+            </div>
+          </div>
+
+          <div class="sheet-backdrop"></div>
+          <div class="sheet" style="height: 78%">
+            <div class="sheet-handle"></div>
+            <div class="flex items-center justify-between px-4 pt-3">
+              <p class="font-heading text-base font-bold text-datealo-text">Tus comunas</p>
+              <span class="text-lg text-datealo-muted">✕</span>
+            </div>
+            <div class="px-4 pt-3">
+              <div class="flex items-center gap-2 rounded-xl px-3 py-2.5" style="background: var(--ui-bg-elevated)">
+                <span class="text-datealo-muted">🔍</span>
+                <span class="text-sm text-datealo-muted">¿Qué comuna buscas?</span>
+              </div>
+            </div>
+            <div class="mt-2 flex-1 overflow-auto">
+              <div class="comuna-row"><span class="checkbox checked">✓</span><span class="text-sm font-semibold text-datealo-text">Frutillar</span></div>
+              <div class="comuna-row"><span class="checkbox checked">✓</span><span class="text-sm font-semibold text-datealo-text">Llanquihue</span></div>
+              <div class="comuna-row"><span class="checkbox">–</span><span class="text-sm text-datealo-text">La Reina</span></div>
+              <div class="comuna-row"><span class="checkbox">–</span><span class="text-sm text-datealo-text">Las Condes</span></div>
+              <div class="comuna-row"><span class="checkbox">–</span><span class="text-sm text-datealo-text">Ñuñoa</span></div>
+              <div class="comuna-row"><span class="checkbox">–</span><span class="text-sm text-datealo-text">Providencia</span></div>
+              <div class="comuna-row"><span class="checkbox">–</span><span class="text-sm text-datealo-text">Puerto Montt</span></div>
+              <div class="comuna-row"><span class="checkbox">–</span><span class="text-sm text-datealo-text">Puerto Octay</span></div>
+              <div class="comuna-row"><span class="checkbox checked">✓</span><span class="text-sm font-semibold text-datealo-text">Puerto Varas</span></div>
+              <div class="comuna-row"><span class="checkbox">–</span><span class="text-sm text-datealo-text">Santiago</span></div>
+            </div>
+            <div class="safe-bottom border-t px-4 pt-3" style="border-color: var(--ui-border)">
+              <div class="flex items-center justify-between">
+                <span class="text-sm text-datealo-muted">3 comunas marcadas</span>
+                <button class="rounded-xl bg-primary px-5 py-2.5 text-sm font-bold text-white">Listo</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="frame frame-mobile">
+        <div class="frame-label">V-001 · modo buscando</div>
+        <div class="frame-viewport">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="sheet-backdrop"></div>
+          <div class="sheet" style="height: 78%">
+            <div class="sheet-handle"></div>
+            <div class="flex items-center justify-between px-4 pt-3">
+              <p class="font-heading text-base font-bold text-datealo-text">Tus comunas</p>
+              <span class="text-lg text-datealo-muted">✕</span>
+            </div>
+            <div class="px-4 pt-3">
+              <div class="flex items-center gap-2 rounded-xl border px-3 py-2.5" style="border-color: var(--ui-primary)">
+                <span class="text-datealo-muted">🔍</span>
+                <span class="text-sm text-datealo-text">frut</span>
+              </div>
+            </div>
+            <div class="mt-2 flex-1 overflow-auto">
+              <div class="comuna-row"><span class="checkbox checked">✓</span><span class="text-sm font-semibold text-datealo-text">Frutillar</span></div>
+            </div>
+            <div class="safe-bottom border-t px-4 pt-3" style="border-color: var(--ui-border)">
+              <div class="flex items-center justify-between">
+                <span class="text-sm text-datealo-muted">3 comunas marcadas</span>
+                <button class="rounded-xl bg-primary px-5 py-2.5 text-sm font-bold text-white">Listo</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="frame frame-mobile">
+        <div class="frame-label">V-001 · modo sin resultados</div>
+        <div class="frame-viewport">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="sheet-backdrop"></div>
+          <div class="sheet" style="height: 60%">
+            <div class="sheet-handle"></div>
+            <div class="flex items-center justify-between px-4 pt-3">
+              <p class="font-heading text-base font-bold text-datealo-text">Tus comunas</p>
+              <span class="text-lg text-datealo-muted">✕</span>
+            </div>
+            <div class="px-4 pt-3">
+              <div class="flex items-center gap-2 rounded-xl border px-3 py-2.5" style="border-color: var(--ui-primary)">
+                <span class="text-datealo-muted">🔍</span>
+                <span class="text-sm text-datealo-text">zzz</span>
+              </div>
+            </div>
+            <div class="flex flex-1 flex-col items-center justify-center gap-1 px-6 text-center">
+              <p class="text-sm text-datealo-muted">No encontramos "zzz"</p>
+            </div>
+            <div class="safe-bottom border-t px-4 pt-3" style="border-color: var(--ui-border)">
+              <div class="flex items-center justify-between">
+                <span class="text-sm text-datealo-muted">3 comunas marcadas</span>
+                <button class="rounded-xl bg-primary px-5 py-2.5 text-sm font-bold text-white">Listo</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="frame frame-mobile">
+        <div class="frame-label">V-001 · modo cero marcadas</div>
+        <div class="frame-viewport">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="sheet-backdrop"></div>
+          <div class="sheet" style="height: 78%">
+            <div class="sheet-handle"></div>
+            <div class="flex items-center justify-between px-4 pt-3">
+              <p class="font-heading text-base font-bold text-datealo-text">Tus comunas</p>
+              <span class="text-lg text-datealo-muted">✕</span>
+            </div>
+            <div class="px-4 pt-3">
+              <div class="flex items-center gap-2 rounded-xl px-3 py-2.5" style="background: var(--ui-bg-elevated)">
+                <span class="text-datealo-muted">🔍</span>
+                <span class="text-sm text-datealo-muted">¿Qué comuna buscas?</span>
+              </div>
+            </div>
+            <div class="mt-2 flex-1 overflow-auto">
+              <div class="comuna-row"><span class="checkbox">–</span><span class="text-sm text-datealo-text">Frutillar</span></div>
+              <div class="comuna-row"><span class="checkbox">–</span><span class="text-sm text-datealo-text">La Reina</span></div>
+              <div class="comuna-row"><span class="checkbox">–</span><span class="text-sm text-datealo-text">Las Condes</span></div>
+              <div class="comuna-row"><span class="checkbox">–</span><span class="text-sm text-datealo-text">Llanquihue</span></div>
+              <div class="comuna-row"><span class="checkbox">–</span><span class="text-sm text-datealo-text">Ñuñoa</span></div>
+            </div>
+            <div class="safe-bottom border-t px-4 pt-2" style="border-color: var(--ui-border)">
+              <div class="flex items-center justify-between">
+                <span class="text-sm font-semibold text-error">Marca al menos una comuna</span>
+                <button class="rounded-xl px-5 py-2.5 text-sm font-bold text-white opacity-40" style="background: var(--ui-primary)">Listo</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="frame frame-mobile">
+        <div class="frame-label">V-001 · modo cargando</div>
+        <div class="frame-viewport">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="sheet-backdrop"></div>
+          <div class="sheet" style="height: 60%">
+            <div class="sheet-handle"></div>
+            <div class="flex items-center justify-between px-4 pt-3">
+              <p class="font-heading text-base font-bold text-datealo-text">Tus comunas</p>
+              <span class="text-lg text-datealo-muted">✕</span>
+            </div>
+            <div class="space-y-3 px-5 py-6">
+              <div class="h-3 w-3/4 animate-pulse rounded" style="background: var(--ui-bg-elevated)"></div>
+              <div class="h-3 w-1/2 animate-pulse rounded" style="background: var(--ui-bg-elevated)"></div>
+              <div class="h-3 w-2/3 animate-pulse rounded" style="background: var(--ui-bg-elevated)"></div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="frame frame-mobile">
+        <div class="frame-label">V-001 · modo error</div>
+        <div class="frame-viewport">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div class="sheet-backdrop"></div>
+          <div class="sheet" style="height: 60%">
+            <div class="sheet-handle"></div>
+            <div class="flex items-center justify-between px-4 pt-3">
+              <p class="font-heading text-base font-bold text-datealo-text">Tus comunas</p>
+              <span class="text-lg text-datealo-muted">✕</span>
+            </div>
+            <div class="flex flex-1 flex-col items-center justify-center gap-3 px-6 py-8 text-center">
+              <p class="text-sm text-datealo-muted">No pudimos cargar las comunas.</p>
+              <button class="rounded-xl bg-primary px-5 py-2.5 text-sm font-bold text-white">Reintentar</button>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  </body>
+</html>

--- a/docs/missions/15-multiples-comunas-profesional/experiencia.md
+++ b/docs/missions/15-multiples-comunas-profesional/experiencia.md
@@ -1,183 +1,328 @@
-# Misión: <nombre> — Experiencia
+# Misión 15: múltiples comunas por profesional — Experiencia
 
-**Estado:** borrador
+**Estado:** vigente — aprobado por Patricio Tabilo el 2026-09-07
 
-**Última actualización:** AAAA-MM-DD
+**Última actualización:** 2026-09-07
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-<!--
-Fuente de verdad para flujos, estados, contenido e interacción. No redefine reglas de producto: si el
-diseño descubre una regla nueva o invalida una, abre o actualiza una decisión en producto.md.
+## Decisión de experiencia: un profesional marca sus comunas en un sheet que no cierra hasta confirmar, y esa lista completa se ve tal cual en su perfil público
 
-Núcleo obligatorio: vistas, mapa de estados, flujos críticos y estados por superficie. Las secciones bajo
-demanda (modelo mental, jerarquía de información, validación) se agregan solo cuando una decisión las
-necesita.
+Un solo componente nuevo — un bottom sheet con lista de comunas y checkboxes — resuelve las dos entradas
+del flujo (registro y edición de perfil). El profesional marca todas las comunas donde atiende sin que la
+lista se cierre en cada toque, ve un contador permanente de cuántas lleva marcadas, y confirma con "Listo".
+Esa misma lista completa, sin resumir ni truncar, es lo que ve cualquiera que visite su perfil público — la
+card de resultados de búsqueda no cambia, porque nunca mostró más de una comuna: sigue mostrando solo la
+que produjo la coincidencia de esa búsqueda puntual.
 
-Gate de salida — experiencia.md está lista para ingenieria.md cuando:
-- cada flujo crítico tiene secuencia, variantes, recuperación y criterio de término
-- cada estado tiene contenido concreto (texto real, información visible, acción disponible)
-- cada vista lista sus modos, y el mapa de estados cubre todas las transiciones entre ellos
-- cada modo tiene su indicador permanente de estado, y cada flujo tiene todas sus salidas documentadas
-- los casos límite de producto.md tienen flujo o estado mapeado
-- cada flujo crítico está mockeado en móvil (390px), y en desktop si también vive ahí
-- ninguna pantalla queda descrita como "similar a X" sin especificar qué cambia
--->
-
-## Decisión de experiencia: <qué cambia para quien usa el producto>
-
-<Modelo de interacción elegido, flujo más importante y la incertidumbre que sigue abierta.>
-
-- **Funcionalidades cubiertas:** F-001, <otras>.
-- **Pendiente bloqueante:** <pregunta o "ninguna">.
+- **Funcionalidades cubiertas:** F-001.
+- **Pendiente bloqueante:** ninguna. La evaluación heurística en contexto separado que exige el Carril Full
+  Spec (`ui-ux-pro-max`, `web-design-guidelines`, `frontend-design`) ya corrió — sin hallazgos de enfoque,
+  con tres hallazgos de ejecución (altura táctil del botón "Listo", `aria-live` del contador, retorno de
+  foco al cerrar) ya incorporados arriba. El barrido de copy contra `ux-writing` también corrió, con dos
+  ajustes aplicados (el buscador del sheet reusa el placeholder de `ComunaSelect`; el contador del pie
+  concuerda en número). La verificación de volumen alto de comunas que quedaba pendiente en Cobertura ya se
+  hizo con un caso sintético (Camila Reyes, 6 comunas) y encontró una inconsistencia real que corrigió
+  UX-004: el perfil público no trunca, pero el campo compacto de registro y la fila de perfil sí, con
+  elipsis, porque son controles de una sola línea.
 
 ## Vistas
 
-<!--
-El listado de pantallas que define la experiencia — el mapa que se entrega antes de los flujos. Una línea
-por vista, sin tabla, con sus modos anidados debajo. Una vista es un destino: se llega a ella. Un modo es
-un estado de esa vista que cambia qué se puede hacer y qué se ve — se anida, nunca se lista como vista
-hermana.
+- **V-001 — Selector de comunas** · móvil + desktop · resuelve F-001 · flujos UXF-001 · nuevo componente
+  - modo **lista** — catálogo completo de comunas activas, orden alfabético, cada fila con checkbox; las
+    ya marcadas llegan premarcadas
+  - modo **buscando** — el usuario escribió en el campo de búsqueda del sheet; la lista se filtra en vivo,
+    sin perder las marcas que quedan fuera del filtro
+  - modo **sin resultados** — el término no matchea ninguna comuna del catálogo
+  - modo **cargando** — el catálogo de comunas todavía no llegó
+  - modo **error** — la carga del catálogo falló
 
-El porqué de cada vista, su trade-off o su justificación no van aquí: viven en su flujo (UXF) o en una
-decisión (UX-xxx). Regla de formato para todo el documento: las tablas se reservan para índices de celdas
-cortas; lo que lleva justificación extensa va en secciones con header + bullets, nunca en una celda.
--->
+- **V-002 — Registro de profesional** (existente, `app/pages/profesional/registro.vue`) · móvil ·
+  resuelve F-001 · flujos UXF-001 · el campo "Tu comuna" pasa a "Tus comunas" y abre V-001 en vez de un
+  select de valor único
+  - modo **campo vacío** — ninguna comuna marcada todavía (estado inicial de un registro nuevo)
+  - modo **campo con selección** — una o más comunas marcadas, listadas en el propio campo en una sola
+    línea; si no caben todas, el texto trunca con elipsis (ver UX-004)
 
-- **V-001 — <vista>** · móvil / desktop · resuelve F-001 · flujos UXF-001 · pendiente
-  - modo **<nombre>** — <qué lo distingue y qué se puede hacer en él>
-  - modo **<nombre>** — <ídem>
+- **V-003 — Perfil editable** (existente, `app/pages/profesional/perfil.vue`) · móvil · resuelve F-001 ·
+  flujos UXF-001 · la fila "Comuna" pasa a "Comunas" y abre V-001 en vez del slot de edición en línea que
+  usan hoy Nombre, Categoría y Contacto
+  - modo **fila con selección** — siempre tiene al menos una comuna (D-003 garantiza que ningún
+    profesional migrado llega en cero); no existe un modo "vacía" para esta vista. Igual que en registro,
+    el valor trunca con elipsis en una sola línea si no caben todas las comunas (ver UX-004)
+
+- **V-004 — Perfil público de profesional** (existente, `app/pages/profesionales/[id].vue`) · móvil +
+  desktop · resuelve F-001 · sin flujo ni modo nuevo — cambia el contenido del subtítulo y del título SEO,
+  ver UX-004
+
+- **V-005 — Card de resultados de búsqueda** (existente, `app/components/search/SearchResultCard.vue`) ·
+  móvil + desktop · resuelve F-001 · sin flujo ni modo nuevo — confirma que el contenido no cambia, ver
+  UX-005
 
 ## Mapa de estados
 
-<!--
-Vistas y flujos son listas, y una lista no muestra un camino. Esta tabla conecta los modos: qué acción
-lleva de uno a otro y qué pasa con el trabajo del usuario en cada salto. Cada fila que falte es una
-pregunta que ingeniería resuelve inventando.
--->
+| Desde                                             | Acción                                          | Queda en                                          | Qué pasa con el trabajo                                                                 |
+| -------------------------------------------------- | ------------------------------------------------ | --------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| V-002 campo vacío, o V-002/V-003 con selección     | toca el campo o la fila                          | V-001 modo lista                                    | lo ya marcado llega premarcado y visible sin scrollear                                    |
+| V-001 modo lista                                   | escribe en el buscador del sheet                 | V-001 modo buscando (o sin resultados)              | lo marcado se conserva aunque el ítem salga del filtro                                    |
+| V-001 modo buscando                                | borra el término de búsqueda                     | V-001 modo lista                                    | vuelve a mostrar el catálogo completo, sin perder marcas                                  |
+| V-001 (lista o buscando)                           | toca una fila (marca o desmarca)                 | mismo modo                                          | el contador del pie se actualiza al instante; nada se guarda todavía                      |
+| V-001                                               | toca "Listo" con 1+ comunas marcadas             | V-002 campo con selección / V-003 fila con selección | registro: la selección queda en el estado local del formulario. Perfil: dispara el guardado inmediato del campo |
+| V-001                                               | cierra el sheet sin tocar "Listo" (toca fuera, swipe, Esc) | V-002 / V-003, exactamente como estaban antes de abrir | se descarta cualquier marca o desmarca hecha en esta apertura                             |
+| V-001 modo error                                    | toca "Reintentar"                                | V-001 modo cargando → lista                          | —                                                                                          |
 
-| Desde  | Acción             | Queda en | Qué pasa con el trabajo              |
-| ------ | ------------------ | -------- | ------------------------------------ |
-| <modo> | <acción concreta>  | <modo>   | <qué se aplicó, qué quedó pendiente> |
-| <modo> | <salir sin cerrar> | <modo>   | <qué se pierde o se conserva>        |
+## UXF-001 — Declarar o editar las comunas donde atiendo
 
-## UXF-001 — <flujo principal en verbo>
+**Objetivo:** el profesional marca todas las comunas donde atiende, sea al completar su registro por
+primera vez o al editar un perfil ya publicado. **Contrato:** [F-001](./producto.md#f-001).
 
-<!--
-Duplica por flujo crítico. Cada paso describe acción → respuesta al nivel de "el usuario toca X → Datealo
-muestra Y". Un mockup no reemplaza la secuencia porque no explica estados ni recuperación.
--->
+**Punto de entrada:** dos entradas distintas al mismo selector (V-001) — el campo "Tus comunas" del
+formulario de registro (V-002), antes de publicar el perfil; o la fila "Comunas" del perfil editable
+(V-003), en cualquier momento después de publicado.
 
-**Objetivo:** <qué se completa o comprende>. **Contrato:** [F-001](./producto.md#f-001).
+**Criterio de término:** el sheet se cierra con "Listo" y el campo o la fila muestra el listado de comunas
+marcadas, en el mismo orden alfabético del catálogo, unidas con coma y "y" antes de la última — en una sola
+línea, truncado con elipsis si no caben todas (ver UX-004).
 
-**Punto de entrada:** <estado y superficie inicial, y qué acción trae al usuario hasta acá>.
-
-**Criterio de término:** <estado observable que confirma que el flujo terminó bien>.
-
-**Cómo sabe el usuario dónde está:** <el elemento concreto y permanente en pantalla que se lo dice, por
-cada modo que toca este flujo>.
+**Cómo sabe el usuario dónde está:** el pie fijo del sheet siempre muestra cuántas comunas lleva marcadas
+("3 comunas marcadas") — visible sin scrollear la lista, en todos los modos salvo carga y error.
 
 ### Salidas
 
-<!--
-Todas las formas de irse, no solo terminar bien. El criterio de término cubre la salida buena; las otras
-son las que el usuario encuentra primero. Un modo del que no se sabe salir es un modo donde el usuario se
-pierde.
--->
-
-| Salida                | Cómo se ejecuta       | Qué queda del trabajo           |
-| --------------------- | --------------------- | ------------------------------- |
-| <termina bien>        | <acción>              | <qué se aplicó y dónde>         |
-| <descarta>            | <acción, Esc, cerrar> | <nada, ni a medias>             |
-| <abandona sin cerrar> | <navega a otra parte> | <se conserva, se pierde, avisa> |
+| Salida                | Cómo se ejecuta                                | Qué queda del trabajo                                                              |
+| ---------------------- | ------------------------------------------------ | -------------------------------------------------------------------------------------- |
+| Confirma               | toca "Listo" (habilitado desde 1 comuna marcada) | registro: selección local, se envía junto al resto al publicar. Perfil: se guarda de inmediato |
+| Descarta                | toca fuera del sheet, swipe hacia abajo, o Esc   | nada, ni a medias — vuelve exactamente a lo que había antes de abrir el sheet          |
 
 ### Secuencia principal
 
-| Paso | Acción            | Respuesta del sistema         | Información visible |
-| ---- | ----------------- | ----------------------------- | ------------------- |
-| 1    | <acción concreta> | <feedback o cambio de estado> | <dato y jerarquía>  |
+| Paso | Acción                                                  | Respuesta del sistema                                                                                                        | Información visible                                                     |
+| ---- | -------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| 1    | Toca el campo "Tus comunas" (registro) o la fila "Comunas" (perfil) | Se abre el sheet desde abajo con el catálogo completo en orden alfabético; las comunas ya marcadas llegan con el checkbox activado | Título "Tus comunas", buscador, lista de comunas, pie con el contador       |
+| 2    | Escribe en el buscador (ej. "frut")                      | La lista se filtra en vivo                                                                                                        | Solo las comunas cuyo nombre contiene el término                            |
+| 3    | Toca una comuna sin marcar                                | El checkbox se marca; el contador del pie sube en uno                                                                              | El checkbox pasa a marcado, el sheet sigue abierto                          |
+| 4    | Toca una comuna ya marcada                                | El checkbox se desmarca; el contador baja en uno                                                                                    | Si el conteo llega a cero, "Listo" se deshabilita (ver Variantes)            |
+| 5    | Toca "Listo"                                              | El sheet se cierra; el campo o la fila muestra el listado actualizado                                                              | Ej. "Llanquihue, Frutillar y Puerto Varas" en el campo o la fila             |
 
 ### Variantes y recuperación
 
-| Condición          | Qué cambia              | Cómo se entiende    | Cómo se recupera             |
-| ------------------ | ----------------------- | ------------------- | ---------------------------- |
-| <sin resultados>   | <estado>                | <mensaje concreto>  | <acción disponible>          |
-| <sin permiso de ubicación> | <comportamiento> | <indicador visible> | <alternativa manual>         |
-| <conexión lenta>   | <skeleton, no spinner>  | <qué se ve mientras>| <qué pasa si falla>          |
+| Condición                                        | Qué cambia                                             | Cómo se entiende                                                        | Cómo se recupera                                              |
+| -------------------------------------------------- | --------------------------------------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| Cero comunas marcadas                              | "Listo" queda deshabilitado                                | "Marca al menos una comuna" bajo el pie, mismo tratamiento que el aviso de registro ("Completa los 4 campos para continuar") | Marca cualquier comuna para habilitar "Listo"                       |
+| El término de búsqueda no matchea ninguna comuna   | La lista se vacía                                          | 'No encontramos "frut"' (mismo texto que ya usa `CatalogSelect`)             | Borra o corrige el término                                          |
+| El catálogo todavía no cargó                       | Skeleton de 3 filas en vez de la lista                     | Igual al skeleton que ya usa `CatalogSelect`                                 | —                                                                    |
+| La carga del catálogo falló                        | El sheet muestra el error en vez de la lista               | "No pudimos cargar las comunas." + botón "Reintentar"                        | Toca "Reintentar"                                                    |
+| En perfil, el guardado falla tras confirmar        | La fila vuelve a mostrar el listado anterior al intento     | "No se pudo guardar, toca para reintentar" bajo la fila, igual que las otras filas del perfil | Toca la fila de nuevo: reabre el sheet con la selección que había intentado guardar |
 
 ### Decisiones que no deben quedar implícitas
 
-- <qué ocurre al cancelar, volver atrás, reintentar o confirmar>.
-- <qué cambio se guarda inmediato y cuál necesita confirmación>.
+- Cerrar el sheet sin tocar "Listo" siempre descarta los cambios de esa apertura (marcas y desmarcas por
+  igual) — nunca autoguarda.
+- En perfil, confirmar "Listo" dispara el guardado igual que cualquier otro campo de `ProfessionalCatalogRow`:
+  optimista, con el mismo texto de error y reintento si falla.
+- En registro, confirmar "Listo" no dispara ninguna llamada al servidor — la selección viaja junto con el
+  resto del formulario recién al tocar "Publicar mi perfil".
+- Un profesional migrado por D-003 ve su comuna actual ya marcada la primera vez que abre el sheet — nunca
+  arranca en cero para alguien que ya tenía una comuna antes de esta entrega.
+- El botón "Listo" y cada fila de comuna miden al menos 44×44px de área táctil, el mínimo que ya sigue el
+  resto de la app (ver "Patrones de interacción que ya están decididos" del skill `discovery-ux`) — el
+  mockup usa `py-2.5` como aproximación visual, pero la implementación debe verificar el alto real contra
+  ese mínimo, no copiar el padding tal cual.
+- El contador del pie ("3 comunas marcadas") y el aviso "Marca al menos una comuna" son contenido dinámico
+  que cambia sin recargar la pantalla: ambos llevan `aria-live="polite"`, igual que ya lo exige el patrón de
+  errores de campo de `discovery-ux` para el resto del perfil.
+- Al cerrar el sheet (con "Listo" o descartando), el foco vuelve al campo o la fila que lo abrió — nunca se
+  queda huérfano en un elemento ya desmontado.
+- El buscador dentro del sheet reusa el placeholder que ya usa `ComunaSelect` en toda la app ("¿Qué comuna
+  buscas?"), en vez de un texto nuevo — es la misma acción de buscar una comuna, así que lleva el mismo
+  texto.
+- El contador del pie concuerda en número: "1 comuna marcada" en singular, "3 comunas marcadas" en plural —
+  el caso de una sola comuna marcada no es un borde raro, es el estado más común al empezar a declarar.
+- CL-001 (marcar la misma comuna dos veces) queda resuelto por cómo está armada la lista, no por una regla
+  aparte: cada comuna es un único checkbox, así que no existe una acción que la marque "dos veces" — tocarla
+  de nuevo la desmarca. No hace falta un flujo especial para este caso límite.
 
 ## Estados por superficie
 
-<!--
-El contenido es concreto: texto real, no "mensaje apropiado". El estado vacío de un marketplace
-pre-lanzamiento no es un detalle: para muchas búsquedas será el estado principal durante meses.
--->
+**V-001 — sheet**
 
-| Estado  | Qué se muestra (texto e información real) | Acción disponible                   |
-| ------- | ----------------------------------------- | ----------------------------------- |
-| inicial | <contenido>                               | <acción>                            |
-| vacío   | <por qué está vacío, con texto concreto>  | <cómo avanzar, o ninguna y por qué> |
-| carga   | <skeleton de qué forma>                   | <ninguna>                           |
-| error   | <causa útil y alcance>                    | <recuperación>                      |
+| Estado                            | Qué se muestra                                             | Acción disponible          |
+| ----------------------------------- | -------------------------------------------------------------- | ------------------------------ |
+| lista (inicial)                     | catálogo completo, orden alfabético, ya marcadas con check     | buscar, marcar o desmarcar, Listo |
+| sin resultados de búsqueda          | 'No encontramos "{término}"'                                    | borrar el término               |
+| cargando                            | 3 líneas skeleton, igual al patrón ya usado en `CatalogSelect` | ninguna                         |
+| error                                | "No pudimos cargar las comunas." + botón "Reintentar"          | Reintentar                      |
+
+**V-004 — perfil público, subtítulo**
+
+| Estado                | Qué se muestra                                                                 | Acción disponible |
+| ----------------------- | ----------------------------------------------------------------------------------- | ---------------------- |
+| con comunas declaradas  | "{categoría} · {comuna1}, {comuna2} y {comuna3}" — todas, orden alfabético, sin truncar | ninguna, es contenido   |
+| con muchas comunas declaradas | mismo formato, sin truncar, en varias líneas — verificado con el caso sintético de Camila Reyes (6 comunas de Santiago Oriente, ~65 caracteres de listado): ocupa dos líneas dentro del `<p>` existente, sin romper el layout a 390px | ninguna, es contenido |
+
+**V-002/V-003 — campo de registro y fila de perfil**
+
+| Estado                | Qué se muestra                                                                 | Acción disponible |
+| ----------------------- | ----------------------------------------------------------------------------------- | ---------------------- |
+| con pocas comunas       | listado completo en una sola línea (ej. "Llanquihue, Frutillar y Puerto Varas")     | tocar para reabrir el sheet |
+| con muchas comunas      | listado truncado con elipsis en una sola línea (ej. "La Reina, Las Condes, Lo Barnechea…") — el caso de Camila con sus 6 comunas no cabe entero; tocar el campo reabre el sheet con las 6 ya marcadas | tocar para reabrir el sheet |
+
+**V-005 — card de resultados**
+
+| Estado                    | Qué se muestra                                                                     | Acción disponible |
+| --------------------------- | ---------------------------------------------------------------------------------------- | ---------------------- |
+| coincidencia exacta          | la comuna buscada, texto normal — sin cambio respecto de hoy                             | ninguna, es contenido   |
+| coincidencia por vecina      | la comuna declarada del profesional que produjo el match, en negrita — sin cambio respecto de hoy | ninguna, es contenido   |
 
 ## Mockups
 
-<!--
-Los mockups viven en design-mockups/ como HTML (ver el skill discovery-ux y docs/design/README.md).
-Exploran o materializan una decisión; no son fuente de verdad de reglas de producto.
--->
-
-| Mockup   | Cubre   | Estado                 | Ruta                              |
-| -------- | ------- | ---------------------- | --------------------------------- |
-| <nombre> | UXF-001 | exploración o validado | `./design-mockups/<archivo>.html` |
+| Mockup             | Cubre            | Estado      | Ruta                                        |
+| -------------------- | ------------------ | ------------- | ---------------------------------------------- |
+| selector-comunas    | UXF-001, V-001    | validado     | `./design-mockups/selector-comunas.html`       |
+| registro-perfil     | UXF-001, V-002, V-003 | validado    | `./design-mockups/registro-perfil.html`        |
+| perfil-publico      | UX-004, V-004     | validado     | `./design-mockups/perfil-publico.html`         |
+| card-resultados     | UX-005, V-005     | validado     | `./design-mockups/card-resultados.html`        |
 
 ## Cobertura
 
-<!-- Detecta huecos antes de construir. Una funcionalidad sin pantalla nueva igual tiene estados. -->
-
-| Funcionalidad | Flujo   | Estados cubiertos       | Estado    |
-| ------------- | ------- | ----------------------- | --------- |
-| F-001         | UXF-001 | principal, vacío, error | pendiente |
-
-## Secciones bajo demanda
-
-<!--
-Agregar solo cuando una decisión las necesite, con estos títulos:
-
-- "Modelo mental y lenguaje": cuando un concepto de producto pueda confundirse en la interfaz.
-- "Jerarquía de información": cuando una superficie densa exija decidir qué se ve primero (una card de
-  resultado con foto, rating, distancia, precio y disponibilidad es exactamente ese caso).
-- "Validación (UXV-xxx)": cuando una incertidumbre de diseño necesite prueba con usuarios.
-- "Accesibilidad y adaptación": cuando el contexto de uso cambie el flujo o la representación.
--->
+| Funcionalidad | Flujo    | Estados cubiertos                                             | Estado    |
+| ------------- | -------- | ---------------------------------------------------------------- | --------- |
+| F-001         | UXF-001  | principal, sin resultados de búsqueda, carga, error, cero marcadas, volumen alto de comunas (verificado con el caso sintético de Camila Reyes: V-004 en dos líneas sin truncar, V-002/V-003 truncado con elipsis) | pendiente |
 
 ## Decisiones de experiencia
 
 <a id="ux-001"></a>
 
-### UX-001 — <decisión en una frase>
+### UX-001 — El selector múltiple se construye como bottom sheet con lista de checkboxes propia, no como el combobox `multiple` de Nuxt UI
 
-- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
-- **Sustento:** F-001 o <hallazgo>.
-- **Alternativas descartadas:** <opciones relevantes y trade-off, con el porqué del rechazo>.
-- **Decisión y consecuencia:** <qué flujo o superficie cambia>.
-- **Impacto en producto:** <ninguno o enlace a D-xxx/F-xxx actualizado>.
+- **Estado:** aceptada. **Fecha:** 2026-09-07.
+- **Sustento:** F-001, y el comentario en `app/components/CatalogSelect.vue:1-9`, que documenta que
+  `UInputMenu` (el combobox de Nuxt UI) falló en pruebas reales de browser al combinar items controlados
+  con la selección interna de Reka UI.
+- **Alternativas descartadas:** `USelectMenu` con `multiple: true` — se descarta porque, revisando
+  `node_modules/@nuxt/ui/dist/runtime/components/SelectMenu.vue`, su modo múltiple sigue construido sobre
+  los mismos primitivos de Reka UI (`ComboboxRoot`/`ComboboxInput`/`ComboboxItem`) que ya causaron el bug
+  documentado en `CatalogSelect` — adoptarlo arriesgaría repetir el mismo problema en un flujo más crítico
+  (declarar dónde trabaja un profesional). Extender el propio `ComunaSelect` (campo de texto + lista
+  flotante) a modo múltiple sin cerrar al elegir — se descarta porque un dropdown flotante con checkboxes
+  sobre un catálogo de 346 filas es difícil de operar con una mano en 390px sin tapar el resto del
+  formulario, y compite mal con el teclado abierto.
+- **Decisión y consecuencia:** el selector se construye sobre `UDrawer` (primitivo distinto, sobre
+  vaul-vue, sin relación con los combobox de Reka UI) con una lista de checkboxes hecha a mano, reusando el
+  mismo patrón de filtro por texto ya probado en `CatalogSelect` (`searchTerm` + `normalize` +
+  `matchesSearch`) pero sin el `<input>` de combobox — solo un campo de búsqueda simple. Habilita reusar
+  código ya validado en producción; limita: es un componente nuevo, no una extensión directa de
+  `ComunaSelect`.
+- **Impacto en producto:** ninguno.
+
+<a id="ux-002"></a>
+
+### UX-002 — El pie del sheet siempre muestra el conteo de comunas marcadas, y "Listo" se deshabilita en cero
+
+- **Estado:** aceptada. **Fecha:** 2026-09-07.
+- **Sustento:** [CL-004](./producto.md#f-001) — no se puede quedar sin ninguna comuna declarada.
+- **Alternativas descartadas:** permitir confirmar con cero marcadas y mostrar el error de guardado
+  después (reactivo) — se descarta porque el registro ya bloquea el submit con un aviso visible en vez de
+  dejar fallar un guardado evitable ("Completa los 4 campos para continuar"), y repetir ese patrón es más
+  consistente que introducir un error nuevo para el mismo caso.
+- **Decisión y consecuencia:** "Listo" queda deshabilitado mientras el conteo sea cero, con el texto "Marca
+  al menos una comuna" debajo, mismo tratamiento visual que el aviso de registro. Evita que CL-004 dependa
+  de un guardado fallido para hacerse visible.
+- **Impacto en producto:** ninguno, es la misma regla de CL-004 aplicada de forma preventiva en vez de
+  reactiva.
+
+<a id="ux-003"></a>
+
+### UX-003 — Dentro del sheet, la selección previa se conserva marcada aunque el filtro de búsqueda la oculte
+
+- **Estado:** aceptada. **Fecha:** 2026-09-07.
+- **Sustento:** F-001 — declarar una comuna nueva no debería perder una ya marcada por estar buscando otra.
+- **Alternativas descartadas:** limpiar la búsqueda automáticamente al marcar una opción, como hace
+  `CatalogSelect` en modo único (que cierra y resetea) — se descarta porque en single-select cerrar tiene
+  sentido (la tarea terminó), pero en multi-select cerrar el sheet en la primera marca contradice el
+  propósito de dejarlo abierto para seguir eligiendo.
+- **Decisión y consecuencia:** el estado de selección vive independiente del término de búsqueda —
+  filtrar nunca desmarca nada, solo cambia qué filas son visibles.
+- **Impacto en producto:** ninguno.
+
+<a id="ux-004"></a>
+
+### UX-004 — El perfil público y el título SEO listan todas las comunas sin truncar; el campo compacto de registro y perfil sí trunca, porque es un control de una línea
+
+- **Estado:** aceptada. **Fecha:** 2026-09-07.
+- **Sustento:** [D-002](./producto.md#d-002) (sin tope numérico) y [D-001](./producto.md#d-001) (sin
+  jerarquía entre comunas). Verificación con datos sintéticos: Camila Reyes, electricista de Santiago
+  Oriente con 6 comunas (La Reina, Las Condes, Lo Barnechea, Ñuñoa, Providencia y Vitacura) — el caso de
+  volumen alto que la fila pendiente de Cobertura pedía confirmar.
+- **Alternativas descartadas (para el perfil público y el título SEO):** truncar a las primeras 2 con "y N
+  más" expandible — se descarta porque el subtítulo del perfil público (`app/pages/profesionales/[id].vue:74`)
+  ya no trunca hoy (sin `class="truncate"`, deja que el texto haga wrap), y con el caso de Camila (~65
+  caracteres solo de comunas) el texto ocupa dos líneas dentro del mismo `<p>` sin romper el layout — agregar
+  una mecánica de expandir/colapsar sería una pieza de interacción nueva que la verificación con datos
+  sintéticos no encontró necesaria. Mostrar solo el conteo ("Atiende en 6 comunas") con el detalle en otra
+  parte del perfil — se descarta porque esconde justo el dato que alguien evaluando cobertura necesita ver
+  de inmediato.
+- **Decisión y consecuencia (perfil público y título SEO):** el subtítulo del perfil público y el `<title>`
+  listan todas las comunas activas declaradas, en el mismo orden alfabético que ya usa el catálogo
+  (`server/utils/comunas.ts`, `orderBy(asc(comunas.nombre))`), unidas con coma y "y" antes de la última (o
+  "e" si la última empieza con "i"/"hi", regla del español que `Intl.ListFormat('es-CL', { type:
+  'conjunction' })` ya resuelve sin reglas a mano) — sin truncar, porque ambos son texto en prosa sin límite
+  de una línea.
+- **Decisión y consecuencia (campo de registro y fila de perfil):** acá el criterio es distinto, y la
+  verificación con el caso de Camila mostró por qué: el campo "Tus comunas" y la fila "Comunas" son
+  controles compactos de una sola línea, con el mismo alto que el resto de los campos del formulario
+  (`Tu nombre`, `Tu categoría`, `Tu contacto`) — dejar que crezcan en alto para no truncar rompería esa
+  consistencia visual, y el listado completo de 6 comunas de Camila no cabe en una línea. Estos dos lugares
+  sí truncan, con `text-overflow: ellipsis` en una sola línea, igual que cualquier `<select>` nativo con una
+  opción larga. No es una regresión respecto de "sin truncar": tocar el campo o la fila siempre reabre el
+  sheet con la selección completa ya marcada, así que nada se pierde, solo se resume en el lugar donde
+  resumir no cuesta nada.
+- **Impacto en producto:** ninguno.
+- **Reapertura:** si aparece evidencia de que el corte por elipsis en el campo compacto confunde a
+  profesionales sobre qué llevan marcado (por ejemplo, si abandonan el formulario creyendo que guardaron
+  menos comunas de las que realmente marcaron).
+
+<a id="ux-005"></a>
+
+### UX-005 — La card de resultados y el `matchType` no cambian: siguen mostrando solo la comuna que produjo la coincidencia
+
+- **Estado:** aceptada. **Fecha:** 2026-09-07.
+- **Sustento:** F-001 ("No incluye") y [CL-003](./producto.md#f-001) — el fallback de comunas vecinas
+  sigue operando igual.
+- **Alternativas descartadas:** mostrar todas las comunas declaradas en la card — es la capacidad que
+  `producto.md` deja explícitamente postergada por sobrecargar la card (ver su sección "Fuera de alcance");
+  no se retoma acá porque nada de esta misión exige mostrar más de una comuna en un resultado que ya
+  responde a una comuna concreta buscada.
+- **Decisión y consecuencia:** `SearchResultProfessional.comunaNombre` sigue siendo un único string, no una
+  lista — la comuna buscada si la coincidencia fue exacta, o la comuna declarada del profesional que
+  resultó vecina de la buscada si fue ese el camino, exactamente el mismo dato que muestra hoy.
+  `SearchResultCard.vue` no cambia. Lo que sí cambia es cómo `server/utils/search.ts` resuelve ese valor:
+  hoy lo lee de una columna única (`professionals.comunaCodigo`); con la relación profesional↔comuna,
+  tiene que resolver cuál de las comunas declaradas fue la que produjo el match — el cómo es de
+  `ingenieria.md`, esta decisión solo fija qué debe verse.
+- **Impacto en producto:** ninguno — confirma la nota "No incluye" de F-001.
+- **Reapertura:** si `producto.md` decide en el futuro que la card sí debe reflejar más de una comuna.
+
+<a id="ux-006"></a>
+
+### UX-006 — El sheet reemplaza la edición en línea que usa hoy `ProfessionalCatalogRow` para la fila "Comunas"
+
+- **Estado:** aceptada. **Fecha:** 2026-09-07.
+- **Sustento:** F-001 aplicado a V-003 (perfil editable).
+- **Alternativas descartadas:** mantener el slot `#select` en línea (`w-40`) que usan Nombre, Categoría y
+  Contacto hoy — se descarta porque ese ancho fijo alcanza para un valor único, no para un catálogo
+  filtrable con selección múltiple y su propio pie de confirmación.
+- **Decisión y consecuencia:** tocar la fila "Comunas" abre el mismo sheet que en registro, en vez de
+  intercambiar a un slot en línea. El resto de las filas (Nombre, Categoría, Contacto) no cambia.
+- **Impacto en producto:** ninguno.
 
 ## Preguntas
 
-<!--
-Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
-Estado: abierta | resuelta AAAA-MM-DD | disuelta AAAA-MM-DD. Solo las abiertas llevan bloque de detalle.
--->
+No queda ninguna pregunta abierta que bloquee el diseño. La evaluación heurística del Carril Full Spec y el
+barrido de copy contra `ux-writing` ya corrieron (ver "Decisión de experiencia" arriba); sus hallazgos de
+ejecución quedaron incorporados en el propio documento.
 
-<Una frase que responde "¿qué falta?": la pregunta que bloquea construcción y qué bloquea.>
-
-| ID      | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
-| ------- | ---------------------- | ------------------- | --------------------------------------------------------------- |
-| UXQ-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
-| UXQ-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |
+| ID | La duda | Estado | Respuesta, o quién la resuelve |
+| -- | ------- | ------ | ------------------------------- |
+| —  | —       | —      | —                                |

--- a/docs/missions/15-multiples-comunas-profesional/ingenieria.md
+++ b/docs/missions/15-multiples-comunas-profesional/ingenieria.md
@@ -1,162 +1,433 @@
-# Misión: <nombre> — Ingeniería
+# Misión 15: múltiples comunas por profesional — Ingeniería
 
-**Estado:** borrador
+**Estado:** vigente — aprobado por Patricio Tabilo el 2026-09-07
 
-**Última actualización:** AAAA-MM-DD
+**Última actualización:** 2026-09-07
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-<!--
-Fuente de verdad para arquitectura, datos, contratos, factibilidad y pruebas. Consume el comportamiento
-definido en producto. Una limitación técnica cambia el alcance solo mediante una decisión explícita en
-producto.md.
+## Decisión técnica: `professionals.comuna_codigo` pasa a ser una tabla de relación, y el resto del sistema se adapta a leer un conjunto en vez de un valor
 
-Núcleo obligatorio: contratos, modelo de datos, RLS y riesgos de factibilidad. Las secciones bajo demanda
-(migración, rendimiento, entrega por etapas) se agregan solo cuando el riesgo lo justifica.
+`comuna_codigo` deja de ser una columna de `professionals` y pasa a una tabla `professional_comunas`
+(profesional↔comuna, muchos a muchos). Todo lo que hoy lee o escribe esa columna —registro, edición de
+perfil, perfil público, correo de bienvenida, búsqueda— se adapta a leer/escribir un conjunto. La columna
+vieja se elimina en un slice aparte, al final, cuando ya nada la lee — no conviven las dos fuentes de
+verdad más tiempo del necesario para migrar con seguridad.
 
-Gate de salida — ingenieria.md está lista para construir cuando:
-- los contratos definen qué entra, qué sale y qué invariantes se mantienen, sin ambigüedad
-- el modelo de datos soporta los casos límite de producto.md sin workarounds
-- el impacto en RLS está resuelto: qué policy se crea o cambia, o por qué ninguna
-- la migración de datos existentes tiene estrategia o está explícitamente fuera del alcance
-- los escenarios verificables de producto están mapeados a pruebas
-- el plan de construcción corta el diseño en slices atómicos ordenados (un slice = un Issue = un PR)
--->
+- **Contratos de producto cubiertos:** F-001.
+- **Riesgo bloqueante:** ninguno. El patrón (tabla de relación + agrupación en memoria) es estándar y la
+  escala actual (decenas de profesionales, pre-lanzamiento) no exige optimización adicional — ver "Riesgos
+  y experimentos de factibilidad". Sí hay una ventana de migración entre slices que el diseño resuelve
+  explícitamente en [T-005](#t-005), no una que se haya pasado por alto.
 
-## Decisión técnica: <arquitectura y riesgo principal>
+## Arquitectura: la relación vive en su propia tabla; `professionals.ts` sigue siendo el único dueño de las reglas de negocio del profesional
 
-<Dirección técnica, trade-off principal y el riesgo que todavía podría invalidarla.>
+`server/utils/professionals.ts` ya es, por A-006, el dominio dueño de todo lo que es "reglas y queries de
+un profesional" — declarar comunas es una operación de ese dominio, no una tabla que necesite su propio
+archivo de utils. `search.ts` sigue resolviendo búsqueda, ahora contra la relación en vez de la columna. El
+selector múltiple es un componente nuevo, específico de comunas — no una generalización de `CatalogSelect`
+para "cualquier catálogo múltiple": hoy solo tiene un consumidor real (comunas); si la misión 14 (categorías
+múltiples) termina necesitando el mismo patrón de interacción, ahí se evalúa extraer un `CatalogMultiSelect`
+compartido, con el mismo criterio que ya usó [T-003 de la misión 03](../../03-taxonomia-categorias-y-comunas/ingenieria.md#t-003)
+para `CatalogSelect` — no antes, porque esa misión ni siquiera tiene `experiencia.md` todavía y su
+interacción podría no ser un bottom sheet.
 
-- **Contratos de producto cubiertos:** F-001, <otros>.
-- **Riesgo bloqueante:** <incertidumbre o "ninguna">.
+| Componente | Responsabilidad | No debe decidir | Contratos |
+| ---------- | ---------------- | ---------------- | --------- |
+| `server/db/schema/professional-comunas.ts` (nuevo) | Define la relación profesional↔comuna y sus índices | Validación de negocio (vive en `professionals.ts`) | F-001 |
+| `server/utils/professionals.ts` | Crear/reemplazar/leer el conjunto de comunas de un profesional, junto con el resto de sus reglas | Cómo se resuelve una búsqueda | F-001 |
+| `server/utils/search.ts` | Resolver coincidencias exacta/vecina y cuál comuna declarada las produjo (función pura `pickMatchedComuna`, sin Drizzle) | Cómo se declara o edita una comuna | F-001, UX-005 |
+| `server/utils/comunas.ts` | `findComunasFrecuentes` cuenta comunas por profesionales activos que las declararon — se adapta a la relación, mismo criterio que hoy | Reglas de negocio de `professionals` | F-001 |
+| `server/api/professionals/index.post.ts`, `me/index.patch.ts`, `me/index.get.ts`, `[id].get.ts` | Traducir HTTP ↔ funciones de `professionals.ts`; validar forma del body | Reglas de negocio (viven en `utils/`) | F-001 |
+| `app/composables/useProfessionalRegistration.ts`, `useProfessionalProfile.ts` | Estado reactivo del formulario/perfil, incluida la selección de comunas | Cómo se ve el selector | F-001, UXF-001 |
+| `app/components/ComunasMultiSelect.vue` (nuevo) | El sheet: catálogo, filtro, checkboxes, contador, confirmar/descartar | De qué formulario viene, qué hace con el valor confirmado | UXF-001, V-001 |
 
-## Arquitectura: <cómo se divide la responsabilidad>
+## Vocabulario e invariantes alineados con producto
 
-<!--
-La lógica de negocio se separa de la infraestructura: funciones puras en utils/ y server/utils/,
-reactividad en composables, acceso a datos en server/api/ con Drizzle. Incluye diagrama solo cuando tres o
-más partes interactúan.
--->
+| Término de producto (`producto.md`/`experiencia.md`) | Entidad/campo en código |
+| -------------------------------------------------------- | -------------------------- |
+| comuna declarada                                          | fila en `professional_comunas` |
+| declarar/editar comunas                                    | `POST /api/professionals` (creación) o `PATCH /api/professionals/me` (reemplazo del conjunto) |
+| comuna que produjo la coincidencia (card de resultados)    | ver [T-002](#t-002) — `pickMatchedComuna`, función pura en `search.ts` |
 
-<Descripción del enfoque y por qué satisface los contratos con menor riesgo.>
-
-| Componente | Responsabilidad       | No debe decidir | Contratos |
-| ---------- | --------------------- | --------------- | --------- |
-| <nombre>   | <una responsabilidad> | <frontera>      | F-001     |
+Invariante de `CLAUDE.md` que este diseño respeta sin tocar: el contacto sigue yendo directo al
+profesional — nada de esta misión introduce una bandeja intermedia ni un paso nuevo antes de contactar.
 
 ## Contratos
 
-<!--
-Cada contrato especifica entrada, salida e invariantes al nivel en que se puede implementar sin reuniones
-de aclaración. Incluye los errores observables y el código HTTP cuando es un endpoint.
--->
+<a id="tc-001"></a>
 
-### TC-001 — <contrato en una frase>
+### TC-001 — `POST /api/professionals` crea el profesional y sus comunas declaradas en una sola operación atómica
 
-- **Entrada:** <datos y precondiciones, con tipos y forma concreta>.
-- **Salida:** <resultado y su forma concreta>.
-- **Invariantes:** <qué se cumple siempre: atomicidad, consistencia, idempotencia>.
-- **Errores:** <condición → código HTTP y cuerpo `{ error, code? }`, y qué puede hacer el llamador>.
+- **Entrada:** body `{ displayName: string, categoriaSlug: string, comunaCodigos: string[], contact: string }`.
+  `comunaCodigos` reemplaza a `comunaCodigo` en el body — al menos un elemento, cada código debe existir y
+  estar activo, sin duplicados (el servidor deduplica con `Set` antes de validar, no confía en que el
+  cliente ya lo hizo).
+- **Salida:** `{ professional: Professional }`, 201 si se crea, 200 si el profesional ya existía (mismo
+  comportamiento idempotente de hoy vía `onConflictDoNothing` en `userId`). `Professional.comunas:
+  { codigo: string, nombre: string }[]` reemplaza a `comunaCodigo`.
+- **Invariantes:** la fila de `professionals` y las N filas de `professional_comunas` se crean en una sola
+  transacción (`useDb().transaction(...)`) — si algún código de comuna no es válido, no se crea ni el
+  profesional ni ninguna comuna. Nunca queda un profesional sin comunas.
+- **Errores:** `comunaCodigos` ausente o vacío → 400 `{ error: 'missing_field', field: 'comunaCodigos' }`
+  (mismo shape que ya usan los otros campos requeridos). Algún código no existe o está inactivo → 400
+  `{ error: 'invalid_comuna' }` (mismo error que ya existía, sin señalar cuál código — igual que hoy).
+- **Contrato de producto:** [F-001](./producto.md#f-001), [CL-004](./producto.md#f-001).
+
+<a id="tc-002"></a>
+
+### TC-002 — `PATCH /api/professionals/me` reemplaza el conjunto completo de comunas declaradas del profesional autenticado
+
+- **Entrada:** `comunaCodigos?: string[]` se agrega a los campos parciales que ya acepta el patch. Cuando
+  está presente, **reemplaza el conjunto completo, no aplica un delta** — el cliente siempre envía el
+  estado final tal como lo confirmó "Listo" en el sheet (UXF-001), nunca "agregar esta comuna" o "quitar
+  esa otra".
+- **Salida:** `{ professional: Professional }` con `comunas` ya actualizado.
+- **Invariantes:**
+  - El `professionalId` que se actualiza nunca viene del body — se resuelve siempre desde
+    `requireUser(event).id` → la fila de `professionals` cuyo `userId` coincide, exactamente como ya hace
+    `updateProfessional` hoy. Ningún id de comuna ni de profesional llega del cliente sin pasar por esa
+    resolución (A-002).
+  - Reemplazo atómico dentro de una transacción: `delete from professional_comunas where professional_id =
+    ?` seguido del `insert` del nuevo conjunto — nunca un estado intermedio en cero visible a otra request
+    concurrente (ej. una búsqueda que corre a mitad del `DELETE`).
+  - `comunaCodigos` deduplicado antes de insertar ([CL-001](./producto.md#f-001)).
+- **Errores:** `comunaCodigos` presente y vacío → 400 `{ error: 'missing_field', field: 'comunaCodigos' }`
+  — la fila existente no se toca ([CL-004](./producto.md#f-001)). Algún código inválido/inactivo → 400
+  `{ error: 'invalid_comuna' }`. Profesional no encontrado → 404 `{ error: 'not_found' }` (caso ya
+  existente).
+- **Contrato de producto:** [F-001](./producto.md#f-001), [CL-001](./producto.md#f-001),
+  [CL-004](./producto.md#f-001).
+
+<a id="tc-003"></a>
+
+### TC-003 — La forma pública y propia de un profesional expone `comunas: { codigo, nombre }[]`, nunca `comunaCodigo`/`comunaNombre` singular
+
+- **Entrada:** ninguna — afecta la forma de salida de `GET /api/professionals/me`, `GET
+  /api/professionals/[id]` y las respuestas de TC-001/TC-002.
+- **Salida:** `Professional.comunas` y `PublicProfessionalProfile.comunas`: array de `{ codigo: string,
+  nombre: string }`, **siempre en orden alfabético por nombre** — mismo orden que ya usa
+  `findActiveComunas` (`orderBy(asc(comunas.nombre))`). Ningún consumidor (app) reordena: el orden ya viene
+  resuelto desde el servidor, siguiendo [UX-004](./experiencia.md#ux-004).
+- **Invariantes:** `comunas` nunca es un array vacío para un profesional activo válido — D-003 (migración)
+  y CL-004 (validación de escritura) lo garantizan juntos, ninguno de los dos solo.
+- **Errores:** ninguno nuevo — hereda los 404 que estos endpoints ya devuelven.
+- **Impacto en consumidores existentes:** `buildProfessionalWelcomeEmail` (correo de bienvenida) y el
+  `<title>` SEO de `app/pages/profesionales/[id].vue` arman su texto con
+  `Intl.ListFormat('es-CL', { type: 'conjunction' }).format(comunas.map(c => c.nombre))`, la misma regla
+  de formato que fijó UX-004 para el resto de la app — ninguno de los dos inventa su propio criterio de
+  unión de la lista.
 - **Contrato de producto:** [F-001](./producto.md#f-001).
+
+<a id="tc-004"></a>
+
+### TC-004 — `GET /api/search` resuelve, por cada profesional del resultado, cuál de sus comunas declaradas produjo la coincidencia
+
+- **Entrada:** sin cambio — `?categoria=<slug>&comuna=<codigo>`.
+- **Salida:** sin cambio de forma — `SearchResultProfessional.comunaNombre` sigue siendo un único string
+  ([UX-005](./experiencia.md#ux-005)), nunca un array.
+- **Invariantes:** cuando un profesional califica por más de una comuna del conjunto buscado a la vez (ej.
+  coincidencia `vecina` que hace match con dos comunas distintas que el profesional declaró), se elige la
+  que sea alfabéticamente primera de las que matchearon — resuelto por una función pura, `pickMatchedComuna`,
+  ver [T-002](#t-002). Determinístico: la misma búsqueda siempre devuelve la misma `comunaNombre` para ese
+  profesional, nunca varía entre requests.
+- **Errores:** sin cambio respecto de hoy.
+- **Contrato de producto:** [F-001](./producto.md#f-001), [CL-002](./producto.md#f-001),
+  [CL-003](./producto.md#f-001), [UX-005](./experiencia.md#ux-005).
+- **Impacto en otro consumidor de `professionals.comunaCodigo`:** `findComunasFrecuentes`
+  (`server/utils/comunas.ts`), que arma la lista de comunas sugeridas en el buscador del hero, cuenta hoy
+  profesionales activos por comuna vía `innerJoin(professionals, eq(professionals.comunaCodigo,
+  comunas.codigo))`. Pasa a unirse contra `professional_comunas` en su lugar — mismo `groupBy`/`orderBy` de
+  hoy, sin cambio de contrato externo (`{ codigo, nombre }[]`, límite 3). Un profesional con varias comunas
+  cuenta una vez por cada una que declaró, correctamente: si Rudiberto declaró Llanquihue, Frutillar y
+  Puerto Varas, contribuye al conteo de las tres, porque de verdad atiende en las tres — no es un
+  double-count indebido, es la misma semántica de hoy generalizada de 1 a N comunas por profesional.
 
 ## Modelo de datos
 
-<!-- Entidades con significado, escritura y ciclo de vida. El schema completo vive en server/db/. -->
+| Entidad o campo | Significado | Escritura | Retención o historial |
+| ---------------- | ------------ | ---------- | ----------------------- |
+| `professional_comunas` (nueva) | Una fila = "este profesional declaró que atiende en esta comuna" | `POST /api/professionals` (creación), `PATCH /api/professionals/me` (reemplazo) — nunca `UPDATE` en el lugar | Sin historial: al reemplazar el conjunto, las filas quitadas se borran de verdad, no se marcan inactivas — no hay ningún caso de producto que necesite recordar qué comuna declaró antes un profesional |
+| `professionals.comuna_codigo` (columna actual) | Se elimina — ver "Migración y compatibilidad" | — | — |
 
-| Entidad o campo | Significado             | Escritura          | Retención o historial |
-| --------------- | ----------------------- | ------------------ | --------------------- |
-| <dato>          | <semántica de producto> | <endpoint o acción>| <política>            |
+```ts
+// server/db/schema/professional-comunas.ts
+export const professionalComunas = pgTable(
+  'professional_comunas',
+  {
+    professionalId: uuid('professional_id')
+      .notNull()
+      .references(() => professionals.id, { onDelete: 'cascade' }),
+    comunaCodigo: text('comuna_codigo')
+      .notNull()
+      .references(() => comunas.codigo),
+  },
+  table => [
+    primaryKey({ columns: [table.professionalId, table.comunaCodigo] }),
+    // La PK ya cubre "todas las comunas de un profesional" (professionalId es su columna líder).
+    // La búsqueda necesita el sentido contrario: "qué profesionales declararon esta comuna" — sin este
+    // índice, /api/search hace seq scan de toda la tabla en cada request.
+    index('professional_comunas_comuna_codigo_idx').on(table.comunaCodigo),
+  ],
+)
+```
+
+La PK compuesta hace dos cosas a la vez: es la unicidad que resuelve CL-001 a nivel de base de datos (un
+`INSERT` duplicado del mismo par falla, aunque el servidor ya deduplica antes de llegar ahí — defensa en
+profundidad, no el único mecanismo), y es el índice que sirve "traer todas las comunas de un profesional"
+sin necesitar uno aparte.
+
+`onDelete: 'cascade'` en `professionalId`: hoy nada borra una fila de `professionals` (sin policy de
+`delete`, ver `rls.sql`), así que esta cláusula no se ejerce todavía — se deja puesta porque es la
+semántica correcta de la relación (si algún día existe un borrado de cuenta, no debería dejar comunas
+huérfanas) y no cuesta nada declararla ahora.
 
 ### Invariantes de datos
 
-- <unicidad, pertenencia, orden o consistencia temporal>.
-- <qué operación es atómica o qué dato tiene una única fuente de verdad>.
+- Un profesional activo válido tiene siempre al menos una fila en `professional_comunas` — lo garantizan
+  juntos D-003 (migración) y la validación de escritura de TC-001/TC-002 (CL-004). Ninguna operación deja a
+  un profesional existente en cero.
+- El reemplazo del conjunto (TC-002) es atómico: nunca hay una ventana donde el conjunto esté vacío para
+  otra request que lea en paralelo.
+- `professional_comunas` no tiene historial ni soft-delete: una comuna que el profesional quita
+  desaparece de la tabla. Esto es intencional (ver tabla de arriba) — no hay ninguna funcionalidad de
+  producto (auditoría, "comunas que alguna vez atendiste") que dependa de conservarla.
 
 ### Impacto en RLS
 
-<!--
-Obligatorio. Fuente de verdad: server/db/sql/rls.sql. Si el cambio no toca ownership ni relaciones usadas
-en policies, decirlo explícitamente con esa razón — no dejar la sección vacía.
--->
+Corrido el checklist del skill `seguridad-datos` contra este diseño:
 
-| Tabla    | Cambio                 | Policy afectada | Acción                    |
-| -------- | ---------------------- | --------------- | ------------------------- |
-| <tabla>  | <nueva, ownership, FK> | <nombre>        | <crear, actualizar, nada> |
+| Tabla | Cambio | Policy afectada | Acción |
+| ------ | ------- | ----------------- | -------- |
+| `professional_comunas` | Tabla nueva | `professional_comunas_select_public` | Crear — `for select using (true)`, mismo criterio asimétrico que `professionals` (lectura pública, es parte del perfil) |
+| `professional_comunas` | Tabla nueva | `professional_comunas_insert_own` | Crear — `for insert to authenticated with check (exists (select 1 from professionals p where p.id = professional_comunas.professional_id and p.user_id = (select auth.uid())))` |
+| `professional_comunas` | Tabla nueva | `professional_comunas_delete_own` | Crear — mismo `EXISTS` que insert, con `using` en vez de `with check` |
+| `professionals` | Ninguno — `comuna_codigo` se elimina, pero las policies existentes (`select_public`, `insert_own`, `update_own`) no la nombran explícitamente | — | Nada |
+
+Notas del checklist, explícitas porque el skill pide no dejarlas implícitas:
+
+- **`alter table professional_comunas enable row level security`** va en el diseño, no se asume.
+- **Sin policy de `update`**: ninguna operación actualiza una fila de `professional_comunas` en el lugar —
+  el reemplazo siempre es `delete` + `insert` (TC-002). Una policy de `update` sin uso real es superficie
+  sin beneficio.
+- **`revoke all on public.professional_comunas from anon, authenticated`** — igual que `professionals`
+  (A-007): esta tabla se lee y escribe solo vía Drizzle desde `server/api/`, nunca por PostgREST. Sin este
+  revoke, las tres policies de arriba serían la única puerta, no un respaldo.
+- **Sin `force row level security`** — forzarlo aplicaría RLS también a la conexión de Drizzle (rol dueño),
+  donde `auth.uid()` es `NULL`, y rompería el `INSERT`/`DELETE` del propio servidor. Mismo razonamiento que
+  ya deja `professionals` sin forzar.
+- **Dónde se verifica pertenencia en el servidor (A-002):** en `updateProfessionalComunas` (nuevo, en
+  `server/utils/professionals.ts`) — recibe siempre el `userId` de `requireUser(event)`, resuelve el
+  `professionalId` propio con una query a `professionals` antes de tocar `professional_comunas`, nunca un
+  `professionalId` del body. Las policies de arriba son la red de esa vía, no el mecanismo — coherente con
+  cómo ya está documentado el resto de `professionals` en `rls.sql`.
+- **Índice de soporte para el `EXISTS` de las policies:** ya cubierto — `professionals.id` es PK y
+  `professionals.user_id` tiene `unique()`, ambos ya indexados por esas restricciones; no hace falta un
+  índice nuevo para las policies de arriba (además son respaldo, nunca las evalúa la conexión real).
+- **Cliente de Supabase en el browser:** esta misión no cambia qué tablas son alcanzables desde ahí —
+  `professional_comunas` queda tan cerrada a `anon`/`authenticated` como `professionals` ya lo está.
 
 ## Riesgos y experimentos de factibilidad
 
-<!--
-Un riesgo que podría cambiar el producto se enlaza como pregunta o decisión en producto.md. Un experimento
-tiene pregunta, límite de tiempo y resultado capaz de cerrar la incertidumbre.
--->
-
-| ID     | Riesgo o pregunta | Qué invalida        | Experimento o mitigación  | Criterio de salida      | Estado  |
-| ------ | ----------------- | ------------------- | ------------------------- | ----------------------- | ------- |
-| TR-001 | <incertidumbre>   | <alcance en riesgo> | <spike, prueba o recorte> | <resultado concluyente> | abierto |
+Sin riesgos de factibilidad que bloqueen el diseño. El patrón (tabla de relación muchos-a-muchos, join +
+agrupación en memoria) es estándar en Postgres, ya usado en el propio schema de Datealo (`comuna_vecinas`,
+aunque ahí simétrico); no hay incertidumbre de rendimiento real a la escala actual (decenas de profesionales
+pre-lanzamiento, catálogo de 346 comunas como máximo teórico de filas por profesional). Si el volumen crece
+lo suficiente para que el join de búsqueda deje de usar el índice de `professional_comunas_comuna_codigo_idx`
+de forma eficiente, se revisa con un `EXPLAIN` real en ese momento — no hay nada que experimentar hoy contra
+datos que no existen.
 
 ## Estrategia de pruebas
 
-<!-- Mapea los ejemplos verificables de producto.md a niveles de prueba. Qué demuestra cada una. -->
-
-| Contrato o riesgo | Nivel                          | Caso principal | Límite o falla |
-| ----------------- | ------------------------------ | -------------- | -------------- |
-| F-001, CL-001     | <unidad, contrato, integración>| <caso>         | <caso>         |
+| Contrato o riesgo | Nivel | Caso principal | Límite o falla |
+| ------------------- | ------ | ---------------- | ---------------- |
+| TC-001, F-001, CL-004 | integración (`server/api/professionals/index.post.test.ts`, Vitest) | crear con 3 comunas válidas → 201, `comunas` con las 3, en orden alfabético | `comunaCodigos: []` → 400 `missing_field`; un código inactivo → 400 `invalid_comuna`, no se crea el profesional |
+| TC-002, CL-001 | integración | reemplazar de 3 a 1 comuna → `comunas` refleja solo la 1; enviar un código duplicado en el array → se guarda una sola vez | `comunaCodigos: []` sobre un profesional existente → 400, el conjunto anterior sigue intacto (releer después del 400 y confirmar) |
+| TC-004, CL-003, UX-005 (unidad, `server/utils/search.test.ts`) | unidad | profesional con comunas [Llanquihue, Frutillar], búsqueda exacta en Frutillar → `comunaNombre: 'Frutillar'` | profesional que matchea por dos comunas vecinas a la vez → `comunaNombre` es la alfabéticamente primera de las dos, estable entre corridas |
+| CL-002 | unidad (`search.test.ts`) | profesional cuyas únicas comunas se desactivan → no aparece en ningún resultado de esa comuna, `existsActiveProfessionalForCategoria` tampoco lo cuenta | — |
+| D-003 (migración) | integración, una sola vez al desplegar | correr el backfill contra una copia con profesionales existentes → cada uno termina con exactamente 1 fila en `professional_comunas`, igual a su `comuna_codigo` anterior | ningún profesional queda con 0 filas después del backfill |
 
 ### Propiedades que deben probarse
 
-- <invariante bajo reintentos, concurrencia o distintas entradas>.
-- <ausencia de efectos parciales en falla>.
+- El reemplazo de TC-002 no deja nunca un estado parcial visible: una búsqueda que corre a mitad de un
+  `PATCH` en curso ve el conjunto viejo completo o el nuevo completo, nunca ninguno.
+- `comunaCodigos` con duplicados produce el mismo resultado final que sin ellos, en ambos endpoints
+  (TC-001 y TC-002) — la deduplicación es idempotente.
 
 ## Plan de construcción
 
-<!--
-Se completa al final, cuando el gate de salida se cumple y ninguna pregunta bloqueante sigue abierta —
-cortar sobre decisiones abiertas produce issues que mueren. Cada slice es un cambio funcional atómico: un
-Issue, un PR, ejecutable sin haber leído la misión (el issue lleva su contrato inline) y con criterios
-pass/fail enumerables como tests. Guía completa en el skill discovery-engineering.
--->
+| ID | Slice (una frase, sin "y") | Sustento | Criterio de aceptación principal | Depende de |
+| ---- | ---------------------------- | ---------- | ----------------------------------- | ------------ |
+| S-001 | Crear la tabla `professional_comunas` con su RLS y migrar los datos existentes | D-003, "Modelo de datos", "Impacto en RLS" | Migración corre sin error contra datos reales; cada profesional existente termina con exactamente 1 fila igual a su `comuna_codigo` anterior; `professional_comunas` cerrada a `anon`/`authenticated` (verificado con un `curl` directo a PostgREST, no solo desde la app) | — |
+| S-002 | `POST /api/professionals` crea el profesional con varias comunas | TC-001, T-005 | `POST` con `comunaCodigos: ['10101','10102']` válidos → 201, `comunas` con las 2; con un código inválido → 400 y no queda profesional creado; el backfill de S-001 se vuelve a correr al desplegar (T-005), sin error, sin duplicar filas | S-001 |
+| S-003 | `PATCH /api/professionals/me` reemplaza el conjunto de comunas | TC-002, CL-001, CL-004 | `PATCH` con un conjunto nuevo → refleja exactamente ese conjunto; `comunaCodigos: []` → 400, conjunto anterior intacto | S-001 |
+| S-004 | `GET /api/professionals/me` y `GET /api/professionals/[id]` devuelven `comunas[]` | TC-003 | Ambos responden `comunas: [{codigo,nombre}]` en orden alfabético; correo de bienvenida y `<title>` SEO usan `Intl.ListFormat` sobre esa lista | S-001, S-002 |
+| S-005 | `/api/search` resuelve la comuna que produjo cada coincidencia contra `professional_comunas`, y `findComunasFrecuentes` cuenta contra la misma relación | TC-004, T-002, CL-002, CL-003 | Búsqueda exacta y vecina devuelven `comunaNombre` correcto en casos de una y de varias comunas coincidentes (probado con `pickMatchedComuna` a nivel unidad, sin DB); profesional sin comunas activas no aparece; comunas frecuentes del hero siguen sugiriendo las comunas con más profesionales activos, ahora contando por `professional_comunas` | S-001 |
+| S-006 | Eliminar `professionals.comuna_codigo` y su índice | Limpieza — ninguna fuente de verdad duplicada | `npx nuxi typecheck` y `npm run build` pasan sin ninguna referencia a `professionals.comunaCodigo`; migración de columna corre sin error | S-002, S-003, S-004, S-005 |
+| S-007 | Construir `ComunasMultiSelect.vue` (el sheet) | UXF-001, V-001, UX-001, UX-002, UX-003 | Los 6 modos del mockup `selector-comunas.html` funcionan: marcar/desmarcar sin cerrar, buscar sin perder marcas, "Listo" deshabilitado en cero, error con reintentar | — |
+| S-008 | Registro de profesional usa el selector múltiple | V-002, TC-001 | Formulario de registro completo con 3 comunas → `POST` con `comunaCodigos` correcto; campo vacío bloquea "Publicar mi perfil" igual que hoy | S-002, S-007 |
+| S-009 | Fila "Comunas" del perfil editable usa el selector múltiple | V-003, UX-004, UX-006 | Tocar la fila abre el sheet con lo ya marcado; confirmar dispara `PATCH` y actualiza la fila; con muchas comunas, la fila trunca con elipsis | S-003, S-007 |
+| S-010 | Perfil público muestra el listado completo de comunas | V-004, UX-004 | Perfil con 6 comunas muestra la lista completa sin truncar, en el subtítulo y en el `<title>` | S-004 |
 
-| ID    | Slice (una frase, sin "y") | Sustento      | Criterio de aceptación principal          | Depende de |
-| ----- | -------------------------- | ------------- | ----------------------------------------- | ---------- |
-| S-001 | <cambio atómico>           | TC-001, D-001 | <entrada concreta → resultado observable> | —          |
+`S-010` no depende de `S-007`/`S-008`/`S-009`: solo necesita el contrato de datos de `S-004`, así que puede
+construirse y mergearse en paralelo al trabajo del selector — el orden de la tabla es por número, no una
+secuencia estricta salvo donde "Depende de" lo dice.
 
 ## Secciones bajo demanda
 
-<!--
-Agregar solo cuando el riesgo lo justifique, con estos títulos:
+### Migración y compatibilidad
 
-- "Migración y compatibilidad": cuando existan datos o consumidores que deben llegar al nuevo contrato.
-  Incluye rollback lógico si la migración física no puede revertirse.
-- "Rendimiento y observabilidad": cuando haya presupuesto de latencia o volumen que defender (búsqueda
-  geográfica y listados paginados son los candidatos naturales).
-- "SEO e indexación": cuando la superficie deba ser indexable (páginas por categoría + comuna, datos
-  estructurados).
-- "Entrega por etapas": cuando el cambio necesite despliegue incremental o feature flags.
--->
+**Backfill, corrido dos veces (S-001 y de nuevo en S-002 — ver [T-005](#t-005)):**
+
+```sql
+insert into professional_comunas (professional_id, comuna_codigo)
+select id, comuna_codigo from professionals
+on conflict do nothing;
+```
+
+`on conflict do nothing` la vuelve re-ejecutable sin duplicar filas — mismo criterio de idempotencia que ya
+sigue `rls.sql` con sus `drop policy if exists`. La primera corrida (S-001) migra a todos los profesionales
+que ya existían antes de esta misión. Entre que S-001 se despliega y S-002 se despliega, el código de
+registro sigue siendo el viejo (escribe solo `professionals.comunaCodigo`) — cualquier profesional
+registrado en esa ventana queda momentáneamente sin filas en `professional_comunas`. La segunda corrida,
+al desplegar S-002, cierra ese hueco. Después de S-002, `TC-001` garantiza que todo registro nuevo crea sus
+filas en la misma transacción, así que no hace falta una tercera corrida.
+
+**Orden de despliegue, no solo de código:** `S-001` (crea la tabla y migra) tiene que estar desplegado y
+con el backfill corrido **antes** de que `S-002`/`S-003`/`S-004`/`S-005` lean o escriban
+`professional_comunas` — si no, esos slices leerían una tabla vacía para profesionales que ya existían.
+`S-006` (borrar la columna vieja) es lo último, y solo después de confirmar que ningún código en `main`
+sigue leyendo `professionals.comunaCodigo` — el propio `npx nuxi typecheck` lo confirma, porque Drizzle
+tipa el schema y una referencia a una columna que ya no existe en el schema no compila.
+
+**Sin ventana de downtime necesaria:** mientras `S-001` a `S-005` conviven (columna vieja todavía presente,
+tabla nueva ya poblada y ya siendo la fuente de verdad para lectura/escritura), la columna vieja queda sin
+usar por el código apenas S-002 se despliega (con la ventana entre S-001 y S-002 ya cerrada por la segunda
+corrida del backfill) — no hace falta sincronizarla ni mantenerla actualizada durante el resto de la
+transición.
 
 ## Decisiones técnicas
 
 <a id="t-001"></a>
 
-### T-001 — <decisión en una frase>
+### T-001 — El `PATCH` de comunas reemplaza el conjunto completo, nunca aplica un delta agregar/quitar
 
-- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
-- **Contratos:** F-001 y <regla relevante>.
-- **Alternativas descartadas:** <opciones y trade-offs, con el porqué del rechazo>.
-- **Decisión y consecuencias:** <enfoque elegido, beneficio, costo y trabajo futuro aceptado>.
-- **Reapertura:** <medición o cambio que justificaría revisar>.
+- **Estado:** aceptada. **Fecha:** 2026-09-07.
+- **Contratos:** [TC-002](#tc-002), [UXF-001](./experiencia.md#uxf-001-declarar-o-editar-las-comunas-donde-atiendo).
+- **Alternativas descartadas:** un endpoint de delta (`POST .../comunas` para agregar una, `DELETE
+  .../comunas/:codigo` para quitar una) — se descarta porque el sheet de `experiencia.md` no produce un
+  delta: el usuario marca y desmarca libremente dentro de una misma apertura y confirma con "Listo" un
+  estado final completo. Modelar el backend como delta obligaría al frontend a reconstruir qué cambió
+  respecto de lo que había, trabajo que el propio flujo de UX ya resolvió mostrando el estado final.
+- **Decisión y consecuencias:** `PATCH /api/professionals/me` con `comunaCodigos` presente borra todas las
+  filas de `professional_comunas` del profesional e inserta el conjunto recibido, en una transacción.
+  Habilita un contrato simple (un solo campo, una sola operación) que refleja exactamente la interacción
+  real. Costo aceptado: un `PATCH` con un conjunto casi idéntico al anterior igual borra e inserta todo —
+  aceptable porque el volumen por profesional es chico (D-002 no impone tope, pero ni Rudiberto ni Camila
+  pasan de una decena).
+- **Reapertura:** si el volumen real de comunas por profesional crece lo suficiente para que borrar e
+  insertar todo el conjunto en cada edición sea un costo medible.
+
+<a id="t-002"></a>
+
+### T-002 — La comuna que produjo la coincidencia en `/api/search` se elige con una función pura, `pickMatchedComuna`, no dentro de la query SQL
+
+- **Estado:** aceptada. **Fecha:** 2026-09-07.
+- **Contratos:** [TC-004](#tc-004), [UX-005](./experiencia.md#ux-005).
+- **Alternativas descartadas:** un `EXISTS` simple (como el resto de los filtros de esta misión) — resuelve
+  si el profesional califica, pero no dice **cuál** de sus comunas fue la que matcheó, y UX-005 exige mostrar
+  esa comuna específica en la card. Resolver el desempate dentro de la query con `.selectDistinctOn([professionals.id])`
+  ordenado por `comunas.nombre` — funciona, pero deja una regla de negocio (cuál comuna "gana" cuando hay
+  varias candidatas) enterrada en SQL, sin poder probarla sin una base de datos real — exactamente el
+  antipatrón que `discovery-engineering` nombra ("la lógica pura vive fuera de la infraestructura") y que
+  el propio `search.ts` ya evita en `rankByCompleteness`, la función pura y testeable que ordena por
+  completitud de perfil. Mantener las dos reglas de desempate en lugares distintos (una en SQL, otra en JS)
+  sin necesidad real es la inconsistencia que esta decisión corrige.
+- **Decisión y consecuencias:** `findActiveProfessionals` trae **todas** las filas que matchean (un join
+  simple entre `professionals`, `professional_comunas` y `comunas`, sin `DISTINCT`) — un profesional que
+  matchea por dos comunas a la vez aparece en dos filas. El resultado se agrupa por `professionals.id` en
+  memoria, y una función pura nueva decide cuál mostrar:
+
+  ```ts
+  // server/utils/search.ts — sin Drizzle, sin event: se prueba con un array literal
+  export function pickMatchedComuna(
+    candidatas: { codigo: string, nombre: string }[],
+  ): { codigo: string, nombre: string } {
+    return [...candidatas].sort((a, b) => a.nombre.localeCompare(b.nombre, 'es'))[0]!
+  }
+  ```
+
+  Reusa el mismo criterio de orden alfabético que ya fija D-001/UX-004 para toda la misión, sin inventar una
+  jerarquía nueva, y queda al lado de `rankByCompleteness` con el mismo patrón: dato crudo de la query,
+  regla de negocio en una función que no importa Drizzle. Costo aceptado: la query trae más filas que un
+  `DISTINCT ON` (como mucho, una por cada comuna que un profesional tenga en común con la búsqueda — un
+  número chico, acotado por D-002 solo por el catálogo completo de 346 comunas en el peor caso teórico), y
+  hay un paso de agrupación en JS antes de pasarle el resultado a `orderResults`/`rankByCompleteness`.
+- **Reapertura:** ninguna prevista.
+
+<a id="t-003"></a>
+
+### T-003 — El servidor deduplica y valida `comunaCodigos` antes de escribir, sin confiar en que el sheet ya lo hizo
+
+- **Estado:** aceptada. **Fecha:** 2026-09-07.
+- **Contratos:** [TC-001](#tc-001), [TC-002](#tc-002), [CL-001](./producto.md#f-001).
+- **Alternativas descartadas:** confiar en que la interacción del sheet (checkboxes, imposible marcar dos
+  veces la misma fila) ya garantiza un array sin duplicados — se descarta por A-002: el servidor nunca
+  confía en invariantes que solo la UI garantiza, porque nada impide una request armada a mano (o un bug de
+  cliente) que sí traiga duplicados.
+- **Decisión y consecuencias:** ambos endpoints pasan `comunaCodigos` por `new Set(...)` antes de validar
+  cada código y antes de insertar. Sin este paso, un array con duplicados rompería la PK compuesta de
+  `professional_comunas` con un error de constraint poco claro para quien lo depure.
+- **Reapertura:** ninguna prevista.
+
+<a id="t-004"></a>
+
+### T-004 — `professionals.comuna_codigo` se elimina en un slice separado, al final, no en el mismo cambio que crea la tabla nueva
+
+- **Estado:** aceptada. **Fecha:** 2026-09-07.
+- **Contratos:** "Modelo de datos", "Migración y compatibilidad".
+- **Alternativas descartadas:** eliminar la columna vieja en el mismo slice que crea `professional_comunas`
+  y migra los datos (S-001) — se descarta porque en ese momento todavía existen cuatro slices de código
+  (S-002 a S-005) que no se escribieron todavía y podrían necesitar leer el valor viejo como referencia
+  durante su propio desarrollo o rollback. Mantener las dos fuentes de verdad para siempre, sin plan de
+  eliminarla — se descarta porque duplica el dato sin ningún consumidor real del duplicado, con el riesgo de
+  que diverjan si algo llegara a escribir una sin la otra.
+- **Decisión y consecuencias:** la columna vieja convive entre S-001 y S-006. `S-006` la elimina recién
+  cuando `npx nuxi typecheck` confirma que ninguna referencia sobrevive. Costo aceptado: dos fuentes de
+  datos técnicamente presentes durante la ventana de construcción de la misión — **con una excepción real
+  entre S-001 y S-002, que T-005 resuelve explícitamente**: hasta que S-002 se despliega, el código de
+  registro sigue siendo el viejo y sigue escribiendo la columna vieja para cualquier profesional nuevo.
+- **Reapertura:** ninguna prevista.
+
+<a id="t-005"></a>
+
+### T-005 — El backfill de `professional_comunas` se corre dos veces, no una: al desplegar S-001 y de nuevo al desplegar S-002
+
+- **Estado:** aceptada. **Fecha:** 2026-09-07.
+- **Contratos:** "Migración y compatibilidad", [TC-001](#tc-001), invariante "un profesional activo válido
+  tiene siempre al menos una fila en `professional_comunas`" (Modelo de datos).
+- **Alternativas descartadas:** fusionar S-001 (schema + backfill) y S-002 (`POST` con `comunaCodigos`) en
+  un solo slice — cierra la ventana por construcción, pero mezcla un cambio de infraestructura (tabla, RLS,
+  migración de datos) con un cambio de contrato de API en el mismo PR, más grande y más difícil de revisar
+  que cualquier otro slice del plan, sin necesidad real. Confiar en que S-001 y S-002 se despliegan lo
+  bastante rápido como para que la ventana no importe — se descarta porque el propio flujo de `CLAUDE.md`
+  exige un checkpoint de revisión humana entre cada PR, y esa revisión puede tardar horas o días; cualquier
+  registro que ocurra en el medio queda con cero comunas, violando la invariante que este mismo documento
+  declara.
+- **Decisión y consecuencias:** el backfill de S-001 (`insert into professional_comunas select id,
+  comuna_codigo from professionals on conflict do nothing`) es idempotente por diseño — se vuelve a correr,
+  sin cambios, como parte del despliegue de S-002, después de mergear. La segunda corrida es una operación
+  barata (un `INSERT ... ON CONFLICT DO NOTHING` sobre una tabla chica) que cierra cualquier profesional
+  registrado por el código viejo durante la ventana entre ambos despliegues, sin migrar nada dos veces de
+  forma incorrecta. Después de S-002, ningún código vuelve a crear un profesional sin sus filas de
+  `professional_comunas` en la misma transacción (TC-001), así que no hace falta una tercera corrida.
+- **Reapertura:** ninguna prevista.
 
 ## Preguntas
 
-<!--
-Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
-Estado: abierta | resuelta AAAA-MM-DD | disuelta AAAA-MM-DD. Solo las abiertas llevan bloque de detalle.
--->
+No queda ninguna pregunta abierta que bloquee el plan de construcción.
 
-<Una frase que responde "¿qué falta?": la pregunta que bloquea construcción y qué bloquea.>
-
-| ID     | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
-| ------ | ---------------------- | ------------------- | --------------------------------------------------------------- |
-| TQ-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
-| TQ-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |
+| ID | La duda | Estado | Respuesta, o quién la resuelve |
+| ---- | --------- | -------- | --------------------------------- |
+| —    | —         | —        | —                                    |

--- a/docs/missions/15-multiples-comunas-profesional/investigacion.md
+++ b/docs/missions/15-multiples-comunas-profesional/investigacion.md
@@ -1,118 +1,243 @@
-# Misión: <nombre> — Investigación
+# Misión 15: múltiples comunas por profesional — Investigación
 
 **Estado:** activo
 
-**Última actualización:** AAAA-MM-DD
+**Última actualización:** 2026-09-06
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-<!--
-Este documento se acumula: la evidencia y las conclusiones no se borran cuando el alcance cambia, porque
-explican por qué el producto es como es. Lo que sí se actualiza es el ideal, que resume la dirección que
-la investigación sostiene hoy.
+## El problema aparece cuando Rudiberto no puede declarar dónde trabaja de verdad
 
-Gate de salida — la investigación sostiene un producto.md cuando:
-- el problema tiene situación y consecuencia concretas, no una categoría abstracta
-- al menos una conclusión con confianza alta o media respalda la dirección
-- el ideal describe capacidades observables, no intenciones
--->
+**Situación:** Rudiberto es gasfitero y trabaja en la zona de Llanquihue, Frutillar y Puerto Varas —
+comunas vecinas de la Región de los Lagos, pero administrativamente distintas. No es un área de excepción
+ocasional: es su zona habitual de trabajo, las tres comunas por igual.
 
-## El problema aparece cuando <historia concreta>
+**Acción o necesidad:** Registrar en Datealo un perfil que refleje esa cobertura real, para aparecer en la
+búsqueda de cualquiera de las tres comunas.
 
-<!--
-Una situación real o reconstruida con precisión. No abras con una categoría como "falta de confianza" —
-abre con quién estaba haciendo qué y qué salió mal. Nombra a la persona y el servicio concreto.
--->
+**Respuesta actual:** El registro de profesional exige elegir una sola comuna (`professionals.comunaCodigo`
+es un único valor). Rudiberto tiene que declarar una y renunciar a las otras dos como coincidencia directa.
+La única red de respaldo que existe hoy es "comunas vecinas" (misión 06), pero es un mecanismo de
+*búsqueda*, no de declaración: solo entra en juego cuando la comuna buscada tiene cero profesionales, y ahí
+lo muestra con la etiqueta más débil, `vecina`, no como alguien que efectivamente dijo "yo trabajo acá".
 
-**Situación:** <qué está ocurriendo antes del problema>.
-
-**Acción o necesidad:** <qué se intenta resolver o decidir>.
-
-**Respuesta actual:** <qué hace hoy la persona: grupo de WhatsApp, Google, recomendación de un vecino,
-Datealo si ya existe la superficie>.
-
-**Consecuencia:** <error, demora, riesgo o decisión que no puede tomarse>.
+**Consecuencia:** Alguien que busca un gasfitero en Frutillar puede no encontrar a Rudiberto — o lo
+encuentra solo si Frutillar no tiene ningún otro profesional, y con una señal de confianza menor de la que
+merece (aparece como sugerencia de cercanía, no como alguien que declaró atender ahí).
 
 ## Preguntas que la investigación debe resolver
 
-<!--
-Solo preguntas capaces de cambiar el ideal o una decisión. Al resolver una, moverla a evidencia o
-conclusión. No es un backlog.
--->
-
-- ¿<pregunta y decisión que depende de ella>?
+Las dos preguntas originales de esta sección (tope de comunas, y si el patrón es propio de zonas rurales o
+también aplica en Santiago) se investigaron y movieron a evidencia y conclusiones — ver
+[E-004](#e-004), [E-005](#e-005), [E-006](#e-006) y [C-004](#c-004), [C-005](#c-005), [C-006](#c-006). No
+queda ninguna pregunta abierta pendiente por ahora.
 
 ## Evidencia
 
-<!--
-Un hecho verificable con fuente y límite. Prioriza observación directa, entrevistas y comportamiento
-comprobado. Los benchmarks de otros productos también son evidencia: qué hacen, qué trade-off eligieron y
-qué no aplica a Datealo.
-
-Datealo no tiene datos de uso propios todavía. Cuando la única evidencia disponible sea un benchmark o
-una entrevista, la columna "límite" es lo que impide que se lea como dato duro.
--->
-
-| ID    | Tipo                                              | Fuente                | Hecho verificable | Límite de la evidencia |
-| ----- | ------------------------------------------------- | --------------------- | ----------------- | ---------------------- |
-| E-001 | <entrevista, benchmark, uso, código, observación> | <enlace o referencia> | <hecho>           | <qué no demuestra>     |
+| ID    | Tipo                     | Fuente                                                        | Hecho verificable | Límite de la evidencia |
+| ----- | ------------------------ | -------------------------------------------------------------- | ------------------ | ----------------------- |
+| E-001 | Conversación con un profesional real | Conversación informal con Rudiberto, gasfitero, zona Región de los Lagos (registrada en esta misión el 2026-09-06) | Rudiberto trabaja en Frutillar, Puerto Varas, Llanquihue "y alrededores" — lo nombra como su zona habitual, no como excepción | Conversación única (N=1), sin protocolo estructurado de entrevista — no confirma cuán extendido es el patrón entre otros profesionales ni rubros |
+| <a id="e-002"></a>E-002 | Benchmark                | [Comparativas Thumbtack/Angi](#referencias)                     | Thumbtack y Angi dejan que el profesional elija una lista explícita de zip codes donde quiere recibir trabajo, no un radio | Mercado de EE.UU., otra escala y otro tipo de usuario — no valida qué tope numérico conviene en Chile |
+| <a id="e-003"></a>E-003 | Benchmark                | [TaskRabbit — radio de servicio](#referencias)                  | TaskRabbit usa un radio en millas desde la ubicación del Tasker, en vez de una lista discreta de zonas | No aplica directamente al modelo geográfico de Datealo (comuna como unidad administrativa, no coordenadas) — sirve para descartar el radio como alternativa, no para adoptarlo |
+| E-004 | Código (decisión previa ya tomada) | `server/db/seed/taxonomia.ts:15-22` | El comentario del seed dice explícitamente: Puerto Varas, Frutillar y Puerto Montt se activaron el 2026-08-28 "porque un profesional que vive en Puerto Varas normalmente ya atiende ahí también, no solo su propia comuna" | Confirma el caso de Rudiberto desde una segunda fuente (el propio historial del código), pero sigue siendo el mismo profesional — no suma un segundo caso independiente |
+| E-005 | Código (grafo de datos existente) | `server/db/seed/comuna-vecinas.ts` | Frutillar (10105) y Puerto Varas (10109) no figuran como vecinas entre sí en la tabla `comuna_vecinas` — ambas son vecinas de Llanquihue (10107), pero no lo son directamente una de la otra | Es un hecho verificable sobre el grafo actual, no sobre geografía real — no dice si el límite administrativo debería redibujarse, solo que el grafo de bordes no captura la "zona del lago" como unidad funcional |
+| E-006 | Benchmark (datos públicos, Censo 2024) | [Resultados Censo 2024 — Puerto Varas](#referencias), [Frutillar Hoy — Censo 2024](#referencias) | Frutillar (22.554 hab.) + Llanquihue (18.088 hab.) + Puerto Varas (52.942 hab.) suman ~93.584 habitantes en 3 comunas; Ñuñoa sola tiene un orden de magnitud comparable o mayor de población en 1 sola comuna | Dos puntos de comparación, no un estudio sistemático de las 346 comunas — no cuantifica cuántos profesionales activos hay en cada zona, solo población total |
 
 <a id="e-001"></a>
 
-### E-001 — <fuente o hecho en una frase>
+### E-001 — Rudiberto declara tres comunas como su zona habitual, no como excepción
 
-<!--
-Desarrollar solo cuando la tabla no alcanza para evaluar la calidad de la evidencia. Cierra con la
-consecuencia para la investigación.
--->
+Rudiberto es gasfitero y describe su zona de trabajo como Frutillar, Puerto Varas y Llanquihue "y
+alrededores" — sin distinguir una comuna principal y dos secundarias. Las tres son, para él, la misma
+categoría de "acá trabajo".
 
-<Observación precisa y contexto necesario.>
+Esto permite afirmar que al menos un profesional real de una zona de baja densidad opera de forma habitual
+en más de una comuna administrativa, pero no demuestra que sea el comportamiento típico del gremio de
+gasfitería ni de otros oficios, ni cuántas comunas es razonable esperar en el caso general.
 
-Esto permite afirmar <alcance>, pero no demuestra <límite>.
+<a id="e-004"></a>
+
+### E-004 — El propio historial del código ya registró este mismo caso antes de que existiera esta misión
+
+El comentario en `server/db/seed/taxonomia.ts` explica por qué Puerto Varas, Frutillar y Puerto Montt están
+activas junto con Llanquihue: "un profesional que vive en Puerto Varas normalmente ya atiende ahí también,
+no solo su propia comuna". Es el mismo caso que E-001, documentado el 2026-08-28, antes de que esta misión
+se abriera.
+
+Esto confirma que el problema ya había obligado una solución manual (activar comunas adicionales a mano en
+el seed) antes de tener una forma real de declararlo en el producto, pero no aporta un segundo caso
+independiente — sigue siendo el mismo profesional.
+
+<a id="e-005"></a>
+
+### E-005 — El grafo de "comunas vecinas" no conecta Frutillar con Puerto Varas
+
+Frutillar (código 10105) tiene como vecinas registradas a 10104, 10107 (Llanquihue), 10302 y 10303. Puerto
+Varas (código 10109) tiene como vecinas a 10101, 10103, 10106, 10107 (Llanquihue), 10302 y 10304. Ninguna
+de las dos listas incluye a la otra comuna, aunque ambas comparten borde con Llanquihue y las tres forman,
+en la práctica, la misma cuenca del lago.
+
+Esto permite afirmar que si Rudiberto no declara sus comunas y solo existiera el fallback de vecinas, una
+búsqueda en Frutillar nunca ampliaría hacia Puerto Varas (ni viceversa) aunque él trabaje en ambas — el
+grafo de adyacencia por borde administrativo no reconstruye la zona funcional real. No demuestra que el
+grafo esté mal construido para su propósito original (backup cuando una comuna queda en cero), solo que no
+sirve como sustituto de la declaración explícita.
+
+<a id="e-006"></a>
+
+### E-006 — Tres comunas de la cuenca del lago Llanquihue juntas tienen menos población que una sola comuna grande de Santiago
+
+Según el Censo 2024, Frutillar tiene 22.554 habitantes, Llanquihue 18.088 y Puerto Varas 52.942 — un total
+de ~93.584 personas repartidas en tres comunas. Ñuñoa, una sola comuna del Gran Santiago, ronda un orden de
+magnitud de población comparable o mayor ella sola (fuentes con cifras entre ~163.000 y ~267.000 según el
+corte de datos consultado).
+
+Esto permite afirmar que la base de clientes y de profesionales potenciales de una sola comuna grande de
+Santiago puede superar a la de tres comunas rurales combinadas, lo que hace más probable que un mercado
+más chico por comuna necesite sumar comunas vecinas para alcanzar un volumen viable de oferta y demanda. No
+demuestra cuántos profesionales activos hay realmente en cada zona hoy, solo la diferencia de población
+base disponible.
 
 ## Conclusiones
 
-<!--
-Una conclusión interpreta evidencia; no es una preferencia ni una funcionalidad. El título expresa el
-hallazgo, no el tema.
--->
-
 <a id="c-001"></a>
 
-### C-001 — <conclusión en una frase>
+### C-001 — El modelo de una sola comuna por profesional no representa la cobertura real de al menos un caso confirmado
 
 - **Sustento:** [E-001](#e-001).
-- **Razonamiento:** <por qué la evidencia conduce a esta lectura y no a otra>.
-- **Implicación:** <qué deberá ser cierto en el producto o qué alternativa queda debilitada>.
-- **Confianza:** <alta, media o baja> porque <razón o validación pendiente>.
+- **Razonamiento:** Rudiberto no tiene una comuna "de verdad" y dos ocasionales — las tres son su zona de
+  trabajo habitual. Forzar el registro a una sola comuna exige una elección arbitraria (¿cuál de las tres
+  declara?) que dejaría a las otras dos dependiendo del fallback débil de comunas vecinas, en vez de una
+  declaración directa.
+- **Implicación:** El producto necesita permitir declarar más de una comuna por profesional, y esas
+  comunas deben contar como coincidencia exacta en la búsqueda — no solo como vecina de respaldo.
+- **Confianza:** media, porque el sustento es una sola conversación sin protocolo estructurado (N=1) — es
+  un caso real y concreto, pero no confirma qué tan extendido está el patrón fuera de este caso.
 
-## El ideal: <resultado completo, sin recortar>
+<a id="c-002"></a>
 
-<!--
-El ideal es el producto de la investigación: la dirección que la evidencia sostiene, sin restricciones de
-implementación. El recorte a la primera entrega no vive aquí — vive en producto.md como decisión de
-alcance. Esta sección sí se reescribe cuando nueva evidencia cambia la dirección.
--->
+### C-002 — La forma correcta de declarar cobertura geográfica en Datealo es una lista de comunas, no un radio
+
+- **Sustento:** [E-002](#e-002), [E-003](#e-003).
+- **Razonamiento:** Datealo ya modela toda su geografía por comuna — schema, búsqueda, comunas vecinas —
+  como unidad discreta y nombrada. Un radio en kilómetros introduciría una unidad nueva (coordenadas,
+  distancia) que hoy no existe en ningún otro punto del producto, y el benchmark de TaskRabbit no resuelve
+  mejor el problema que el de lista explícita de Thumbtack/Angi. Elegir comunas por nombre es además más
+  legible para un profesional como Rudiberto que calibrar un número de kilómetros sin referencia clara.
+- **Implicación:** La solución de datos es una relación profesional↔comuna de varias filas, no un campo de
+  radio o distancia.
+- **Confianza:** media — los benchmarks son de mercados de otra escala (EE.UU.) y no validan directamente
+  el comportamiento de un profesional chileno, pero sí alcanzan para descartar el radio por incompatibilidad
+  con el modelo de datos que Datealo ya tiene.
+
+<a id="c-003"></a>
+
+### C-003 — Declarar comunas no reemplaza el fallback de comunas vecinas: resuelven problemas distintos en momentos distintos
+
+- **Sustento:** lectura directa de `server/utils/search.ts` y `server/utils/comunas.ts` (código vigente),
+  sin evidencia externa nueva.
+- **Razonamiento:** "comunas vecinas" es un mecanismo de búsqueda que solo se activa cuando la comuna
+  buscada tiene cero profesionales — amplía la búsqueda como último recurso, y siempre marca el resultado
+  como `vecina`. Comunas declaradas es información propia del profesional, verdadera sin importar cuántos
+  otros profesionales haya en esa comuna: un profesional que declaró Frutillar aparece ahí como coincidencia
+  exacta aunque Frutillar ya tenga otros profesionales — algo que el fallback de vecinas nunca hace, porque
+  solo entra en juego con cero resultados.
+- **Implicación:** el ideal conserva ambos mecanismos. Comunas declaradas eleva a un profesional de
+  "aparece solo si la comuna está vacía, marcado como vecina" a "aparece siempre que alguien busque ahí,
+  marcado como exacto" — sin apagar el fallback para las comunas que nadie declaró.
+- **Confianza:** alta — es una lectura directa del comportamiento del código existente, no depende de datos
+  externos.
+
+<a id="c-004"></a>
+
+### C-004 — La adyacencia geográfica de "comunas vecinas" no reconstruye la zona funcional real de un profesional
+
+- **Sustento:** [E-005](#e-005).
+- **Razonamiento:** Frutillar y Puerto Varas no son vecinas entre sí en el grafo de bordes administrativos,
+  aunque ambas formen parte de la misma cuenca del lago donde Rudiberto trabaja. Un grafo pensado para
+  "comunas que comparten límite" no captura "comunas donde la gente realmente se mueve para trabajar o
+  contratar" — son conceptos distintos que coinciden a veces y otras no.
+- **Implicación:** el fallback de comunas vecinas nunca habría resuelto el caso de Rudiberto por sí solo,
+  incluso en el escenario más favorable (Frutillar en cero profesionales). Refuerza [C-003](#c-003): la
+  declaración explícita no es una mejora incremental sobre el fallback, es la única forma de representar
+  esta cobertura.
+- **Confianza:** alta — es un hecho verificable directamente en los datos de `comuna_vecinas`, no depende
+  de interpretación.
+
+<a id="c-005"></a>
+
+### C-005 — El patrón de cubrir varias comunas es más urgente en mercados chicos que en el Gran Santiago
+
+- **Sustento:** [E-006](#e-006).
+- **Razonamiento:** una sola comuna grande de Santiago concentra, ella sola, más población que las tres
+  comunas de la cuenca del lago Llanquihue combinadas. Eso hace más probable que un profesional de Ñuñoa
+  encuentre suficiente trabajo sin salir de su comuna, mientras que un profesional de una comuna rural
+  pequeña necesita sumar comunas vecinas para tener una base de clientes viable — y lo mismo aplica del
+  lado de quien busca: en una comuna rural chica hay menos profesionales disponibles por categoría.
+- **Implicación:** esta misión no es exclusiva de zonas rurales, pero su urgencia relativa es mayor fuera
+  del Gran Santiago — un dato relevante para decidir si `producto.md` prioriza el recorte inicial hacia
+  esas zonas.
+- **Confianza:** media — se apoya en dos puntos de comparación de población, no en un estudio sistemático
+  de las 346 comunas ni en el número real de profesionales activos por zona.
+
+<a id="c-006"></a>
+
+### C-006 — No hay evidencia que sugiera imponer un tope numérico duro de comunas por profesional en el lanzamiento
+
+- **Sustento:** [E-002](#e-002), [E-003](#e-003).
+- **Razonamiento:** ni Thumbtack ni Angi imponen un tope bajo — Thumbtack permite hasta 1.000 zip codes por
+  profesional, varios órdenes de magnitud más que las ~346 comunas que existen en todo Chile. Ningún
+  benchmark revisado sugiere que un tope numérico duro sea necesario para mantener la señal de "atiendo acá
+  de verdad" — esa plataforma resuelve el problema con relevancia de ranking, no con restricción de
+  entrada.
+- **Implicación:** el ideal no necesita un límite numérico duro de comunas. Si hiciera falta una guía para
+  evitar que un profesional declare comunas sin sentido (todo el país, por ejemplo), es una decisión de
+  diseño de `producto.md`/`experiencia.md` — no algo que esta investigación deba resolver de antemano.
+- **Confianza:** media — el benchmark es de una plataforma de otra escala (EE.UU., miles de zip codes) que
+  no enfrenta el mismo riesgo de un catálogo pequeño y cerrado de 346 comunas.
+
+## El ideal: cualquier profesional aparece como coincidencia exacta en cada comuna donde de verdad trabaja
 
 ### El resultado ideal se ve así
 
-<Narra de principio a fin una situación futura con datos concretos: nombres, comunas, oficios, horarios.
-Qué acción ocurre, qué responde Datealo, qué decisión puede tomar la persona. Evita "una experiencia
-simple" sin comportamiento observable.>
+Rudiberto entra a su perfil de profesional en Datealo y en la zona de trabajo ve una lista de comunas donde
+puede marcar las que atiende: junto a Llanquihue, que ya tenía, marca también Frutillar y Puerto Varas.
+Guarda el cambio.
+
+Una persona en Puerto Varas busca "gasfitero" y ve a Rudiberto en los resultados como coincidencia exacta
+— igual que si buscara en Llanquihue o en Frutillar. Si Rudiberto además trabajara alguna vez en Puerto
+Octay (comuna vecina de Llanquihue que no declaró), seguiría sin aparecer ahí como exacto: solo aparecería
+si Puerto Octay se queda sin ningún profesional propio, vía el mismo fallback de comunas vecinas que existe
+hoy.
 
 ### Capacidades del ideal
 
-| Capacidad | Acción habilitada    | Respuesta esperada              | Conclusión que la justifica |
-| --------- | -------------------- | ------------------------------- | --------------------------- |
-| <nombre>  | <qué se puede hacer> | <qué produce o explica Datealo> | [C-001](#c-001)             |
+| Capacidad                              | Acción habilitada                                                                 | Respuesta esperada                                                                                  | Conclusión que la justifica |
+| --------------------------------------- | ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ---------------------------- |
+| Declarar varias comunas                 | El profesional marca en su perfil todas las comunas donde atiende, no solo una     | Aparece como coincidencia exacta en la búsqueda de cualquiera de esas comunas                          | [C-001](#c-001)              |
+| Cobertura por lista, no por radio       | El profesional elige comunas por nombre de una lista, sin calibrar un radio en km  | La zona de trabajo se guarda como un conjunto concreto de comunas nombradas                            | [C-002](#c-002)              |
+| Convivencia con comunas vecinas         | El fallback de comunas vecinas sigue activo para comunas sin ningún profesional declarado | Una comuna sin cobertura declarada directa sigue mostrando profesionales de comunas vecinas cuando la búsqueda exacta da cero | [C-003](#c-003)              |
 
-### El ideal no significa <confusión probable>
+### El ideal no significa cobertura automática por cercanía
 
-- <límite conceptual que evita una interpretación incorrecta>.
+- No significa que el profesional recibe comunas adicionales por cercanía geográfica de forma automática —
+  cada comuna que cuenta como "exacta" fue elegida a mano por el profesional, nunca inferida por el sistema.
+- No significa que desaparece el concepto de comunas vecinas — sigue siendo el mecanismo de respaldo para
+  las comunas donde nadie declaró cobertura directa.
+- No significa que las comunas declaradas tengan que ser geográficamente contiguas — Rudiberto declara tres
+  comunas vecinas entre sí porque así trabaja, pero el mecanismo no exige contigüidad; solo la refleja
+  cuando es cierta.
 
 ## Referencias
 
-<!-- Fuentes primarias citadas por las evidencias. El enlace no sustituye el hecho y el límite en E-xxx. -->
-
-- [<título descriptivo>](URL): usado en E-001 para <afirmación concreta>.
+- [Thumbtack vs Angi para plomeros](https://plumberlocator.us/blog/thumbtack-vs-angi-plumbers-comparison/):
+  usado en E-002 para confirmar que el profesional filtra leads por zip code explícito, no por radio.
+- [Angi vs Thumbtack — comparativa de plataformas](https://www.recommended.app/compare/angi-vs-thumbtack):
+  usado en E-002 para el mismo hallazgo desde una segunda fuente.
+- [TaskRabbit — actualización de la app del Tasker](https://www.taskrabbit.com/blog/tasker-update-app-version-4-58-0/):
+  usado en E-003 para confirmar el modelo de radio en millas como alternativa descartada.
+- [Resultados Censo 2024 — Puerto Varas](https://www.eha.cl/noticia/local/resultados-censo-2024-en-puerto-varas-somos-52942-habitantes):
+  usado en E-006 para la población de Puerto Varas y Llanquihue.
+- [Censo 2024: Frutillar supera los 22 mil habitantes](https://frutillarhoy.cl/noticias-frutillar-censo-2024-poblacion/):
+  usado en E-006 para la población de Frutillar.

--- a/docs/missions/15-multiples-comunas-profesional/producto.md
+++ b/docs/missions/15-multiples-comunas-profesional/producto.md
@@ -1,149 +1,180 @@
-# Misión: <nombre> — Producto
+# Misión 15: múltiples comunas por profesional — Producto
 
-**Estado:** borrador
+**Estado:** vigente — aprobado por Patricio Tabilo el 2026-09-06
 
-**Última actualización:** AAAA-MM-DD
+**Última actualización:** 2026-09-06
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-<!--
-Este documento es la spec viva del resultado: qué construimos ahora y bajo qué reglas. El porqué vive en
-investigacion.md — aquí solo se enlaza. Se reescribe cuando el alcance cambia; no acumula historia.
+## Qué construimos: un profesional declara todas las comunas donde atiende, no solo una
 
-Gate de salida — producto.md está listo para experiencia.md cuando:
-- cada funcionalidad tiene formato JTBD, reglas y al menos un caso límite con comportamiento definido
-- cada funcionalidad enlaza una conclusión de investigacion.md y una señal de éxito
-- cada funcionalidad declara a qué lado del marketplace sirve, y qué necesita del otro lado para funcionar
-- no hay decisiones de producto delegadas a diseño o ingeniería
-- las decisiones propuestas tienen fecha límite en el README
--->
+**Resultado:** un profesional como Rudiberto puede marcar en su perfil todas las comunas donde trabaja de
+verdad — Llanquihue, Frutillar y Puerto Varas — y aparece como coincidencia exacta en la búsqueda de
+cualquiera de ellas, no solo en la que declaró al registrarse.
 
-## Qué construimos: <resultado en una frase>
+**Recorte respecto del ideal:** el ideal ([investigacion.md](./investigacion.md)) no impone restricciones
+de cantidad ni de zona. Esta entrega tampoco las impone — el recorte real está en la superficie donde se
+muestran las comunas declaradas (perfil público, card de resultados), que queda para `experiencia.md`, y en
+que no introduce ninguna jerarquía entre comunas ni ningún tope (ver [D-001](#d-001), [D-002](#d-002)).
 
-<!--
-El recorte vigente del ideal y por qué sigue entregando el resultado central. Máximo cuatro párrafos
-cortos. El ideal completo vive en investigacion.md.
--->
-
-**Resultado:** <qué podrá lograr una persona al finalizar esta entrega>.
-
-**Recorte respecto del ideal:** <qué dimensión se reduce y por qué sigue siendo suficiente>
-(ver [el ideal](./investigacion.md)).
-
-**Restricciones aceptadas:** <plataforma, cobertura geográfica, categorías, volumen inicial de
-profesionales>.
+**Restricciones aceptadas:** aplica solo a comunas activas, con el mismo criterio que usa hoy la búsqueda
+(`comunas.activa = true`); no cambia el conjunto de comunas activas (Gran Santiago y la cuenca del lago
+Llanquihue) ni depende de en cuál de ellas esté el profesional.
 
 ## Funcionalidades
 
-| ID    | Funcionalidad                  | Lado         | Sustento     | Éxito |
-| ----- | ------------------------------ | ------------ | ------------ | ----- |
-| F-001 | <verbo + resultado observable> | buscador     | C-001, D-001 | M-001 |
+| ID    | Funcionalidad                                                    | Lado         | Sustento              | Éxito |
+| ----- | ------------------------------------------------------------------ | ------------ | ---------------------- | ----- |
+| F-001 | Declarar varias comunas y aparecer como coincidencia exacta en todas | profesional (con efecto directo en buscador) | C-001, C-004, D-001 | M-001 |
 
 <a id="f-001"></a>
 
-### F-001 — <verbo + resultado observable>
+### F-001 — Declarar varias comunas y aparecer como coincidencia exacta en todas
 
-<!--
-Duplica este bloque por funcionalidad. Se escribe desde el resultado del usuario (working backwards):
-primero el JTBD, después las reglas. Si la respuesta de Datealo no se puede describir sin hablar de tablas
-o componentes, falta cerrar la decisión de producto.
--->
+Cuando Rudiberto atiende de forma habitual en Llanquihue, Frutillar y Puerto Varas,
+quiero marcar las tres en mi perfil de profesional,
+para que alguien que busque gasfitería en cualquiera de esas comunas me encuentre como resultado directo,
+no como una sugerencia de comuna vecina.
 
-Cuando <usuario en contexto concreto>,
-quiero <acción>,
-para <resultado observable>.
+**Lado del marketplace:** profesional declara, buscador recibe el efecto directo en `/api/search`. **Qué
+necesita del otro lado:** ninguna precondición de volumen — la funcionalidad entrega su resultado igual con
+uno o con muchos profesionales en la comuna buscada.
 
-**Lado del marketplace:** buscador, profesional o ambos. **Qué necesita del otro lado:** <volumen mínimo
-de perfiles, reseñas o cobertura sin el cual esta funcionalidad no entrega su resultado>.
-
-**Sustento:** [C-001](./investigacion.md#c-001) y [D-001](#d-001). **Éxito:** [M-001](#m-001).
+**Sustento:** [C-001](./investigacion.md#c-001), [C-004](./investigacion.md#c-004) y [D-001](#d-001).
+**Éxito:** [M-001](#m-001).
 
 **Reglas:**
 
-- Si <condición>, Datealo <comportamiento esperado>.
-- Si <caso límite>, Datealo <comportamiento seguro y qué información muestra>.
-- Datealo nunca <comportamiento que rompería el significado o la confianza>.
+- Si el profesional marca una comuna activa además de la que ya tenía, esa comuna cuenta como coincidencia
+  exacta en `/api/search`, con las mismas reglas de orden (completitud del perfil, luego antigüedad) que
+  ya aplican hoy a una sola comuna.
+- Si un profesional ya existía antes de este cambio, su comuna actual se preserva automáticamente como una
+  de sus comunas declaradas — no tiene que volver a configurar nada para no perder la cobertura que ya
+  tenía (ver [D-003](#d-003)).
+- Si el profesional intenta guardar su perfil sin ninguna comuna marcada, Datealo no permite guardar — debe
+  declarar al menos una, igual que exige hoy.
+- El profesional puede desmarcar una comuna que había declarado, igual que puede marcar una nueva — sujeto
+  a la misma regla anterior: no puede quedar con cero.
+- Si una comuna que el profesional había declarado se desactiva más adelante, Datealo deja de mostrarlo ahí
+  pero no borra la declaración — el mismo criterio que ya aplica a la comuna única de hoy.
+- Datealo nunca agrega una comuna a la declaración de un profesional por cercanía geográfica — toda comuna
+  que cuenta como exacta fue elegida a mano por él. El fallback de comunas vecinas (misión 06) sigue
+  operando sin cambios para las comunas donde ningún profesional declaró cobertura directa.
 
-**Ejemplo verificable:** dado <estado con datos concretos>, cuando <acción>, entonces <resultado
-observable>.
+**Ejemplo verificable:** dado que Rudiberto declaró Llanquihue, Frutillar y Puerto Varas, cuando alguien
+busca "gasfitería" en Puerto Varas, entonces Rudiberto aparece en los resultados con `matchType: 'exacta'`,
+igual que si buscaran en Llanquihue o en Frutillar.
 
-**No incluye:** <variante del ideal excluida de esta funcionalidad>.
+**No incluye:** cómo se muestran las comunas declaradas en el perfil público o en la card de resultados —
+hoy `comunaNombre` es un solo valor y esta funcionalidad no define su reemplazo visual, eso se resuelve en
+`experiencia.md`.
 
-**Experiencia:** <enlace a UXF-xxx cuando exista>. **Ingeniería:** <enlace a T-xxx cuando exista>.
+**Experiencia:** pendiente. **Ingeniería:** pendiente.
 
 ## Casos límite que cruzan funcionalidades
 
-<!--
-Solo condiciones que afectan varias funcionalidades. Las propias de una viven en su bloque. Un caso
-retirado no se borra ni se reutiliza: conserva su fila, o se nombra con su motivo en una línea debajo.
-
-Los casos límite propios de un marketplace pre-lanzamiento aparecen acá: cero resultados en una comuna,
-un profesional sin reseñas, una categoría con un solo perfil, un perfil sin verificar.
--->
-
-| ID     | Condición concreta     | Comportamiento esperado | Funcionalidades |
-| ------ | ---------------------- | ----------------------- | --------------- |
-| CL-001 | <estado o combinación> | <qué hace Datealo>      | F-001           |
+| ID     | Condición concreta                                                        | Comportamiento esperado                                                                 | Funcionalidades |
+| ------ | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ---------------- |
+| CL-001 | El profesional marca la misma comuna dos veces                             | Datealo la trata como una sola declaración — no genera una fila duplicada ni un resultado repetido | F-001            |
+| CL-002 | Todas las comunas declaradas por un profesional quedan inactivas           | Datealo lo trata igual que hoy trata a un profesional cuya única comuna está inactiva — no aparece en ningún resultado de búsqueda | F-001            |
+| CL-003 | Una comuna buscada no tiene ningún profesional con coincidencia exacta (ni declarada ni por comuna vecina propia) | El fallback de comunas vecinas se activa exactamente como hoy, sin cambios — la declaración explícita no lo reemplaza | F-001            |
+| CL-004 | El profesional intenta desmarcar su única comuna declarada                | Datealo no permite guardar el cambio — la misma regla que exige al menos una comuna se aplica también al eliminar, no solo al guardar por primera vez | F-001            |
 
 ## Fuera de alcance
 
-<!-- Distingue postergado de descartado y qué condición justificaría reabrirlo. -->
-
-| Capacidad o caso      | Estado                  | Razón del recorte | Condición para reconsiderar |
-| --------------------- | ----------------------- | ----------------- | --------------------------- |
-| <capacidad del ideal> | postergada o descartada | <trade-off>       | <evidencia o hito>          |
+| Capacidad o caso                                                             | Estado      | Razón del recorte                                                                                          | Condición para reconsiderar |
+| ------------------------------------------------------------------------------ | ----------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------ |
+| Mostrar la lista completa de comunas declaradas en la card de resultados y el perfil público | postergada  | Es una decisión de diseño de superficie, no de qué datos existen — corresponde a `experiencia.md`, no a esta entrega | cuando `experiencia.md` defina cómo mostrarlo sin sobrecargar la card |
+| Tope numérico o advertencia de UX sobre cuántas comunas puede declarar un profesional | descartada por ahora | Ningún benchmark revisado (Thumbtack, Angi) sugiere que haga falta ([C-006](./investigacion.md#c-006)) | si aparece un caso real de abuso (comunas declaradas sin relación con dónde trabaja el profesional) |
+| Rediseñar el grafo de "comunas vecinas" para incluir zonas funcionales como la cuenca de un lago | descartada  | La declaración explícita ya resuelve el problema que esto intentaría resolver, sin tocar un mecanismo que cumple otro propósito ([C-004](./investigacion.md#c-004)) | si aparece evidencia de que el grafo de vecinas necesita ajustarse por otra razón, independiente de esta misión |
 
 ## Señales de éxito
 
 <a id="m-001"></a>
 
-### M-001 — <señal que demuestra el resultado>
+### M-001 — Los profesionales que atienden más de una comuna la declaran, en vez de quedarse con una sola
 
-- **Pregunta:** ¿<qué queremos comprobar>?
-- **Señal:** <comportamiento o resultado observable>.
-- **Método y umbral:** <instrumentación o revisión, qué resultado, en qué población y ventana>.
-- **Guardrail:** <daño que no debe aumentar para conseguir la señal>.
+- **Pregunta:** ¿los profesionales en la situación de Rudiberto usan la nueva capacidad, o el problema
+  seguía sin resolverse solo porque nadie sabía que podía pedirlo?
+- **Señal:** de los profesionales activos, qué proporción tiene más de una comuna declarada.
+- **Método y umbral:** revisión manual del total de profesionales activos con 2+ comunas declaradas, sobre
+  el total de profesionales activos, en las primeras semanas tras el lanzamiento — con el volumen actual
+  (pre-lanzamiento, decenas de profesionales) no alcanza para un umbral estadístico, así que la primera
+  lectura es cualitativa: ¿apareció al menos un caso más además de Rudiberto?
+- **Guardrail:** la proporción de profesionales con cero comunas activas válidas no debe subir respecto de
+  antes del cambio — significaría que alguien perdió cobertura por un error en la migración de datos
+  existentes ([D-003](#d-003)).
+- **Verificación funcional (una sola vez, al implementar, no una métrica recurrente):** buscar "gasfitería"
+  en Frutillar o Puerto Varas y confirmar que Rudiberto aparece con `matchType: 'exacta'` — parte del QA
+  del feature, no algo que se repite después.
 
 ## Decisiones de producto
 
-<!--
-Solo decisiones con alternativas reales. No borres decisiones reemplazadas: explican por qué el producto
-es como es. Toda decisión propuesta se refleja en el README con fecha límite.
--->
-
 <a id="d-001"></a>
 
-### D-001 — <decisión en una frase que se entiende sola>
+### D-001 — Todas las comunas declaradas por un profesional cuentan igual, sin una comuna "principal"
 
-- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
+- **Estado:** propuesta. **Fecha:** 2026-09-13.
 - **Sustento:** [C-001](./investigacion.md#c-001).
-- **Tensión:** <criterios que no podían maximizarse al mismo tiempo>.
-- **Alternativas descartadas:** <opciones y razón concreta del rechazo, en la misma línea>.
-- **Decisión y consecuencia:** <qué se hará y qué habilita, limita o exige revisar en UX e ingeniería>.
-- **Reapertura:** <evidencia o cambio que justificaría revisarla>.
+- **Tensión:** simplicidad del dato y de la búsqueda (todas las comunas son iguales) contra la posibilidad
+  de que el perfil público quiera destacar una comuna "de origen" para dar contexto (por ejemplo, "vive en
+  Puerto Varas, también atiende en Frutillar y Llanquihue").
+- **Alternativas descartadas:** mantener una comuna "principal" obligatoria más comunas "adicionales"
+  opcionales — se descarta porque Rudiberto no tiene una comuna más real que las otras dos, y forzar esa
+  jerarquía inventaría una distinción que el caso que motivó la misión no tiene. Ordenar las comunas
+  declaradas por antigüedad de registro sin marcarlas como "principal" en los datos — se descarta como
+  complejidad sin justificación: no hay evidencia de que el orden de despliegue le importe a nadie todavía.
+- **Decisión y consecuencia:** las comunas declaradas se guardan como un conjunto sin orden ni jerarquía.
+  Habilita que ingeniería modele una relación simple profesional↔comuna, sin una columna de "es principal".
+  Limita: si más adelante el perfil público necesita destacar una comuna de origen distinta de las demás,
+  hace falta una decisión nueva.
+- **Reapertura:** si `experiencia.md` encuentra que el perfil público necesita mostrar una comuna "de
+  origen" distinta de las demás.
+
+<a id="d-002"></a>
+
+### D-002 — Sin tope numérico de comunas por profesional en esta entrega
+
+- **Estado:** propuesta. **Fecha:** 2026-09-13.
+- **Sustento:** [C-006](./investigacion.md#c-006).
+- **Tensión:** simplicidad (no construir ni mantener una regla de límite) contra el riesgo de que un
+  profesional declare comunas sin relación real con dónde trabaja, degradando la confianza de "esta persona
+  sí atiende acá".
+- **Alternativas descartadas:** un tope fijo bajo (por ejemplo, máximo 5 comunas) — se descarta porque
+  ningún benchmark revisado respalda un número específico, y un tope arbitrario podría bloquear a un
+  profesional real con una cobertura más amplia que el número elegido. Un tope distinto según la densidad
+  de la zona (más comunas permitidas en regiones que en Santiago) — se descarta por la misma razón que la
+  misión 14 ya documentó para reglas dependientes de densidad: no hay datos de uso reales todavía para
+  calibrarlo con algo mejor que una intuición.
+- **Decisión y consecuencia:** cualquier profesional puede declarar cualquier cantidad de comunas activas.
+  Si en producción aparece abuso real, se revisa con datos concretos en vez de una intuición previa.
+- **Reapertura:** si se observa un profesional declarando un número de comunas que no corresponde a un área
+  de trabajo real, o si aparece un reporte concreto de perfiles poco creíbles por esta razón.
+
+<a id="d-003"></a>
+
+### D-003 — Las comunas que un profesional ya tenía declaradas hoy se preservan automáticamente
+
+- **Estado:** propuesta. **Fecha:** 2026-09-13.
+- **Sustento:** [C-001](./investigacion.md#c-001) — ningún profesional existente debe perder cobertura por
+  este cambio.
+- **Tensión:** ninguna tensión fuerte entre alternativas reales — se documenta igual porque es una decisión
+  sobre migración de datos existentes, cara de revertir si sale mal (Carril Full Spec de esta misión).
+- **Alternativas descartadas:** pedirle a cada profesional existente que vuelva a confirmar sus comunas al
+  iniciar sesión — se descarta porque agrega fricción sin resolver ninguna ambigüedad real: la comuna que
+  ya tenían sigue siendo válida tal cual estaba.
+- **Decisión y consecuencia:** la migración de datos convierte automáticamente el valor actual de
+  `professionals.comunaCodigo` en la primera fila de la nueva relación profesional↔comuna, sin que el
+  profesional tenga que hacer nada. Cómo se ejecuta esa migración en concreto es de `ingenieria.md`.
+- **Reapertura:** ninguna prevista.
 
 ## Preguntas
 
-<!--
-Solo preguntas que pueden cambiar una decisión o funcionalidad. Lo demás va a un issue.
-Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
-Estado: abierta | resuelta AAAA-MM-DD (alguien la respondió) | disuelta AAAA-MM-DD (el producto cambió y la
-pregunta dejó de tener sentido). Solo las abiertas llevan bloque de detalle debajo de la tabla.
--->
+No queda ninguna pregunta abierta que bloquee `experiencia.md`: las dos dudas originales de esta misión
+(relación con comunas vecinas, tope de comunas) se resolvieron en `investigacion.md`
+([C-004](./investigacion.md#c-004), [C-006](./investigacion.md#c-006)) y en las decisiones de esta página.
 
-<Una frase que responde "¿qué falta?": la pregunta que bloquea y qué bloquea.>
-
-| ID    | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
-| ----- | ---------------------- | ------------------- | --------------------------------------------------------------- |
-| Q-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
-| Q-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |
-
-<a id="q-001"></a>
-
-### Q-001 — <la pregunta en una frase que se entiende sola>
-
-- **La duda, con un ejemplo:** <el caso concreto que muestra por qué hay dos respuestas posibles>.
-- **Afecta a:** D-001 o F-001.
-- **Cómo se resolverá:** <quién y con qué método>.
-- **¿Bloquea algo?:** <qué bloquea y su fecha límite, o no>.
+| ID | La duda | Estado | Respuesta, o quién la resuelve |
+| -- | ------- | ------ | ------------------------------- |
+| —  | —       | —      | —                                |

--- a/docs/missions/README.md
+++ b/docs/missions/README.md
@@ -23,7 +23,7 @@ abrieron y de dónde salió cada una.
 | 12  | [hero y copy de la landing](./12-hero-y-copy-landing/) | producto | 2026-09-01 | cerrada 2026-09-06 | — | — |
 | 13  | [tamaño de fuente](./13-tamano-de-fuente/) | producto | 2026-09-06 | cerrada 2026-09-06 | — | — |
 | 14  | [múltiples categorías por profesional](./14-multiples-categorias-profesional/) | producto | 2026-09-06 | exploración | Investigación | — |
-| 15  | [múltiples comunas por profesional](./15-multiples-comunas-profesional/) | producto | 2026-09-06 | exploración | Investigación | — |
+| 15  | [múltiples comunas por profesional](./15-multiples-comunas-profesional/) | producto | 2026-09-06 | lista para construir | — | — |
 
 Misiones 02 a 07 son las seis que llevan al MVP (registrarse, mostrarse, buscar, reseñar), en el orden de
 dependencia definido en la conversación de roadmap del 2026-08-13 — el número no es prioridad, pero acá sí


### PR DESCRIPTION
## Resumen

Discovery completo de la misión 15: un profesional puede declarar todas las comunas donde atiende
(no solo una), y aparece como coincidencia exacta en la búsqueda de cualquiera de ellas.

- **`investigacion.md`** — el caso de Rudiberto (gasfitero, atiende en Llanquihue, Frutillar y
  Puerto Varas) y la evidencia que sustenta la misión.
- **`producto.md`** (vigente) — F-001, sin comuna principal (D-001), sin tope numérico (D-002),
  migración automática de la comuna actual (D-003).
- **`experiencia.md`** (vigente) — selector múltiple en bottom sheet (UXF-001), con 4 mockups
  verificados en `design-mockups/`. Perfil público y título SEO listan todas las comunas sin
  truncar; el campo compacto de registro/perfil trunca con elipsis por ser un control de una sola
  línea (UX-004, verificado con un caso sintético de 6 comunas). La card de resultados no cambia
  (UX-005). Pasó la evaluación heurística del Carril Full Spec.
- **`ingenieria.md`** (vigente) — nueva tabla `professional_comunas`, 4 contratos (TC-001 a
  TC-004), RLS auditada contra el checklist de `seguridad-datos`, y un plan de 10 slices (S-001 a
  S-010) que migra los datos existentes sin ventana de riesgo (T-005). Pasó la auditoría de
  `clean-architecture`, `domain-driven-design` y `supabase-postgres-best-practices`.

## Test plan

- [x] Los tres documentos que requieren aprobación (`producto.md`, `experiencia.md`,
      `ingenieria.md`) están marcados `vigente`, aprobados por Patricio Tabilo.
- [x] `experiencia.md`: evaluación heurística en contexto separado corrida, sin hallazgos de
      enfoque.
- [x] `ingenieria.md`: auditoría en contexto separado corrida; los dos hallazgos que encontró
      (ventana de migración, `findComunasFrecuentes` sin cubrir) ya están resueltos en el propio
      documento.
- [ ] Al mergear: cerrar el worktree de discovery (`ExitWorktree action: "remove"`) antes de crear
      los issues del Plan de construcción.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K1tbxRuiWA9jP8TPVN8PXN