### PR TITLE
feat(server): registro y PATCH /me escriben professional_categorias

### DIFF
--- a/server/utils/professional-categorias.ts
+++ b/server/utils/professional-categorias.ts
@@ -9,6 +9,28 @@ export type PublicCategoria = {
   description: string | null
 }
 
+type DbOrTx = Parameters<Parameters<ReturnType<typeof useDb>['transaction']>[0]>[0]
+
+// Recibe la transacción de quien llama (createProfessional), para que insertar el profesional y su
+// primera categoría sea atómico — o existen las dos filas, o ninguna.
+export async function createProfessionalCategoria(
+  tx: DbOrTx,
+  professionalId: string,
+  categoriaSlug: string,
+): Promise<void> {
+  await tx.insert(professionalCategorias).values({ professionalId, categoriaSlug })
+}
+
+// Hasta que exista más de una categoría por profesional, esta es siempre la única fila — no hace
+// falta el slug en la firma para saber cuál actualizar.
+export async function updateSoleProfessionalCategoria(
+  tx: DbOrTx,
+  professionalId: string,
+  patch: { categoriaSlug?: string, priceFrom?: number | null, description?: string | null },
+): Promise<void> {
+  await tx.update(professionalCategorias).set(patch).where(eq(professionalCategorias.professionalId, professionalId))
+}
+
 // Orden por createdAt ascendente: la primera categoría declarada queda primera, que es lo que usa el
 // resto del sistema como categoría de contexto por default sin un query param de búsqueda.
 export async function findProfessionalCategorias(professionalId: string): Promise<PublicCategoria[]> {

--- a/server/utils/professionals.ts
+++ b/server/utils/professionals.ts
@@ -1,7 +1,12 @@
 import { and, eq, sql } from 'drizzle-orm'
 import { existsActiveCategoria } from './categorias'
 import { existsActiveComuna } from './comunas'
-import { findProfessionalCategorias, type PublicCategoria } from './professional-categorias'
+import {
+  createProfessionalCategoria,
+  findProfessionalCategorias,
+  updateSoleProfessionalCategoria,
+  type PublicCategoria,
+} from './professional-categorias'
 import { isUuid } from './validation'
 import { comunas } from '../db/schema/comunas'
 import { professionals } from '../db/schema/professionals'
@@ -235,11 +240,18 @@ export async function createProfessional(
   fields: ProfessionalCoreFields,
   email: string | null,
 ): Promise<{ professional: Professional, created: boolean }> {
-  const [inserted] = await useDb()
-    .insert(professionals)
-    .values({ userId, ...fields, email })
-    .onConflictDoNothing({ target: professionals.userId })
-    .returning(publicColumns)
+  const inserted = await useDb().transaction(async (tx) => {
+    const [professional] = await tx
+      .insert(professionals)
+      .values({ userId, ...fields, email })
+      .onConflictDoNothing({ target: professionals.userId })
+      .returning(publicColumns)
+
+    if (!professional) return null
+
+    await createProfessionalCategoria(tx, professional.id, fields.categoriaSlug)
+    return professional
+  })
 
   if (inserted) {
     return { professional: toPublicProfessional(inserted), created: true }
@@ -254,13 +266,29 @@ export async function createProfessional(
 export async function updateProfessional(
   userId: string,
   patch: ProfessionalFieldsInput,
-): Promise<Professional | null> {
-  const [updated] = await useDb()
-    .update(professionals)
-    .set({ ...patch, updatedAt: new Date() })
-    .where(eq(professionals.userId, userId))
-    .returning(publicColumns)
-  return updated ? toPublicProfessional(updated) : null
+): Promise<ProfessionalProfile | null> {
+  const { categoriaSlug, priceFrom, description, ...professionalPatch } = patch
+
+  const updated = await useDb().transaction(async (tx) => {
+    const [row] = await tx
+      .update(professionals)
+      .set({ ...professionalPatch, updatedAt: new Date() })
+      .where(eq(professionals.userId, userId))
+      .returning({ id: professionals.id })
+
+    if (!row) return null
+
+    if (categoriaSlug !== undefined || priceFrom !== undefined || description !== undefined) {
+      await updateSoleProfessionalCategoria(tx, row.id, { categoriaSlug, priceFrom, description })
+    }
+
+    return row
+  })
+
+  // Releer en vez de armar la respuesta a mano con lo que se acaba de escribir: priceFrom/description
+  // ahora viven en professional_categorias, no en la fila de professionals que devolvería el update de
+  // arriba, así que reconstruirla acá evitaría duplicar exactamente el cálculo que ya hace GET /me.
+  return updated ? findProfessionalProfileByUserId(userId) : null
 }
 
 export async function addProfessionalPhoto(userId: string, path: string): Promise<Professional | null> {


### PR DESCRIPTION
Closes #227

## Qué hace

Tercer slice (S-003) del Plan de construcción de la [misión 14](docs/missions/14-multiples-categorias-profesional/ingenieria.md).

- `POST /api/professionals` (registro) crea `professionals` y su primera fila de `professional_categorias` en una sola transacción: o existen las dos filas, o ninguna.
- `PATCH /api/professionals/me` redirige `categoriaSlug`/`priceFrom`/`description` a la fila de `professional_categorias` del profesional (hoy siempre única, hasta que exista un endpoint para declarar una segunda) en vez de a las columnas legacy de `professionals`, que quedan congeladas — nada las lee desde S-002, y nada las escribe desde este slice. `displayName`/`comunaCodigo`/`contact` no cambian: siguen actualizando `professionals` como siempre.
- `updateProfessional` pasó de devolver la fila de `professionals` recién actualizada a releer con `findProfessionalProfileByUserId` después de escribir — encontré en la verificación manual que devolver la fila vieja mostraba el precio/descripción desactualizados en la respuesta del PATCH (esos campos ya no viven ahí). Con la relectura, la respuesta siempre refleja el valor real.

Sustento: TC-002, T-004 (`ingenieria.md`).

## Test plan

- [x] `npx nuxi typecheck` sin errores
- [x] `npm run build` compila
- [x] Verificación funcional real contra la base (sesión real vía magic link admin, sin enviar correo): un registro nuevo con un usuario descartable crea `professionals` + `professional_categorias` en la misma transacción; un `PATCH /me` de precio/descripción actualiza solo `professional_categorias` (las columnas legacy quedan congeladas, confirmado en la base) y la respuesta del PATCH ya refleja el valor nuevo; un `PATCH /me` de `displayName` sigue tocando solo `professionals`
- [x] Datos de prueba y usuario descartable eliminados al terminar; el perfil real usado para la prueba quedó restaurado a sus valores originales

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cx9fvJrGPvcHHPU6b6dyFz