### PR TITLE
feat(server): PATCH/DELETE /api/professionals/me/categorias/[slug]

### DIFF
--- a/server/api/professionals/me/categorias/[slug].delete.ts
+++ b/server/api/professionals/me/categorias/[slug].delete.ts
@@ -1,0 +1,22 @@
+export default defineEventHandler(async (event) => {
+  const user = await requireUser(event)
+  const categoriaSlug = getRouterParam(event, 'slug') ?? ''
+
+  const professional = await findProfessionalByUserId(user.id)
+  if (!professional) {
+    setResponseStatus(event, 404)
+    return { error: 'not_found' }
+  }
+
+  const result = await removeProfessionalCategoria(professional.id, categoriaSlug)
+  if (result === 'not_found') {
+    setResponseStatus(event, 404)
+    return { error: 'not_found' }
+  }
+  if (result === 'last_category') {
+    setResponseStatus(event, 409)
+    return { error: 'last_category' }
+  }
+
+  return result
+})

--- a/server/api/professionals/me/categorias/[slug].patch.ts
+++ b/server/api/professionals/me/categorias/[slug].patch.ts
@@ -1,0 +1,45 @@
+export default defineEventHandler(async (event) => {
+  const user = await requireUser(event)
+  const categoriaSlug = getRouterParam(event, 'slug') ?? ''
+  const body = await readBody<Record<string, unknown>>(event)
+
+  const patch: { priceFrom?: number | null, description?: string | null } = {}
+
+  if ('priceFrom' in body) {
+    const value = body.priceFrom
+    if (value !== null && typeof value !== 'number') {
+      setResponseStatus(event, 400)
+      return { error: 'invalid_price' }
+    }
+    patch.priceFrom = value
+  }
+
+  if ('description' in body) {
+    const value = body.description
+    if (value !== null && typeof value !== 'string') {
+      setResponseStatus(event, 400)
+      return { error: 'invalid_description' }
+    }
+    patch.description = typeof value === 'string' ? value.trim() || null : null
+  }
+
+  const fieldError = await validateProfessionalFields(patch)
+  if (fieldError) {
+    setResponseStatus(event, 400)
+    return fieldError
+  }
+
+  const professional = await findProfessionalByUserId(user.id)
+  if (!professional) {
+    setResponseStatus(event, 404)
+    return { error: 'not_found' }
+  }
+
+  const categorias = await updateProfessionalCategoria(professional.id, categoriaSlug, patch)
+  if (!categorias) {
+    setResponseStatus(event, 404)
+    return { error: 'not_found' }
+  }
+
+  return { categorias }
+})

--- a/server/utils/professional-categorias.ts
+++ b/server/utils/professional-categorias.ts
@@ -1,6 +1,7 @@
-import { asc, eq } from 'drizzle-orm'
+import { and, asc, eq } from 'drizzle-orm'
 import { categorias } from '../db/schema/categorias'
 import { professionalCategorias } from '../db/schema/professional-categorias'
+import { professionals } from '../db/schema/professionals'
 
 export type PublicCategoria = {
   slug: string
@@ -9,7 +10,9 @@ export type PublicCategoria = {
   description: string | null
 }
 
-type DbOrTx = Parameters<Parameters<ReturnType<typeof useDb>['transaction']>[0]>[0]
+type Db = ReturnType<typeof useDb>
+type Tx = Parameters<Parameters<Db['transaction']>[0]>[0]
+type DbOrTx = Db | Tx
 
 // Recibe la transacción de quien llama (createProfessional), para que insertar el profesional y su
 // primera categoría sea atómico — o existen las dos filas, o ninguna.
@@ -32,9 +35,11 @@ export async function updateSoleProfessionalCategoria(
 }
 
 // Orden por createdAt ascendente: la primera categoría declarada queda primera, que es lo que usa el
-// resto del sistema como categoría de contexto por default sin un query param de búsqueda.
-export async function findProfessionalCategorias(professionalId: string): Promise<PublicCategoria[]> {
-  return useDb()
+// resto del sistema como categoría de contexto por default sin un query param de búsqueda. Acepta un
+// tx opcional para poder leer el estado ya actualizado desde dentro de la misma transacción
+// (removeProfessionalCategoria), en vez de una conexión aparte que todavía no vería el cambio.
+export async function findProfessionalCategorias(professionalId: string, db: DbOrTx = useDb()): Promise<PublicCategoria[]> {
+  return db
     .select({
       slug: professionalCategorias.categoriaSlug,
       nombre: categorias.nombre,
@@ -45,6 +50,58 @@ export async function findProfessionalCategorias(professionalId: string): Promis
     .innerJoin(categorias, eq(professionalCategorias.categoriaSlug, categorias.slug))
     .where(eq(professionalCategorias.professionalId, professionalId))
     .orderBy(asc(professionalCategorias.createdAt))
+}
+
+export async function updateProfessionalCategoria(
+  professionalId: string,
+  categoriaSlug: string,
+  patch: { priceFrom?: number | null, description?: string | null },
+): Promise<PublicCategoria[] | null> {
+  const [updated] = await useDb()
+    .update(professionalCategorias)
+    .set(patch)
+    .where(and(
+      eq(professionalCategorias.professionalId, professionalId),
+      eq(professionalCategorias.categoriaSlug, categoriaSlug),
+    ))
+    .returning({ professionalId: professionalCategorias.professionalId })
+
+  if (!updated) return null
+
+  return findProfessionalCategorias(professionalId)
+}
+
+export type RemoveProfessionalCategoriaResult = 'not_found' | 'last_category' | { categorias: PublicCategoria[] }
+
+// El lock de fila sobre professionals es lo que hace seguro el conteo: sin él, dos DELETE
+// concurrentes sobre las dos únicas categorías de un profesional podrían ambos contar 2 antes de que
+// el otro confirme su borrado, y los dos pasarían el chequeo de "no es la última". Con `for update`,
+// la segunda request espera a que la primera termine (commit o rollback) y cuenta sobre el estado ya
+// actualizado.
+export async function removeProfessionalCategoria(
+  professionalId: string,
+  categoriaSlug: string,
+): Promise<RemoveProfessionalCategoriaResult> {
+  return useDb().transaction(async (tx) => {
+    await tx.select({ id: professionals.id }).from(professionals).where(eq(professionals.id, professionalId)).for('update')
+
+    const declared = await tx
+      .select({ categoriaSlug: professionalCategorias.categoriaSlug })
+      .from(professionalCategorias)
+      .where(eq(professionalCategorias.professionalId, professionalId))
+
+    if (!declared.some(row => row.categoriaSlug === categoriaSlug)) return 'not_found'
+    if (declared.length <= 1) return 'last_category'
+
+    await tx
+      .delete(professionalCategorias)
+      .where(and(
+        eq(professionalCategorias.professionalId, professionalId),
+        eq(professionalCategorias.categoriaSlug, categoriaSlug),
+      ))
+
+    return { categorias: await findProfessionalCategorias(professionalId, tx) }
+  })
 }
 
 // null en vez de lanzar: onConflictDoNothing captura el choque contra la PK compuesta


### PR DESCRIPTION
Closes #230

## Qué hace

Sexto slice (S-006) del Plan de construcción de la [misión 14](docs/missions/14-multiples-categorias-profesional/ingenieria.md).

- `PATCH /api/professionals/me/categorias/[slug]` — edita `priceFrom`/`description` de una categoría propia sin tocar las demás. 404 `not_found` si no la tiene declarada.
- `DELETE /api/professionals/me/categorias/[slug]` — quita una categoría propia, nunca la última. El conteo y el borrado ocurren dentro de una transacción que toma `select ... for update` sobre la fila de `professionals` del dueño antes de contar: una segunda request concurrente queda bloqueada hasta que la primera termina, y cuenta sobre el estado ya actualizado. 404 `not_found` si no la tiene, 409 `last_category` si es la única que le queda.
- `findProfessionalCategorias` acepta ahora un `tx` opcional, para leer el estado ya actualizado desde dentro de la misma transacción de borrado en vez de una conexión aparte que todavía no vería el cambio (la transacción no ha hecho commit).

Sustento: TC-005, TC-006, CL-002, T-002 (`ingenieria.md`).

## Test plan

- [x] `npx nuxi typecheck` sin errores
- [x] `npm run build` compila
- [x] Verificación funcional real con un profesional de prueba descartable con 2 categorías: **dos `DELETE` concurrentes reales** (`Promise.all` contra el dev server), uno sobre cada categoría — resultado: uno 200 (queda 1 categoría), el otro 409 `last_category`, confirmado también contra la base (queda exactamente 1 fila)
- [x] `PATCH` de precio sobre la categoría restante → 200, no afecta otras
- [x] `DELETE` secuencial sobre la última categoría → 409 `last_category`, no se ejecuta la baja
- [x] `PATCH`/`DELETE` sobre una categoría no declarada → 404 `not_found`
- [x] Usuario y datos de prueba eliminados al terminar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cx9fvJrGPvcHHPU6b6dyFz