### PR TITLE
feat(server): GET /api/professionals/[id] y /me agregan categorias

### DIFF
--- a/server/api/professionals/me/index.get.ts
+++ b/server/api/professionals/me/index.get.ts
@@ -1,7 +1,7 @@
 export default defineEventHandler(async (event) => {
   const user = await requireUser(event)
 
-  const professional = await findProfessionalByUserId(user.id)
+  const professional = await findProfessionalProfileByUserId(user.id)
   if (!professional) {
     setResponseStatus(event, 404)
     return { error: 'not_found' }

--- a/server/utils/professional-categorias.ts
+++ b/server/utils/professional-categorias.ts
@@ -1,0 +1,26 @@
+import { asc, eq } from 'drizzle-orm'
+import { categorias } from '../db/schema/categorias'
+import { professionalCategorias } from '../db/schema/professional-categorias'
+
+export type PublicCategoria = {
+  slug: string
+  nombre: string
+  priceFrom: number | null
+  description: string | null
+}
+
+// Orden por createdAt ascendente: la primera categoría declarada queda primera, que es lo que usa el
+// resto del sistema como categoría de contexto por default sin un query param de búsqueda.
+export async function findProfessionalCategorias(professionalId: string): Promise<PublicCategoria[]> {
+  return useDb()
+    .select({
+      slug: professionalCategorias.categoriaSlug,
+      nombre: categorias.nombre,
+      priceFrom: professionalCategorias.priceFrom,
+      description: professionalCategorias.description,
+    })
+    .from(professionalCategorias)
+    .innerJoin(categorias, eq(professionalCategorias.categoriaSlug, categorias.slug))
+    .where(eq(professionalCategorias.professionalId, professionalId))
+    .orderBy(asc(professionalCategorias.createdAt))
+}

--- a/server/utils/professionals.ts
+++ b/server/utils/professionals.ts
@@ -1,8 +1,8 @@
 import { and, eq, sql } from 'drizzle-orm'
 import { existsActiveCategoria } from './categorias'
 import { existsActiveComuna } from './comunas'
+import { findProfessionalCategorias, type PublicCategoria } from './professional-categorias'
 import { isUuid } from './validation'
-import { categorias } from '../db/schema/categorias'
 import { comunas } from '../db/schema/comunas'
 import { professionals } from '../db/schema/professionals'
 
@@ -37,6 +37,10 @@ export type Professional = {
 
 // Forma que ve un buscador sin sesión (misión 05): categoría/comuna ya resueltas a su nombre (nunca el
 // slug/código, que no significa nada para quien mira el perfil) y createdAt, que Professional no expone.
+//
+// categoriaNombre/priceFrom/description quedan calculados desde categorias[0] mientras conviva con el
+// array nuevo — categorias es la forma real; esos tres campos se retiran una vez que perfil.vue y
+// [id].vue dejen de leerlos directamente.
 export type PublicProfessionalProfile = {
   id: string
   displayName: string
@@ -45,6 +49,7 @@ export type PublicProfessionalProfile = {
   contact: string
   description: string | null
   priceFrom: number | null
+  categorias: PublicCategoria[]
   photoUrls: string[]
   avatarUrl: string | null
   createdAt: string
@@ -141,32 +146,34 @@ export async function findPublicProfessionalProfile(id: string): Promise<PublicP
     .select({
       id: professionals.id,
       displayName: professionals.displayName,
-      categoriaSlug: professionals.categoriaSlug,
-      categoriaNombre: categorias.nombre,
       comunaCodigo: professionals.comunaCodigo,
       comunaNombre: comunas.nombre,
       contact: professionals.contact,
-      description: professionals.description,
-      priceFrom: professionals.priceFrom,
       photoPaths: professionals.photoPaths,
       avatarPath: professionals.avatarPath,
       createdAt: professionals.createdAt,
     })
     .from(professionals)
-    .leftJoin(categorias, eq(professionals.categoriaSlug, categorias.slug))
     .leftJoin(comunas, eq(professionals.comunaCodigo, comunas.codigo))
     .where(and(eq(professionals.id, id), eq(professionals.active, true)))
 
   if (!row) return null
 
+  const categoriasList = await findProfessionalCategorias(row.id)
+  // Un profesional activo nunca tiene 0 filas en professional_categorias — la única forma de llegar
+  // a cero se bloquea al quitar la última categoría, no acá, así que esta lectura confía en que
+  // categoriasList siempre trae al menos una fila.
+  const [primaryCategoria] = categoriasList
+
   return {
     id: row.id,
     displayName: row.displayName,
-    categoriaNombre: row.categoriaNombre ?? row.categoriaSlug,
+    categoriaNombre: primaryCategoria!.nombre,
     comunaNombre: row.comunaNombre ?? row.comunaCodigo,
     contact: row.contact,
-    description: row.description,
-    priceFrom: row.priceFrom,
+    description: primaryCategoria!.description,
+    priceFrom: primaryCategoria!.priceFrom,
+    categorias: categoriasList,
     photoUrls: buildPhotoUrls(row.photoPaths),
     avatarUrl: buildAvatarUrl(row.avatarPath),
     createdAt: row.createdAt.toISOString(),
@@ -185,6 +192,30 @@ export async function professionalExists(id: string): Promise<boolean> {
 export async function findProfessionalByUserId(userId: string): Promise<Professional | null> {
   const [row] = await useDb().select(publicColumns).from(professionals).where(eq(professionals.userId, userId))
   return row ? toPublicProfessional(row) : null
+}
+
+// categoriaSlug/priceFrom/description quedan calculados desde categorias[0], igual que
+// findPublicProfessionalProfile — esto es solo para GET /me. Los endpoints de escritura (POST /me,
+// PATCH /me) todavía leen y escriben la fila de professionals tal cual, sin pasar por acá.
+export type ProfessionalProfile = Professional & { categorias: PublicCategoria[] }
+
+export async function findProfessionalProfileByUserId(userId: string): Promise<ProfessionalProfile | null> {
+  const professional = await findProfessionalByUserId(userId)
+  if (!professional) return null
+
+  const categoriasList = await findProfessionalCategorias(professional.id)
+  // Un profesional activo nunca tiene 0 filas en professional_categorias — la única forma de llegar
+  // a cero se bloquea al quitar la última categoría, no acá, así que esta lectura confía en que
+  // categoriasList siempre trae al menos una fila.
+  const [primaryCategoria] = categoriasList
+
+  return {
+    ...professional,
+    categoriaSlug: primaryCategoria!.slug,
+    priceFrom: primaryCategoria!.priceFrom,
+    description: primaryCategoria!.description,
+    categorias: categoriasList,
+  }
 }
 
 // Lo único que necesita el correo de aviso de reseña nueva (misión 07) — nunca active, que ya decidió


### PR DESCRIPTION
Closes #226

## Qué hace

Segundo slice (S-002) del Plan de construcción de la [misión 14](docs/missions/14-multiples-categorias-profesional/ingenieria.md).

- `GET /api/professionals/[id]` y `GET /api/professionals/me` agregan `categorias: PublicCategoria[]` (`{ slug, nombre, priceFrom, description }`), ordenado por `created_at` ascendente de `professional_categorias` (la primera categoría declarada queda primera).
- Los campos legacy (`categoriaNombre`/`priceFrom`/`description` en `[id]`, `categoriaSlug`/`priceFrom`/`description` en `/me`) siguen expuestos a nivel raíz, sin cambio de shape — pero ahora se calculan desde `categorias[0]` en vez de leerse directo de las columnas de `professionals`, para no romper `perfil.vue` ni `[id].vue` mientras no migren a consumir el array nuevo.
- `findProfessionalByUserId` (compartida con los endpoints de escritura: `POST /me`, `PATCH /me`, fotos, avatar) queda sin tocar — siguen leyendo/escribiendo la fila de `professionals` tal cual. El wrapper nuevo `findProfessionalProfileByUserId` es exclusivo de `GET /me`.

Sustento: TC-001 (`ingenieria.md`).

## Test plan

- [x] `npx nuxi typecheck` sin errores
- [x] `npm run build` compila
- [x] Verificación funcional real: `GET /api/professionals/[id]` contra la base real devuelve exactamente los mismos campos legacy que antes, más `categorias` con la fila migrada en S-001
- [x] Ningún endpoint de escritura tocado

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cx9fvJrGPvcHHPU6b6dyFz