### PR TITLE
docs(docs): discovery de la misión 14 — múltiples categorías por profesional

### DIFF
--- a/docs/missions/14-multiples-categorias-profesional/README.md
+++ b/docs/missions/14-multiples-categorias-profesional/README.md
@@ -4,17 +4,18 @@
 categoría por profesional) y cómo `/api/search` filtra por categoría. **Abierta el** 2026-09-06.
 **Nace de:** ninguna.
 
-**Estado de la misión:** exploración
+**Estado de la misión:** lista para construir
 
-**En foco:** Investigación
+**En foco:** ninguno — los tres documentos (`producto.md`, `experiencia.md`, `ingenieria.md`) están
+`vigente`
 
-**Última actualización:** 2026-09-06
+**Última actualización:** 2026-09-07
 
 **Documentos:** [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-**Próximo hito:** completar `investigacion.md` con el problema concreto y evidencia de que un profesional
-real ofrece más de un oficio — sin fecha límite todavía, recién se abre la misión.
+**Próximo hito:** abrir el PR de discovery con los tres documentos vigentes (paso 6 de la secuencia en
+`docs/missions/README.md`). Sin fecha límite todavía.
 
 ## Brief
 

--- a/docs/missions/14-multiples-categorias-profesional/design-mockups/perfil-edicion-categorias.html
+++ b/docs/missions/14-multiples-categorias-profesional/design-mockups/perfil-edicion-categorias.html
@@ -1,0 +1,360 @@
+<!doctype html>
+<html lang="es-CL">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>V-001 Editar perfil con varias categorías — misión 14</title>
+
+    <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+    <link
+      href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&family=Plus+Jakarta+Sans:wght@600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../../design/datealo-mockup-kit.css" />
+    <style type="text/tailwindcss">
+      @theme {
+        --color-primary: var(--ui-primary);
+        --color-secondary: var(--ui-secondary);
+        --color-success: var(--ui-success);
+        --color-error: var(--ui-error);
+      }
+    </style>
+    <style>
+      .field-card {
+        border: 1px solid var(--ui-border);
+        border-radius: 1rem;
+        padding: 1rem;
+      }
+      .field-card + .field-card {
+        margin-top: 0.75rem;
+      }
+      .field-card.is-editing {
+        border-color: var(--ui-primary);
+        background: color-mix(in oklab, var(--ui-primary) 4%, var(--ui-bg));
+      }
+      .field-title {
+        font-family: var(--font-heading);
+        font-weight: 700;
+        font-size: 0.875rem;
+        color: var(--color-datealo-text);
+        margin: 0;
+      }
+      /* padding vertical/horizontal invisible: el texto se ve chico (0.75rem) pero el área de toque real
+         cumple el mínimo de 24x24px con 8px de separación entre "Quitar" y "Editar" (hallazgo de la
+         evaluación heurística de esta misión) */
+      .field-link {
+        font-size: 0.75rem;
+        font-weight: 700;
+        color: var(--ui-primary);
+        text-decoration: underline;
+        padding: 0.5rem;
+        margin: -0.5rem;
+      }
+      .input-mock {
+        border: 1px solid var(--ui-border-accented);
+        border-radius: var(--ui-radius);
+        padding: 0.5rem 0.75rem;
+        font-size: 0.875rem;
+        color: var(--color-datealo-text);
+        background: var(--ui-bg);
+      }
+      .add-category-btn {
+        border: 1.5px dashed var(--ui-border-accented);
+        border-radius: 1rem;
+        padding: 0.875rem;
+        text-align: center;
+        font-size: 0.875rem;
+        font-weight: 700;
+        color: var(--ui-primary);
+      }
+      .select-mock {
+        border: 1px solid var(--ui-primary);
+        border-radius: var(--ui-radius);
+        padding: 0.625rem 0.75rem;
+        font-size: 0.875rem;
+        color: var(--ui-text-muted);
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div class="frames">
+      <!-- ============================================== MOBILE · LISTA CON 2 CATEGORÍAS ================= -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-001 · modo lista de categorías — 2 declaradas
+          <small>cada categoría es un bloque con precio y descripción propios (D-002/D-003 producto.md);
+            "+ Agregar categoría" queda al final, siempre visible</small>
+        </div>
+        <div class="frame-viewport is-auto">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div style="padding:1.25rem;">
+            <h1 style="font-family:var(--font-heading);font-weight:800;font-size:1.25rem;margin:0;color:var(--color-datealo-text);">
+              Tu perfil
+            </h1>
+            <p style="margin:0.25rem 0 1.25rem;font-size:0.8125rem;color:var(--ui-text-muted);">Feña Silva · Ñuñoa</p>
+
+            <p style="font-size:0.75rem;font-weight:700;text-transform:uppercase;letter-spacing:0.04em;color:var(--ui-text-muted);margin:0 0 0.5rem;">
+              Tus categorías
+            </p>
+
+            <div class="field-card">
+              <div style="display:flex;justify-content:space-between;align-items:center;">
+                <p class="field-title">Gasfitería</p>
+                <button class="field-link" style="color:var(--ui-error);text-decoration:none;" aria-label="Quitar Gasfitería">Quitar</button>
+              </div>
+              <p style="margin:0.375rem 0 0;font-size:0.875rem;color:var(--color-datealo-text);">Desde $18.000</p>
+              <p style="margin:0.25rem 0 0;font-size:0.8125rem;color:var(--ui-text-muted);">
+                Reparación de filtraciones, estanques y llaves. Atiendo fines de semana.
+              </p>
+              <button class="field-link" style="margin-top:0.5rem;display:inline-block;" aria-label="Editar Gasfitería">Editar</button>
+            </div>
+
+            <div class="field-card">
+              <div style="display:flex;justify-content:space-between;align-items:center;">
+                <p class="field-title">Electricidad</p>
+                <button class="field-link" style="color:var(--ui-error);text-decoration:none;" aria-label="Quitar Electricidad">Quitar</button>
+              </div>
+              <p style="margin:0.375rem 0 0;font-size:0.875rem;color:var(--color-datealo-text);">Desde $20.000</p>
+              <p style="margin:0.25rem 0 0;font-size:0.8125rem;color:var(--ui-text-muted);">
+                Instalaciones y reparación de tableros. 8 años de experiencia en Ñuñoa.
+              </p>
+              <button class="field-link" style="margin-top:0.5rem;display:inline-block;" aria-label="Editar Electricidad">Editar</button>
+            </div>
+
+            <div class="add-category-btn" style="margin-top:0.75rem;">+ Agregar categoría</div>
+
+            <div class="field-card" style="margin-top:1.5rem;">
+              <p class="field-title">Tus datos</p>
+              <p style="margin:0.5rem 0 0;font-size:0.8125rem;color:var(--ui-text-muted);">Nombre · Comuna · Contacto</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================================== DESKTOP · MISMA COLUMNA ANGOSTA ================= -->
+      <section class="frame frame-desktop">
+        <div class="frame-label">
+          V-001 · modo lista de categorías · desktop
+          <small>`perfil.vue` ya fuerza `max-w-md` sin importar el ancho de pantalla (decisión previa a
+            esta misión) — en desktop es la misma columna angosta centrada, con más espacio vacío a los
+            costados, no un layout de dos columnas como el perfil público</small>
+        </div>
+        <div class="frame-viewport">
+          <div style="height:100%;overflow:hidden;display:flex;justify-content:center;background:var(--color-datealo-bg);">
+            <div style="width:28rem;padding:2rem 1.25rem;">
+              <h1 style="font-family:var(--font-heading);font-weight:800;font-size:1.25rem;margin:0;color:var(--color-datealo-text);">
+                Tu perfil
+              </h1>
+              <p style="margin:0.25rem 0 1.25rem;font-size:0.8125rem;color:var(--ui-text-muted);">Feña Silva · Ñuñoa</p>
+
+              <p style="font-size:0.75rem;font-weight:700;text-transform:uppercase;letter-spacing:0.04em;color:var(--ui-text-muted);margin:0 0 0.5rem;">
+                Tus categorías
+              </p>
+
+              <div class="field-card">
+                <div style="display:flex;justify-content:space-between;align-items:center;">
+                  <p class="field-title">Gasfitería</p>
+                  <button class="field-link" style="color:var(--ui-error);text-decoration:none;">Quitar</button>
+                </div>
+                <p style="margin:0.375rem 0 0;font-size:0.875rem;color:var(--color-datealo-text);">Desde $18.000</p>
+                <p style="margin:0.25rem 0 0;font-size:0.8125rem;color:var(--ui-text-muted);">
+                  Reparación de filtraciones, estanques y llaves. Atiendo fines de semana.
+                </p>
+                <button class="field-link" style="margin-top:0.5rem;display:inline-block;">Editar</button>
+              </div>
+
+              <div class="field-card">
+                <div style="display:flex;justify-content:space-between;align-items:center;">
+                  <p class="field-title">Electricidad</p>
+                  <button class="field-link" style="color:var(--ui-error);text-decoration:none;">Quitar</button>
+                </div>
+                <p style="margin:0.375rem 0 0;font-size:0.875rem;color:var(--color-datealo-text);">Desde $20.000</p>
+                <p style="margin:0.25rem 0 0;font-size:0.8125rem;color:var(--ui-text-muted);">
+                  Instalaciones y reparación de tableros. 8 años de experiencia en Ñuñoa.
+                </p>
+                <button class="field-link" style="margin-top:0.5rem;display:inline-block;">Editar</button>
+              </div>
+
+              <div class="add-category-btn" style="margin-top:0.75rem;">+ Agregar categoría</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================================== MOBILE · CONFIRMANDO QUITAR ===================== -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-001 · modo confirmando quitar categoría
+          <small>pide confirmar con la consecuencia dicha explícitamente — no un "¿estás seguro?" genérico
+            (benchmark: LinkedIn al quitar una habilidad, Fiverr al eliminar un gig, ambos confirman)</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div style="padding:1.25rem;opacity:0.4;">
+            <h1 style="font-family:var(--font-heading);font-weight:800;font-size:1.25rem;margin:0;color:var(--color-datealo-text);">
+              Tu perfil
+            </h1>
+            <p style="margin:0.25rem 0 1.25rem;font-size:0.8125rem;color:var(--ui-text-muted);">Feña Silva · Ñuñoa</p>
+            <p style="font-size:0.75rem;font-weight:700;text-transform:uppercase;letter-spacing:0.04em;color:var(--ui-text-muted);margin:0 0 0.5rem;">
+              Tus categorías
+            </p>
+            <div class="field-card">
+              <p class="field-title">Gasfitería</p>
+              <p style="margin:0.375rem 0 0;font-size:0.875rem;color:var(--color-datealo-text);">Desde $18.000</p>
+            </div>
+            <div class="field-card">
+              <p class="field-title">Electricidad</p>
+              <p style="margin:0.375rem 0 0;font-size:0.875rem;color:var(--color-datealo-text);">Desde $20.000</p>
+            </div>
+            <div class="add-category-btn" style="margin-top:0.75rem;">+ Agregar categoría</div>
+          </div>
+
+          <!-- Overlay a todo el alto real del viewport (844px, no is-auto) — así el sheet queda anclado
+               al borde inferior de una pantalla real, no al borde de un contenido recortado. -->
+          <div style="position:absolute;inset:0;background:rgb(31 41 55 / 0.45);">
+            <div style="position:absolute;left:0;right:0;bottom:0;background:var(--ui-bg);border-radius:1.25rem 1.25rem 0 0;padding:0.75rem 1.5rem 1.5rem;box-shadow:0 -8px 24px -12px rgb(31 41 55 / 0.35);">
+              <div style="width:2.25rem;height:0.25rem;border-radius:999px;background:var(--ui-border-accented);margin:0 auto 1rem;"></div>
+              <p style="font-family:var(--font-heading);font-weight:800;font-size:1.0625rem;margin:0;color:var(--color-datealo-text);">
+                ¿Quitar Gasfitería de tu perfil?
+              </p>
+              <p style="margin-top:0.5rem;font-size:0.875rem;line-height:1.5;color:var(--ui-text-muted);">
+                Perderás el precio y la descripción que escribiste para esta categoría.
+              </p>
+              <div style="margin-top:1.25rem;display:flex;gap:0.75rem;">
+                <button style="flex:1;padding:0.75rem;border-radius:var(--ui-radius);border:1.5px solid var(--ui-border-accented);font-weight:700;font-size:0.875rem;color:var(--ui-text-toned);background:none;">
+                  Cancelar
+                </button>
+                <button style="flex:1;padding:0.75rem;border-radius:var(--ui-radius);border:none;font-weight:700;font-size:0.875rem;color:#fff;background:#ef4444;">
+                  Quitar
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================================== DESKTOP · CONFIRMANDO QUITAR, MODAL CENTRADO ==== -->
+      <section class="frame frame-desktop">
+        <div class="frame-label">
+          V-001 · modo confirmando quitar categoría · desktop
+          <small>el bottom sheet es un patrón táctil (deslizar para cerrar) que no aplica con mouse — en
+            desktop es el modal centrado por defecto de `UModal` (Nuxt UI), fondo atenuado cubriendo todo
+            el viewport, no solo la columna angosta del perfil</small>
+        </div>
+        <div class="frame-viewport">
+          <div style="height:100%;overflow:hidden;display:flex;justify-content:center;background:var(--color-datealo-bg);position:relative;">
+            <div style="width:28rem;padding:2rem 1.25rem;opacity:0.4;">
+              <h1 style="font-family:var(--font-heading);font-weight:800;font-size:1.25rem;margin:0;color:var(--color-datealo-text);">
+                Tu perfil
+              </h1>
+              <p style="margin:0.25rem 0 1.25rem;font-size:0.8125rem;color:var(--ui-text-muted);">Feña Silva · Ñuñoa</p>
+              <div class="field-card">
+                <p class="field-title">Gasfitería</p>
+                <p style="margin:0.375rem 0 0;font-size:0.875rem;color:var(--color-datealo-text);">Desde $18.000</p>
+              </div>
+              <div class="field-card">
+                <p class="field-title">Electricidad</p>
+                <p style="margin:0.375rem 0 0;font-size:0.875rem;color:var(--color-datealo-text);">Desde $20.000</p>
+              </div>
+            </div>
+
+            <div style="position:absolute;inset:0;background:rgb(31 41 55 / 0.45);display:flex;align-items:center;justify-content:center;">
+              <div style="width:24rem;background:var(--ui-bg);border-radius:1rem;padding:1.75rem;box-shadow:0 20px 40px -12px rgb(31 41 55 / 0.4);">
+                <p style="font-family:var(--font-heading);font-weight:800;font-size:1.125rem;margin:0;color:var(--color-datealo-text);">
+                  ¿Quitar Gasfitería de tu perfil?
+                </p>
+                <p style="margin-top:0.625rem;font-size:0.875rem;line-height:1.5;color:var(--ui-text-muted);">
+                  Perderás el precio y la descripción que escribiste para esta categoría.
+                </p>
+                <div style="margin-top:1.5rem;display:flex;justify-content:flex-end;gap:0.75rem;">
+                  <button style="padding:0.625rem 1.25rem;border-radius:var(--ui-radius);border:1.5px solid var(--ui-border-accented);font-weight:700;font-size:0.875rem;color:var(--ui-text-toned);background:none;">
+                    Cancelar
+                  </button>
+                  <button style="padding:0.625rem 1.25rem;border-radius:var(--ui-radius);border:none;font-weight:700;font-size:0.875rem;color:#fff;background:#ef4444;">
+                    Quitar
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================================== MOBILE · AGREGANDO, ELIGIENDO CATEGORÍA ========= -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-001 · modo agregando categoría — paso 1, eligiendo
+          <small>el selector excluye Gasfitería y Electricidad, que ya están declaradas</small>
+        </div>
+        <div class="frame-viewport is-auto">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div style="padding:1.25rem;">
+            <p style="font-size:0.75rem;font-weight:700;text-transform:uppercase;letter-spacing:0.04em;color:var(--ui-text-muted);margin:0 0 0.5rem;">
+              Tus categorías
+            </p>
+            <div class="field-card" style="opacity:0.55;">
+              <p class="field-title">Gasfitería</p>
+              <p style="margin:0.375rem 0 0;font-size:0.875rem;color:var(--color-datealo-text);">Desde $18.000</p>
+            </div>
+            <div class="field-card" style="opacity:0.55;">
+              <p class="field-title">Electricidad</p>
+              <p style="margin:0.375rem 0 0;font-size:0.875rem;color:var(--color-datealo-text);">Desde $20.000</p>
+            </div>
+
+            <div class="field-card is-editing">
+              <p class="field-title">Categoría nueva</p>
+              <div class="select-mock" style="margin-top:0.5rem;">
+                Elige una categoría
+                <svg class="icon" style="width:0.875rem;height:0.875rem;" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m6 9 6 6 6-6" /></svg>
+              </div>
+              <button class="field-link" style="margin-top:0.625rem;display:inline-block;color:var(--ui-text-muted);text-decoration:none;">Cancelar</button>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================================== MOBILE · AGREGANDO, CATEGORÍA ELEGIDA =========== -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-001 · modo agregando categoría — paso 2, precio y descripción
+          <small>ambos campos son opcionales, igual que hoy permite un perfil sin descripción; se guardan
+            al perder el foco (mismo patrón que "Descripción"/"Precio")</small>
+        </div>
+        <div class="frame-viewport is-auto">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div style="padding:1.25rem;">
+            <p style="font-size:0.75rem;font-weight:700;text-transform:uppercase;letter-spacing:0.04em;color:var(--ui-text-muted);margin:0 0 0.5rem;">
+              Tus categorías
+            </p>
+            <div class="field-card" style="opacity:0.55;">
+              <p class="field-title">Gasfitería</p>
+              <p style="margin:0.375rem 0 0;font-size:0.875rem;color:var(--color-datealo-text);">Desde $18.000</p>
+            </div>
+            <div class="field-card" style="opacity:0.55;">
+              <p class="field-title">Electricidad</p>
+              <p style="margin:0.375rem 0 0;font-size:0.875rem;color:var(--color-datealo-text);">Desde $20.000</p>
+            </div>
+
+            <div class="field-card is-editing">
+              <p class="field-title">Jardín y áreas verdes</p>
+              <div style="margin-top:0.625rem;display:flex;align-items:center;gap:0.5rem;">
+                <span style="font-size:0.875rem;color:var(--ui-text-muted);">Desde $</span>
+                <div class="input-mock" style="width:5rem;">10.000</div>
+              </div>
+              <textarea
+                class="input-mock"
+                style="margin-top:0.625rem;width:100%;resize:none;"
+                rows="2"
+                placeholder='Ej: "Corte de pasto y desmalezado con máquina"'
+              ></textarea>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  </body>
+</html>

--- a/docs/missions/14-multiples-categorias-profesional/design-mockups/perfil-publico-categorias.html
+++ b/docs/missions/14-multiples-categorias-profesional/design-mockups/perfil-publico-categorias.html
@@ -1,0 +1,332 @@
+<!doctype html>
+<html lang="es-CL">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>V-003 Perfil público con varias categorías — misión 14</title>
+
+    <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+    <link
+      href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&family=Plus+Jakarta+Sans:wght@600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../../design/datealo-mockup-kit.css" />
+    <style type="text/tailwindcss">
+      @theme {
+        --color-primary: var(--ui-primary);
+        --color-secondary: var(--ui-secondary);
+        --color-success: var(--ui-success);
+        --color-error: var(--ui-error);
+      }
+    </style>
+    <style>
+      .avatar-circle {
+        width: 3.5rem;
+        height: 3.5rem;
+        border-radius: 9999px;
+        background: color-mix(in oklab, var(--ui-primary) 12%, var(--ui-bg));
+        color: var(--ui-primary);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-family: var(--font-heading);
+        font-weight: 800;
+        font-size: 1.125rem;
+        flex-shrink: 0;
+      }
+      .icon {
+        width: 1rem;
+        height: 1rem;
+        fill: none;
+        stroke: currentColor;
+        stroke-width: 2;
+        stroke-linecap: round;
+        stroke-linejoin: round;
+      }
+      .icon-star {
+        width: 0.8125rem;
+        height: 0.8125rem;
+        fill: #fbbf24;
+        stroke: none;
+      }
+      .secondary-row {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 0.625rem 0;
+        font-size: 0.8125rem;
+        color: var(--color-datealo-text);
+        border-bottom: 1px solid var(--ui-border-muted);
+      }
+      .secondary-row:last-child {
+        border-bottom: none;
+      }
+      .btn-primary {
+        flex: 1;
+        background: var(--ui-primary);
+        color: #fff;
+        border-radius: var(--ui-radius);
+        padding: 0.875rem 1rem;
+        font-weight: 700;
+        font-size: 0.875rem;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.5rem;
+      }
+      .btn-secondary {
+        border: 1.5px solid var(--ui-border-accented);
+        border-radius: var(--ui-radius);
+        padding: 0.875rem;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: var(--ui-text-toned);
+      }
+      .cta-fixed {
+        position: absolute;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        border-top: 1px solid var(--ui-border);
+        background: var(--color-datealo-bg);
+        padding: 1rem;
+        display: flex;
+        gap: 0.5rem;
+      }
+      .scroll-window {
+        position: relative;
+        height: 100%;
+        overflow: hidden;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div class="frames">
+      <!-- ==================================================== MOBILE · UNA SOLA CATEGORÍA (sin cambios) === -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-003 · modo una categoría
+          <small>CL-001 producto.md: idéntico a como se ve hoy, sin bloques de categoría</small>
+        </div>
+        <div class="frame-viewport">
+          <div class="scroll-window">
+            <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+            <div
+              style="aspect-ratio:4/3;width:100%;background:color-mix(in oklab, var(--ui-primary) 10%, var(--ui-bg));display:flex;align-items:center;justify-content:center;"
+            >
+              <div class="avatar-circle" style="width:5.5rem;height:5.5rem;font-size:1.5rem;">MF</div>
+            </div>
+            <div style="padding:1.25rem;">
+              <h1 style="font-family:var(--font-heading);font-weight:800;font-size:1.25rem;margin:0;color:var(--color-datealo-text);">
+                Marcela Fuentes
+              </h1>
+              <p style="margin:0.25rem 0 0;font-size:0.875rem;color:var(--ui-text-muted);">
+                Peluquería a domicilio · Ñuñoa
+              </p>
+              <p style="margin-top:0.625rem;font-family:var(--font-heading);font-weight:800;font-size:1.0625rem;color:var(--color-datealo-text);">
+                Desde $12.000
+              </p>
+              <p style="margin-top:1rem;font-size:0.875rem;line-height:1.6;color:var(--color-datealo-text);">
+                Corte, color y peinados a domicilio. Trabajo en Ñuñoa y Providencia.
+              </p>
+            </div>
+          </div>
+          <div class="cta-fixed">
+            <div class="btn-primary">
+              <svg class="icon" aria-hidden="true" style="stroke:#fff;" viewBox="0 0 24 24"><path d="M7.9 20A9 9 0 1 0 4 16.1L2 22Z" /></svg>
+              Escribir por WhatsApp
+            </div>
+            <div class="btn-secondary" aria-label="Llamar">
+              <svg class="icon" aria-hidden="true" viewBox="0 0 24 24"><path d="M13.832 16.568a1 1 0 0 0 1.213-.303l.355-.465A2 2 0 0 1 17 15h3a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2A18 18 0 0 1 2 4a2 2 0 0 1 2-2h3a2 2 0 0 1 2 2v3a2 2 0 0 1-.8 1.6l-.468.351a1 1 0 0 0-.288 1.223 14.1 14.1 0 0 0 6.288 6.394Z" /></svg>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ==================================================== MOBILE · VARIAS CATEGORÍAS =================== -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-003 · modo varias categorías — llegó desde "Gasfitería en Ñuñoa"
+          <small>F-003: la categoría por la que llegó (Gasfitería) se ve con el mismo layout de siempre,
+            sin caja nueva; las demás quedan como filas compactas debajo, bajo "También hace"</small>
+        </div>
+        <div class="frame-viewport is-auto">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div
+            style="aspect-ratio:4/3;width:100%;background:color-mix(in oklab, var(--ui-primary) 10%, var(--ui-bg));display:flex;align-items:center;justify-content:center;"
+          >
+            <div class="avatar-circle" style="width:5.5rem;height:5.5rem;font-size:1.5rem;">FS</div>
+          </div>
+          <div style="padding:1.25rem;">
+            <h1 style="font-family:var(--font-heading);font-weight:800;font-size:1.25rem;margin:0;color:var(--color-datealo-text);">
+              Feña Silva
+            </h1>
+            <p style="margin:0.25rem 0 0;font-size:0.875rem;color:var(--ui-text-muted);">Gasfitería · Ñuñoa</p>
+
+            <p style="margin-top:0.625rem;font-family:var(--font-heading);font-weight:800;font-size:1.0625rem;color:var(--color-datealo-text);">
+              Desde $18.000
+            </p>
+
+            <p style="margin-top:1rem;font-size:0.875rem;line-height:1.6;color:var(--color-datealo-text);">
+              Reparación de filtraciones, estanques y llaves. Atiendo urgencias los fines de semana.
+            </p>
+
+            <div style="margin-top:1.25rem;border-top:1px solid var(--ui-border-muted);padding-top:1rem;">
+              <p style="margin:0 0 0.375rem;font-size:0.75rem;font-weight:700;color:var(--ui-text-muted);">
+                También hace
+              </p>
+              <div class="secondary-row">
+                <span>Electricidad</span>
+                <span style="font-weight:700;color:var(--color-datealo-text);">Desde $20.000</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ==================================================== MOBILE · VARIAS CATEGORÍAS, SIN CONTEXTO === -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-003 · modo varias categorías — sin contexto de categoría (link directo)
+          <small>sin query param, la categoría de contexto pasa a ser la primera que Feña declaró
+            (Gasfitería); el resto se ve exactamente igual que en el modo con contexto</small>
+        </div>
+        <div class="frame-viewport is-auto">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div
+            style="aspect-ratio:4/3;width:100%;background:color-mix(in oklab, var(--ui-primary) 10%, var(--ui-bg));display:flex;align-items:center;justify-content:center;"
+          >
+            <div class="avatar-circle" style="width:5.5rem;height:5.5rem;font-size:1.5rem;">FS</div>
+          </div>
+          <div style="padding:1.25rem;">
+            <h1 style="font-family:var(--font-heading);font-weight:800;font-size:1.25rem;margin:0;color:var(--color-datealo-text);">
+              Feña Silva
+            </h1>
+            <p style="margin:0.25rem 0 0;font-size:0.875rem;color:var(--ui-text-muted);">Gasfitería · Ñuñoa</p>
+
+            <p style="margin-top:0.625rem;font-family:var(--font-heading);font-weight:800;font-size:1.0625rem;color:var(--color-datealo-text);">
+              Desde $18.000
+            </p>
+
+            <p style="margin-top:1rem;font-size:0.875rem;line-height:1.6;color:var(--color-datealo-text);">
+              Reparación de filtraciones, estanques y llaves. Atiendo urgencias los fines de semana.
+            </p>
+
+            <div style="margin-top:1.25rem;border-top:1px solid var(--ui-border-muted);padding-top:1rem;">
+              <p style="margin:0 0 0.375rem;font-size:0.75rem;font-weight:700;color:var(--ui-text-muted);">
+                También hace
+              </p>
+              <div class="secondary-row">
+                <span>Electricidad</span>
+                <span style="font-weight:700;color:var(--color-datealo-text);">Desde $20.000</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ==================================================== MOBILE · MUCHAS CATEGORÍAS (5) ============= -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-003 · modo varias categorías — 5 declaradas (CL-004 producto.md, sin tope)
+          <small>la de contexto se ve con el layout de siempre; las otras 4 son filas compactas — no se
+            vuelve una pared de bloques idénticos aunque no haya límite de categorías</small>
+        </div>
+        <div class="frame-viewport is-auto">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div style="padding:1.25rem;">
+            <h1 style="font-family:var(--font-heading);font-weight:800;font-size:1.25rem;margin:0;color:var(--color-datealo-text);">
+              Feña Silva
+            </h1>
+            <p style="margin:0.25rem 0 0;font-size:0.875rem;color:var(--ui-text-muted);">Gasfitería · Ñuñoa</p>
+
+            <p style="margin-top:0.625rem;font-family:var(--font-heading);font-weight:800;font-size:1.0625rem;color:var(--color-datealo-text);">
+              Desde $18.000
+            </p>
+
+            <p style="margin-top:1rem;font-size:0.875rem;line-height:1.6;color:var(--color-datealo-text);">
+              Reparación de filtraciones, estanques y llaves. Atiendo urgencias los fines de semana.
+            </p>
+
+            <div style="margin-top:1.25rem;border-top:1px solid var(--ui-border-muted);padding-top:1rem;">
+              <p style="margin:0 0 0.375rem;font-size:0.75rem;font-weight:700;color:var(--ui-text-muted);">
+                También hace
+              </p>
+              <div class="secondary-row"><span>Electricidad</span><span style="font-weight:700;color:var(--color-datealo-text);">Desde $20.000</span></div>
+              <div class="secondary-row"><span>Jardín y áreas verdes</span><span style="font-weight:700;color:var(--color-datealo-text);">Desde $10.000</span></div>
+              <div class="secondary-row"><span>Pintura</span><span style="font-weight:700;color:var(--color-datealo-text);">Desde $25.000</span></div>
+              <div class="secondary-row"><span>Cerrajería</span><span style="font-weight:700;color:var(--color-datealo-text);">Desde $15.000</span></div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ==================================================== DESKTOP · VARIAS CATEGORÍAS ================== -->
+      <section class="frame frame-desktop">
+        <div class="frame-label">
+          V-003 · modo varias categorías · desktop
+          <small>la columna principal se ve igual que siempre (sin caja nueva) con la categoría de
+            contexto; "también hace" vive en la barra lateral, junto al CTA — no compite con la info
+            principal ni suma una caja más a la columna central</small>
+        </div>
+        <div class="frame-viewport">
+          <div style="max-width:64rem;margin:0 auto;padding:2rem;display:grid;grid-template-columns:55fr 45fr;gap:2rem;align-items:start;">
+            <div>
+              <div
+                style="aspect-ratio:4/3;width:100%;border-radius:1rem;background:color-mix(in oklab, var(--ui-primary) 10%, var(--ui-bg));display:flex;align-items:center;justify-content:center;"
+              >
+                <div class="avatar-circle" style="width:6rem;height:6rem;font-size:1.75rem;">FS</div>
+              </div>
+              <h1 style="font-family:var(--font-heading);font-weight:800;font-size:1.5rem;margin:1rem 0 0;color:var(--color-datealo-text);">
+                Feña Silva
+              </h1>
+              <p style="margin:0.25rem 0 0;font-size:0.875rem;color:var(--ui-text-muted);">Gasfitería · Ñuñoa</p>
+
+              <p style="margin-top:0.625rem;font-size:1.125rem;font-weight:800;color:var(--color-datealo-text);">
+                Desde $18.000
+              </p>
+
+              <p style="margin-top:1rem;font-size:0.9375rem;line-height:1.6;color:var(--color-datealo-text);">
+                Reparación de filtraciones, estanques y llaves. Atiendo urgencias los fines de semana.
+              </p>
+            </div>
+
+            <div style="border:1px solid var(--ui-border);border-radius:1rem;padding:1.5rem;">
+              <div style="display:flex;align-items:center;gap:0.75rem;">
+                <div class="avatar-circle">FS</div>
+                <div>
+                  <p style="font-family:var(--font-heading);font-weight:800;margin:0;color:var(--color-datealo-text);">Feña Silva</p>
+                  <div style="margin-top:0.25rem;display:flex;align-items:center;gap:0.25rem;font-size:0.875rem;">
+                    <svg class="icon-star" aria-hidden="true" viewBox="0 0 24 24"><path d="M12 2l2.9 6.6 7.1.6-5.4 4.7 1.7 7-6.3-3.8-6.3 3.8 1.7-7L2 9.2l7.1-.6z" /></svg>
+                    <span style="font-weight:700;">4,9</span>
+                    <span style="color:var(--ui-text-muted);">· 8 reseñas</span>
+                  </div>
+                </div>
+              </div>
+              <div style="margin-top:1.25rem;display:flex;gap:0.5rem;">
+                <div class="btn-primary">
+                  <svg class="icon" aria-hidden="true" style="stroke:#fff;" viewBox="0 0 24 24"><path d="M7.9 20A9 9 0 1 0 4 16.1L2 22Z" /></svg>
+                  Escribir por WhatsApp
+                </div>
+                <div class="btn-secondary" aria-label="Llamar">
+                  <svg class="icon" aria-hidden="true" viewBox="0 0 24 24"><path d="M13.832 16.568a1 1 0 0 0 1.213-.303l.355-.465A2 2 0 0 1 17 15h3a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2A18 18 0 0 1 2 4a2 2 0 0 1 2-2h3a2 2 0 0 1 2 2v3a2 2 0 0 1-.8 1.6l-.468.351a1 1 0 0 0-.288 1.223 14.1 14.1 0 0 0 6.288 6.394Z" /></svg>
+                </div>
+              </div>
+              <div style="margin-top:1.25rem;border-top:1px solid var(--ui-border);padding-top:1rem;">
+                <p style="margin:0 0 0.375rem;font-size:0.75rem;font-weight:700;color:var(--ui-text-muted);">
+                  También hace
+                </p>
+                <div class="secondary-row">
+                  <span>Electricidad</span>
+                  <span style="font-weight:700;color:var(--color-datealo-text);">Desde $20.000</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  </body>
+</html>

--- a/docs/missions/14-multiples-categorias-profesional/experiencia.md
+++ b/docs/missions/14-multiples-categorias-profesional/experiencia.md
@@ -1,183 +1,342 @@
-# Misión: <nombre> — Experiencia
+# Misión: múltiples categorías por profesional — Experiencia
 
-**Estado:** borrador
+**Estado:** vigente — aprobado por Patricio Tabilo el 2026-09-06
 
-**Última actualización:** AAAA-MM-DD
+**Última actualización:** 2026-09-06
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-<!--
-Fuente de verdad para flujos, estados, contenido e interacción. No redefine reglas de producto: si el
-diseño descubre una regla nueva o invalida una, abre o actualiza una decisión en producto.md.
+## Decisión de experiencia: cada categoría es un bloque propio, tanto al editar el perfil como al verlo
 
-Núcleo obligatorio: vistas, mapa de estados, flujos críticos y estados por superficie. Las secciones bajo
-demanda (modelo mental, jerarquía de información, validación) se agregan solo cuando una decisión las
-necesita.
+Un profesional agrega categorías igual que hoy edita descripción o precio: un bloque más en la misma
+pantalla de perfil, sin modal ni wizard aparte. Quien busca ve esos mismos bloques en el perfil público,
+cada uno con su precio y descripción, y el botón de contacto usa la categoría por la que llegó (o la
+primera que el profesional declaró, si llegó sin ese contexto). Declarar categorías adicionales queda
+fuera del registro inicial — solo se hace editando el perfil ya creado.
 
-Gate de salida — experiencia.md está lista para ingenieria.md cuando:
-- cada flujo crítico tiene secuencia, variantes, recuperación y criterio de término
-- cada estado tiene contenido concreto (texto real, información visible, acción disponible)
-- cada vista lista sus modos, y el mapa de estados cubre todas las transiciones entre ellos
-- cada modo tiene su indicador permanente de estado, y cada flujo tiene todas sus salidas documentadas
-- los casos límite de producto.md tienen flujo o estado mapeado
-- cada flujo crítico está mockeado en móvil (390px), y en desktop si también vive ahí
-- ninguna pantalla queda descrita como "similar a X" sin especificar qué cambia
--->
-
-## Decisión de experiencia: <qué cambia para quien usa el producto>
-
-<Modelo de interacción elegido, flujo más importante y la incertidumbre que sigue abierta.>
-
-- **Funcionalidades cubiertas:** F-001, <otras>.
-- **Pendiente bloqueante:** <pregunta o "ninguna">.
+- **Funcionalidades cubiertas:** F-001, F-002, F-003.
+- **Pendiente bloqueante:** ninguna.
 
 ## Vistas
 
-<!--
-El listado de pantallas que define la experiencia — el mapa que se entrega antes de los flujos. Una línea
-por vista, sin tabla, con sus modos anidados debajo. Una vista es un destino: se llega a ella. Un modo es
-un estado de esa vista que cambia qué se puede hacer y qué se ve — se anida, nunca se lista como vista
-hermana.
-
-El porqué de cada vista, su trade-off o su justificación no van aquí: viven en su flujo (UXF) o en una
-decisión (UX-xxx). Regla de formato para todo el documento: las tablas se reservan para índices de celdas
-cortas; lo que lleva justificación extensa va en secciones con header + bullets, nunca en una celda.
--->
-
-- **V-001 — <vista>** · móvil / desktop · resuelve F-001 · flujos UXF-001 · pendiente
-  - modo **<nombre>** — <qué lo distingue y qué se puede hacer en él>
-  - modo **<nombre>** — <ídem>
+- **V-001 — Editar perfil (profesional)** · móvil / desktop (misma columna angosta en los dos — `perfil.vue`
+  ya fuerza `max-w-md` sin importar el ancho de pantalla, decisión previa a esta misión) · resuelve F-001 ·
+  flujo UXF-001
+  - modo **lista de categorías** — cada categoría declarada como bloque con su precio y descripción; "+
+    Agregar categoría" al final, siempre visible
+  - modo **agregando categoría** — un bloque nuevo en edición: primero el selector de categoría, después
+    precio y descripción
+  - modo **confirmando quitar** — bottom sheet con la consecuencia explícita, Cancelar/Quitar
+- **V-002 — Resultados de búsqueda** · móvil / desktop · resuelve F-002 · sin flujo nuevo
+  - Vista ya construida (misión 10); esta misión no le agrega modos. Un profesional con 2+ categorías
+    aparece en cada búsqueda por separado, con el precio de la categoría que corresponde a esa búsqueda —
+    cambio de dato, no de vista.
+- **V-003 — Perfil público de profesional** · móvil / desktop · resuelve F-003 · flujo UXF-002
+  - modo **una categoría** — igual a como se ve hoy, sin cambios (CL-001 producto.md)
+  - modo **varias categorías** — la categoría de contexto (o la primera declarada si no hay contexto) se
+    ve con el mismo layout de siempre, sin caja nueva (nombre, categoría · comuna, precio, descripción);
+    las demás aparecen como una fila compacta (nombre + precio, sin descripción) bajo el título "También
+    hace". En móvil esa fila va debajo de la descripción, antes de la sección de reseñas; en desktop vive
+    en la barra lateral, junto al CTA (ver [UX-004](#ux-004)). El rating y las reseñas son siempre las del
+    profesional completo, iguales en cualquier modo — `reviews` no distingue categoría (ver "Fuera de
+    alcance" en `producto.md`)
+- **Registro (`registro.vue`, paso "Tu categoría")** · móvil · sin flujo ni modo nuevo — un solo texto de
+  ayuda agregado bajo el selector (ver [UX-001](#ux-001)), para que quede claro que la categoría elegida
+  acá no es la única que podrá tener.
 
 ## Mapa de estados
 
-<!--
-Vistas y flujos son listas, y una lista no muestra un camino. Esta tabla conecta los modos: qué acción
-lleva de uno a otro y qué pasa con el trabajo del usuario en cada salto. Cada fila que falte es una
-pregunta que ingeniería resuelve inventando.
--->
+| Desde                          | Acción                                             | Queda en                       | Qué pasa con el trabajo                                    |
+| ------------------------------- | --------------------------------------------------- | -------------------------------- | -------------------------------------------------------------- |
+| V-001 · lista de categorías      | Toca "+ Agregar categoría"                            | V-001 · agregando categoría       | Los bloques existentes no cambian                              |
+| V-001 · agregando categoría      | Elige categoría, llena precio/descripción (o no) y sale del bloque | V-001 · lista de categorías | Se agrega el bloque nuevo al final de la lista                 |
+| V-001 · agregando categoría      | Toca "Cancelar" antes de elegir categoría             | V-001 · lista de categorías       | No se guarda nada, el bloque en blanco desaparece               |
+| V-001 · lista de categorías      | Toca "Quitar" en un bloque (con 2+ categorías)        | V-001 · lista de categorías       | Ese bloque desaparece de inmediato, el resto no cambia          |
+| V-002 · resultados de "Gasfitería en Ñuñoa" | Toca la card de un profesional multi-categoría | V-003 · perfil (contexto: Gasfitería) | El precio, la descripción y el mensaje de WhatsApp usan Gasfitería |
+| V-003 · perfil (cualquier modo)  | Toca "Escribir por WhatsApp" o "Llamar"               | WhatsApp / marcador (fuera de Datealo) | El perfil queda en la misma posición al volver                 |
 
-| Desde  | Acción             | Queda en | Qué pasa con el trabajo              |
-| ------ | ------------------ | -------- | ------------------------------------ |
-| <modo> | <acción concreta>  | <modo>   | <qué se aplicó, qué quedó pendiente> |
-| <modo> | <salir sin cerrar> | <modo>   | <qué se pierde o se conserva>        |
+## UXF-001 — Agregar una categoría al perfil
 
-## UXF-001 — <flujo principal en verbo>
+**Objetivo:** el profesional agrega una categoría que no tenía, con su propio precio y descripción.
+**Contrato:** [F-001](./producto.md#f-001).
 
-<!--
-Duplica por flujo crítico. Cada paso describe acción → respuesta al nivel de "el usuario toca X → Datealo
-muestra Y". Un mockup no reemplaza la secuencia porque no explica estados ni recuperación.
--->
+**Punto de entrada:** el profesional está en su perfil (V-001), con al menos una categoría ya declarada
+(todo profesional tiene una desde el registro).
 
-**Objetivo:** <qué se completa o comprende>. **Contrato:** [F-001](./producto.md#f-001).
+**Criterio de término:** la nueva categoría aparece como un bloque más en la lista, con su precio y
+descripción guardados (o vacíos si no los llenó), y desde ese momento cuenta para las búsquedas de esa
+categoría.
 
-**Punto de entrada:** <estado y superficie inicial, y qué acción trae al usuario hasta acá>.
-
-**Criterio de término:** <estado observable que confirma que el flujo terminó bien>.
-
-**Cómo sabe el usuario dónde está:** <el elemento concreto y permanente en pantalla que se lo dice, por
-cada modo que toca este flujo>.
+**Cómo sabe el usuario dónde está:** cada bloque de categoría muestra su nombre como título; el bloque en
+edición se distingue con el mismo borde/fondo resaltado que ya usan hoy los bloques de "Descripción" y
+"Precio" al editarse.
 
 ### Salidas
 
-<!--
-Todas las formas de irse, no solo terminar bien. El criterio de término cubre la salida buena; las otras
-son las que el usuario encuentra primero. Un modo del que no se sabe salir es un modo donde el usuario se
-pierde.
--->
-
-| Salida                | Cómo se ejecuta       | Qué queda del trabajo           |
-| --------------------- | --------------------- | ------------------------------- |
-| <termina bien>        | <acción>              | <qué se aplicó y dónde>         |
-| <descarta>            | <acción, Esc, cerrar> | <nada, ni a medias>             |
-| <abandona sin cerrar> | <navega a otra parte> | <se conserva, se pierde, avisa> |
+| Salida                | Cómo se ejecuta                                                  | Qué queda del trabajo                                |
+| ---------------------- | ------------------------------------------------------------------ | -------------------------------------------------------- |
+| Termina bien           | Elige categoría y llena precio/descripción (guardado automático al perder el foco de cada campo) | El bloque nuevo queda guardado y visible                 |
+| Cancela                | Toca "Cancelar" antes de elegir categoría                           | Nada se guarda, el bloque en blanco desaparece            |
+| Abandona sin cerrar    | Cierra la app o navega a otra parte a medio llenar                 | Nada se guarda (no hay borrador); al volver ve la lista como estaba antes de tocar "+ Agregar" |
+| Quita una categoría    | Toca "Quitar", confirma en el modal ("¿Quitar Gasfitería de tu perfil? Perderás el precio y la descripción que escribiste.") | El bloque desaparece; si cancela el modal, no cambia nada |
 
 ### Secuencia principal
 
-| Paso | Acción            | Respuesta del sistema         | Información visible |
-| ---- | ----------------- | ----------------------------- | ------------------- |
-| 1    | <acción concreta> | <feedback o cambio de estado> | <dato y jerarquía>  |
+| Paso | Acción                                                              | Respuesta del sistema                                                                 | Información visible                                                                 |
+| ---- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------- |
+| 1    | Toca "+ Agregar categoría" al final de la lista                        | Aparece un bloque nuevo en modo edición, con el selector de categoría enfocado              | El selector solo lista las categorías que le faltan (excluye las ya declaradas)            |
+| 2    | Elige una categoría (ej. "Gasfitería")                                  | El bloque muestra el nombre elegido y dos campos: precio y descripción, vacíos              | "Gasfitería" como título del bloque, con el mismo placeholder de ejemplo que ya usa el bloque general de descripción |
+| 3    | Llena precio y/o descripción (ambos opcionales) y sale del campo (blur) | Cada campo se guarda al perder el foco, con el mismo loader que usa hoy "Descripción"/"Precio" | Spinner breve junto al campo que se está guardando                                        |
+| 4    | Termina de editar (toca fuera del bloque, o pasa a otro)                | El bloque pasa a modo lectura: "Gasfitería · Desde $18.000" y la descripción si la ingresó   | El bloque queda tan compacto como los de "Descripción"/"Precio" existentes                 |
 
 ### Variantes y recuperación
 
-| Condición          | Qué cambia              | Cómo se entiende    | Cómo se recupera             |
-| ------------------ | ----------------------- | ------------------- | ---------------------------- |
-| <sin resultados>   | <estado>                | <mensaje concreto>  | <acción disponible>          |
-| <sin permiso de ubicación> | <comportamiento> | <indicador visible> | <alternativa manual>         |
-| <conexión lenta>   | <skeleton, no spinner>  | <qué se ve mientras>| <qué pasa si falla>          |
+| Condición                                              | Qué cambia                                                    | Cómo se entiende                                                        | Cómo se recupera                                             |
+| --------------------------------------------------------- | ------------------------------------------------------------------ | ---------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| Ya declaró todas las categorías activas                    | El botón "+ Agregar categoría" no aparece                          | Se omite en silencio — es un estado normal, no un error                       | No aplica                                                          |
+| Falla el guardado (categoría, precio o descripción)        | El bloque conserva su valor anterior                                | "No se pudo guardar, toca para reintentar" bajo el campo (patrón ya existente en descripción/precio) | Tocar el mensaje reintenta el guardado                              |
+| Intenta quitar su única categoría restante                 | El botón "Quitar" de esa categoría no aparece                       | Texto breve junto al bloque: "No puedes quitar tu única categoría. Agrega otra antes de quitar esta." | Agregar otra categoría primero habilita quitar la actual            |
+| Conexión lenta al guardar                                  | El campo muestra el mismo spinner que hoy usan precio/descripción   | Spinner junto al campo, no bloquea el resto del perfil                        | Mismo reintento que ya tienen los demás campos editables            |
 
 ### Decisiones que no deben quedar implícitas
 
-- <qué ocurre al cancelar, volver atrás, reintentar o confirmar>.
-- <qué cambio se guarda inmediato y cuál necesita confirmación>.
+- Elegir una categoría del selector la guarda de inmediato, sin un botón "Confirmar" aparte — mismo patrón
+  de guardado inmediato por campo que ya usa el resto del perfil.
+- Cancelar antes de elegir categoría no deja un bloque vacío a medio crear: el bloque desaparece.
+- Quitar una categoría pide confirmar, con la consecuencia dicha explícitamente: "¿Quitar Gasfitería de
+  tu perfil? Perderás el precio y la descripción que escribiste para esta categoría." con botones
+  Cancelar/Quitar. No es el mismo caso que quitar una foto de trabajo (`ProfessionalPhotos.vue`, sin
+  confirmar): una foto se resube igual de fácil, pero acá se pierde un párrafo redactado a mano. Los dos
+  análogos más directos de otros productos — LinkedIn al quitar una habilidad del perfil, Fiverr al
+  eliminar un gig — piden confirmar por la misma razón: es contenido propio que cuesta rehacer, no un
+  archivo reemplazable. No llega al extremo de "escribe el nombre para confirmar" (como sí amerita borrar
+  una cuenta): acá no hay reputación ni reseñas en juego, esas quedan con el profesional completo, no con
+  la categoría (ver "Fuera de alcance" en `producto.md`). Salvo que sea la única categoría restante, en
+  cuyo caso ni siquiera se ofrece la opción de quitarla. En móvil el modal aparece como bottom sheet (sube
+  desde abajo, esquinas superiores redondeadas) — el patrón que Datealo ya tiene decidido para overlays
+  en móvil. Aunque `perfil.vue` mantiene su columna angosta (`max-w-md`) en cualquier ancho de pantalla
+  (ver la vista V-001 más arriba), el modal de confirmación no hereda ese ancho: en desktop se ve
+  centrado en toda la pantalla, con el fondo atenuado cubriendo el viewport completo (no solo la columna),
+  esquinas redondeadas en los cuatro lados y sin el tirador de arrastre — el bottom sheet es un patrón
+  táctil (deslizar para cerrar) que no tiene sentido con mouse, y un sheet de ancho completo en una
+  pantalla de escritorio se vería como una franja larga y vacía. Es el comportamiento por defecto de
+  `UModal` de Nuxt UI entre breakpoints, no algo que haya que construir a mano.
+- Los botones "Quitar" y "Editar" llevan `aria-label` con el nombre de la categoría ("Quitar Gasfitería",
+  "Editar Gasfitería") — el texto visible se queda corto ("Quitar" a secas) cuando hay más de un bloque en
+  pantalla y un lector de pantalla los anuncia sin el contexto visual que los separa. Cada uno lleva
+  padding suficiente para un área de toque de al menos 24×24px (el texto visible es más chico) y al menos
+  8px de separación entre ambos, aunque compartan la misma línea — no solo tamaño de fuente pequeño sin
+  margen alrededor.
+- Agregar o quitar un bloque de categoría anuncia el cambio con `aria-live="polite"` sobre la lista de
+  categorías (ej. "Gasfitería agregada" / "Gasfitería quitada") — sin esto, alguien que usa lector de
+  pantalla no se entera de que la lista cambió, porque el bloque aparece o desaparece en silencio.
+
+## UXF-002 — Ver y contactar a un profesional con varias categorías
+
+**Objetivo:** quien busca ve toda la oferta del profesional y lo contacta por la categoría correcta.
+**Contrato:** [F-002](./producto.md#f-002), [F-003](./producto.md#f-003).
+
+**Punto de entrada:** llega al perfil desde una card de resultados de una categoría específica (ej.
+"Gasfitería en Ñuñoa"), o directo por un link compartido, sin ese contexto.
+
+**Criterio de término:** toca "Escribir por WhatsApp" y el mensaje prellenado menciona la categoría
+correcta.
+
+**Cómo sabe el usuario dónde está:** la categoría de contexto se nombra junto al precio y la descripción,
+igual que hoy ("Gasfitería · Ñuñoa"); cada categoría secundaria repite su propio nombre en su fila bajo
+"También hace", junto a su precio si el profesional lo declaró ([UX-005](#ux-005)), así que no hay
+ambigüedad sobre a qué categoría corresponde cada dato aunque no compartan el mismo bloque visual.
+
+### Salidas
+
+| Salida                  | Cómo se ejecuta                     | Qué queda del trabajo                                            |
+| ------------------------- | -------------------------------------- | ---------------------------------------------------------------------- |
+| Contacta por WhatsApp    | Toca "Escribir por WhatsApp"           | Se abre WhatsApp con el mensaje prellenado; el perfil sigue en la misma posición al volver |
+| Contacta por teléfono    | Toca el ícono de llamada                | Igual: el perfil queda donde estaba al volver                          |
+| Vuelve a resultados      | Botón atrás                            | Vuelve a la lista de resultados en la misma posición de scroll (comportamiento ya existente) |
+
+### Secuencia principal
+
+| Paso | Acción                                                            | Respuesta del sistema                                                                                    | Información visible                                                                 |
+| ---- | ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| 1    | Busca "gasfiter" en Ñuñoa y toca la card de Feña                        | Navega al perfil con el contexto de categoría "Gasfitería" (via query, ej. `?categoria=gasfiteria`)              | —                                                                                          |
+| 2    | El perfil carga                                                         | Si Feña tiene una sola categoría, se ve igual que hoy (CL-001). Si tiene varias, la de contexto (Gasfitería) se ve con el mismo layout de siempre — mismo texto, mismo tamaño, sin caja — y las demás aparecen como fila compacta bajo "También hace": en móvil debajo de la descripción, en desktop en la barra lateral junto al CTA | "Gasfitería · Ñuñoa · Desde $18.000 · [descripción]" igual que hoy; "También hace: Electricidad · Desde $20.000" como fila compacta aparte (o solo "Electricidad" si no declaró precio, [UX-005](#ux-005)) |
+| 3    | Toca "Escribir por WhatsApp" (barra fija)                               | Se abre WhatsApp con el mensaje prellenado usando la categoría de contexto (Gasfitería)                          | "Hola Feña, vi tu perfil de Gasfitería en Datealo y quería consultarte algo"                |
+
+### Variantes y recuperación
+
+| Condición                                         | Qué cambia                                                          | Cómo se entiende                                             | Cómo se recupera                                                     |
+| ------------------------------------------------------ | -------------------------------------------------------------------------- | ------------------------------------------------------------------ | --------------------------------------------------------------------------- |
+| Llega sin contexto de categoría (link directo)          | El mensaje de WhatsApp usa la primera categoría que el profesional declaró | Sin indicador especial en pantalla                                  | Puede editar el texto dentro de WhatsApp antes de enviarlo, como cualquier mensaje prellenado |
+| Profesional con una sola categoría                      | El perfil se ve exactamente igual que hoy — línea única "Categoría · Comuna" | —                                                                    | No aplica                                                                   |
+| Profesional con muchas categorías (5 o más)             | Solo la de contexto sigue siendo bloque completo; el resto son filas compactas de una línea (D-001 producto.md: sin límite, resuelto con jerarquía en vez de truncar — ver [UX-004](#ux-004)) | El scroll de la página crece de a poco (una línea por categoría extra), nunca una pared de bloques idénticos | No aplica                                                                   |
+| Categoría secundaria sin precio declarado               | La fila muestra solo el nombre, sin precio ([UX-005](#ux-005))              | —                                                                    | No aplica                                                                   |
+
+### Decisiones que no deben quedar implícitas
+
+- El precio y la descripción que muestra la card de resultados (V-002) son los de la categoría por la que
+  se buscó, no los de la primera categoría declarada — nota para `ingenieria.md`: `/api/search` debe
+  devolver el precio/descripción de la categoría que hizo match, no un valor genérico del profesional.
+- El query param de categoría en la URL del perfil (`?categoria=slug`) solo sirve para elegir qué
+  categoría prellena el mensaje de contacto — nunca oculta las otras categorías del profesional, que
+  siempre se muestran todas.
+- No hay un badge ni ningún otro texto que explique "por qué" el mensaje menciona esa categoría —
+  descartado en el diseño (ver [UX-003](#ux-003)). La jerarquía visual ya cumple ese rol sin texto extra:
+  la categoría de contexto es el único bloque completo (nombre grande, precio, descripción), así que es
+  obvio cuál es "la" categoría de la que trata el perfil en este momento, sin necesitar una explicación
+  aparte (ver [UX-004](#ux-004)).
 
 ## Estados por superficie
 
-<!--
-El contenido es concreto: texto real, no "mensaje apropiado". El estado vacío de un marketplace
-pre-lanzamiento no es un detalle: para muchas búsquedas será el estado principal durante meses.
--->
-
-| Estado  | Qué se muestra (texto e información real) | Acción disponible                   |
-| ------- | ----------------------------------------- | ----------------------------------- |
-| inicial | <contenido>                               | <acción>                            |
-| vacío   | <por qué está vacío, con texto concreto>  | <cómo avanzar, o ninguna y por qué> |
-| carga   | <skeleton de qué forma>                   | <ninguna>                           |
-| error   | <causa útil y alcance>                    | <recuperación>                      |
+| Estado                                       | Qué se muestra (texto e información real)                                                                | Acción disponible                          |
+| ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| V-001 · con una categoría                        | Igual que hoy: línea "Categoría · Comuna" arriba, bloques de Descripción/Precio compartidos                     | Editar categoría, agregar otra                 |
+| V-001 · con varias categorías                    | Un bloque por categoría con su nombre, precio y descripción propios; "+ Agregar categoría" al final              | Editar cada bloque, agregar otra, quitar cualquiera salvo la última |
+| V-001 · agregando categoría                      | Bloque nuevo con el selector de categoría enfocado (excluye las ya declaradas)                                  | Elegir categoría, cancelar                     |
+| V-001 · error al guardar                         | "No se pudo guardar, toca para reintentar" bajo el campo que falló                                              | Reintentar tocando el mensaje                  |
+| V-003 · con una categoría                        | Igual que hoy                                                                                                    | Contactar                                      |
+| V-003 · con varias categorías                    | La categoría de contexto se ve con el layout normal de siempre (nombre, categoría · comuna, precio, descripción, sin caja); las demás como fila compacta bajo "También hace" (nombre, + precio si lo declaró, [UX-005](#ux-005)) — en móvil debajo, en desktop en la barra lateral junto al CTA. Filas informativas, no interactivas. Rating y reseñas iguales en cualquier modo | Contactar (con la categoría de contexto)       |
+| Registro · paso "Tu categoría"                    | Debajo del selector: "Puedes agregar otras categorías más adelante, desde tu perfil."                            | Elegir categoría, continuar (sin cambios de flujo) |
 
 ## Mockups
 
-<!--
-Los mockups viven en design-mockups/ como HTML (ver el skill discovery-ux y docs/design/README.md).
-Exploran o materializan una decisión; no son fuente de verdad de reglas de producto.
--->
-
-| Mockup   | Cubre   | Estado                 | Ruta                              |
-| -------- | ------- | ---------------------- | --------------------------------- |
-| <nombre> | UXF-001 | exploración o validado | `./design-mockups/<archivo>.html` |
+| Mockup                          | Cubre           | Estado    | Ruta                                                          |
+| ---------------------------------- | ----------------- | ---------- | ------------------------------------------------------------------ |
+| Editar perfil con categorías        | UXF-001            | exploración | `./design-mockups/perfil-edicion-categorias.html`                   |
+| Perfil público con categorías       | UXF-002            | exploración | `./design-mockups/perfil-publico-categorias.html`                   |
 
 ## Cobertura
 
-<!-- Detecta huecos antes de construir. Una funcionalidad sin pantalla nueva igual tiene estados. -->
-
-| Funcionalidad | Flujo   | Estados cubiertos       | Estado    |
-| ------------- | ------- | ----------------------- | --------- |
-| F-001         | UXF-001 | principal, vacío, error | pendiente |
-
-## Secciones bajo demanda
-
-<!--
-Agregar solo cuando una decisión las necesite, con estos títulos:
-
-- "Modelo mental y lenguaje": cuando un concepto de producto pueda confundirse en la interfaz.
-- "Jerarquía de información": cuando una superficie densa exija decidir qué se ve primero (una card de
-  resultado con foto, rating, distancia, precio y disponibilidad es exactamente ese caso).
-- "Validación (UXV-xxx)": cuando una incertidumbre de diseño necesite prueba con usuarios.
-- "Accesibilidad y adaptación": cuando el contexto de uso cambie el flujo o la representación.
--->
+| Funcionalidad | Flujo    | Estados cubiertos                                     | Estado    |
+| -------------- | --------- | -------------------------------------------------------- | ---------- |
+| F-001          | UXF-001   | lista (1 y 2+ categorías), agregando, error al guardar, sin categorías por agregar | pendiente |
+| F-002          | —         | resultados de búsqueda sin cambio de vista (dato distinto por categoría) | pendiente |
+| F-003          | UXF-002   | una categoría, varias categorías, sin contexto de categoría | pendiente |
 
 ## Decisiones de experiencia
 
 <a id="ux-001"></a>
 
-### UX-001 — <decisión en una frase>
+### UX-001 — Declarar categorías adicionales solo se hace editando el perfil, nunca en el registro inicial
 
-- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
-- **Sustento:** F-001 o <hallazgo>.
-- **Alternativas descartadas:** <opciones relevantes y trade-off, con el porqué del rechazo>.
-- **Decisión y consecuencia:** <qué flujo o superficie cambia>.
-- **Impacto en producto:** <ninguno o enlace a D-xxx/F-xxx actualizado>.
+- **Estado:** aceptada. **Fecha:** 2026-09-06.
+- **Sustento:** resuelve [Q-001](./producto.md#q-001) de `producto.md`.
+- **Alternativas descartadas:** agregar un selector múltiple al wizard de registro (`registro.vue`) —
+  descartada porque el registro es un flujo de 4 pasos pensado para lo mínimo indispensable, y con
+  [D-002](./producto.md#d-002)/[D-003](./producto.md#d-003) cada categoría adicional necesita su propio
+  precio y descripción: pedir eso en el primer contacto de un profesional con Datealo (que además "tiene
+  poca familiaridad con apps", ver contexto de uso de este skill) agrega fricción justo donde el arranque
+  en frío del lado profesional ya es difícil.
+- **Decisión y consecuencia:** el registro sigue pidiendo una sola categoría, sin tocar la estructura de
+  la misión 04 (ya cerrada). Declarar una segunda o tercera categoría es una acción de "editar perfil"
+  (V-001), que ya existe como superficie y ya resuelve el patrón de edición campo por campo que esta
+  funcionalidad reutiliza. La única adición al registro es una línea de ayuda bajo el selector de
+  categoría (`registro.vue`, paso "Tu categoría"), para que nadie termine el registro pensando que esa
+  categoría es la única que podrá tener: "Puedes agregar otras categorías más adelante, desde tu perfil."
+  Es texto nuevo, no un paso ni un campo nuevo — no cambia el conteo de 4 pasos del wizard.
+- **Impacto en producto:** cierra [Q-001](./producto.md#q-001) — actualizar su estado a "resuelta" en
+  `producto.md`.
+
+<a id="ux-002"></a>
+
+### UX-002 — Agregar una categoría es un bloque más en el mismo perfil, no un modal ni un wizard aparte
+
+- **Estado:** aceptada. **Fecha:** 2026-09-06.
+- **Sustento:** [F-001](./producto.md#f-001).
+- **Alternativas descartadas:** un modal o bottom sheet "Gestionar categorías" separado del scroll
+  principal del perfil — descartado porque el perfil ya es una sola pantalla scrolleable y no hay ninguna
+  razón real para segmentar las categorías en otra superficie que hay que abrir y cerrar; un wizard de
+  pasos igual al del registro (selector → precio → descripción → confirmar, en pantallas separadas) —
+  descartado por sobre-construir un flujo de varios pasos para agregar un solo bloque con dos campos,
+  cuando el registro lo justifica ahí por tener 4 datos heterogéneos de una sola vez, no por ser el patrón
+  correcto para "agregar un dato más" sobre un perfil que ya existe.
+- **Decisión y consecuencia:** agregar una categoría reutiliza el mismo patrón de "bloque con borde +
+  edición de campo por campo con guardado automático" que ya usan "Descripción" y "Precio" en V-001. No
+  agrega pantallas nuevas ni navegación fuera del perfil.
+- **Impacto en producto:** ninguno.
+
+<a id="ux-003"></a>
+
+### UX-003 — El mensaje de contacto usa la categoría de la búsqueda que trajo al usuario, sin selector ni aviso visible
+
+- **Estado:** aceptada. **Fecha:** 2026-09-06.
+- **Sustento:** [F-002](./producto.md#f-002), [F-003](./producto.md#f-003), guardrail de CLAUDE.md de no
+  agregar pasos al flujo buscar → perfil → contactar.
+- **Alternativas descartadas:** un botón de "Escribir por WhatsApp" por cada bloque de categoría (en vez
+  de un único CTA fijo) — descartado porque diluye la acción principal con varios botones idénticos
+  compitiendo por atención, y cambia el patrón de CTA fijo único que ya existe para la inmensa mayoría de
+  perfiles (una sola categoría, CL-001); un selector de categoría dentro de la barra de contacto fija
+  ("Contactar por: Gasfitería ▾") — descartado porque agrega un control visible incluso a los perfiles de
+  una sola categoría (la mayoría) para resolver un caso donde el default por contexto ya acierta casi
+  siempre, y el costo de un default equivocado es bajo (el mensaje es editable en WhatsApp antes de
+  enviar); un badge visible explicando "por qué" el mensaje menciona esa categoría — descartado como ruido
+  sin problema real detrás (ver [UXF-002](#uxf-002-ver-y-contactar-a-un-profesional-con-varias-categorías)).
+- **Decisión y consecuencia:** el perfil recibe la categoría de contexto por query param
+  (`?categoria=slug`) desde la card que lo trajo; sin ese contexto, usa la primera categoría que el
+  profesional declaró. El CTA de contacto sigue siendo el mismo botón único y fijo de siempre. Esta
+  decisión depende de que la categoría de contexto sea visualmente inconfundible (ver
+  [UX-004](#ux-004)) — sin esa jerarquía, un badge o selector sí haría falta.
+- **Impacto en producto:** ninguno.
+
+<a id="ux-004"></a>
+
+### UX-004 — El perfil público distingue la categoría de contexto con el detalle completo; el resto son filas compactas
+
+- **Estado:** aceptada. **Fecha:** 2026-09-06.
+- **Sustento:** [D-001](./producto.md#d-001) (que delega a esta misión resolver la legibilidad con
+  varias categorías), [F-003](./producto.md#f-003).
+- **Alternativas descartadas:** todos los bloques iguales y completos, apilados uno tras otro (primera
+  versión de este documento) — descartada porque con 5+ categorías (D-001: sin tope) se vuelve una pared
+  de bloques idénticos donde nada distingue cuál es relevante para la búsqueda que trajo a la persona;
+  truncar a N bloques completos con un "+2 categorías más" que expande el resto (la sugerencia literal de
+  D-001) — descartada porque trata todas las categorías como igual de probables de importar, cuando en la
+  práctica casi siempre hay una categoría concreta que trajo a la persona hasta acá (la de la búsqueda), y
+  esa es la que necesita el detalle completo; mantener la categoría de contexto en una caja con borde,
+  tanto en móvil como en desktop (segunda versión de este documento) — descartada porque tanto la
+  pantalla de perfil de móvil como la columna principal de desktop ya tienen su propio layout para
+  nombre, precio y descripción (el de siempre, CL-001), y ponerle una caja encima solo por tener varias
+  categorías le agrega una jerarquía visual nueva a algo que no la necesita.
+- **Decisión y consecuencia:** la categoría de contexto (o la primera declarada, sin contexto) se muestra
+  con el mismo layout que ya existe para un profesional de una sola categoría — sin caja ni bloque nuevo,
+  solo con "Gasfitería" en vez de la categoría única de siempre, en móvil y en desktop por igual. Las
+  demás categorías aparecen como una fila de una línea (nombre + precio, sin descripción) bajo "También
+  hace": en móvil, debajo de la descripción; en desktop, en la barra lateral, junto al CTA de contacto (no
+  en la columna principal). Si la
+  persona quiere el detalle de una categoría secundaria, contacta y pregunta, coherente con que el
+  contacto es directo y no necesita agotar cada dato en el perfil primero. Esto también resuelve, sin
+  badge ni selector, cuál categoría es la del mensaje de contacto ([UX-003](#ux-003)): es visualmente la
+  única con el detalle completo.
+- **Impacto en producto:** ninguno — es una resolución visual de algo que D-001 ya delegó explícitamente a
+  `experiencia.md`.
+
+<a id="ux-005"></a>
+
+### UX-005 — La fila de "También hace" omite el precio si falta, y no es interactiva
+
+- **Estado:** aceptada. **Fecha:** 2026-09-06.
+- **Sustento:** [UX-004](#ux-004) (la fila ya es un resumen, no el detalle); el patrón ya vigente en
+  `SearchResultCard.vue:54` y `perfil.vue:124`, que ocultan la línea de precio completa cuando
+  `priceFrom` es nulo en vez de mostrar un placeholder; precio y descripción opcionales por categoría
+  ([D-003](./producto.md#d-003)).
+- **Alternativas descartadas:** un texto tipo "Precio a consultar" cuando falta el precio — descartada
+  porque introduce una convención que no existe en ningún otro punto de la app (hoy la línea
+  simplemente desaparece cuando no hay dato) y ningún benchmark externo (TaskRabbit, Thumbtack, Fiverr) la
+  sustenta; hacer la fila interactiva para recontextualizar el CTA a esa categoría — descartada porque
+  ninguna `F-xxx` ni evidencia de `investigacion.md` la pide, agrega una interacción nueva a una fila
+  pensada como resumen (UX-004), y el costo de un default equivocado en el mensaje de WhatsApp ya es bajo
+  y editable (UX-003).
+- **Decisión y consecuencia:** la fila muestra el nombre de la categoría y, si el profesional lo declaró,
+  su precio ("Electricidad · Desde $20.000"); sin precio, la fila muestra solo el nombre ("Electricidad"),
+  igual que la línea de precio del bloque principal desaparece hoy cuando `priceFrom` es nulo. La fila no
+  navega ni cambia la categoría de contexto del CTA — es texto, no un control; el único camino para
+  contactar por esa categoría es buscarla directamente.
+- **Impacto en producto:** ninguno.
 
 ## Preguntas
 
-<!--
-Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
-Estado: abierta | resuelta AAAA-MM-DD | disuelta AAAA-MM-DD. Solo las abiertas llevan bloque de detalle.
--->
+Ninguna pregunta abierta bloquea el paso a `ingenieria.md`.
 
-<Una frase que responde "¿qué falta?": la pregunta que bloquea construcción y qué bloquea.>
-
-| ID      | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
-| ------- | ---------------------- | ------------------- | --------------------------------------------------------------- |
-| UXQ-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
-| UXQ-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |
+| ID      | La duda | Estado | Respuesta, o quién la resuelve |
+| ------- | ------- | ------ | ------------------------------- |
+| —       | —       | —      | —                                |

--- a/docs/missions/14-multiples-categorias-profesional/ingenieria.md
+++ b/docs/missions/14-multiples-categorias-profesional/ingenieria.md
@@ -1,162 +1,419 @@
-# Misión: <nombre> — Ingeniería
+# Misión: múltiples categorías por profesional — Ingeniería
 
-**Estado:** borrador
+**Estado:** vigente — aprobado por Patricio Tabilo el 2026-09-07
 
-**Última actualización:** AAAA-MM-DD
+**Última actualización:** 2026-09-07
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-<!--
-Fuente de verdad para arquitectura, datos, contratos, factibilidad y pruebas. Consume el comportamiento
-definido en producto. Una limitación técnica cambia el alcance solo mediante una decisión explícita en
-producto.md.
+## Decisión técnica: la categoría deja de ser una columna de `professionals` y pasa a ser una tabla de relación `professional_categorias`, con su propio precio y descripción
 
-Núcleo obligatorio: contratos, modelo de datos, RLS y riesgos de factibilidad. Las secciones bajo demanda
-(migración, rendimiento, entrega por etapas) se agregan solo cuando el riesgo lo justifica.
+Hoy `professionals` tiene `categoria_slug`, `price_from` y `description` como columnas únicas. D-002 y
+D-003 de `producto.md` ya decidieron que precio y descripción varían por categoría — eso descarta cualquier
+diseño que mantenga esas tres columnas en `professionals` y solo agregue una tabla de vínculo N:N sin
+campos propios. La tabla nueva, `professional_categorias`, lleva `professional_id`, `categoria_slug`,
+`price_from` y `description` propios; las tres columnas equivalentes de `professionals` se retiran una vez
+migrados los datos existentes (CL-005 de `producto.md`).
 
-Gate de salida — ingenieria.md está lista para construir cuando:
-- los contratos definen qué entra, qué sale y qué invariantes se mantienen, sin ambigüedad
-- el modelo de datos soporta los casos límite de producto.md sin workarounds
-- el impacto en RLS está resuelto: qué policy se crea o cambia, o por qué ninguna
-- la migración de datos existentes tiene estrategia o está explícitamente fuera del alcance
-- los escenarios verificables de producto están mapeados a pruebas
-- el plan de construcción corta el diseño en slices atómicos ordenados (un slice = un Issue = un PR)
--->
+El riesgo principal no es el modelo de datos en sí —es una tabla de relación estándar— sino no dejar el
+sistema inconsistente a mitad de camino mientras se migra: `professionals` ya tiene filas reales (aunque
+sean de prueba, no hay usuarios de producción todavía) con esas tres columnas pobladas, y media docena de
+lugares en `app/` y `server/` las leen hoy (`search.ts`, `professionals.ts`, `[id].vue`, `perfil.vue`,
+`registro.vue`, `ProfessionalPublicContactBar.vue`). Por eso el Plan de construcción corta esto como
+expand/contract (ver [T-001](#t-001)) en vez de un solo slice que cambie todo a la vez.
 
-## Decisión técnica: <arquitectura y riesgo principal>
+- **Contratos de producto cubiertos:** F-001, F-002, F-003.
+- **Riesgo bloqueante:** ninguno.
 
-<Dirección técnica, trade-off principal y el riesgo que todavía podría invalidarla.>
+## Arquitectura: la relación profesional-categoría es su propia tabla; el resto de las capas ya estaba separado correctamente
 
-- **Contratos de producto cubiertos:** F-001, <otros>.
-- **Riesgo bloqueante:** <incertidumbre o "ninguna">.
+`server/utils/search.ts` ya separa la lógica pura (`rankByCompleteness`, `completenessScore`) de la
+infraestructura (`findActiveProfessionals` con Drizzle) — el Principio central del skill
+`discovery-engineering` ya se cumple ahí, y esta misión no lo toca: `rankByCompleteness` sigue recibiendo
+la misma forma (`ProfessionalCompletenessInput`), solo cambia de dónde `findActiveProfessionals` saca
+`priceFrom`/`description` (ahora de `professional_categorias`, vía join). No hace falta ninguna
+reestructuración de capas para esta misión, solo un componente nuevo del mismo tipo que ya existen
+(`server/utils/professional-categorias.ts`, junto a `professionals.ts`, `search.ts`, `reviews.ts`).
 
-## Arquitectura: <cómo se divide la responsabilidad>
-
-<!--
-La lógica de negocio se separa de la infraestructura: funciones puras en utils/ y server/utils/,
-reactividad en composables, acceso a datos en server/api/ con Drizzle. Incluye diagrama solo cuando tres o
-más partes interactúan.
--->
-
-<Descripción del enfoque y por qué satisface los contratos con menor riesgo.>
-
-| Componente | Responsabilidad       | No debe decidir | Contratos |
-| ---------- | --------------------- | --------------- | --------- |
-| <nombre>   | <una responsabilidad> | <frontera>      | F-001     |
+| Componente                                         | Responsabilidad                                                                 | No debe decidir                                  | Contratos                    |
+| ---------------------------------------------------- | ----------------------------------------------------------------------------------- | -------------------------------------------------- | ------------------------------ |
+| `server/db/schema/professional-categorias.ts`        | Define la tabla, su PK compuesta y sus índices                                      | Reglas de negocio                                  | Modelo de datos                |
+| `server/utils/professional-categorias.ts`            | CRUD de la relación + invariantes (no duplicar, nunca sin categoría)                | Autenticación, forma de la respuesta HTTP          | TC-004, TC-005, TC-006, CL-002 |
+| `server/api/professionals/me/categorias/*.ts`        | Autenticación (`requireUser`), validación de entrada, códigos HTTP                  | Cómo se guarda o se ordena una categoría           | TC-004, TC-005, TC-006         |
+| `server/utils/professionals.ts` (existente, se achica) | Identidad del profesional (nombre, comuna, contacto, fotos) — pierde categoría/precio/descripción propios | Qué categorías tiene declaradas                    | TC-001, TC-002                 |
+| `server/utils/search.ts` (existente, cambia su query) | Ranking y filtro de resultados — lee precio/descripción de la categoría que hizo match | Qué categorías existen o cómo se declaran          | TC-003                         |
+| `app/pages/profesional/perfil.vue`                   | Renderiza un bloque por categoría declarada; dispara agregar/editar/quitar          | Si se puede quitar la última (lo decide el 409 del endpoint) | UXF-001               |
+| `app/pages/profesionales/[id].vue`                   | Elige la categoría de contexto (query param o la primera declarada) y arma "También hace" | Qué precio/descripción tiene cada categoría (viene ya resuelto del endpoint) | UXF-002 |
 
 ## Contratos
 
-<!--
-Cada contrato especifica entrada, salida e invariantes al nivel en que se puede implementar sin reuniones
-de aclaración. Incluye los errores observables y el código HTTP cuando es un endpoint.
--->
+### TC-001 — `GET /api/professionals/[id]` y `GET /api/professionals/me` devuelven todas las categorías declaradas, no una
 
-### TC-001 — <contrato en una frase>
+- **Entrada:** `id` (path, uuid) para el primero; sesión del usuario para el segundo.
+- **Salida:** `{ professional: { id, displayName, comunaNombre, contact, categorias: PublicCategoria[], photoUrls, avatarUrl, createdAt, ... } }`, donde
+  `PublicCategoria = { slug: string, nombre: string, priceFrom: number | null, description: string | null }`.
+  `GET /api/professionals/me` devuelve la misma forma más los campos privados que ya expone (`email`,
+  `active`).
+- **Transición (S-002 a S-008, ver [T-004](#t-004)):** mientras `perfil.vue` y `[id].vue` no migraron a
+  consumir `categorias`, la respuesta expone **además** los campos legacy `categoriaNombre`/`priceFrom`/`description`
+  a nivel raíz de `professional` (calculados desde `categorias[0]`, la primera declarada), para no romper
+  esos dos consumidores. `categorias` reemplaza a esos campos sueltos recién cuando ambos migran (S-009).
+- **Invariantes:** `categorias.length >= 1` siempre — un profesional activo nunca queda sin categoría
+  (CL-002). El orden es por `createdAt` ascendente de `professional_categorias` — la primera categoría
+  declarada queda primera en el array, que es lo que UX-003 usa como default sin contexto de búsqueda.
+- **Errores:** 404 `not_found` si el id no existe o el profesional está inactivo (sin cambio respecto a
+  hoy).
+- **Contrato de producto:** [F-003](./producto.md#f-003).
 
-- **Entrada:** <datos y precondiciones, con tipos y forma concreta>.
-- **Salida:** <resultado y su forma concreta>.
-- **Invariantes:** <qué se cumple siempre: atomicidad, consistencia, idempotencia>.
-- **Errores:** <condición → código HTTP y cuerpo `{ error, code? }`, y qué puede hacer el llamador>.
+### TC-002 — `POST /api/professionals` crea el profesional y su primera categoría de forma atómica
+
+- **Entrada:** `{ displayName, categoriaSlug, comunaCodigo, contact }` — sin cambio de forma respecto al
+  registro actual (misión 04); precio y descripción no se piden acá (UX-001: solo se declaran editando el
+  perfil).
+- **Salida:** `{ professional: Professional }` — sin cambio de forma visible mientras dure la ventana de
+  transición de [T-004](#t-004): `Professional` gana `categorias: PublicCategoria[]` con una sola fila,
+  y conserva `categoriaSlug`/`priceFrom`/`description` calculados desde esa fila hasta S-009.
+- **Invariantes:** la fila de `professionals` y su primera fila de `professional_categorias` (con
+  `priceFrom: null`, `description: null`) nacen en la misma transacción — o existe el profesional con su
+  categoría, o no existe ninguna de las dos filas. Nunca un profesional sin categoría.
+- **Errores:** sin cambio respecto a hoy (400 `missing_field`/`invalid_categoria`/`invalid_comuna`/`invalid_contact`).
+- **Contrato de producto:** [F-001](./producto.md#f-001) (la categoría inicial es una declaración de
+  categoría como cualquier otra, solo que ocurre en el registro).
+
+**Transición (S-003 a S-007, ver [T-004](#t-004)):** `PATCH /api/professionals/me` (el endpoint que ya
+existe hoy) sigue aceptando `priceFrom`/`description` sueltos durante esta ventana — internamente
+actualiza la fila de `professional_categorias` de la única categoría que el profesional tiene hasta que
+S-006 exista, que sigue siendo inambiguo porque todavía nadie puede declarar una segunda. Deja de
+aceptarlos en S-007, cuando `perfil.vue` migra a `/me/categorias/*`.
+
+### TC-003 — `GET /api/search` devuelve el precio y la completitud de la categoría buscada, nunca de otra
+
+- **Entrada:** sin cambio de forma (`categoria`, `comuna` por query string).
+- **Salida:** sin cambio de forma (`SearchResultProfessional[]`); `priceFrom` y la señal de completitud
+  (`hasDescription`, `hasPrice` para `rankByCompleteness`) se leen de la fila de `professional_categorias`
+  que matchea `categoria_slug = :categoria`, nunca de otra categoría del mismo profesional.
+- **Invariantes:** un profesional con 2+ categorías nunca aparece dos veces en los resultados de una sola
+  búsqueda (ya lo garantiza el filtro por una sola `categoria_slug`); el precio mostrado es siempre el de
+  la categoría por la que se buscó (ejemplo verificable de F-002 en `producto.md`).
+- **Errores:** sin cambio respecto a hoy.
+- **Contrato de producto:** [F-002](./producto.md#f-002).
+
+### TC-004 — `POST /api/professionals/me/categorias` agrega una categoría al perfil propio
+
+- **Entrada:** `{ categoriaSlug: string, priceFrom?: number | null, description?: string | null }` —
+  precio y descripción opcionales (D-002, D-003 de `producto.md`; F-001 regla 1).
+- **Salida:** `{ categorias: PublicCategoria[] }` — la lista completa ya actualizada, mismo shape que
+  TC-001, para que el cliente reemplace su estado local sin recalcular nada.
+- **Invariantes:** un profesional nunca tiene dos filas con la misma `categoria_slug` (PK compuesta en
+  `professional_categorias`, ver Modelo de datos).
+- **Errores:** 401 sin sesión; 400 `invalid_categoria` si el slug no existe o no está activa; 400
+  `invalid_price` si `priceFrom` no es un entero positivo; 400 `already_declared` si el profesional ya
+  tiene esa categoría (conflicto de PK capturado explícitamente, nunca un 500).
 - **Contrato de producto:** [F-001](./producto.md#f-001).
+
+### TC-005 — `PATCH /api/professionals/me/categorias/[slug]` edita precio o descripción de una categoría propia
+
+- **Entrada:** `{ priceFrom?: number | null, description?: string | null }`.
+- **Salida:** `{ categorias: PublicCategoria[] }`, mismo shape que TC-004.
+- **Invariantes:** no cambia qué categorías tiene el profesional, solo sus dos campos editables.
+- **Errores:** 401 sin sesión; 404 `not_found` si el profesional no tiene declarada esa categoría; 400
+  `invalid_price` igual que TC-004.
+- **Contrato de producto:** [F-001](./producto.md#f-001).
+
+### TC-006 — `DELETE /api/professionals/me/categorias/[slug]` quita una categoría propia, nunca la última
+
+- **Entrada:** `slug` (path).
+- **Salida:** `{ categorias: PublicCategoria[] }` tras la baja.
+- **Invariantes:** un profesional activo nunca queda con `categorias.length === 0` (F-001 regla 3, CL-002
+  de `producto.md`) — **incluso bajo dos `DELETE` concurrentes del mismo profesional** (ver
+  [T-002](#t-002)): el conteo y el borrado ocurren dentro de una única transacción que toma
+  `select ... for update` sobre la fila de `professionals`, así una segunda request concurrente queda
+  bloqueada hasta que la primera termine (commit o rollback) y vuelve a contar sobre el estado ya
+  actualizado — nunca las dos leen el mismo conteo de 2 y las dos pasan el chequeo.
+- **Errores:** 401 sin sesión; 404 `not_found` si no tiene esa categoría declarada; 409 `last_category` si
+  es la única que le queda — no se ejecuta la baja.
+- **Contrato de producto:** [F-001](./producto.md#f-001), [CL-002](./producto.md#casos-límite-que-cruzan-funcionalidades).
 
 ## Modelo de datos
 
-<!-- Entidades con significado, escritura y ciclo de vida. El schema completo vive en server/db/. -->
-
-| Entidad o campo | Significado             | Escritura          | Retención o historial |
-| --------------- | ----------------------- | ------------------ | --------------------- |
-| <dato>          | <semántica de producto> | <endpoint o acción>| <política>            |
+| Entidad o campo                          | Significado                                                    | Escritura                                                              | Retención o historial                    |
+| ------------------------------------------- | -------------------------------------------------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------- |
+| `professional_categorias` (tabla nueva)     | Una categoría que un profesional declaró, con su precio y descripción propios (término de producto: "categoría declarada") | `POST`/`PATCH`/`DELETE /api/professionals/me/categorias/*`, y el registro (TC-002) crea la primera | Se borra la fila al quitar la categoría — sin historial, igual que hoy no hay historial de precio/descripción |
+| `professional_categorias.created_at`        | Cuándo se declaró — determina cuál es "la primera categoría" (UX-003) | Automático, `defaultNow()`, nunca se actualiza                               | Permanente mientras la fila exista           |
+| `professionals.categoria_slug`, `.price_from`, `.description` (columnas existentes) | Retirados — su significado pasa íntegro a `professional_categorias` | — (columnas eliminadas en S-009, ver Plan de construcción) | Los datos existentes se migran, no se pierden (ver Migración) |
 
 ### Invariantes de datos
 
-- <unicidad, pertenencia, orden o consistencia temporal>.
-- <qué operación es atómica o qué dato tiene una única fuente de verdad>.
+- Un profesional nunca tiene dos filas de `professional_categorias` con la misma `categoria_slug` — PK
+  compuesta `(professional_id, categoria_slug)`, no una constraint aplicada a mano en el endpoint.
+- Un profesional activo nunca tiene cero filas en `professional_categorias` — invariante de aplicación
+  (TC-006), verificado dentro de una transacción con lock de fila: ver [T-002](#t-002) por qué no es un
+  trigger, y cómo se cierra la condición de carrera de dos bajas concurrentes.
+- `professional_categorias.professional_id` referencia `professionals.id` con `on delete cascade` — hoy
+  nada borra un `professionals`, pero si alguna vez se agrega esa operación, sus categorías no quedan
+  huérfanas.
+- `professional_categorias.categoria_slug` referencia `categorias.slug` con `onUpdate: 'cascade'` — misma
+  FK que `professionals.categoria_slug` tiene hoy; se traslada, no se descarta.
+- **Índice `professional_categorias_categoria_slug_idx` sobre `categoria_slug`** — Postgres no indexa una
+  FK automáticamente, y esta es la columna por la que filtra `/api/search` (TC-003), la superficie de más
+  tráfico esperado. Se crea junto con la tabla en S-001, no como una acción pendiente de TR-001: TR-001
+  solo verifica con `EXPLAIN` que el plan la usa, la creación del índice ya es parte del schema.
+- El precio y la descripción de una categoría nunca se leen ni se muestran mezclados con los de otra — ya
+  lo garantiza el modelo (cada fila es autónoma), pero es el invariante que hace cumplir F-003 regla 3.
 
 ### Impacto en RLS
 
-<!--
-Obligatorio. Fuente de verdad: server/db/sql/rls.sql. Si el cambio no toca ownership ni relaciones usadas
-en policies, decirlo explícitamente con esa razón — no dejar la sección vacía.
--->
+`professionals` pierde tres columnas pero no cambia su ownership ni sus relaciones — las tres policies
+existentes (`professionals_select_public`, `professionals_insert_own`, `professionals_update_own`) siguen
+aplicando igual, sin editarlas.
 
-| Tabla    | Cambio                 | Policy afectada | Acción                    |
-| -------- | ---------------------- | --------------- | ------------------------- |
-| <tabla>  | <nueva, ownership, FK> | <nombre>        | <crear, actualizar, nada> |
+`professional_categorias` es una tabla nueva con datos de usuario, así que nace con policy — mismo patrón
+asimétrico que `professionals` (A-002 del skill `arquitectura`): lectura pública, escritura solo del dueño.
+La diferencia es que esta tabla no tiene `user_id` propio — la pertenencia se resuelve con un `exists`
+contra `professionals.user_id`, igual que cualquier tabla hija.
+
+| Tabla                    | Cambio                                                        | Policy afectada                                                                     | Acción                                             |
+| --------------------------- | -------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| `professionals`             | Se eliminan `categoria_slug`, `price_from`, `description` (S-009); `user_id` y relaciones sin cambio | `professionals_select_public`, `professionals_insert_own`, `professionals_update_own`      | Nada — ninguna policy referencia esas tres columnas    |
+| `professional_categorias`   | Tabla nueva, lectura pública, escritura solo del dueño (vía join)     | `professional_categorias_select_public`, `_insert_own`, `_update_own`, `_delete_own` (nuevas) | Crear, más el `revoke` que cierra PostgREST (A-007)    |
+
+SQL a agregar a `server/db/sql/rls.sql`, en el mismo bloque que documenta `professionals` (ver [T-003](#t-003) por qué lleva policy de `delete`, a diferencia de `professionals`):
+
+```sql
+alter table professional_categorias enable row level security;
+
+drop policy if exists professional_categorias_select_public on professional_categorias;
+create policy professional_categorias_select_public on professional_categorias
+  for select to authenticated, anon using (true);
+
+drop policy if exists professional_categorias_insert_own on professional_categorias;
+create policy professional_categorias_insert_own on professional_categorias
+  for insert to authenticated with check (
+    exists (
+      select 1 from professionals p
+      where p.id = professional_categorias.professional_id and p.user_id = (select auth.uid())
+    )
+  );
+
+drop policy if exists professional_categorias_update_own on professional_categorias;
+create policy professional_categorias_update_own on professional_categorias
+  for update to authenticated using (
+    exists (
+      select 1 from professionals p
+      where p.id = professional_categorias.professional_id and p.user_id = (select auth.uid())
+    )
+  ) with check (
+    exists (
+      select 1 from professionals p
+      where p.id = professional_categorias.professional_id and p.user_id = (select auth.uid())
+    )
+  );
+
+drop policy if exists professional_categorias_delete_own on professional_categorias;
+create policy professional_categorias_delete_own on professional_categorias
+  for delete to authenticated using (
+    exists (
+      select 1 from professionals p
+      where p.id = professional_categorias.professional_id and p.user_id = (select auth.uid())
+    )
+  );
+
+-- Igual que professionals: cierra PostgREST por completo. Drizzle usa el rol dueño y no le afecta.
+revoke all on public.professional_categorias from anon, authenticated;
+```
+
+Checklist de `seguridad-datos` corrido contra este diseño: RLS habilitado explícito, las cuatro operaciones
+tienen policy o razón documentada, `revoke` presente (sin él estas policies serían la única puerta, no un
+respaldo), ningún `update` sin `with check`, sin `force row level security` (rompería la conexión de rol
+dueño de Drizzle, mismo motivo que `professionals`). La autorización real —A-002— vive en
+`server/api/professionals/me/categorias/*.ts`: cada endpoint resuelve primero el `professionals.id` del
+`user.id` autenticado (`requireUser(event)`) y opera sobre esa fila, nunca confía en el `professionalId`
+que mandara el cliente.
 
 ## Riesgos y experimentos de factibilidad
 
-<!--
-Un riesgo que podría cambiar el producto se enlaza como pregunta o decisión en producto.md. Un experimento
-tiene pregunta, límite de tiempo y resultado capaz de cerrar la incertidumbre.
--->
-
-| ID     | Riesgo o pregunta | Qué invalida        | Experimento o mitigación  | Criterio de salida      | Estado  |
-| ------ | ----------------- | ------------------- | ------------------------- | ----------------------- | ------- |
-| TR-001 | <incertidumbre>   | <alcance en riesgo> | <spike, prueba o recorte> | <resultado concluyente> | abierto |
+| ID     | Riesgo o pregunta                                                                 | Qué invalida                          | Experimento o mitigación                                                                                  | Criterio de salida                                          | Estado  |
+| ------ | -------------------------------------------------------------------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- | ------- |
+| TR-001 | ¿La query de `/api/search` con el join nuevo contra `professional_categorias` usa el índice `professional_categorias_categoria_slug_idx` (creado en S-001), o cae a un seq scan? | Rendimiento de la superficie de más tráfico del producto | Correr `EXPLAIN` sobre la query de S-004 antes de mergear ese slice | El plan usa el índice para filtrar por `categoria_slug`, no un seq scan | abierto |
 
 ## Estrategia de pruebas
 
-<!-- Mapea los ejemplos verificables de producto.md a niveles de prueba. Qué demuestra cada una. -->
-
-| Contrato o riesgo | Nivel                          | Caso principal | Límite o falla |
-| ----------------- | ------------------------------ | -------------- | -------------- |
-| F-001, CL-001     | <unidad, contrato, integración>| <caso>         | <caso>         |
+| Contrato o riesgo     | Nivel                 | Caso principal                                                                 | Límite o falla                                                        |
+| ------------------------ | ------------------------ | ------------------------------------------------------------------------------------ | --------------------------------------------------------------------------- |
+| TC-004                   | contrato (`server/api`)  | Feña agrega Gasfitería con precio $18.000 → 201, `categorias` incluye ambas          | Agregar una categoría que ya tiene → 400 `already_declared`, no duplica     |
+| TC-006, CL-002           | contrato                 | Quitar Electricidad con 2 categorías declaradas → 200, queda solo Gasfitería         | Quitar la única categoría que le queda → 409 `last_category`, no se borra   |
+| TC-006, T-002 (concurrencia) | contrato, concurrente | Dos `DELETE` simultáneos sobre las 2 categorías de un mismo profesional → uno termina en 200, el otro en 409 (nunca los dos en 200) | — |
+| TC-003, F-002            | integración              | Buscar "Gasfitería" en Ñuñoa muestra el precio de Gasfitería, no el de Electricidad  | Profesional con la categoría pero sin esa comuna → no aparece (sin cambio)  |
+| TC-002                   | contrato                 | Registro nuevo crea `professionals` + 1 fila de `professional_categorias`            | Falla el insert de la categoría → no queda un `professionals` sin categoría (transacción) |
+| CL-005 (migración)       | integración, una vez     | Un profesional preexistente con `categoria_slug`/`price_from`/`description` conserva exactamente esos valores en su fila migrada | —                                                                            |
+| RLS de `professional_categorias` | bypass real (ver `seguridad-datos`) | Insertar una fila directo con el cliente de sesión (`$supabase.from('professional_categorias')`) queda bloqueado por el `revoke` | Un `select`/`insert` directo por PostgREST no devuelve ni escribe nada |
 
 ### Propiedades que deben probarse
 
-- <invariante bajo reintentos, concurrencia o distintas entradas>.
-- <ausencia de efectos parciales en falla>.
+- Agregar una categoría es idempotente en el sentido correcto: agregar dos veces la misma nunca produce
+  dos filas — la segunda falla explícitamente (400), no se ignora en silencio ni sobrescribe la primera.
+- Ninguna secuencia de agregar/quitar categorías deja a un profesional activo con `categorias.length === 0`,
+  probado tanto con 1 como con 2+ categorías de partida, **y también bajo dos bajas concurrentes** sobre
+  el mismo profesional (el lock de fila de TC-006/T-002 es lo que hace esto verificable, no solo deseable).
+- El precio/descripción que devuelve `/api/search` para una categoría nunca cambia si se edita la
+  descripción de otra categoría del mismo profesional (aislamiento entre filas).
+
+## Migración y compatibilidad
+
+Datos existentes: cada fila actual de `professionals` tiene `categoria_slug`, `price_from` y `description`
+poblados (o `null` en los dos últimos, que ya son opcionales hoy). CL-005 de `producto.md` exige que esos
+valores se conserven como la primera categoría declarada, sin pedirle a nadie que los vuelva a ingresar.
+
+**Expand/contract en dos fases, no un solo paso** (ver [T-001](#t-001)):
+
+1. **Expand (S-001):** se crea `professional_categorias` y se migran los datos con un `insert ... select`
+   en la misma migración generada por `drizzle-kit generate` (a mano, agregado al archivo `.sql` que
+   Drizzle genera — el backfill de datos no es algo que Drizzle infiera del diff de schema):
+
+   ```sql
+   insert into professional_categorias (professional_id, categoria_slug, price_from, description, created_at)
+   select id, categoria_slug, price_from, description, created_at
+   from professionals;
+   ```
+
+   Usar `professionals.created_at` como `created_at` de la fila migrada —no `now()`— es lo que preserva el
+   orden real de "categoría declarada primero" (TC-001) para profesionales que ya existían antes de esta
+   misión: su única categoría de hoy sigue siendo la primera después de migrar. Las columnas legacy de
+   `professionals` siguen existiendo en este paso — nada las borra todavía.
+
+2. **Contract (S-009):** una vez que `perfil.vue` (S-007) y `[id].vue` (S-008) migraron a `categorias` y
+   a `/me/categorias/*`, y ya no queda ningún consumidor de los campos legacy (ver [T-004](#t-004) sobre
+   la compatibilidad temporal que hace posible este orden), se elimina `categoria_slug`, `price_from`,
+   `description` y su índice (`professionals_categoria_slug_idx`) de `professionals` en una migración
+   aparte, y `PATCH /me`/`GET .../[id]`/`GET .../me` dejan de exponer o aceptar esos campos.
+
+Sin rollback físico distinto del que ya da `drizzle-kit` (revertir la migración reconstruye las columnas,
+pero no repuebla sus valores desde `professional_categorias` automáticamente) — aceptable porque no hay
+tráfico de producción real todavía que dependa de una reversión sin pérdida de datos.
 
 ## Plan de construcción
 
-<!--
-Se completa al final, cuando el gate de salida se cumple y ninguna pregunta bloqueante sigue abierta —
-cortar sobre decisiones abiertas produce issues que mueren. Cada slice es un cambio funcional atómico: un
-Issue, un PR, ejecutable sin haber leído la misión (el issue lleva su contrato inline) y con criterios
-pass/fail enumerables como tests. Guía completa en el skill discovery-engineering.
--->
+Corte vertical, no por capa (ver [T-001](#t-001)/[T-004](#t-004)): cada slice deja la app funcionando de
+punta a punta si se mergea solo. Ningún slice cambia la forma externa de un endpoint sin que, en el mismo
+slice o ya de antemano, exista compatibilidad para quien todavía lo consume con la forma vieja.
 
-| ID    | Slice (una frase, sin "y") | Sustento      | Criterio de aceptación principal          | Depende de |
-| ----- | -------------------------- | ------------- | ----------------------------------------- | ---------- |
-| S-001 | <cambio atómico>           | TC-001, D-001 | <entrada concreta → resultado observable> | —          |
+| ID    | Slice (una frase, sin "y")                                                                  | Sustento                | Criterio de aceptación principal                                                                                 | Depende de |
+| ----- | -------------------------------------------------------------------------------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ---------- |
+| S-001 | Crear `professional_categorias` (con su índice) con su RLS y migrar los datos existentes desde `professionals` | D-002, D-003, CL-005, T-001 | La tabla existe con RLS habilitado, sus 4 policies y `professional_categorias_categoria_slug_idx`; cada profesional activo tiene exactamente 1 fila migrada con sus valores actuales de categoría/precio/descripción; ningún endpoint cambia de comportamiento todavía | —          |
+| S-002 | `GET /api/professionals/[id]` y `GET /api/professionals/me` agregan `categorias`, sin quitar los campos legacy | TC-001, T-004            | Perfil público y editor de perfil siguen mostrando exactamente lo mismo que hoy (leen los campos legacy, ahora calculados desde `professional_categorias`); `categorias` ya está disponible en la respuesta aunque nada lo consuma todavía | S-001      |
+| S-003 | Registro y `PATCH /me` dejan de escribir directo en `professionals.categoria_slug`/`price_from`/`description`, y pasan a escribir la fila de `professional_categorias` por debajo | TC-002, T-004             | Un registro nuevo crea `professionals` + su primera `professional_categorias` en una transacción; `PATCH /me` con `priceFrom`/`description` sigue funcionando igual que hoy para quien todavía tiene una sola categoría | S-002      |
+| S-004 | `/api/search` lee precio y completitud de la categoría buscada desde `professional_categorias`      | TC-003, F-002              | Buscar una categoría de un profesional con 2+ categorías muestra el precio de esa categoría, nunca el de otra            | S-001      |
+| S-005 | `POST /api/professionals/me/categorias` — agregar una categoría al perfil propio                    | TC-004, F-001              | Ejemplo verificable de F-001: Feña agrega Gasfitería con precio $18.000; endpoint nuevo, no lo consume ninguna UI todavía | S-002, S-003 |
+| S-006 | `PATCH`/`DELETE /api/professionals/me/categorias/[slug]` — editar y quitar una categoría propia, con lock de fila | TC-005, TC-006, CL-002, T-002 | CL-002 bajo concurrencia: dos `DELETE` simultáneos sobre la última categoría — solo uno la borra, el otro recibe 409; editar una categoría no toca las demás | S-005      |
+| S-007 | `perfil.vue` pasa de un formulario de una categoría (vía `PATCH /me`) a bloques por categoría (vía `/me/categorias/*`) | UXF-001                  | El flujo completo mockeado en `experiencia.md` (lista, agregando, confirmando quitar) funciona en la app; `perfil.vue` deja de mandar `priceFrom`/`description` a `PATCH /me` | S-006      |
+| S-008 | `[id].vue` migra de los campos legacy a `categorias`: categoría de contexto completa, el resto bajo "También hace" | UXF-002, UX-004, UX-005  | Flujo UXF-002 completo: categoría de contexto con detalle, secundarias sin precio si falta (UX-005), filas no interactivas | S-002      |
+| S-009 | Contract: eliminar los campos legacy de las respuestas, `PATCH /me` deja de aceptar `priceFrom`/`description`, y se borran `categoria_slug`/`price_from`/`description` y su índice de `professionals` | T-001 (fase contract), T-004 | `npx nuxi typecheck` y `npm run build` pasan sin ninguna referencia a las columnas ni campos viejos; nada en `app/`/`server/` los usa | S-007, S-008 |
 
-## Secciones bajo demanda
-
-<!--
-Agregar solo cuando el riesgo lo justifique, con estos títulos:
-
-- "Migración y compatibilidad": cuando existan datos o consumidores que deben llegar al nuevo contrato.
-  Incluye rollback lógico si la migración física no puede revertirse.
-- "Rendimiento y observabilidad": cuando haya presupuesto de latencia o volumen que defender (búsqueda
-  geográfica y listados paginados son los candidatos naturales).
-- "SEO e indexación": cuando la superficie deba ser indexable (páginas por categoría + comuna, datos
-  estructurados).
-- "Entrega por etapas": cuando el cambio necesite despliegue incremental o feature flags.
--->
+S-004 depende solo de S-001 (no de S-002/S-003) porque la query de búsqueda no expone ninguno de los campos
+legacy — puede leer de `professional_categorias` sin esperar a que los otros consumidores migren. S-005 y
+S-006 son endpoints nuevos y aditivos: no rompen nada aunque ninguna UI los use aún, así que no necesitan
+esperar a S-007/S-008 para mergearse.
 
 ## Decisiones técnicas
 
 <a id="t-001"></a>
 
-### T-001 — <decisión en una frase>
+### T-001 — La migración de categoría/precio/descripción se corta en expand/contract, nunca en un solo slice
 
-- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
-- **Contratos:** F-001 y <regla relevante>.
-- **Alternativas descartadas:** <opciones y trade-offs, con el porqué del rechazo>.
-- **Decisión y consecuencias:** <enfoque elegido, beneficio, costo y trabajo futuro aceptado>.
-- **Reapertura:** <medición o cambio que justificaría revisar>.
+- **Estado:** aceptada. **Fecha:** 2026-09-06.
+- **Contratos:** TC-001, TC-002, TC-003, CL-005.
+- **Alternativas descartadas:** un solo slice gigante que crea la tabla, migra los datos, actualiza los
+  tres endpoints, borra las columnas viejas y actualiza las dos vistas a la vez — descartada porque
+  produce un PR imposible de revisar (CLAUDE.md: "un PR chico y revisable") y porque si algo falla a mitad
+  de camino no hay forma de mergear una parte y dejar el resto para después sin romper la app. Una primera
+  versión de este documento cortó expand/contract **por capa** (todos los endpoints de lectura primero,
+  luego escritura, luego borrar columnas) — descartada tras la auditoría en contexto separado del gate:
+  ese corte cambiaba la forma de `GET`/`PATCH` antes de que `perfil.vue`/`[id].vue` supieran leerla,
+  dejando la app rota entre slices — exactamente lo que esta decisión dice que hay que evitar. Se
+  reemplaza por el corte vertical con compatibilidad temporal de [T-004](#t-004).
+- **Decisión y consecuencias:** expand (S-001: tabla + backfill, sin tocar consumidores) → cada slice
+  siguiente es vertical y mergeable solo, con compatibilidad temporal en las respuestas mientras dure la
+  migración (T-004) → contract (S-009: borrar columnas y campos legacy, ya sin consumidores). Costo
+  aceptado: durante la ventana de transición existen dos formas de la misma información (campos legacy +
+  `categorias`) — deliberado, no un descuido; S-009 es obligatorio y entra al plan desde el principio, no
+  "después si hay tiempo".
+- **Reapertura:** ninguna prevista — el patrón es estándar para este tipo de cambio (ver
+  `references/slicing.md` de `discovery-engineering`).
+
+<a id="t-002"></a>
+
+### T-002 — "Nunca sin categoría" se verifica en el endpoint con un lock de fila, no con un trigger de Postgres
+
+- **Estado:** aceptada. **Fecha:** 2026-09-06.
+- **Contratos:** TC-006, CL-002.
+- **Alternativas descartadas:** (a) un trigger `before delete` en `professional_categorias` que cuente las
+  filas del mismo `professional_id` y aborte si quedaría en cero — técnicamente más robusto contra
+  cualquier vía de escritura, pero la única vía de escritura real es `server/api/` (Drizzle, rol dueño;
+  PostgREST está cerrado por el `revoke`), así que el trigger protegería contra un camino que no existe;
+  es la misma sobre-construcción que el skill `discovery-engineering` pide evitar para lógica que no
+  cambia de forma. (b) Contar y borrar como dos pasos sueltos sin transacción ni lock — descartada tras la
+  auditoría del gate: dos `DELETE` concurrentes del mismo profesional (ej. doble tap en una conexión
+  lenta, el perfil de usuario que describe `CLAUDE.md`) pueden ambos leer el mismo conteo de 2 antes de
+  que el otro confirme su borrado, y los dos pasan el chequeo — el invariante "nunca cero categorías" se
+  rompe en el único camino de escritura real, no en uno hipotético. Esto es justo la asimetría que la
+  auditoría señaló contra TC-002 (que sí es transaccional) y TC-004 (que sí se apoya en una constraint real
+  de la base).
+- **Decisión y consecuencias:** el conteo y el borrado ocurren dentro de una transacción de Drizzle que
+  toma `select ... for update` sobre la fila de `professionals` del dueño antes de contar — el lock hace
+  que una segunda request concurrente espere hasta que la primera termine, y vuelva a contar sobre el
+  estado ya actualizado. La lógica vive en una función de `server/utils/professional-categorias.ts`
+  (coherente con la tabla de "Arquitectura"), invocada por el endpoint — no inline en el handler de Nitro,
+  así se puede probar con una conexión de test sin pasar por HTTP. Consecuencia aceptada: si algún día se
+  abre una vía de escritura fuera de `server/api/` (job externo, admin panel directo a la base), esta
+  protección no aplica ahí — mismo trade-off que ya acepta A-002 para el resto de las reglas de negocio de
+  Datealo.
+- **Reapertura:** si se agrega una vía de escritura a `professional_categorias` fuera de `server/api/`.
+
+<a id="t-003"></a>
+
+### T-003 — `professional_categorias` sí lleva policy de `delete`, a diferencia de `professionals`
+
+- **Estado:** aceptada. **Fecha:** 2026-09-06.
+- **Contratos:** TC-006, Impacto en RLS.
+- **Alternativas descartadas:** omitir la policy de `delete` como hace `professionals` (que confía en el
+  default-deny de Postgres porque nada la borra) — descartada porque acá sí existe una operación real de
+  borrado (TC-006, quitar una categoría), a diferencia de `professionals`, que ninguna operación de
+  ninguna misión borra hoy.
+- **Decisión y consecuencias:** `professional_categorias_delete_own` sigue el mismo patrón `exists (...)`
+  que `_update_own`. Es respaldo, no el mecanismo real — igual que el resto de las policies de esta tabla
+  — porque el `revoke` cierra PostgREST por completo y la verificación real ocurre en TC-006.
+- **Reapertura:** ninguna prevista.
+
+<a id="t-004"></a>
+
+### T-004 — Los endpoints existentes exponen y aceptan la forma legacy en paralelo a `categorias`, hasta que ambos consumidores migran
+
+- **Estado:** aceptada. **Fecha:** 2026-09-06.
+- **Contratos:** TC-001, TC-002, S-002, S-003, S-009.
+- **Alternativas descartadas:** cortar el Plan de construcción por capa (todos los `GET` primero, después
+  los `POST`/`PATCH`/`DELETE`, después la UI) — es la versión que auditó el gate y no sobrevivió: `TC-001`
+  cambiaba la forma de `GET .../[id]` y `.../me` en S-002 reemplazando los campos sueltos, pero
+  `perfil.vue` y `[id].vue` (que los leen como campos planos) no se actualizaban hasta S-008/S-009, varios
+  slices después — cualquiera de esos slices intermedios mergeado solo deja el perfil público y el editor
+  de perfil rotos en producción. Es la misma inconsistencia que [T-001](#t-001) dice que el expand/contract
+  existe para evitar.
+- **Decisión y consecuencias:** durante la ventana S-002 a S-008, `GET /api/professionals/[id]` y
+  `GET /api/professionals/me` devuelven **tanto** los campos legacy (`categoriaNombre`/`priceFrom`/`description`,
+  calculados desde `categorias[0]`) **como** el array `categorias` nuevo; `PATCH /api/professionals/me`
+  sigue aceptando `priceFrom`/`description` sueltos (que hasta S-006 son inambiguos: todo profesional
+  tiene una sola categoría) y los escribe en la fila de `professional_categorias` correspondiente. Ningún
+  slice de esta ventana rompe a `perfil.vue` ni a `[id].vue`, que sigue leyendo/escribiendo exactamente
+  como hoy sin saber que el storage cambió por debajo. Consecuencia aceptada: el código de los tres
+  endpoints existentes lleva temporalmente ambas formas (más ramas, más superficie) hasta que S-009 las
+  retira — costo aceptado a cambio de que cada slice intermedio sea mergeable solo.
+- **Reapertura:** ninguna prevista — S-009 cierra la ventana en el mismo Plan de construcción, no queda
+  como trabajo futuro sin fecha.
 
 ## Preguntas
 
-<!--
-Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
-Estado: abierta | resuelta AAAA-MM-DD | disuelta AAAA-MM-DD. Solo las abiertas llevan bloque de detalle.
--->
+Ninguna pregunta bloquea el gate.
 
-<Una frase que responde "¿qué falta?": la pregunta que bloquea construcción y qué bloquea.>
-
-| ID     | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
-| ------ | ---------------------- | ------------------- | --------------------------------------------------------------- |
-| TQ-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
-| TQ-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |
+| ID     | La duda | Estado | Respuesta, o quién la resuelve |
+| ------ | ------- | ------ | ------------------------------- |
+| —      | —       | —      | —                                |

--- a/docs/missions/14-multiples-categorias-profesional/investigacion.md
+++ b/docs/missions/14-multiples-categorias-profesional/investigacion.md
@@ -1,118 +1,186 @@
-# Misión: <nombre> — Investigación
+# Misión: múltiples categorías por profesional — Investigación
 
 **Estado:** activo
 
-**Última actualización:** AAAA-MM-DD
+**Última actualización:** 2026-09-06
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-<!--
-Este documento se acumula: la evidencia y las conclusiones no se borran cuando el alcance cambia, porque
-explican por qué el producto es como es. Lo que sí se actualiza es el ideal, que resume la dirección que
-la investigación sostiene hoy.
-
-Gate de salida — la investigación sostiene un producto.md cuando:
-- el problema tiene situación y consecuencia concretas, no una categoría abstracta
-- al menos una conclusión con confianza alta o media respalda la dirección
-- el ideal describe capacidades observables, no intenciones
--->
-
-## El problema aparece cuando <historia concreta>
+## El problema aparece cuando un profesional cubre más de un oficio y Datealo solo le deja declarar uno
 
 <!--
-Una situación real o reconstruida con precisión. No abras con una categoría como "falta de confianza" —
-abre con quién estaba haciendo qué y qué salió mal. Nombra a la persona y el servicio concreto.
+Reconstruido a partir del patrón que describió el dueño de producto (no es una entrevista formal ni un
+caso con nombre real) — ver E-001.
 -->
 
-**Situación:** <qué está ocurriendo antes del problema>.
+**Situación:** Feña trabaja de forma independiente en Ñuñoa. Además de arreglos eléctricos, también hace
+gasfitería — es común que quien instala o repara circuitos en una casa antigua también sepa resolver una
+llave que gotea o un estanque de WC tapado, porque son trabajos que se piden juntos en el mismo tipo de
+casa. Se registra en Datealo para que lo encuentren clientes de su zona.
 
-**Acción o necesidad:** <qué se intenta resolver o decidir>.
+**Acción o necesidad:** Al crear su perfil, Datealo le pide elegir **una** categoría. Feña tiene que decidir
+si se registra como "Electricidad" o como "Gasfitería" — no puede declarar las dos.
 
-**Respuesta actual:** <qué hace hoy la persona: grupo de WhatsApp, Google, recomendación de un vecino,
-Datealo si ya existe la superficie>.
+**Respuesta actual:** Elige la que más le da trabajo hoy (Electricidad) y deja la otra fuera del perfil. Si
+alguien lo conoce personalmente le pide también por la gasfitería, pero quien lo encuentra buscando
+"gasfiter" en Ñuñoa por primera vez no lo ve en esa lista.
 
-**Consecuencia:** <error, demora, riesgo o decisión que no puede tomarse>.
+**Consecuencia:** Feña pierde la mitad de su demanda potencial dentro de la misma plataforma, y Datealo
+muestra menos oferta de la que realmente tiene en Ñuñoa para gasfitería — un buscador que entra a esa
+categoría ve una lista más corta de la real. El mismo patrón se repite con otras combinaciones de oficios
+de mantención del hogar: un profesional que corta pasto también desmaleza con máquina, y hoy solo puede
+declarar una de las dos.
 
 ## Preguntas que la investigación debe resolver
 
-<!--
-Solo preguntas capaces de cambiar el ideal o una decisión. Al resolver una, moverla a evidencia o
-conclusión. No es un backlog.
--->
-
-- ¿<pregunta y decisión que depende de ella>?
+- ¿Cuántas categorías tiene sentido permitir por profesional, si la restricción real termina siendo la
+  legibilidad de la card y del perfil, no el control de calidad? De esto depende si `experiencia.md` diseña
+  con o sin tope, y si `ingenieria.md` necesita imponerlo a nivel de dato.
+- ¿El precio orientativo (`priceFrom`) y la descripción siguen siendo un solo valor por profesional, o
+  pasan a variar por categoría? De esto depende si la futura tabla de relación profesional-categoría es
+  solo un vínculo, o si necesita campos propios.
+- ¿Declarar más de una categoría es parte del registro inicial (misión 04) o una acción posterior de
+  edición de perfil? Afecta si esta misión toca el flujo de registro o solo la edición y la búsqueda.
 
 ## Evidencia
 
-<!--
-Un hecho verificable con fuente y límite. Prioriza observación directa, entrevistas y comportamiento
-comprobado. Los benchmarks de otros productos también son evidencia: qué hacen, qué trade-off eligieron y
-qué no aplica a Datealo.
-
-Datealo no tiene datos de uso propios todavía. Cuando la única evidencia disponible sea un benchmark o
-una entrevista, la columna "límite" es lo que impide que se lea como dato duro.
--->
-
-| ID    | Tipo                                              | Fuente                | Hecho verificable | Límite de la evidencia |
-| ----- | ------------------------------------------------- | --------------------- | ----------------- | ---------------------- |
-| E-001 | <entrevista, benchmark, uso, código, observación> | <enlace o referencia> | <hecho>           | <qué no demuestra>     |
+| ID    | Tipo         | Fuente                                                                                                  | Hecho verificable                                                                                                        | Límite de la evidencia                                                                                          |
+| ----- | ------------ | --------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| E-001 | Observación  | Dueño de producto, conocimiento directo del rubro de oficios en Chile                                            | Profesionales de oficios de mantención del hogar suelen cubrir más de un rubro relacionado (electricidad+gasfitería, jardín+desmalezado a máquina) | No es una entrevista ni un conteo — no dice qué fracción de profesionales tiene esta característica ni cuántas categorías es lo típico. |
+| E-002 | Benchmark    | [Thumbtack — guía de perfil](https://help.thumbtack.com/article/profile-guide)                                   | Un profesional puede agregar cualquier número de categorías de servicio a su perfil, sin límite explícito documentado                     | Thumbtack opera con millones de profesionales y moderación de contenido — no valida si la ausencia de tope es sana con la oferta baja de Datealo pre-lanzamiento. |
+| E-003 | Benchmark    | [TaskRabbit — qué categorías agregar](https://support.taskrabbit.com/hc/en-us/articles/360052736472) y [cómo describir habilidades por categoría](https://www.taskrabbit.com/blog/crafting-the-ultimate-skills-and-experience-description/) | Cada categoría que un tasker agrega exige auto-certificar habilidad/herramientas/licencias para ella, y el texto de "Skills & Experience" se redacta por separado en cada categoría, no una sola vez para todo el perfil | TaskRabbit es de tareas domésticas variadas (mudanza, ensamblaje), no oficios técnicos regulados como en Chile; y no confirma si el precio también varía por categoría. |
 
 <a id="e-001"></a>
 
-### E-001 — <fuente o hecho en una frase>
+### E-001 — El dueño de producto reporta el patrón directamente desde el rubro
 
-<!--
-Desarrollar solo cuando la tabla no alcanza para evaluar la calidad de la evidencia. Cierra con la
-consecuencia para la investigación.
--->
+Dos ejemplos de combinaciones distintas de oficios que se dan juntas en la práctica: alguien que hace
+electricidad y también gasfitería, y alguien que corta pasto y también desmaleza con máquina. No son la
+misma pareja de categorías, lo que sugiere que el patrón es una familia de combinaciones dentro de oficios
+de mantención del hogar, no un caso aislado de dos categorías específicas.
 
-<Observación precisa y contexto necesario.>
+Esto permite afirmar que el problema existe hoy con la oferta que Datealo ya tiene diseñada (categorías de
+oficios del hogar), pero no demuestra con qué frecuencia ocurre ni si aplica igual a categorías de
+servicios personales (peluquería, por ejemplo).
 
-Esto permite afirmar <alcance>, pero no demuestra <límite>.
+<a id="e-002"></a>
+
+### E-002 — Thumbtack no pone tope numérico a las categorías de un profesional
+
+Un pro de Thumbtack puede sumar cualquier cantidad de categorías de servicio a su cuenta; cada categoría
+trae su propio set de preferencias configurables, pero no hay un máximo documentado.
+
+Esto permite afirmar que a la escala de un marketplace maduro un tope duro no es necesario para que el
+sistema funcione, pero no demuestra que la ausencia de tope sea igual de sana con la oferta reducida que
+tendrá Datealo el primer año (ver "Cold start" y guardrail de spam de categorías del README de la misión).
+
+<a id="e-003"></a>
+
+### E-003 — TaskRabbit condiciona cada categoría a una certificación propia y separa la experiencia por categoría
+
+Para sumar una categoría, TaskRabbit exige que el tasker certifique que tiene las habilidades, herramientas
+y licencias necesarias para esa categoría específica — no es un permiso genérico de "puedo hacer tareas".
+Además, el texto de "Skills & Experience" se redacta categoría por categoría, no una sola vez para todo el
+perfil.
+
+Esto permite afirmar que el control de calidad de "quién puede declarar qué categoría" se resuelve con una
+certificación por categoría, no con un tope numérico — y que la experiencia/descripción de un profesional
+puede no ser uniforme entre sus categorías. No demuestra que el precio deba seguir el mismo patrón, ni que
+Datealo necesite un paso de certificación explícito por categoría (ese es un problema de verificación que
+la misión no tiene por qué resolver de nuevo si ya hay una decisión vigente al respecto).
 
 ## Conclusiones
 
-<!--
-Una conclusión interpreta evidencia; no es una preferencia ni una funcionalidad. El título expresa el
-hallazgo, no el tema.
--->
-
 <a id="c-001"></a>
 
-### C-001 — <conclusión en una frase>
+### C-001 — Cubrir más de un oficio relacionado es un patrón real y esperable, no una excepción rara
 
 - **Sustento:** [E-001](#e-001).
-- **Razonamiento:** <por qué la evidencia conduce a esta lectura y no a otra>.
-- **Implicación:** <qué deberá ser cierto en el producto o qué alternativa queda debilitada>.
-- **Confianza:** <alta, media o baja> porque <razón o validación pendiente>.
+- **Razonamiento:** el dueño de producto reporta el patrón desde conocimiento directo del rubro, con dos
+  ejemplos de combinaciones distintas de categorías, lo que indica una familia de casos y no una pareja
+  puntual de categorías que se podría resolver con una excepción ad hoc.
+- **Implicación:** el modelo de datos de "una categoría por profesional" subcuenta oferta real desde el
+  día uno de Datealo — no es un caso límite que aparecerá más adelante con volumen, ya existe hoy con la
+  primera oferta que se registre.
+- **Confianza:** media, porque no hay conteo ni entrevista formal — es la lectura de un experto del
+  dominio, no una medición sobre profesionales reales de Datealo (todavía no existen).
 
-## El ideal: <resultado completo, sin recortar>
+<a id="c-002"></a>
 
-<!--
-El ideal es el producto de la investigación: la dirección que la evidencia sostiene, sin restricciones de
-implementación. El recorte a la primera entrega no vive aquí — vive en producto.md como decisión de
-alcance. Esta sección sí se reescribe cuando nueva evidencia cambia la dirección.
--->
+### C-002 — El tope a las categorías, si existe, se justifica por legibilidad del perfil, no por control de calidad
+
+- **Sustento:** [E-002](#e-002), [E-003](#e-003).
+- **Razonamiento:** Thumbtack y TaskRabbit, con volumen y necesidad de calidad mucho mayores que Datealo,
+  no imponen un tope numérico a las categorías por profesional; en cambio, TaskRabbit condiciona cada
+  categoría a una auto-certificación de habilidad. Eso separa dos problemas que el README de la misión
+  trae mezclados ("sin límite, o un tope para que no se use como spam de categorías"): evitar que alguien
+  se declare en una categoría sin poder cubrirla es un problema de verificación, y mantener el perfil
+  legible con 2-3 categorías visibles es un problema de diseño visual.
+- **Implicación:** un tope a las categorías por profesional, si `producto.md` lo decide, debe justificarse
+  por espacio y jerarquía en la card/perfil (una decisión de `experiencia.md`), no como sustituto de
+  verificación de habilidad — la verificación, si Datealo la necesita, es una decisión aparte que ya existe
+  o debe abrirse en su propia misión, no inventarse acá para justificar el tope.
+- **Confianza:** media — el benchmark no transfiere 1:1 por diferencia de escala (millones de
+  profesionales vs. los primeros que se registren en Datealo) y de rubro (oficios técnicos regulados en
+  Chile vs. tareas domésticas variadas en EE.UU.).
+
+<a id="c-003"></a>
+
+### C-003 — La información asociada a una categoría puede no ser uniforme dentro de un mismo profesional
+
+- **Sustento:** [E-003](#e-003).
+- **Razonamiento:** TaskRabbit separa el texto de experiencia por categoría porque la experiencia de un
+  tasker en "Ensamblaje de muebles" no es la misma que en "Ayuda para mudanza", aun siendo la misma
+  persona. El mismo argumento aplica a Feña: su experiencia y su precio orientativo en electricidad no
+  tienen por qué ser los mismos que en gasfitería.
+- **Implicación:** si Datealo sigue este patrón, la futura relación profesional-categoría no es solo un
+  vínculo N:N — puede necesitar campos propios (ej. precio orientativo por categoría), lo que cambia
+  `priceFrom` y `description` de columnas únicas del profesional a algo que varía por categoría. Esta
+  conclusión no decide el cambio, solo advierte el costo de rediseño si `producto.md` lo adopta.
+- **Confianza:** baja — una sola fuente de benchmark, y Datealo hoy ya tiene `priceFrom` y `description`
+  como campos únicos del profesional, así que el costo de cambiarlo es real y debe evaluarse en
+  `producto.md`/`ingenieria.md`, no asumirse acá.
+
+## El ideal: cualquier profesional aparece en todas las categorías que realmente cubre, sin duplicar su perfil
 
 ### El resultado ideal se ve así
 
-<Narra de principio a fin una situación futura con datos concretos: nombres, comunas, oficios, horarios.
-Qué acción ocurre, qué responde Datealo, qué decisión puede tomar la persona. Evita "una experiencia
-simple" sin comportamiento observable.>
+Feña arregla instalaciones eléctricas y hace gasfitería en Ñuñoa y comunas vecinas. Declaró ambas
+categorías en su perfil de Datealo. Cuando Constanza busca "gasfiter" en Ñuñoa porque se le tapó el
+estanque del baño, Feña aparece en esa lista junto a los gasfiters que solo hacen gasfitería, con la
+etiqueta "Gasfitería" visible en su card — no aparece mezclado con resultados de electricidad en esa misma
+búsqueda. Cuando Constanza entra a su perfil completo, ve las dos categorías que ofrece, así que piensa "ya
+que vino, le pregunto también por el enchufe que no funciona en la pieza". En el otro extremo, don Sergio
+corta pasto y desmaleza con máquina en La Reina — dos categorías del mismo rubro de jardín y aseo exterior
+— y aparece en los resultados de ambas búsquedas sin tener que crear dos perfiles ni pagarle a Datealo el
+doble por existir dos veces.
 
 ### Capacidades del ideal
 
-| Capacidad | Acción habilitada    | Respuesta esperada              | Conclusión que la justifica |
-| --------- | -------------------- | ------------------------------- | --------------------------- |
-| <nombre>  | <qué se puede hacer> | <qué produce o explica Datealo> | [C-001](#c-001)             |
+| Capacidad                                    | Acción habilitada                                                                                  | Respuesta esperada                                                                                     | Conclusión que la justifica |
+| --------------------------------------------- | --------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | ---------------------------- |
+| Declarar más de una categoría                 | El profesional agrega, al crear o editar su perfil, cualquier categoría activa donde tenga las herramientas o habilidades | Datealo guarda todas las categorías que declaró, no solo una                                             | [C-001](#c-001)               |
+| Aparecer en cualquiera de sus búsquedas       | El buscador filtra por una categoría a la vez (`/buscar?categoria=X`)                                | El profesional multi-categoría aparece en los resultados de cada categoría que declaró, no solo la primera | [C-001](#c-001), [C-002](#c-002) |
+| Ver todas sus categorías desde cualquier entrada | Alguien llega al perfil completo del profesional desde cualquiera de sus categorías                | El perfil muestra todas las categorías que ofrece, no solo la que trajo la búsqueda                       | [C-001](#c-001)               |
 
-### El ideal no significa <confusión probable>
+### El ideal no significa que cualquiera declara cualquier categoría sin control, ni que el precio cambia por categoría desde ya
 
-- <límite conceptual que evita una interpretación incorrecta>.
+- No significa que un profesional puede declarar cualquier categoría sin ningún control de que realmente
+  tiene esa habilidad — la verificación real (si Datealo la implementa) es un problema de confianza
+  aparte, no algo que esta misión deba inventar para justificar un tope.
+- No significa que el precio orientativo o la descripción tienen que variar por categoría desde el día uno
+  — eso es una pregunta abierta (ver C-003), no una conclusión cerrada; puede resolverse manteniendo un
+  precio y una descripción únicos por profesional en la primera entrega.
+- No significa "categorías ilimitadas" como decisión ya tomada — el benchmark descarta que el tope exista
+  por control de calidad, pero si existe un tope por legibilidad visual, esa es una decisión de
+  `producto.md`/`experiencia.md`, no algo que la investigación resuelva por sí sola.
 
 ## Referencias
 
-<!-- Fuentes primarias citadas por las evidencias. El enlace no sustituye el hecho y el límite en E-xxx. -->
-
-- [<título descriptivo>](URL): usado en E-001 para <afirmación concreta>.
+- [Thumbtack — guía de perfil](https://help.thumbtack.com/article/profile-guide): usado en E-002 para
+  confirmar que no hay tope documentado de categorías por profesional.
+- [TaskRabbit — qué categorías agregar a tu perfil](https://support.taskrabbit.com/hc/en-us/articles/360052736472-Which-Task-Categories-Should-I-Add-To-My-Profile):
+  usado en E-003 para la auto-certificación por categoría.
+- [TaskRabbit — cómo redactar la experiencia por categoría](https://www.taskrabbit.com/blog/crafting-the-ultimate-skills-and-experience-description/):
+  usado en E-003 para confirmar que la experiencia se describe por categoría, no una sola vez.

--- a/docs/missions/14-multiples-categorias-profesional/producto.md
+++ b/docs/missions/14-multiples-categorias-profesional/producto.md
@@ -1,149 +1,240 @@
-# Misión: <nombre> — Producto
+# Misión: múltiples categorías por profesional — Producto
 
-**Estado:** borrador
+**Estado:** vigente — aprobado por Patricio Tabilo el 2026-09-06. [Q-001](#q-001) quedó resuelta por
+`experiencia.md`.
 
-**Última actualización:** AAAA-MM-DD
+**Última actualización:** 2026-09-06
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-<!--
-Este documento es la spec viva del resultado: qué construimos ahora y bajo qué reglas. El porqué vive en
-investigacion.md — aquí solo se enlaza. Se reescribe cuando el alcance cambia; no acumula historia.
+## Qué construimos: un profesional declara más de una categoría, cada una con su propio precio y descripción, y aparece en los resultados de todas
 
-Gate de salida — producto.md está listo para experiencia.md cuando:
-- cada funcionalidad tiene formato JTBD, reglas y al menos un caso límite con comportamiento definido
-- cada funcionalidad enlaza una conclusión de investigacion.md y una señal de éxito
-- cada funcionalidad declara a qué lado del marketplace sirve, y qué necesita del otro lado para funcionar
-- no hay decisiones de producto delegadas a diseño o ingeniería
-- las decisiones propuestas tienen fecha límite en el README
--->
+**Resultado:** un profesional puede agregar categorías adicionales a su perfil (ej. Feña agrega
+"Gasfitería" además de "Electricidad"), cada una con su propio precio orientativo y descripción, y
+aparece en los resultados de búsqueda de cualquiera de las categorías que declaró, con el precio y la
+descripción correctos para esa categoría.
 
-## Qué construimos: <resultado en una frase>
+**Recorte respecto del ideal:** el ideal completo (ver [investigacion.md](./investigacion.md)) no fija
+todavía si declarar una segunda categoría es parte del registro inicial o solo de editar el perfil ya
+creado — resuelto en `experiencia.md` ([UX-001](./experiencia.md#ux-001), ver [Q-001](#q-001)): solo
+editando el perfil, sin tocar el registro. Buscar por varias categorías a la vez en una sola búsqueda
+queda fuera: el buscador sigue siendo de una categoría por vez.
 
-<!--
-El recorte vigente del ideal y por qué sigue entregando el resultado central. Máximo cuatro párrafos
-cortos. El ideal completo vive en investigacion.md.
--->
-
-**Resultado:** <qué podrá lograr una persona al finalizar esta entrega>.
-
-**Recorte respecto del ideal:** <qué dimensión se reduce y por qué sigue siendo suficiente>
-(ver [el ideal](./investigacion.md)).
-
-**Restricciones aceptadas:** <plataforma, cobertura geográfica, categorías, volumen inicial de
-profesionales>.
+**Restricciones aceptadas:** sin tope numérico de categorías por profesional ([D-001](#d-001)); descripción
+por categoría ([D-002](#d-002)) y precio orientativo también por categoría, aunque sin benchmark que lo
+confirme ([D-003](#d-003)); sin verificación de habilidad por categoría — se apoya en la misma confianza
+(reseñas, contacto directo) que ya existe hoy para una sola categoría, no se inventa un paso nuevo de
+certificación.
 
 ## Funcionalidades
 
-| ID    | Funcionalidad                  | Lado         | Sustento     | Éxito |
-| ----- | ------------------------------ | ------------ | ------------ | ----- |
-| F-001 | <verbo + resultado observable> | buscador     | C-001, D-001 | M-001 |
+| ID    | Funcionalidad                                            | Lado                     | Sustento           | Éxito |
+| ----- | --------------------------------------------------------- | ------------------------- | ------------------- | ----- |
+| F-001 | Declarar categorías adicionales en el perfil               | profesional                | C-001, D-001, D-002, D-003 | M-001 |
+| F-002 | Aparecer en los resultados de cualquiera de sus categorías | buscador (consume), profesional (habilita) | C-001, C-002        | M-001 |
+| F-003 | Ver todas las categorías del profesional desde su perfil   | buscador                   | C-001                | M-001 |
 
 <a id="f-001"></a>
 
-### F-001 — <verbo + resultado observable>
+### F-001 — Declarar categorías adicionales en el perfil
 
-<!--
-Duplica este bloque por funcionalidad. Se escribe desde el resultado del usuario (working backwards):
-primero el JTBD, después las reglas. Si la respuesta de Datealo no se puede describir sin hablar de tablas
-o componentes, falta cerrar la decisión de producto.
--->
+Cuando Feña ya tiene su perfil creado con una sola categoría (Electricidad) y quiere que también lo
+encuentren por Gasfitería,
+quiero agregar Gasfitería como otra categoría de su perfil, con su propio precio orientativo y
+descripción,
+para aparecer en las búsquedas de ambas categorías sin crear un perfil nuevo.
 
-Cuando <usuario en contexto concreto>,
-quiero <acción>,
-para <resultado observable>.
+**Lado del marketplace:** profesional. **Qué necesita del otro lado:** nada para que la funcionalidad
+exista — Feña puede declarar una segunda categoría aunque hoy no haya nadie buscando gasfitería en
+Ñuñoa. Pero el valor real de hacerlo (que le llegue un contacto nuevo) depende de que exista demanda de
+búsqueda en esa categoría-comuna; sin eso, declarar es trabajo extra sin retorno visible a corto plazo
+(cold start del lado buscador).
 
-**Lado del marketplace:** buscador, profesional o ambos. **Qué necesita del otro lado:** <volumen mínimo
-de perfiles, reseñas o cobertura sin el cual esta funcionalidad no entrega su resultado>.
-
-**Sustento:** [C-001](./investigacion.md#c-001) y [D-001](#d-001). **Éxito:** [M-001](#m-001).
+**Sustento:** [C-001](./investigacion.md#c-001) y [D-001](#d-001), [D-002](#d-002), [D-003](#d-003).
+**Éxito:** [M-001](#m-001).
 
 **Reglas:**
 
-- Si <condición>, Datealo <comportamiento esperado>.
-- Si <caso límite>, Datealo <comportamiento seguro y qué información muestra>.
-- Datealo nunca <comportamiento que rompería el significado o la confianza>.
+- Si el profesional agrega una categoría que no tenía, Datealo le pide precio orientativo y descripción
+  para esa categoría específica (ambos opcionales, igual que hoy permite un perfil sin descripción).
+- Si el profesional quita una categoría que tenía, Datealo deja de mostrarlo en los resultados de esa
+  categoría de inmediato.
+- Datealo nunca deja a un profesional sin ninguna categoría activa — la interfaz no permite quitar la
+  última que le queda.
 
-**Ejemplo verificable:** dado <estado con datos concretos>, cuando <acción>, entonces <resultado
-observable>.
+**Ejemplo verificable:** dado que Feña tiene declarada Electricidad con precio $20.000, cuando agrega
+Gasfitería con precio $18.000, entonces su perfil público muestra ambas categorías, cada una con su
+propio precio.
 
-**No incluye:** <variante del ideal excluida de esta funcionalidad>.
+**No incluye:** verificar que el profesional realmente sepa hacer el oficio que declara — es un problema
+de confianza aparte, no algo que esta funcionalidad deba resolver.
 
-**Experiencia:** <enlace a UXF-xxx cuando exista>. **Ingeniería:** <enlace a T-xxx cuando exista>.
+**Experiencia:** pendiente. **Ingeniería:** pendiente.
+
+<a id="f-002"></a>
+
+### F-002 — Aparecer en los resultados de cualquiera de sus categorías
+
+Cuando Constanza busca "gasfiter" en Ñuñoa,
+quiero que el buscador filtre por categoría igual que hoy,
+para ver a Feña en esa lista aunque su categoría declarada primero haya sido electricidad.
+
+**Lado del marketplace:** buscador consume el resultado; profesional lo habilita al declarar. **Qué
+necesita del otro lado:** que existan profesionales con 2+ categorías declaradas en esa comuna — sin eso
+esta funcionalidad no cambia nada observable para quien busca.
+
+**Sustento:** [C-001](./investigacion.md#c-001), [C-002](./investigacion.md#c-002). **Éxito:**
+[M-001](#m-001).
+
+**Reglas:**
+
+- Si un profesional declaró 2+ categorías, aparece en los resultados de cada una por separado, como si
+  tuviera un perfil dedicado a esa categoría.
+- Si dos categorías del mismo profesional tienen precios distintos, la card de resultado muestra el
+  precio de la categoría por la que se está buscando, nunca el de otra.
+- Datealo nunca muestra al mismo profesional dos veces dentro de los resultados de una sola búsqueda.
+
+**Ejemplo verificable:** dado que Feña declaró Electricidad ($20.000) y Gasfitería ($18.000), cuando
+alguien busca "gasfiter" en Ñuñoa, entonces Feña aparece en esa lista con el precio $18.000, no $20.000.
+
+**No incluye:** buscar por más de una categoría a la vez (ej. `/buscar?categoria=electricidad,gasfiteria`)
+— el buscador sigue siendo de una categoría por búsqueda.
+
+<a id="f-003"></a>
+
+### F-003 — Ver todas las categorías del profesional desde su perfil
+
+Cuando Constanza entra al perfil completo de Feña desde un resultado de "Gasfitería",
+quiero ver que también hace Electricidad,
+para poder pedirle los dos trabajos sin tener que buscar de nuevo.
+
+**Lado del marketplace:** buscador. **Qué necesita del otro lado:** que el profesional tenga más de una
+categoría declarada — con una sola, el perfil se ve igual que hoy.
+
+**Sustento:** [C-001](./investigacion.md#c-001). **Éxito:** [M-001](#m-001).
+
+**Reglas:**
+
+- El perfil público lista todas las categorías activas que el profesional declaró, cada una con su
+  precio y descripción propios.
+- Si el profesional declaró solo una categoría, el perfil se ve exactamente igual que hoy — sin lista
+  extra ni espacio vacío.
+- Datealo nunca mezcla el precio o la descripción de una categoría con la de otra dentro del mismo
+  perfil.
+
+**Ejemplo verificable:** dado que Feña declaró Electricidad y Gasfitería, cuando alguien abre su perfil
+completo, entonces ve dos bloques de categoría, cada uno con su propio precio y descripción.
+
+**No incluye:** ordenar las categorías por relevancia a la búsqueda que trajo a la persona — el orden de
+presentación queda para `experiencia.md`. Tampoco incluye dividir las reseñas por categoría: el rating y
+las reseñas que ve Constanza son las del profesional completo, iguales sin importar por cuál categoría
+haya llegado (ver "Fuera de alcance").
 
 ## Casos límite que cruzan funcionalidades
 
-<!--
-Solo condiciones que afectan varias funcionalidades. Las propias de una viven en su bloque. Un caso
-retirado no se borra ni se reutiliza: conserva su fila, o se nombra con su motivo en una línea debajo.
-
-Los casos límite propios de un marketplace pre-lanzamiento aparecen acá: cero resultados en una comuna,
-un profesional sin reseñas, una categoría con un solo perfil, un perfil sin verificar.
--->
-
-| ID     | Condición concreta     | Comportamiento esperado | Funcionalidades |
-| ------ | ---------------------- | ----------------------- | --------------- |
-| CL-001 | <estado o combinación> | <qué hace Datealo>      | F-001           |
+| ID     | Condición concreta                                                | Comportamiento esperado                                                                 | Funcionalidades      |
+| ------ | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ---------------------- |
+| CL-001 | Profesional con una sola categoría (la mayoría absoluta hoy), visto desde resultados de búsqueda o perfil público | Datealo se comporta exactamente igual que antes de esta misión, sin ningún cambio visible — la edición de su propio perfil sí gana la opción nueva de agregar otra categoría, aunque no la use | F-002, F-003 (F-001 gana la opción nueva de agregar, pero editar la categoría que ya tenía no cambia) |
+| CL-002 | Profesional intenta quitar su última categoría activa                | Datealo no permite guardar — debe quedar al menos una categoría                          | F-001                  |
+| CL-003 | Dos categorías del mismo profesional con el mismo precio             | Se muestran igual en cada bloque, sin necesidad de indicar que "coinciden"                | F-003                  |
+| CL-004 | Profesional con muchas categorías declaradas (5 o más)                | La card de resultado de una búsqueda no cambia (sigue mostrando solo la categoría buscada); la legibilidad del perfil completo con muchas categorías se resuelve en `experiencia.md` | F-003 |
+| CL-005 | Profesional que ya existía antes de esta funcionalidad, con `priceFrom`/`description` en las columnas actuales de `professionals` | Datealo migra esos valores como el precio y la descripción de la única categoría que ya tenía declarada — no le pide volver a ingresarlos | F-001 |
 
 ## Fuera de alcance
 
-<!-- Distingue postergado de descartado y qué condición justificaría reabrirlo. -->
-
-| Capacidad o caso      | Estado                  | Razón del recorte | Condición para reconsiderar |
-| --------------------- | ----------------------- | ----------------- | --------------------------- |
-| <capacidad del ideal> | postergada o descartada | <trade-off>       | <evidencia o hito>          |
+| Capacidad o caso                                                      | Estado     | Razón del recorte                                                                                                          | Condición para reconsiderar                                  |
+| ------------------------------------------------------------------------ | ---------- | ------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------- |
+| Buscar por más de una categoría a la vez en una sola búsqueda            | postergada | El buscador de una categoría a la vez ya funciona y no hay evidencia de que "buscar electricidad y gasfitería juntos" sea un patrón real | Evidencia de búsquedas combinadas repetidas una vez que haya uso   |
+| Verificación de habilidad por categoría (auto-certificación estilo TaskRabbit) | postergada | Es un problema de confianza/verificación aparte, no de cobertura de categorías — no se inventa acá para justificar nada     | Decisión explícita de abrir una misión de verificación            |
+| Tope numérico de categorías por profesional                              | descartada | [D-001](#d-001) decide sin límite; la legibilidad de card/perfil se resuelve con diseño visual, no con una regla de negocio | Evidencia de spam de categorías una vez en producción             |
+| Dividir las reseñas por categoría                                        | postergada | `reviews` no tiene columna de categoría — es del profesional completo, no de una categoría suya. Separarlas exigiría agregar esa columna y decidir a qué categoría asignar cada reseña que ya existe (todas nacieron cuando el profesional tenía una sola categoría) | Evidencia de que una reseña de una categoría se lea como engañosa al mostrarse en otra (ej. una reseña de corte de pelo mostrada en un perfil que además hace gasfitería) |
 
 ## Señales de éxito
 
 <a id="m-001"></a>
 
-### M-001 — <señal que demuestra el resultado>
+### M-001 — Declarar una segunda categoría le trae contactos nuevos al profesional, no solo trabajo extra
 
-- **Pregunta:** ¿<qué queremos comprobar>?
-- **Señal:** <comportamiento o resultado observable>.
-- **Método y umbral:** <instrumentación o revisión, qué resultado, en qué población y ventana>.
-- **Guardrail:** <daño que no debe aumentar para conseguir la señal>.
+- **Pregunta:** ¿declarar una segunda categoría realmente le trae contactos al profesional, o nadie la
+  usa para contactarlo?
+- **Señal:** de los contactos totales que reciben los profesionales con 2+ categorías declaradas, la
+  proporción que llega por una categoría que no es la primera que declararon.
+- **Método y umbral:** revisión manual (sin volumen para instrumentación estadística todavía) cada dos
+  semanas durante el primer mes desde que la funcionalidad esté disponible, sobre los profesionales
+  multi-categoría activos. Sin umbral numérico fijo todavía — se define una vez que haya al menos 10
+  profesionales multi-categoría con contactos registrados.
+- **Guardrail:** la tasa de contacto de la categoría principal (la primera que declaró cada profesional)
+  no debe bajar. Si declarar una segunda categoría le resta contactos a la primera en vez de sumar
+  contactos nuevos, la funcionalidad no está cumpliendo su propósito.
 
 ## Decisiones de producto
 
-<!--
-Solo decisiones con alternativas reales. No borres decisiones reemplazadas: explican por qué el producto
-es como es. Toda decisión propuesta se refleja en el README con fecha límite.
--->
-
 <a id="d-001"></a>
 
-### D-001 — <decisión en una frase que se entiende sola>
+### D-001 — No hay tope numérico a la cantidad de categorías que un profesional puede declarar
 
-- **Estado:** propuesta, aceptada, reemplazada o descartada. **Fecha:** AAAA-MM-DD.
-- **Sustento:** [C-001](./investigacion.md#c-001).
-- **Tensión:** <criterios que no podían maximizarse al mismo tiempo>.
-- **Alternativas descartadas:** <opciones y razón concreta del rechazo, en la misma línea>.
-- **Decisión y consecuencia:** <qué se hará y qué habilita, limita o exige revisar en UX e ingeniería>.
-- **Reapertura:** <evidencia o cambio que justificaría revisarla>.
+- **Estado:** aceptada. **Fecha:** 2026-09-06.
+- **Sustento:** [C-002](./investigacion.md#c-002).
+- **Tensión:** legibilidad del perfil y la card de resultados frente a cobertura real de oferta — más
+  categorías declaradas es más oferta visible, pero un perfil con demasiadas categorías puede leerse como
+  spam.
+- **Alternativas descartadas:** tope de 2 categorías (alcanza para el caso más común — electricidad +
+  gasfitería — pero corta el patrón real cuando aparece un tercer oficio relacionado, ej. quien además
+  hace mantención general); tope de 3 categorías (no resuelve el problema real, que es legibilidad visual
+  — ese problema se resuelve truncando la presentación en `experiencia.md`, no prohibiendo declarar una
+  cuarta categoría en el dato).
+- **Decisión y consecuencia:** el modelo de datos no impone límite; la legibilidad de card y perfil se
+  resuelve con diseño visual (mostrar un máximo visible con "+N más" si hace falta), decisión que le
+  corresponde a `experiencia.md`, no a esta.
+- **Reapertura:** si en producción aparecen perfiles usando categorías irrelevantes solo para aparecer en
+  más búsquedas, reconsiderar un tope o algo de fricción para agregar categorías adicionales.
+
+<a id="d-002"></a>
+
+### D-002 — La descripción pasa a ser por categoría, no un valor único del profesional
+
+- **Estado:** aceptada. **Fecha:** 2026-09-06.
+- **Sustento:** [C-003](./investigacion.md#c-003).
+- **Tensión:** fidelidad al caso real (la experiencia de Feña en gasfitería no es la misma que en
+  electricidad) frente al costo de rediseñar el modelo de datos y el formulario de perfil — hoy
+  `description` es una columna única de `professionals`, y `perfil.vue` la edita como un solo campo.
+- **Alternativas descartadas:** mantenerla única por profesional (más simple de construir, pero un
+  profesional no puede describir por separado su experiencia en cada oficio — termina con un texto
+  genérico que no dice nada específico de ninguna de sus categorías).
+- **Decisión y consecuencia:** la futura relación profesional-categoría lleva su propia `description`, no
+  solo el vínculo — esto es lo que `ingenieria.md` tiene que modelar. `perfil.vue` pasa de editar una
+  descripción global a editar una por categoría declarada.
+- **Reapertura:** si en la práctica casi todos los profesionales dejan la misma descripción en todas sus
+  categorías, evaluar volver a un valor único con anulación opcional por categoría.
+
+<a id="d-003"></a>
+
+### D-003 — El precio orientativo también pasa a ser por categoría, aunque ningún benchmark lo confirma
+
+- **Estado:** aceptada. **Fecha:** 2026-09-06.
+- **Sustento:** ninguno directo en `investigacion.md` — [E-003](./investigacion.md#e-003) confirma que
+  TaskRabbit separa la *descripción* por categoría, pero no dice nada sobre el precio. Esta decisión es
+  una inferencia del caso real ya registrado en [C-001](./investigacion.md#c-001) (Feña cobra distinto
+  según el oficio), no una lectura de evidencia — se marca así para no leerse como más sólida de lo que
+  es.
+- **Tensión:** la misma fidelidad al caso real (un electricista y un gasfiter no cobran lo mismo por hora)
+  frente al mismo costo de rediseño que D-002, pero acá sin el respaldo de un benchmark que lo confirme.
+- **Alternativas descartadas:** mantener el precio único mientras solo la descripción varía por categoría
+  (opción mixta, más barata de construir y más alineada con la evidencia disponible) — descartada porque
+  un precio único que promedia gasfitería y electricidad no representa bien ninguna de las dos, y separar
+  precio y descripción en dos patrones distintos (uno por categoría, otro global) es más confuso de
+  explicar que tratarlos igual.
+- **Decisión y consecuencia:** la relación profesional-categoría lleva también su propio `priceFrom`. Si
+  en la práctica esto resulta ser una sobre-construcción (ver Reapertura), el costo de revertir es menor
+  que el de dejarlo fuera y tener que agregarlo después sobre una tabla ya en uso.
+- **Reapertura:** si al tener profesionales multi-categoría reales, la mayoría deja el mismo precio en
+  todas sus categorías, esto pasa a confirmar que un precio único hubiera bastado — volver a esa opción.
 
 ## Preguntas
 
-<!--
-Solo preguntas que pueden cambiar una decisión o funcionalidad. Lo demás va a un issue.
-Todas viven en esta tabla ordenada por ID, abiertas y cerradas juntas. Ningún ID se borra ni se reutiliza.
-Estado: abierta | resuelta AAAA-MM-DD (alguien la respondió) | disuelta AAAA-MM-DD (el producto cambió y la
-pregunta dejó de tener sentido). Solo las abiertas llevan bloque de detalle debajo de la tabla.
--->
+Ninguna pregunta bloquea el gate — Q-001 quedó resuelta por `experiencia.md`.
 
-<Una frase que responde "¿qué falta?": la pregunta que bloquea y qué bloquea.>
-
-| ID    | La duda                | Estado              | Respuesta, o quién la resuelve                                  |
-| ----- | ---------------------- | ------------------- | --------------------------------------------------------------- |
-| Q-001 | <la duda en una frase> | abierta             | <quién la resuelve, con qué método, qué bloquea y hasta cuándo> |
-| Q-002 | <la duda en una frase> | resuelta AAAA-MM-DD | <qué se respondió, enlazando la decisión que la cerró>          |
-
-<a id="q-001"></a>
-
-### Q-001 — <la pregunta en una frase que se entiende sola>
-
-- **La duda, con un ejemplo:** <el caso concreto que muestra por qué hay dos respuestas posibles>.
-- **Afecta a:** D-001 o F-001.
-- **Cómo se resolverá:** <quién y con qué método>.
-- **¿Bloquea algo?:** <qué bloquea y su fecha límite, o no>.
+| ID    | La duda                                                                 | Estado  | Respuesta, o quién la resuelve                                                                    |
+| ----- | -------------------------------------------------------------------------- | ------- | ---------------------------------------------------------------------------------------------------- |
+| Q-001 | ¿Declarar categorías adicionales es parte del registro inicial o solo de editar el perfil ya creado? | resuelta 2026-09-06 | Solo editando el perfil, nunca en el registro — [UX-001](./experiencia.md#ux-001) en `experiencia.md`: el registro (misión 04) no se toca, y añadir precio/descripción por categoría al wizard de registro agrega fricción justo donde el arranque en frío del lado profesional ya es difícil. |

--- a/docs/missions/README.md
+++ b/docs/missions/README.md
@@ -22,7 +22,7 @@ abrieron y de dónde salió cada una.
 | 11  | [vista de detalle de perfil](./11-perfil-profesional/) | producto | 2026-09-01 | cerrada 2026-09-04 | — | — |
 | 12  | [hero y copy de la landing](./12-hero-y-copy-landing/) | producto | 2026-09-01 | cerrada 2026-09-06 | — | — |
 | 13  | [tamaño de fuente](./13-tamano-de-fuente/) | producto | 2026-09-06 | lista para construir | — | — |
-| 14  | [múltiples categorías por profesional](./14-multiples-categorias-profesional/) | producto | 2026-09-06 | exploración | Investigación | — |
+| 14  | [múltiples categorías por profesional](./14-multiples-categorias-profesional/) | producto | 2026-09-06 | lista para construir | — | — |
 | 15  | [múltiples comunas por profesional](./15-multiples-comunas-profesional/) | producto | 2026-09-06 | exploración | Investigación | — |
 
 Misiones 02 a 07 son las seis que llevan al MVP (registrarse, mostrarse, buscar, reseñar), en el orden de


### PR DESCRIPTION
## Resumen

- Cierra el discovery de la misión 14: `producto.md`, `experiencia.md` e `ingenieria.md` quedan `vigente`, aprobados por Patricio Tabilo el 2026-09-07.
- Un profesional podrá declarar más de una categoría (ej. electricidad + gasfitería), cada una con su propio precio y descripción, y aparecerá en los resultados de búsqueda de cualquiera que tenga declarada.
- `ingenieria.md` corta el cambio de modelo de datos (`professionals` → tabla `professional_categorias`) en expand/contract, 9 slices verticales, ya pasado por la auditoría en contexto separado del gate. Esa pasada encontró y resolvió dos hallazgos bloqueantes: el corte original por capa dejaba la app rota a mitad de camino, y la baja de la última categoría tenía una condición de carrera (resuelta con `select ... for update`).

## Plan de construcción (referencia)

9 slices, de S-001 (tabla + RLS + migración) a S-009 (contract: retirar columnas legacy). Detalle completo en [`ingenieria.md`](../blob/worktree-14-multiples-categorias-profesional/docs/missions/14-multiples-categorias-profesional/ingenieria.md#plan-de-construcción).

## Test plan

- [ ] Revisar `producto.md`, `experiencia.md` e `ingenieria.md` de la misión 14
- [ ] Confirmar que el estado de la misión en `docs/missions/README.md` quedó como "lista para construir"
- Sin código de aplicación en este PR — es solo discovery, no requiere `typecheck`/`build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cx9fvJrGPvcHHPU6b6dyFz