### PR TITLE
feat(server): POST /api/professionals/me/categorias

### DIFF
--- a/server/api/professionals/me/categorias/index.post.ts
+++ b/server/api/professionals/me/categorias/index.post.ts
@@ -1,0 +1,51 @@
+export default defineEventHandler(async (event) => {
+  const user = await requireUser(event)
+  const body = await readBody<Record<string, unknown>>(event)
+
+  const categoriaSlug = body.categoriaSlug
+  if (typeof categoriaSlug !== 'string' || !categoriaSlug.trim()) {
+    setResponseStatus(event, 400)
+    return { error: 'missing_field', field: 'categoriaSlug' }
+  }
+
+  let priceFrom: number | null = null
+  if ('priceFrom' in body) {
+    const value = body.priceFrom
+    if (value !== null && typeof value !== 'number') {
+      setResponseStatus(event, 400)
+      return { error: 'invalid_price' }
+    }
+    priceFrom = value
+  }
+
+  let description: string | null = null
+  if ('description' in body) {
+    const value = body.description
+    if (value !== null && typeof value !== 'string') {
+      setResponseStatus(event, 400)
+      return { error: 'invalid_description' }
+    }
+    description = typeof value === 'string' ? value.trim() || null : null
+  }
+
+  const fieldError = await validateProfessionalFields({ categoriaSlug, priceFrom })
+  if (fieldError) {
+    setResponseStatus(event, 400)
+    return fieldError
+  }
+
+  const professional = await findProfessionalByUserId(user.id)
+  if (!professional) {
+    setResponseStatus(event, 404)
+    return { error: 'not_found' }
+  }
+
+  const categorias = await addProfessionalCategoria(professional.id, categoriaSlug, priceFrom, description)
+  if (!categorias) {
+    setResponseStatus(event, 400)
+    return { error: 'already_declared' }
+  }
+
+  setResponseStatus(event, 201)
+  return { categorias }
+})

--- a/server/utils/professional-categorias.ts
+++ b/server/utils/professional-categorias.ts
@@ -46,3 +46,23 @@ export async function findProfessionalCategorias(professionalId: string): Promis
     .where(eq(professionalCategorias.professionalId, professionalId))
     .orderBy(asc(professionalCategorias.createdAt))
 }
+
+// null en vez de lanzar: onConflictDoNothing captura el choque contra la PK compuesta
+// (professionalId, categoriaSlug) sin una vuelta redonda de select-antes-de-insert, y el endpoint
+// traduce null a 400 already_declared en vez de dejar que un 500 de Postgres llegue al cliente.
+export async function addProfessionalCategoria(
+  professionalId: string,
+  categoriaSlug: string,
+  priceFrom: number | null,
+  description: string | null,
+): Promise<PublicCategoria[] | null> {
+  const [inserted] = await useDb()
+    .insert(professionalCategorias)
+    .values({ professionalId, categoriaSlug, priceFrom, description })
+    .onConflictDoNothing({ target: [professionalCategorias.professionalId, professionalCategorias.categoriaSlug] })
+    .returning({ professionalId: professionalCategorias.professionalId })
+
+  if (!inserted) return null
+
+  return findProfessionalCategorias(professionalId)
+}


### PR DESCRIPTION
Closes #229

## Qué hace

Quinto slice (S-005) del Plan de construcción de la [misión 14](docs/missions/14-multiples-categorias-profesional/ingenieria.md).

- Endpoint nuevo `POST /api/professionals/me/categorias` — agrega una categoría al perfil propio. Entrada: `{ categoriaSlug, priceFrom?, description? }`. Salida: `{ categorias: PublicCategoria[] }` con la lista completa ya actualizada.
- `addProfessionalCategoria` (`server/utils/professional-categorias.ts`) usa `onConflictDoNothing` sobre la PK compuesta `(professionalId, categoriaSlug)` para capturar el duplicado explícitamente como `400 already_declared`, sin una vuelta redonda de select-antes-de-insert ni dejar pasar un 500 de Postgres.
- Archivo en `me/categorias/index.post.ts` (carpeta, no plano) porque S-006 agrega `[slug].patch.ts`/`[slug].delete.ts` en la misma carpeta — TC-005/TC-006 piden el slug en el path, no en el body.
- Endpoint aditivo: no lo consume ninguna UI todavía (eso es S-007).

Sustento: TC-004, F-001 (`ingenieria.md`).

## Test plan

- [x] `npx nuxi typecheck` sin errores
- [x] `npm run build` compila
- [x] Verificación funcional real (sesión real vía magic link admin, sin enviar correo): agregar Gasfitería con precio $18.000 a un perfil que ya tenía Electricidad → 201, `categorias` incluye ambas en el orden correcto; repetir con la misma categoría → 400 `already_declared`; categoría inexistente → 400 `invalid_categoria`
- [x] Datos de prueba revertidos al terminar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cx9fvJrGPvcHHPU6b6dyFz