### PR TITLE
feat(db): crear professional_categorias con RLS y migrar datos existentes

### DIFF
--- a/docs/missions/14-multiples-categorias-profesional/README.md
+++ b/docs/missions/14-multiples-categorias-profesional/README.md
@@ -4,18 +4,19 @@
 categoría por profesional) y cómo `/api/search` filtra por categoría. **Abierta el** 2026-09-06.
 **Nace de:** ninguna.
 
-**Estado de la misión:** lista para construir
+**Estado de la misión:** en construcción
 
-**En foco:** ninguno — los tres documentos (`producto.md`, `experiencia.md`, `ingenieria.md`) están
-`vigente`
+**En foco:** ninguno — discovery cerrado, los tres documentos (`producto.md`, `experiencia.md`,
+`ingenieria.md`) están `vigente`
 
 **Última actualización:** 2026-09-07
 
 **Documentos:** [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-**Próximo hito:** abrir el PR de discovery con los tres documentos vigentes (paso 6 de la secuencia en
-`docs/missions/README.md`). Sin fecha límite todavía.
+**Próximo hito:** issues creados desde el Plan de construcción (#225 a #233, S-001 a S-009). Trabajando
+S-001 (#225) primero — el resto sigue el orden de dependencias del Plan de construcción de
+`ingenieria.md`.
 
 ## Brief
 

--- a/docs/missions/README.md
+++ b/docs/missions/README.md
@@ -22,7 +22,7 @@ abrieron y de dónde salió cada una.
 | 11  | [vista de detalle de perfil](./11-perfil-profesional/) | producto | 2026-09-01 | cerrada 2026-09-04 | — | — |
 | 12  | [hero y copy de la landing](./12-hero-y-copy-landing/) | producto | 2026-09-01 | cerrada 2026-09-06 | — | — |
 | 13  | [tamaño de fuente](./13-tamano-de-fuente/) | producto | 2026-09-06 | cerrada 2026-09-06 | — | — |
-| 14  | [múltiples categorías por profesional](./14-multiples-categorias-profesional/) | producto | 2026-09-06 | lista para construir | — | — |
+| 14  | [múltiples categorías por profesional](./14-multiples-categorias-profesional/) | producto | 2026-09-06 | en construcción | — | — |
 | 15  | [múltiples comunas por profesional](./15-multiples-comunas-profesional/) | producto | 2026-09-06 | lista para construir | — | — |
 
 Misiones 02 a 07 son las seis que llevan al MVP (registrarse, mostrarse, buscar, reseñar), en el orden de

--- a/server/db/migrations/0009_sturdy_puma.sql
+++ b/server/db/migrations/0009_sturdy_puma.sql
@@ -1,0 +1,18 @@
+CREATE TABLE "professional_categorias" (
+	"professional_id" uuid NOT NULL,
+	"categoria_slug" text NOT NULL,
+	"price_from" integer,
+	"description" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "professional_categorias_professional_id_categoria_slug_pk" PRIMARY KEY("professional_id","categoria_slug")
+);
+--> statement-breakpoint
+ALTER TABLE "professional_categorias" ADD CONSTRAINT "professional_categorias_professional_id_professionals_id_fk" FOREIGN KEY ("professional_id") REFERENCES "public"."professionals"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "professional_categorias" ADD CONSTRAINT "professional_categorias_categoria_slug_categorias_slug_fk" FOREIGN KEY ("categoria_slug") REFERENCES "public"."categorias"("slug") ON DELETE no action ON UPDATE cascade;--> statement-breakpoint
+CREATE INDEX "professional_categorias_categoria_slug_idx" ON "professional_categorias" USING btree ("categoria_slug");--> statement-breakpoint
+-- Backfill: cada profesional existente conserva su categoría/precio/descripción actuales como su
+-- primera categoría declarada. created_at se copia de professionals (no now()) para que el orden
+-- de "primera categoría" siga reflejando cuándo se registró, no cuándo corrió esta migración.
+INSERT INTO "professional_categorias" ("professional_id", "categoria_slug", "price_from", "description", "created_at")
+SELECT "id", "categoria_slug", "price_from", "description", "created_at"
+FROM "professionals";

--- a/server/db/migrations/meta/0009_snapshot.json
+++ b/server/db/migrations/meta/0009_snapshot.json
@@ -1,0 +1,634 @@
+{
+  "id": "ae6f0cdd-2b9e-4f63-95e4-d6c06a0a9129",
+  "prevId": "c9d1e7a5-aae6-4e46-b843-15e6b176757c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.categorias": {
+      "name": "categorias",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "nombre": {
+          "name": "nombre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activa": {
+          "name": "activa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comuna_vecinas": {
+      "name": "comuna_vecinas",
+      "schema": "",
+      "columns": {
+        "comuna_codigo": {
+          "name": "comuna_codigo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vecina_codigo": {
+          "name": "vecina_codigo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comuna_vecinas_comuna_codigo_comunas_codigo_fk": {
+          "name": "comuna_vecinas_comuna_codigo_comunas_codigo_fk",
+          "tableFrom": "comuna_vecinas",
+          "tableTo": "comunas",
+          "columnsFrom": [
+            "comuna_codigo"
+          ],
+          "columnsTo": [
+            "codigo"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "comuna_vecinas_vecina_codigo_comunas_codigo_fk": {
+          "name": "comuna_vecinas_vecina_codigo_comunas_codigo_fk",
+          "tableFrom": "comuna_vecinas",
+          "tableTo": "comunas",
+          "columnsFrom": [
+            "vecina_codigo"
+          ],
+          "columnsTo": [
+            "codigo"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "comuna_vecinas_comuna_codigo_vecina_codigo_pk": {
+          "name": "comuna_vecinas_comuna_codigo_vecina_codigo_pk",
+          "columns": [
+            "comuna_codigo",
+            "vecina_codigo"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comunas": {
+      "name": "comunas",
+      "schema": "",
+      "columns": {
+        "codigo": {
+          "name": "codigo",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "nombre": {
+          "name": "nombre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activa": {
+          "name": "activa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.professional_categorias": {
+      "name": "professional_categorias",
+      "schema": "",
+      "columns": {
+        "professional_id": {
+          "name": "professional_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "categoria_slug": {
+          "name": "categoria_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_from": {
+          "name": "price_from",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "professional_categorias_categoria_slug_idx": {
+          "name": "professional_categorias_categoria_slug_idx",
+          "columns": [
+            {
+              "expression": "categoria_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "professional_categorias_professional_id_professionals_id_fk": {
+          "name": "professional_categorias_professional_id_professionals_id_fk",
+          "tableFrom": "professional_categorias",
+          "tableTo": "professionals",
+          "columnsFrom": [
+            "professional_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "professional_categorias_categoria_slug_categorias_slug_fk": {
+          "name": "professional_categorias_categoria_slug_categorias_slug_fk",
+          "tableFrom": "professional_categorias",
+          "tableTo": "categorias",
+          "columnsFrom": [
+            "categoria_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "professional_categorias_professional_id_categoria_slug_pk": {
+          "name": "professional_categorias_professional_id_categoria_slug_pk",
+          "columns": [
+            "professional_id",
+            "categoria_slug"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.professional_contact_events": {
+      "name": "professional_contact_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "professional_id": {
+          "name": "professional_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "professional_contact_events_professional_id_idx": {
+          "name": "professional_contact_events_professional_id_idx",
+          "columns": [
+            {
+              "expression": "professional_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "professional_contact_events_professional_id_professionals_id_fk": {
+          "name": "professional_contact_events_professional_id_professionals_id_fk",
+          "tableFrom": "professional_contact_events",
+          "tableTo": "professionals",
+          "columnsFrom": [
+            "professional_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.professional_contact_tokens": {
+      "name": "professional_contact_tokens",
+      "schema": "",
+      "columns": {
+        "professional_id": {
+          "name": "professional_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "professional_contact_tokens_professional_id_professionals_id_fk": {
+          "name": "professional_contact_tokens_professional_id_professionals_id_fk",
+          "tableFrom": "professional_contact_tokens",
+          "tableTo": "professionals",
+          "columnsFrom": [
+            "professional_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "professional_contact_tokens_professional_id_token_pk": {
+          "name": "professional_contact_tokens_professional_id_token_pk",
+          "columns": [
+            "professional_id",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.professionals": {
+      "name": "professionals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "categoria_slug": {
+          "name": "categoria_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comuna_codigo": {
+          "name": "comuna_codigo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact": {
+          "name": "contact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_from": {
+          "name": "price_from",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_paths": {
+          "name": "photo_paths",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "avatar_path": {
+          "name": "avatar_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "professionals_categoria_slug_idx": {
+          "name": "professionals_categoria_slug_idx",
+          "columns": [
+            {
+              "expression": "categoria_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "professionals_comuna_codigo_idx": {
+          "name": "professionals_comuna_codigo_idx",
+          "columns": [
+            {
+              "expression": "comuna_codigo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "professionals_categoria_slug_categorias_slug_fk": {
+          "name": "professionals_categoria_slug_categorias_slug_fk",
+          "tableFrom": "professionals",
+          "tableTo": "categorias",
+          "columnsFrom": [
+            "categoria_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "professionals_comuna_codigo_comunas_codigo_fk": {
+          "name": "professionals_comuna_codigo_comunas_codigo_fk",
+          "tableFrom": "professionals",
+          "tableTo": "comunas",
+          "columnsFrom": [
+            "comuna_codigo"
+          ],
+          "columnsTo": [
+            "codigo"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "professionals_user_id_unique": {
+          "name": "professionals_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "professional_id": {
+          "name": "professional_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reviews_professional_id_professionals_id_fk": {
+          "name": "reviews_professional_id_professionals_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "professionals",
+          "columnsFrom": [
+            "professional_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "reviews_professional_id_token_fk": {
+          "name": "reviews_professional_id_token_fk",
+          "tableFrom": "reviews",
+          "tableTo": "professional_contact_tokens",
+          "columnsFrom": [
+            "professional_id",
+            "token"
+          ],
+          "columnsTo": [
+            "professional_id",
+            "token"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reviews_professional_id_token_key": {
+          "name": "reviews_professional_id_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "professional_id",
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "reviews_rating_check": {
+          "name": "reviews_rating_check",
+          "value": "\"reviews\".\"rating\" between 1 and 5"
+        },
+        "reviews_comment_length_check": {
+          "name": "reviews_comment_length_check",
+          "value": "char_length(\"reviews\".\"comment\") <= 500"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/db/migrations/meta/_journal.json
+++ b/server/db/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1788299814878,
       "tag": "0008_open_harrier",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1788812415080,
+      "tag": "0009_sturdy_puma",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/schema/index.ts
+++ b/server/db/schema/index.ts
@@ -1,6 +1,7 @@
 export * from './categorias'
 export * from './comuna-vecinas'
 export * from './comunas'
+export * from './professional-categorias'
 export * from './professional-contact-events'
 export * from './professional-contact-tokens'
 export * from './professionals'

--- a/server/db/schema/professional-categorias.ts
+++ b/server/db/schema/professional-categorias.ts
@@ -1,0 +1,24 @@
+import { index, integer, pgTable, primaryKey, text, timestamp, uuid } from 'drizzle-orm/pg-core'
+import { categorias } from './categorias'
+import { professionals } from './professionals'
+
+export const professionalCategorias = pgTable(
+  'professional_categorias',
+  {
+    professionalId: uuid('professional_id')
+      .notNull()
+      .references(() => professionals.id, { onDelete: 'cascade' }),
+    categoriaSlug: text('categoria_slug')
+      .notNull()
+      .references(() => categorias.slug, { onUpdate: 'cascade' }),
+    priceFrom: integer('price_from'),
+    description: text('description'),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  table => [
+    primaryKey({ columns: [table.professionalId, table.categoriaSlug] }),
+    // Postgres no indexa una FK automáticamente, y esta es la columna por la que filtra
+    // /api/search — la superficie de más tráfico esperado.
+    index('professional_categorias_categoria_slug_idx').on(table.categoriaSlug),
+  ],
+)

--- a/server/db/sql/rls.sql
+++ b/server/db/sql/rls.sql
@@ -74,6 +74,52 @@ create policy professionals_update_own on professionals
 -- rol dueño de Drizzle, donde auth.uid() es NULL, y rompería todo insert/update del servidor.
 revoke all on public.professionals from anon, authenticated;
 
+-- professional_categorias: mismo patrón asimétrico que professionals (lectura pública, escritura
+-- solo del dueño), pero la pertenencia se resuelve con un exists contra professionals.user_id — esta
+-- tabla no tiene user_id propio. A diferencia de professionals, sí lleva policy de delete: acá existe
+-- una operación real de borrado (quitar una categoría propia).
+
+alter table professional_categorias enable row level security;
+
+drop policy if exists professional_categorias_select_public on professional_categorias;
+create policy professional_categorias_select_public on professional_categorias
+  for select to authenticated, anon using (true);
+
+drop policy if exists professional_categorias_insert_own on professional_categorias;
+create policy professional_categorias_insert_own on professional_categorias
+  for insert to authenticated with check (
+    exists (
+      select 1 from professionals p
+      where p.id = professional_categorias.professional_id and p.user_id = (select auth.uid())
+    )
+  );
+
+drop policy if exists professional_categorias_update_own on professional_categorias;
+create policy professional_categorias_update_own on professional_categorias
+  for update to authenticated using (
+    exists (
+      select 1 from professionals p
+      where p.id = professional_categorias.professional_id and p.user_id = (select auth.uid())
+    )
+  ) with check (
+    exists (
+      select 1 from professionals p
+      where p.id = professional_categorias.professional_id and p.user_id = (select auth.uid())
+    )
+  );
+
+drop policy if exists professional_categorias_delete_own on professional_categorias;
+create policy professional_categorias_delete_own on professional_categorias
+  for delete to authenticated using (
+    exists (
+      select 1 from professionals p
+      where p.id = professional_categorias.professional_id and p.user_id = (select auth.uid())
+    )
+  );
+
+-- Igual que professionals: cierra PostgREST por completo. Drizzle usa el rol dueño y no le afecta.
+revoke all on public.professional_categorias from anon, authenticated;
+
 -- professional-photos: acá la policy es la barrera real, no un respaldo — las fotos se suben con el
 -- cliente de sesión del propio usuario (mismo publishable key + JWT que arma requireUser()), que sí
 -- evalúa storage.objects. file_size_limit y allowed_mime_types quedan fijados en el propio bucket:


### PR DESCRIPTION
Closes #225

## Qué hace

Primer slice (S-001) del Plan de construcción de la [misión 14](docs/missions/14-multiples-categorias-profesional/ingenieria.md) — expand puro, sin tocar ningún endpoint ni consumidor todavía.

- Tabla nueva `professional_categorias` (`professional_id`, `categoria_slug`, `price_from`, `description`, `created_at`), PK compuesta, FKs a `professionals`/`categorias`, e índice `professional_categorias_categoria_slug_idx` sobre `categoria_slug` (la columna que va a filtrar `/api/search` en S-004).
- RLS habilitada con sus 4 policies (lectura pública, escritura solo del dueño vía `exists` contra `professionals.user_id`) + `revoke` que cierra PostgREST, mismo patrón que `professionals` (A-002/A-007).
- Backfill de datos: cada profesional existente conserva su categoría/precio/descripción actuales como su primera categoría declarada, usando `professionals.created_at` (no `now()`) para preservar el orden real.
- También arregla un gap de bookkeeping preexistente en `drizzle.__drizzle_migrations` (la migración 0008, que agrega `avatar_path`, ya estaba aplicada al schema real pero no registrada — sin eso, cualquier `db:migrate` futuro fallaba silenciosamente al reintentarla). Sin cambio de schema por esto, solo se corrigió el registro.

Sustento: D-002, D-003, CL-005, T-001 (`ingenieria.md`).

## Test plan

- [x] `npx nuxi typecheck` sin errores
- [x] `npm run build` compila
- [x] Migración aplicada contra la base real: la tabla existe con RLS habilitada, sus 4 policies, el índice, y sin grants a `anon`/`authenticated`
- [x] Cada uno de los 5 profesionales activos tiene exactamente 1 fila migrada, con los mismos valores y `created_at` que tenía en `professionals`
- [x] Ningún endpoint existente cambia de comportamiento (no se tocó ningún `server/api/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cx9fvJrGPvcHHPU6b6dyFz