### PR TITLE
feat(server): /api/search lee precio y completitud de professional_categorias

### DIFF
--- a/server/utils/search.ts
+++ b/server/utils/search.ts
@@ -3,6 +3,7 @@ import { findVecinasActivas } from './comunas'
 import { buildAvatarUrl, buildPhotoUrls } from './professionals'
 import { findRatingSummaries, type RatingSummary } from './reviews'
 import { comunas } from '../db/schema/comunas'
+import { professionalCategorias } from '../db/schema/professional-categorias'
 import { professionals } from '../db/schema/professionals'
 
 export type SearchMatchType = 'exacta' | 'vecina' | 'ninguna'
@@ -102,30 +103,38 @@ async function findActiveProfessionals(
       id: professionals.id,
       displayName: professionals.displayName,
       comunaNombre: comunas.nombre,
-      priceFrom: professionals.priceFrom,
+      priceFrom: professionalCategorias.priceFrom,
       avatarPath: professionals.avatarPath,
       createdAt: professionals.createdAt,
       photoPaths: professionals.photoPaths,
-      description: professionals.description,
+      description: professionalCategorias.description,
     })
     .from(professionals)
     .innerJoin(comunas, eq(professionals.comunaCodigo, comunas.codigo))
+    .innerJoin(professionalCategorias, and(
+      eq(professionalCategorias.professionalId, professionals.id),
+      eq(professionalCategorias.categoriaSlug, categoriaSlug),
+    ))
     .where(and(
-      eq(professionals.categoriaSlug, categoriaSlug),
       inArray(professionals.comunaCodigo, comunaCodigos),
       eq(professionals.active, true),
     ))
 }
 
 // Se une a comunas para excluir zonas que se desactivaron — "existe en otra parte de Chile" solo cuenta
-// comunas donde alguien podría buscar hoy, no cualquier fila histórica de professionals.
+// comunas donde alguien podría buscar hoy, no cualquier fila histórica de professionals. El join contra
+// professional_categorias es el filtro: un profesional cuenta acá solo si esa categoría puntual está
+// entre las que declaró, nunca por tener cualquier otra.
 async function existsActiveProfessionalForCategoria(categoriaSlug: string): Promise<boolean> {
   const [row] = await useDb()
     .select({ id: professionals.id })
     .from(professionals)
     .innerJoin(comunas, eq(professionals.comunaCodigo, comunas.codigo))
+    .innerJoin(professionalCategorias, and(
+      eq(professionalCategorias.professionalId, professionals.id),
+      eq(professionalCategorias.categoriaSlug, categoriaSlug),
+    ))
     .where(and(
-      eq(professionals.categoriaSlug, categoriaSlug),
       eq(professionals.active, true),
       eq(comunas.activa, true),
     ))


### PR DESCRIPTION
Closes #228

## Qué hace

Cuarto slice (S-004) del Plan de construcción de la [misión 14](docs/missions/14-multiples-categorias-profesional/ingenieria.md). Depende solo de S-001 (#225, ya mergeado) — la query de búsqueda no expone ningún campo legacy, así que no necesita esperar a S-002/S-003.

- `findActiveProfessionals` y `existsActiveProfessionalForCategoria` (`server/utils/search.ts`) pasan de filtrar por `professionals.categoria_slug` a un `inner join` contra `professional_categorias` — el join es el filtro (TC-003): un profesional cuenta solo si esa categoría puntual está entre las que declaró.
- `priceFrom`/`description` (para `rankByCompleteness`) se leen de esa misma fila del join, nunca de otra categoría del mismo profesional.
- TR-001 (riesgo abierto en `ingenieria.md`): corrí `EXPLAIN (ANALYZE, BUFFERS)` sobre la query real — usa `Index Scan` sobre la PK compuesta de `professional_categorias` (que cubre `professional_id` + `categoria_slug`), sin seq scan.

Sustento: TC-003, F-002 (`ingenieria.md`).

## Test plan

- [x] `npx nuxi typecheck` sin errores
- [x] `npm run build` compila
- [x] `EXPLAIN (ANALYZE, BUFFERS)` confirma index scan, no seq scan (TR-001)
- [x] Verificación funcional real: buscar "electricidad" en Puerto Varas devuelve los 4 profesionales con sus precios reales (15000/12000/18000/15000, sin cambio respecto a antes); buscar "gasfitería" en la misma comuna devuelve solo al profesional que declaró esa categoría — el que solo tiene electricidad no aparece

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cx9fvJrGPvcHHPU6b6dyFz