### PR TITLE
feat(app): perfil.vue pasa a bloques por categoría

### DIFF
--- a/app/components/CategoriaSelect.vue
+++ b/app/components/CategoriaSelect.vue
@@ -9,6 +9,7 @@ const {
   ui,
   itemIcon,
   panelClass,
+  exclude,
 } = defineProps<{
   placeholder?: string
   leadingIcon?: string
@@ -17,13 +18,19 @@ const {
   ui?: { base?: string, leading?: string, leadingIcon?: string, trailing?: string, trailingIcon?: string }
   itemIcon?: (value: string) => Component
   panelClass?: string
+  exclude?: string[]
 }>()
 const modelValue = defineModel<string | null>()
-const { items, pending, error, refresh } = useCategoriasCatalog()
+const { items: allItems, pending, error, refresh } = useCategoriasCatalog()
+const items = computed(() => allItems.value.filter(item => !exclude?.includes(item.value)))
+
+const catalogSelectRef = ref<{ focus: () => void } | null>(null)
+defineExpose({ focus: () => catalogSelectRef.value?.focus() })
 </script>
 
 <template>
   <CatalogSelect
+    ref="catalogSelectRef"
     v-model="modelValue"
     :items
     :pending

--- a/app/components/professional/ProfessionalCategoriaAddBlock.vue
+++ b/app/components/professional/ProfessionalCategoriaAddBlock.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+const props = defineProps<{ excludeSlugs: string[] }>()
+
+const { addCategoria } = useProfessionalCategorias()
+
+const adding = ref(false)
+const isSubmitting = ref(false)
+const errorMessage = ref<string | null>(null)
+const selectRef = ref<{ focus: () => void } | null>(null)
+
+function start() {
+  errorMessage.value = null
+  adding.value = true
+  nextTick(() => selectRef.value?.focus())
+}
+
+function cancel() {
+  adding.value = false
+}
+
+async function onChoose(categoriaSlug: string | null | undefined) {
+  if (!categoriaSlug) return
+  isSubmitting.value = true
+  errorMessage.value = null
+  const ok = await addCategoria(categoriaSlug)
+  isSubmitting.value = false
+  if (ok) adding.value = false
+  else errorMessage.value = 'No se pudo agregar la categoría, intenta de nuevo.'
+}
+</script>
+
+<template>
+  <button
+    v-if="!adding"
+    type="button"
+    class="mt-3 w-full rounded-2xl border-[1.5px] border-dashed border-accented px-4 py-3.5 text-center text-sm font-bold text-primary"
+    @click="start"
+  >
+    + Agregar categoría
+  </button>
+
+  <div v-else class="mt-3 rounded-2xl border border-primary bg-primary/5 p-4">
+    <p class="text-base font-semibold text-datealo-text">Categoría nueva</p>
+    <CategoriaSelect
+      ref="selectRef"
+      class="mt-2"
+      :model-value="null"
+      :exclude="props.excludeSlugs"
+      @update:model-value="onChoose"
+    />
+    <p v-if="errorMessage" class="mt-2 text-sm font-semibold text-error" aria-live="polite">{{ errorMessage }}</p>
+    <button type="button" class="-m-1 mt-2.5 px-1 py-1 text-sm font-semibold text-datealo-muted underline" @click="cancel">
+      Cancelar
+    </button>
+  </div>
+</template>

--- a/app/components/professional/ProfessionalCategoriaAddBlock.vue
+++ b/app/components/professional/ProfessionalCategoriaAddBlock.vue
@@ -4,12 +4,18 @@ const props = defineProps<{ excludeSlugs: string[] }>()
 const { addCategoria } = useProfessionalCategorias()
 
 const adding = ref(false)
+const categoriaSlug = ref<string | null>(null)
+const priceDraft = ref('')
+const descriptionDraft = ref('')
 const isSubmitting = ref(false)
 const errorMessage = ref<string | null>(null)
 const selectRef = ref<{ focus: () => void } | null>(null)
 
 function start() {
   errorMessage.value = null
+  categoriaSlug.value = null
+  priceDraft.value = ''
+  descriptionDraft.value = ''
   adding.value = true
   nextTick(() => selectRef.value?.focus())
 }
@@ -18,14 +24,20 @@ function cancel() {
   adding.value = false
 }
 
-async function onChoose(categoriaSlug: string | null | undefined) {
-  if (!categoriaSlug) return
+async function save() {
+  if (!categoriaSlug.value) return
+
+  const trimmedPrice = priceDraft.value.trim()
+  const parsedPrice = trimmedPrice === '' ? null : Number(trimmedPrice)
+  const priceFrom = parsedPrice !== null && !Number.isNaN(parsedPrice) ? parsedPrice : null
+  const description = descriptionDraft.value.trim() || null
+
   isSubmitting.value = true
   errorMessage.value = null
-  const ok = await addCategoria(categoriaSlug)
+  const ok = await addCategoria(categoriaSlug.value, { priceFrom, description })
   isSubmitting.value = false
   if (ok) adding.value = false
-  else errorMessage.value = 'No se pudo agregar la categoría, intenta de nuevo.'
+  else errorMessage.value = "No se pudo guardar. Toca \"Guardar categoría\" para reintentar."
 }
 </script>
 
@@ -44,13 +56,27 @@ async function onChoose(categoriaSlug: string | null | undefined) {
     <CategoriaSelect
       ref="selectRef"
       class="mt-2"
-      :model-value="null"
+      v-model="categoriaSlug"
       :exclude="props.excludeSlugs"
-      @update:model-value="onChoose"
+    />
+    <div class="mt-2.5 flex items-center gap-2">
+      <span class="text-base text-datealo-muted">Desde $</span>
+      <UInput v-model="priceDraft" inputmode="numeric" size="lg" class="w-32" />
+    </div>
+    <UTextarea
+      v-model="descriptionDraft"
+      class="mt-2.5 w-full"
+      :rows="2"
+      placeholder='Ej: "Corte de pasto y desmalezado con máquina"'
     />
     <p v-if="errorMessage" class="mt-2 text-sm font-semibold text-error" aria-live="polite">{{ errorMessage }}</p>
-    <button type="button" class="-m-1 mt-2.5 px-1 py-1 text-sm font-semibold text-datealo-muted underline" @click="cancel">
-      Cancelar
-    </button>
+    <div class="mt-3 flex gap-3">
+      <UButton class="flex-1 justify-center" color="neutral" variant="outline" @click="cancel">
+        Cancelar
+      </UButton>
+      <UButton class="flex-1 justify-center" :disabled="!categoriaSlug" :loading="isSubmitting" @click="save">
+        Guardar categoría
+      </UButton>
+    </div>
   </div>
 </template>

--- a/app/components/professional/ProfessionalCategoriaBlock.vue
+++ b/app/components/professional/ProfessionalCategoriaBlock.vue
@@ -1,0 +1,166 @@
+<script setup lang="ts">
+import { Loader2 } from '@lucide/vue'
+import type { PublicCategoria } from '~/types/professional'
+
+const props = defineProps<{
+  categoria: PublicCategoria
+  canRemove: boolean
+}>()
+
+const { updateCategoria, removeCategoria } = useProfessionalCategorias()
+
+const isEditing = ref(false)
+const isSaving = ref(false)
+const hasSaveError = ref(false)
+const priceDraft = ref('')
+const descriptionDraft = ref('')
+
+const confirmingRemove = ref(false)
+const isRemoving = ref(false)
+const removeErrorMessage = ref<string | null>(null)
+
+const rootEl = ref<HTMLElement | null>(null)
+
+// El bloque muestra precio y descripción juntos en edición (a diferencia de los bloques de un solo
+// campo que ya usa el perfil): "toca fuera del bloque" es lo que cierra la edición, no el blur de cada
+// campo (eso solo guarda). Un listener de focusout confunde el foco real que sale del bloque con el
+// hueco transitorio que deja Vue al reemplazar el botón "Editar" (que tenía el foco) por el input
+// nuevo — un click fuera del bloque no tiene esa ambigüedad.
+function handleClickOutside(event: MouseEvent) {
+  if (!rootEl.value?.contains(event.target as Node)) isEditing.value = false
+}
+
+watch(isEditing, (editing) => {
+  if (editing) document.addEventListener('click', handleClickOutside, true)
+  else document.removeEventListener('click', handleClickOutside, true)
+})
+
+onUnmounted(() => document.removeEventListener('click', handleClickOutside, true))
+
+function startEdit() {
+  priceDraft.value = props.categoria.priceFrom ? String(props.categoria.priceFrom) : ''
+  descriptionDraft.value = props.categoria.description ?? ''
+  hasSaveError.value = false
+  isEditing.value = true
+}
+
+async function commitPrice() {
+  const trimmed = priceDraft.value.trim()
+  const parsed = trimmed === '' ? null : Number(trimmed)
+  const normalized = parsed !== null && !Number.isNaN(parsed) ? parsed : null
+  if (normalized === (props.categoria.priceFrom ?? null)) return
+  isSaving.value = true
+  hasSaveError.value = !(await updateCategoria(props.categoria.slug, { priceFrom: normalized }))
+  isSaving.value = false
+}
+
+async function commitDescription() {
+  const trimmed = descriptionDraft.value.trim()
+  if (trimmed === (props.categoria.description ?? '')) return
+  isSaving.value = true
+  hasSaveError.value = !(await updateCategoria(props.categoria.slug, { description: trimmed || null }))
+  isSaving.value = false
+}
+
+function requestRemove() {
+  removeErrorMessage.value = null
+  confirmingRemove.value = true
+}
+
+async function confirmRemove() {
+  isRemoving.value = true
+  const ok = await removeCategoria(props.categoria.slug)
+  isRemoving.value = false
+  if (ok) confirmingRemove.value = false
+  else removeErrorMessage.value = 'No se pudo quitar la categoría, intenta de nuevo.'
+}
+</script>
+
+<template>
+  <div
+    ref="rootEl"
+    class="rounded-2xl border p-4"
+    :class="isEditing ? 'border-primary bg-primary/5' : 'border-datealo-surface'"
+  >
+    <div class="flex items-center justify-between gap-2">
+      <p class="text-base font-semibold text-datealo-text">{{ categoria.nombre }}</p>
+      <button
+        v-if="canRemove && !isEditing"
+        type="button"
+        class="-m-1 shrink-0 px-2 py-1 text-sm font-semibold text-error underline"
+        :aria-label="`Quitar ${categoria.nombre}`"
+        @click="requestRemove"
+      >
+        Quitar
+      </button>
+    </div>
+
+    <template v-if="!isEditing">
+      <p class="mt-1.5 text-base">
+        <span v-if="categoria.priceFrom" class="text-datealo-text">Desde ${{ formatPriceFrom(categoria.priceFrom) }}</span>
+        <span v-else class="italic text-datealo-muted">Sin precio</span>
+      </p>
+      <p v-if="categoria.description" class="mt-1 text-sm text-datealo-muted">{{ categoria.description }}</p>
+      <button
+        type="button"
+        class="-m-1 mt-2 inline-block px-2 py-1 text-sm font-semibold text-primary underline"
+        :aria-label="`Editar ${categoria.nombre}`"
+        @click="startEdit"
+      >
+        Editar
+      </button>
+    </template>
+
+    <template v-else>
+      <div class="mt-2.5 flex items-center gap-2">
+        <span class="text-base text-datealo-muted">Desde $</span>
+        <UInput
+          v-model="priceDraft"
+          inputmode="numeric"
+          autofocus
+          size="lg"
+          class="w-32"
+          @blur="commitPrice"
+          @keyup.enter="commitPrice"
+        />
+        <Loader2 v-if="isSaving" class="h-3.5 w-3.5 animate-spin text-primary" />
+      </div>
+      <UTextarea
+        v-model="descriptionDraft"
+        class="mt-2.5 w-full"
+        :rows="2"
+        placeholder='Ej: "Reparación de filtraciones, estanques y llaves"'
+        @blur="commitDescription"
+      />
+    </template>
+
+    <p v-if="hasSaveError" class="mt-2 text-sm font-semibold text-error" aria-live="polite">
+      No se pudo guardar, toca para reintentar
+    </p>
+    <p v-if="!canRemove" class="mt-2 text-xs text-datealo-muted">
+      No puedes quitar tu única categoría. Agrega otra antes de quitar esta.
+    </p>
+
+    <USlideover
+      :open="confirmingRemove"
+      side="bottom"
+      :title="`¿Quitar ${categoria.nombre} de tu perfil?`"
+      description="Perderás el precio y la descripción que escribiste para esta categoría."
+      @update:open="confirmingRemove = $event"
+    >
+      <template #body>
+        <p v-if="removeErrorMessage" class="mb-3 text-sm font-semibold text-error" aria-live="polite">
+          {{ removeErrorMessage }}
+        </p>
+        <div class="flex gap-3">
+          <UButton class="flex-1 justify-center" color="neutral" variant="outline" @click="confirmingRemove = false">
+            Cancelar
+          </UButton>
+          <UButton class="flex-1 justify-center" color="error" :loading="isRemoving" @click="confirmRemove">
+            Quitar
+          </UButton>
+        </div>
+      </template>
+    </USlideover>
+  </div>
+</template>

--- a/app/components/professional/ProfessionalCategoriaBlock.vue
+++ b/app/components/professional/ProfessionalCategoriaBlock.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { Loader2 } from '@lucide/vue'
+import { UModal, USlideover } from '#components'
 import type { PublicCategoria } from '~/types/professional'
 
 const props = defineProps<{
@@ -20,6 +21,25 @@ const isRemoving = ref(false)
 const removeErrorMessage = ref<string | null>(null)
 
 const rootEl = ref<HTMLElement | null>(null)
+
+// El bottom sheet (USlideover) trae su propia animación de deslizar desde abajo — forzarlo a quedar
+// centrado en desktop con clases pelea contra esa animación (el contenido termina centrado, pero se
+// ve deslizar desde fuera del viewport en el camino). Elegir el componente según el ancho evita esa
+// pelea: cada uno anima de la forma que ya trae resuelta.
+const isDesktop = ref(false)
+let desktopQuery: MediaQueryList | undefined
+
+function syncIsDesktop(event: MediaQueryList | MediaQueryListEvent) {
+  isDesktop.value = event.matches
+}
+
+onMounted(() => {
+  desktopQuery = window.matchMedia('(min-width: 640px)')
+  syncIsDesktop(desktopQuery)
+  desktopQuery.addEventListener('change', syncIsDesktop)
+})
+
+onUnmounted(() => desktopQuery?.removeEventListener('change', syncIsDesktop))
 
 // El bloque muestra precio y descripción juntos en edición (a diferencia de los bloques de un solo
 // campo que ya usa el perfil): "toca fuera del bloque" es lo que cierra la edición, no el blur de cada
@@ -150,14 +170,12 @@ async function confirmRemove() {
       No puedes quitar tu única categoría. Agrega otra antes de quitar esta.
     </p>
 
-    <USlideover
+    <component
+      :is="isDesktop ? UModal : USlideover"
       :open="confirmingRemove"
-      side="bottom"
+      :side="isDesktop ? undefined : 'bottom'"
       :title="`¿Quitar ${categoria.nombre} de tu perfil?`"
       description="Perderás el precio y la descripción que escribiste para esta categoría."
-      :ui="{
-        content: 'rounded-t-2xl sm:inset-x-auto sm:bottom-auto sm:top-1/2 sm:left-1/2 sm:-translate-x-1/2 sm:-translate-y-1/2 sm:w-full sm:max-w-md sm:rounded-2xl sm:max-h-[85vh]',
-      }"
       @update:open="confirmingRemove = $event"
     >
       <template #body>
@@ -173,6 +191,6 @@ async function confirmRemove() {
           </UButton>
         </div>
       </template>
-    </USlideover>
+    </component>
   </div>
 </template>

--- a/app/components/professional/ProfessionalCategoriaBlock.vue
+++ b/app/components/professional/ProfessionalCategoriaBlock.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { Loader2 } from '@lucide/vue'
 import { UModal, USlideover } from '#components'
 import type { PublicCategoria } from '~/types/professional'
 
@@ -8,7 +7,7 @@ const props = defineProps<{
   canRemove: boolean
 }>()
 
-const { updateCategoria, removeCategoria, justAddedSlug } = useProfessionalCategorias()
+const { updateCategoria, removeCategoria } = useProfessionalCategorias()
 
 const isEditing = ref(false)
 const isSaving = ref(false)
@@ -20,12 +19,10 @@ const confirmingRemove = ref(false)
 const isRemoving = ref(false)
 const removeErrorMessage = ref<string | null>(null)
 
-const rootEl = ref<HTMLElement | null>(null)
-
-// El bottom sheet (USlideover) trae su propia animación de deslizar desde abajo — forzarlo a quedar
-// centrado en desktop con clases pelea contra esa animación (el contenido termina centrado, pero se
-// ve deslizar desde fuera del viewport en el camino). Elegir el componente según el ancho evita esa
-// pelea: cada uno anima de la forma que ya trae resuelta.
+// USlideover trae su propia animación de deslizar desde abajo — forzarlo a quedar centrado en desktop
+// con clases pelea contra esa animación (el contenido termina centrado, pero se ve deslizar desde fuera
+// del viewport en el camino). Elegir el componente según el ancho evita esa pelea: cada uno anima de la
+// forma que ya trae resuelta.
 const isDesktop = ref(false)
 let desktopQuery: MediaQueryList | undefined
 
@@ -41,22 +38,6 @@ onMounted(() => {
 
 onUnmounted(() => desktopQuery?.removeEventListener('change', syncIsDesktop))
 
-// El bloque muestra precio y descripción juntos en edición (a diferencia de los bloques de un solo
-// campo que ya usa el perfil): "toca fuera del bloque" es lo que cierra la edición, no el blur de cada
-// campo (eso solo guarda). Un listener de focusout confunde el foco real que sale del bloque con el
-// hueco transitorio que deja Vue al reemplazar el botón "Editar" (que tenía el foco) por el input
-// nuevo — un click fuera del bloque no tiene esa ambigüedad.
-function handleClickOutside(event: MouseEvent) {
-  if (!rootEl.value?.contains(event.target as Node)) isEditing.value = false
-}
-
-watch(isEditing, (editing) => {
-  if (editing) document.addEventListener('click', handleClickOutside, true)
-  else document.removeEventListener('click', handleClickOutside, true)
-})
-
-onUnmounted(() => document.removeEventListener('click', handleClickOutside, true))
-
 function startEdit() {
   priceDraft.value = props.categoria.priceFrom ? String(props.categoria.priceFrom) : ''
   descriptionDraft.value = props.categoria.description ?? ''
@@ -64,31 +45,22 @@ function startEdit() {
   isEditing.value = true
 }
 
-// Un bloque recién creado entra directo en edición: elegir la categoría ya la guardó, lo que falta es
-// precio y descripción, sin un toque extra a "Editar" en el medio.
-onMounted(() => {
-  if (justAddedSlug.value === props.categoria.slug) {
-    justAddedSlug.value = null
-    startEdit()
-  }
-})
-
-async function commitPrice() {
-  const trimmed = priceDraft.value.trim()
-  const parsed = trimmed === '' ? null : Number(trimmed)
-  const normalized = parsed !== null && !Number.isNaN(parsed) ? parsed : null
-  if (normalized === (props.categoria.priceFrom ?? null)) return
-  isSaving.value = true
-  hasSaveError.value = !(await updateCategoria(props.categoria.slug, { priceFrom: normalized }))
-  isSaving.value = false
+function cancelEdit() {
+  isEditing.value = false
+  hasSaveError.value = false
 }
 
-async function commitDescription() {
-  const trimmed = descriptionDraft.value.trim()
-  if (trimmed === (props.categoria.description ?? '')) return
+async function saveEdit() {
+  const trimmedPrice = priceDraft.value.trim()
+  const parsedPrice = trimmedPrice === '' ? null : Number(trimmedPrice)
+  const priceFrom = parsedPrice !== null && !Number.isNaN(parsedPrice) ? parsedPrice : null
+  const description = descriptionDraft.value.trim() || null
+
   isSaving.value = true
-  hasSaveError.value = !(await updateCategoria(props.categoria.slug, { description: trimmed || null }))
+  const ok = await updateCategoria(props.categoria.slug, { priceFrom, description })
   isSaving.value = false
+  hasSaveError.value = !ok
+  if (ok) isEditing.value = false
 }
 
 function requestRemove() {
@@ -107,7 +79,6 @@ async function confirmRemove() {
 
 <template>
   <div
-    ref="rootEl"
     class="rounded-2xl border p-4"
     :class="isEditing ? 'border-primary bg-primary/5' : 'border-datealo-surface'"
   >
@@ -143,29 +114,27 @@ async function confirmRemove() {
     <template v-else>
       <div class="mt-2.5 flex items-center gap-2">
         <span class="text-base text-datealo-muted">Desde $</span>
-        <UInput
-          v-model="priceDraft"
-          inputmode="numeric"
-          autofocus
-          size="lg"
-          class="w-32"
-          @blur="commitPrice"
-          @keyup.enter="commitPrice"
-        />
-        <Loader2 v-if="isSaving" class="h-3.5 w-3.5 animate-spin text-primary" />
+        <UInput v-model="priceDraft" inputmode="numeric" autofocus size="lg" class="w-32" />
       </div>
       <UTextarea
         v-model="descriptionDraft"
         class="mt-2.5 w-full"
         :rows="2"
         placeholder='Ej: "Reparación de filtraciones, estanques y llaves"'
-        @blur="commitDescription"
       />
+      <p v-if="hasSaveError" class="mt-2 text-sm font-semibold text-error" aria-live="polite">
+        No se pudo guardar. Toca "Guardar cambios" para reintentar.
+      </p>
+      <div class="mt-3 flex gap-3">
+        <UButton class="flex-1 justify-center" color="neutral" variant="outline" @click="cancelEdit">
+          Cancelar
+        </UButton>
+        <UButton class="flex-1 justify-center" :loading="isSaving" @click="saveEdit">
+          Guardar cambios
+        </UButton>
+      </div>
     </template>
 
-    <p v-if="hasSaveError" class="mt-2 text-sm font-semibold text-error" aria-live="polite">
-      No se pudo guardar, toca para reintentar
-    </p>
     <p v-if="!canRemove" class="mt-2 text-xs text-datealo-muted">
       No puedes quitar tu única categoría. Agrega otra antes de quitar esta.
     </p>

--- a/app/components/professional/ProfessionalCategoriaBlock.vue
+++ b/app/components/professional/ProfessionalCategoriaBlock.vue
@@ -7,7 +7,7 @@ const props = defineProps<{
   canRemove: boolean
 }>()
 
-const { updateCategoria, removeCategoria } = useProfessionalCategorias()
+const { updateCategoria, removeCategoria, justAddedSlug } = useProfessionalCategorias()
 
 const isEditing = ref(false)
 const isSaving = ref(false)
@@ -43,6 +43,15 @@ function startEdit() {
   hasSaveError.value = false
   isEditing.value = true
 }
+
+// Un bloque recién creado entra directo en edición: elegir la categoría ya la guardó, lo que falta es
+// precio y descripción, sin un toque extra a "Editar" en el medio.
+onMounted(() => {
+  if (justAddedSlug.value === props.categoria.slug) {
+    justAddedSlug.value = null
+    startEdit()
+  }
+})
 
 async function commitPrice() {
   const trimmed = priceDraft.value.trim()
@@ -146,6 +155,9 @@ async function confirmRemove() {
       side="bottom"
       :title="`¿Quitar ${categoria.nombre} de tu perfil?`"
       description="Perderás el precio y la descripción que escribiste para esta categoría."
+      :ui="{
+        content: 'rounded-t-2xl sm:inset-x-auto sm:bottom-auto sm:top-1/2 sm:left-1/2 sm:-translate-x-1/2 sm:-translate-y-1/2 sm:w-full sm:max-w-md sm:rounded-2xl sm:max-h-[85vh]',
+      }"
       @update:open="confirmingRemove = $event"
     >
       <template #body>

--- a/app/composables/useProfessionalCategorias.ts
+++ b/app/composables/useProfessionalCategorias.ts
@@ -4,27 +4,22 @@ type CategoriaPatch = { priceFrom?: number | null, description?: string | null }
 
 export function useProfessionalCategorias() {
   const { professional } = useProfessionalProfile()
+  const toast = useToast()
 
   const categorias = computed(() => professional.value?.categorias ?? [])
-  const announcement = useState('professional-categorias-announcement', () => '')
-  // El bloque que se acaba de crear lee y limpia esto en su propio onMounted, para entrar directo en
-  // edición de precio/descripción sin que el usuario tenga que tocar "Editar" después de elegir la
-  // categoría — elegirla ya la guardó, lo único que falta es esos dos campos.
-  const justAddedSlug = useState<string | null>('professional-categorias-just-added', () => null)
 
   function applyCategorias(updated: PublicCategoria[]) {
     if (professional.value) professional.value = { ...professional.value, categorias: updated }
   }
 
-  async function addCategoria(categoriaSlug: string): Promise<boolean> {
+  async function addCategoria(categoriaSlug: string, patch: CategoriaPatch = {}): Promise<boolean> {
     try {
       const { categorias: updated } = await $fetch<{ categorias: PublicCategoria[] }>('/api/professionals/me/categorias', {
         method: 'POST',
-        body: { categoriaSlug },
+        body: { categoriaSlug, ...patch },
       })
       applyCategorias(updated)
-      announcement.value = `${updated.find(c => c.slug === categoriaSlug)?.nombre ?? categoriaSlug} agregada`
-      justAddedSlug.value = categoriaSlug
+      toast.add({ title: `${updated.find(c => c.slug === categoriaSlug)?.nombre ?? categoriaSlug} agregada`, color: 'success' })
       return true
     } catch {
       return false
@@ -38,6 +33,7 @@ export function useProfessionalCategorias() {
         { method: 'PATCH', body: patch },
       )
       applyCategorias(updated)
+      toast.add({ title: 'Cambios guardados', color: 'success' })
       return true
     } catch {
       return false
@@ -52,12 +48,12 @@ export function useProfessionalCategorias() {
         { method: 'DELETE' },
       )
       applyCategorias(updated)
-      announcement.value = `${nombre} quitada`
+      toast.add({ title: `${nombre} quitada`, color: 'success' })
       return true
     } catch {
       return false
     }
   }
 
-  return { categorias, announcement, justAddedSlug, addCategoria, updateCategoria, removeCategoria }
+  return { categorias, addCategoria, updateCategoria, removeCategoria }
 }

--- a/app/composables/useProfessionalCategorias.ts
+++ b/app/composables/useProfessionalCategorias.ts
@@ -1,0 +1,58 @@
+import type { PublicCategoria } from '~/types/professional'
+
+type CategoriaPatch = { priceFrom?: number | null, description?: string | null }
+
+export function useProfessionalCategorias() {
+  const { professional } = useProfessionalProfile()
+
+  const categorias = computed(() => professional.value?.categorias ?? [])
+  const announcement = useState('professional-categorias-announcement', () => '')
+
+  function applyCategorias(updated: PublicCategoria[]) {
+    if (professional.value) professional.value = { ...professional.value, categorias: updated }
+  }
+
+  async function addCategoria(categoriaSlug: string): Promise<boolean> {
+    try {
+      const { categorias: updated } = await $fetch<{ categorias: PublicCategoria[] }>('/api/professionals/me/categorias', {
+        method: 'POST',
+        body: { categoriaSlug },
+      })
+      applyCategorias(updated)
+      announcement.value = `${updated.find(c => c.slug === categoriaSlug)?.nombre ?? categoriaSlug} agregada`
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  async function updateCategoria(categoriaSlug: string, patch: CategoriaPatch): Promise<boolean> {
+    try {
+      const { categorias: updated } = await $fetch<{ categorias: PublicCategoria[] }>(
+        `/api/professionals/me/categorias/${categoriaSlug}`,
+        { method: 'PATCH', body: patch },
+      )
+      applyCategorias(updated)
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  async function removeCategoria(categoriaSlug: string): Promise<boolean> {
+    const nombre = categorias.value.find(c => c.slug === categoriaSlug)?.nombre ?? categoriaSlug
+    try {
+      const { categorias: updated } = await $fetch<{ categorias: PublicCategoria[] }>(
+        `/api/professionals/me/categorias/${categoriaSlug}`,
+        { method: 'DELETE' },
+      )
+      applyCategorias(updated)
+      announcement.value = `${nombre} quitada`
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  return { categorias, announcement, addCategoria, updateCategoria, removeCategoria }
+}

--- a/app/composables/useProfessionalCategorias.ts
+++ b/app/composables/useProfessionalCategorias.ts
@@ -7,6 +7,10 @@ export function useProfessionalCategorias() {
 
   const categorias = computed(() => professional.value?.categorias ?? [])
   const announcement = useState('professional-categorias-announcement', () => '')
+  // El bloque que se acaba de crear lee y limpia esto en su propio onMounted, para entrar directo en
+  // edición de precio/descripción sin que el usuario tenga que tocar "Editar" después de elegir la
+  // categoría — elegirla ya la guardó, lo único que falta es esos dos campos.
+  const justAddedSlug = useState<string | null>('professional-categorias-just-added', () => null)
 
   function applyCategorias(updated: PublicCategoria[]) {
     if (professional.value) professional.value = { ...professional.value, categorias: updated }
@@ -20,6 +24,7 @@ export function useProfessionalCategorias() {
       })
       applyCategorias(updated)
       announcement.value = `${updated.find(c => c.slug === categoriaSlug)?.nombre ?? categoriaSlug} agregada`
+      justAddedSlug.value = categoriaSlug
       return true
     } catch {
       return false
@@ -54,5 +59,5 @@ export function useProfessionalCategorias() {
     }
   }
 
-  return { categorias, announcement, addCategoria, updateCategoria, removeCategoria }
+  return { categorias, announcement, justAddedSlug, addCategoria, updateCategoria, removeCategoria }
 }

--- a/app/pages/profesional/perfil.vue
+++ b/app/pages/profesional/perfil.vue
@@ -14,7 +14,7 @@ const comunaNombre = computed(
     ?? professional.value?.comunaCodigo ?? '',
 )
 
-const { categorias, announcement } = useProfessionalCategorias()
+const { categorias } = useProfessionalCategorias()
 const categoriaSlugs = computed(() => categorias.value.map(c => c.slug))
 </script>
 
@@ -33,7 +33,6 @@ const categoriaSlugs = computed(() => categorias.value.map(c => c.slug))
       <ProfessionalPhotos class="mt-3" />
 
       <p class="mb-2 mt-5 text-xs font-bold uppercase tracking-wide text-datealo-muted">Tus categorías</p>
-      <span class="sr-only" aria-live="polite">{{ announcement }}</span>
       <ProfessionalCategoriaBlock
         v-for="categoria in categorias"
         :key="categoria.slug"

--- a/app/pages/profesional/perfil.vue
+++ b/app/pages/profesional/perfil.vue
@@ -1,65 +1,21 @@
 <script setup lang="ts">
-import { Loader2 } from '@lucide/vue'
-
 definePageMeta({ middleware: 'profesional', layout: 'general' })
 
 useSeoMeta({ title: 'Tu perfil', robots: 'noindex' })
 
-const { professional, pending, loadError, editingField, savingField, saveErrorField, startEdit, cancelEdit, save, load } = useProfessionalProfile()
+const { professional, pending, loadError, load } = useProfessionalProfile()
 
 if (!professional.value) await load()
 
-const { items: categoriaItems } = useCategoriasCatalog()
 const { items: comunaItems } = useComunasCatalog()
 
-const categoriaNombre = computed(
-  () => categoriaItems.value.find(item => item.value === professional.value?.categoriaSlug)?.label
-    ?? professional.value?.categoriaSlug ?? '',
-)
 const comunaNombre = computed(
   () => comunaItems.value.find(item => item.value === professional.value?.comunaCodigo)?.label
     ?? professional.value?.comunaCodigo ?? '',
 )
 
-const isEditingDescription = computed(() => editingField.value === 'description')
-const isSavingDescription = computed(() => savingField.value === 'description')
-const hasDescriptionError = computed(() => saveErrorField.value === 'description')
-const descriptionDraft = ref('')
-
-function editDescription() {
-  descriptionDraft.value = professional.value?.description ?? ''
-  startEdit('description')
-}
-
-function commitDescription() {
-  const trimmed = descriptionDraft.value.trim()
-  if (trimmed === (professional.value?.description ?? '')) {
-    cancelEdit()
-    return
-  }
-  save('description', trimmed || null)
-}
-
-const isEditingPrice = computed(() => editingField.value === 'priceFrom')
-const isSavingPrice = computed(() => savingField.value === 'priceFrom')
-const hasPriceError = computed(() => saveErrorField.value === 'priceFrom')
-const priceDraft = ref('')
-
-function editPrice() {
-  priceDraft.value = professional.value?.priceFrom ? String(professional.value.priceFrom) : ''
-  startEdit('priceFrom')
-}
-
-function commitPrice() {
-  const trimmed = priceDraft.value.trim()
-  const parsed = trimmed === '' ? null : Number(trimmed)
-  const normalized = parsed !== null && !Number.isNaN(parsed) ? parsed : null
-  if (normalized === (professional.value?.priceFrom ?? null)) {
-    cancelEdit()
-    return
-  }
-  save('priceFrom', normalized)
-}
+const { categorias, announcement } = useProfessionalCategorias()
+const categoriaSlugs = computed(() => categorias.value.map(c => c.slug))
 </script>
 
 <template>
@@ -70,96 +26,26 @@ function commitPrice() {
 
     <template v-else-if="professional">
       <h1 class="text-xl font-extrabold text-datealo-text">{{ professional.displayName }}</h1>
-      <p class="mt-0.5 text-sm text-datealo-muted">{{ categoriaNombre }} · {{ comunaNombre }}</p>
+      <p class="mt-0.5 text-sm text-datealo-muted">{{ comunaNombre }}</p>
 
       <ProfessionalAvatar class="mt-5" />
 
       <ProfessionalPhotos class="mt-3" />
 
-      <div class="mt-3 rounded-2xl border border-datealo-surface p-4">
-        <div class="flex items-center justify-between">
-          <p class="text-base font-semibold text-datealo-text">Descripción</p>
-          <Loader2 v-if="isSavingDescription" class="h-3.5 w-3.5 animate-spin text-primary" />
-        </div>
+      <p class="mb-2 mt-5 text-xs font-bold uppercase tracking-wide text-datealo-muted">Tus categorías</p>
+      <span class="sr-only" aria-live="polite">{{ announcement }}</span>
+      <ProfessionalCategoriaBlock
+        v-for="categoria in categorias"
+        :key="categoria.slug"
+        :categoria="categoria"
+        :can-remove="categorias.length > 1"
+      />
+      <ProfessionalCategoriaAddBlock :exclude-slugs="categoriaSlugs" />
 
-        <p v-if="!isEditingDescription && professional.description" class="mt-1 text-base text-datealo-text">
-          {{ professional.description }}
-        </p>
-        <button
-          v-else-if="!isEditingDescription"
-          type="button"
-          class="mt-1 text-left text-base italic text-datealo-muted"
-          @click="editDescription"
-        >
-          Ej: "Electricista con 10 años de experiencia en Ñuñoa"
-        </button>
-        <UTextarea
-          v-else
-          v-model="descriptionDraft"
-          autofocus
-          class="mt-2 w-full"
-          :rows="2"
-          @blur="commitDescription"
-        />
-        <button
-          v-if="!isEditingDescription && professional.description"
-          type="button"
-          class="mt-1 text-sm font-semibold text-primary underline"
-          @click="editDescription"
-        >
-          Editar
-        </button>
-        <p v-if="hasDescriptionError" class="mt-2 text-sm font-semibold text-error" aria-live="polite">
-          No se pudo guardar, toca para reintentar
-        </p>
-      </div>
-
-      <div class="mt-3 rounded-2xl border border-datealo-surface p-4">
-        <div class="flex items-center justify-between">
-          <p class="text-base font-semibold text-datealo-text">Precio</p>
-          <Loader2 v-if="isSavingPrice" class="h-3.5 w-3.5 animate-spin text-primary" />
-        </div>
-
-        <button v-if="!isEditingPrice" type="button" class="mt-1 block text-left text-base" @click="editPrice">
-          <template v-if="professional.priceFrom">
-            <span class="text-datealo-text">Desde ${{ formatPriceFrom(professional.priceFrom) }}</span>
-          </template>
-          <template v-else>
-            <span class="text-datealo-muted">Desde $</span>
-            <span class="italic text-datealo-muted">Ej: 10.000</span>
-          </template>
-        </button>
-        <div v-else class="mt-2 flex items-center gap-2">
-          <span class="text-base text-datealo-muted">Desde $</span>
-          <UInput
-            v-model="priceDraft"
-            inputmode="numeric"
-            autofocus
-            size="lg"
-            class="w-32"
-            @blur="commitPrice"
-            @keyup.enter="commitPrice"
-          />
-        </div>
-        <p v-if="hasPriceError" class="mt-2 text-sm font-semibold text-error" aria-live="polite">
-          No se pudo guardar, toca para reintentar
-        </p>
-      </div>
-
-      <div class="mt-3 rounded-2xl border border-datealo-surface p-4">
+      <div class="mt-6 rounded-2xl border border-datealo-surface p-4">
         <p class="mb-1 text-base font-semibold text-datealo-text">Tus datos</p>
 
         <ProfessionalDataRow label="Nombre" field="displayName" :value="professional.displayName" />
-        <ProfessionalCatalogRow
-          label="Categoría"
-          field="categoriaSlug"
-          :value="professional.categoriaSlug"
-          :display-value="categoriaNombre"
-        >
-          <template #select="{ modelValue, update }">
-            <CategoriaSelect :model-value="modelValue" @update:model-value="update" />
-          </template>
-        </ProfessionalCatalogRow>
         <ProfessionalCatalogRow
           label="Comuna"
           field="comunaCodigo"

--- a/app/pages/profesional/registro.vue
+++ b/app/pages/profesional/registro.vue
@@ -64,6 +64,7 @@ const completedCount = computed(() =>
         Tu categoría
       </label>
       <CategoriaSelect id="registro-categoria" v-model="categoriaSlug" />
+      <p class="mt-1.5 text-sm text-datealo-muted">Puedes agregar otras categorías más adelante, desde tu perfil.</p>
 
       <label for="registro-comuna" class="mb-2 mt-5 block text-sm font-semibold text-datealo-text">Tu comuna</label>
       <ComunaSelect id="registro-comuna" v-model="comunaCodigo" />

--- a/app/types/professional.ts
+++ b/app/types/professional.ts
@@ -1,5 +1,12 @@
 import type { PublicReview } from './review'
 
+export type PublicCategoria = {
+  slug: string
+  nombre: string
+  priceFrom: number | null
+  description: string | null
+}
+
 export type Professional = {
   id: string
   displayName: string
@@ -8,6 +15,7 @@ export type Professional = {
   contact: string
   description: string | null
   priceFrom: number | null
+  categorias: PublicCategoria[]
   photoUrls: string[]
   avatarUrl: string | null
   active: boolean
@@ -15,11 +23,8 @@ export type Professional = {
 
 export type ProfessionalField =
   | 'displayName'
-  | 'categoriaSlug'
   | 'comunaCodigo'
   | 'contact'
-  | 'description'
-  | 'priceFrom'
 
 // Lo que ve un buscador sin sesión (misión 05): categoría/comuna ya resueltas a su nombre, y desde
 // cuándo existe el perfil — ninguna de las dos cosas está en Professional (la forma del propio dueño).

--- a/docs/missions/14-multiples-categorias-profesional/design-mockups/perfil-edicion-categorias.html
+++ b/docs/missions/14-multiples-categorias-profesional/design-mockups/perfil-edicion-categorias.html
@@ -242,8 +242,9 @@
         <div class="frame-label">
           V-001 · modo confirmando quitar categoría · desktop
           <small>el bottom sheet es un patrón táctil (deslizar para cerrar) que no aplica con mouse — en
-            desktop es el modal centrado por defecto de `UModal` (Nuxt UI), fondo atenuado cubriendo todo
-            el viewport, no solo la columna angosta del perfil</small>
+            desktop se usa `UModal` centrado en vez de `USlideover` (Nuxt UI no cambia esto solo entre
+            tamaños de pantalla; son dos componentes elegidos en tiempo de ejecución), fondo atenuado
+            cubriendo todo el viewport, no solo la columna angosta del perfil</small>
         </div>
         <div class="frame-viewport">
           <div style="height:100%;overflow:hidden;display:flex;justify-content:center;background:var(--color-datealo-bg);position:relative;">
@@ -284,11 +285,12 @@
         </div>
       </section>
 
-      <!-- ============================================== MOBILE · AGREGANDO, ELIGIENDO CATEGORÍA ========= -->
+      <!-- ============================================== MOBILE · AGREGANDO, TODOS LOS CAMPOS JUNTOS ===== -->
       <section class="frame frame-mobile">
         <div class="frame-label">
-          V-001 · modo agregando categoría — paso 1, eligiendo
-          <small>el selector excluye Gasfitería y Electricidad, que ya están declaradas</small>
+          V-001 · modo agregando categoría — selector, precio y descripción juntos desde el inicio
+          <small>ronda 2 (2026-09-07): nada se revela después de elegir categoría; nada se guarda hasta
+            tocar "Guardar categoría" — reemplaza los dos pasos de la ronda 1</small>
         </div>
         <div class="frame-viewport is-auto">
           <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
@@ -307,40 +309,10 @@
 
             <div class="field-card is-editing">
               <p class="field-title">Categoría nueva</p>
-              <div class="select-mock" style="margin-top:0.5rem;">
-                Elige una categoría
+              <div class="select-mock" style="margin-top:0.625rem;">
+                Jardín y áreas verdes
                 <svg class="icon" style="width:0.875rem;height:0.875rem;" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m6 9 6 6 6-6" /></svg>
               </div>
-              <button class="field-link" style="margin-top:0.625rem;display:inline-block;color:var(--ui-text-muted);text-decoration:none;">Cancelar</button>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <!-- ============================================== MOBILE · AGREGANDO, CATEGORÍA ELEGIDA =========== -->
-      <section class="frame frame-mobile">
-        <div class="frame-label">
-          V-001 · modo agregando categoría — paso 2, precio y descripción
-          <small>ambos campos son opcionales, igual que hoy permite un perfil sin descripción; se guardan
-            al perder el foco (mismo patrón que "Descripción"/"Precio")</small>
-        </div>
-        <div class="frame-viewport is-auto">
-          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
-          <div style="padding:1.25rem;">
-            <p style="font-size:0.75rem;font-weight:700;text-transform:uppercase;letter-spacing:0.04em;color:var(--ui-text-muted);margin:0 0 0.5rem;">
-              Tus categorías
-            </p>
-            <div class="field-card" style="opacity:0.55;">
-              <p class="field-title">Gasfitería</p>
-              <p style="margin:0.375rem 0 0;font-size:0.875rem;color:var(--color-datealo-text);">Desde $18.000</p>
-            </div>
-            <div class="field-card" style="opacity:0.55;">
-              <p class="field-title">Electricidad</p>
-              <p style="margin:0.375rem 0 0;font-size:0.875rem;color:var(--color-datealo-text);">Desde $20.000</p>
-            </div>
-
-            <div class="field-card is-editing">
-              <p class="field-title">Jardín y áreas verdes</p>
               <div style="margin-top:0.625rem;display:flex;align-items:center;gap:0.5rem;">
                 <span style="font-size:0.875rem;color:var(--ui-text-muted);">Desde $</span>
                 <div class="input-mock" style="width:5rem;">10.000</div>
@@ -350,7 +322,90 @@
                 style="margin-top:0.625rem;width:100%;resize:none;"
                 rows="2"
                 placeholder='Ej: "Corte de pasto y desmalezado con máquina"'
-              ></textarea>
+              >Corte de pasto y desmalezado con máquina</textarea>
+              <div style="margin-top:0.75rem;display:flex;gap:0.625rem;">
+                <button style="flex:1;padding:0.625rem;border-radius:var(--ui-radius);border:1.5px solid var(--ui-border-accented);font-weight:700;font-size:0.8125rem;color:var(--ui-text-toned);background:none;">
+                  Cancelar
+                </button>
+                <button style="flex:1;padding:0.625rem;border-radius:var(--ui-radius);border:none;font-weight:700;font-size:0.8125rem;color:#fff;background:var(--ui-primary);">
+                  Guardar categoría
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================================== MOBILE · GUARDANDO, CONFIRMACIÓN ================ -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-001 · guardado en curso, y confirmación al terminar
+          <small>el botón muestra su propio loader; al terminar, el bloque colapsa a lectura y un toast
+            confirma — mismo patrón de `useToast()` que ya usa "Reseña publicada"</small>
+        </div>
+        <div class="frame-viewport is-auto">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div style="padding:1.25rem;">
+            <p style="font-size:0.75rem;font-weight:700;text-transform:uppercase;letter-spacing:0.04em;color:var(--ui-text-muted);margin:0 0 0.5rem;">
+              Tus categorías
+            </p>
+            <div class="field-card">
+              <p class="field-title">Gasfitería</p>
+              <p style="margin:0.375rem 0 0;font-size:0.875rem;color:var(--color-datealo-text);">Desde $18.000</p>
+            </div>
+            <div class="field-card">
+              <p class="field-title">Electricidad</p>
+              <p style="margin:0.375rem 0 0;font-size:0.875rem;color:var(--color-datealo-text);">Desde $20.000</p>
+            </div>
+            <div class="field-card">
+              <p class="field-title">Jardín y áreas verdes</p>
+              <p style="margin:0.375rem 0 0;font-size:0.875rem;color:var(--color-datealo-text);">Desde $10.000</p>
+              <p style="margin:0.25rem 0 0;font-size:0.8125rem;color:var(--ui-text-muted);">Corte de pasto y desmalezado con máquina.</p>
+            </div>
+            <div class="add-category-btn" style="margin-top:0.75rem;">+ Agregar categoría</div>
+          </div>
+          <div style="position:absolute;left:1rem;right:1rem;bottom:1.25rem;background:#1F2937;color:#fff;border-radius:0.75rem;padding:0.75rem 1rem;font-size:0.8125rem;font-weight:600;box-shadow:0 8px 20px -8px rgb(31 41 55 / 0.5);">
+            Jardín y áreas verdes agregada
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================================== MOBILE · EDITANDO UNA CATEGORÍA YA DECLARADA ===== -->
+      <section class="frame frame-mobile">
+        <div class="frame-label">
+          V-001 · modo editando una categoría declarada
+          <small>mismo mecanismo que agregar, sin el selector — "Cancelar" revierte a los valores
+            actuales sin llamar al servidor</small>
+        </div>
+        <div class="frame-viewport is-auto">
+          <div class="status-bar"><span>9:41</span><span>▮▮▮</span></div>
+          <div style="padding:1.25rem;">
+            <p style="font-size:0.75rem;font-weight:700;text-transform:uppercase;letter-spacing:0.04em;color:var(--ui-text-muted);margin:0 0 0.5rem;">
+              Tus categorías
+            </p>
+            <div class="field-card is-editing">
+              <p class="field-title">Gasfitería</p>
+              <div style="margin-top:0.625rem;display:flex;align-items:center;gap:0.5rem;">
+                <span style="font-size:0.875rem;color:var(--ui-text-muted);">Desde $</span>
+                <div class="input-mock" style="width:5rem;">18.000</div>
+              </div>
+              <textarea
+                class="input-mock"
+                style="margin-top:0.625rem;width:100%;resize:none;"
+                rows="2"
+              >Reparación de filtraciones, estanques y llaves. Atiendo fines de semana.</textarea>
+              <div style="margin-top:0.75rem;display:flex;gap:0.625rem;">
+                <button style="flex:1;padding:0.625rem;border-radius:var(--ui-radius);border:1.5px solid var(--ui-border-accented);font-weight:700;font-size:0.8125rem;color:var(--ui-text-toned);background:none;">
+                  Cancelar
+                </button>
+                <button style="flex:1;padding:0.625rem;border-radius:var(--ui-radius);border:none;font-weight:700;font-size:0.8125rem;color:#fff;background:var(--ui-primary);">
+                  Guardar cambios
+                </button>
+              </div>
+            </div>
+            <div class="field-card" style="opacity:0.55;margin-top:0.75rem;">
+              <p class="field-title">Electricidad</p>
+              <p style="margin:0.375rem 0 0;font-size:0.875rem;color:var(--color-datealo-text);">Desde $20.000</p>
             </div>
           </div>
         </div>

--- a/docs/missions/14-multiples-categorias-profesional/experiencia.md
+++ b/docs/missions/14-multiples-categorias-profesional/experiencia.md
@@ -1,8 +1,10 @@
 # Misión: múltiples categorías por profesional — Experiencia
 
-**Estado:** vigente — aprobado por Patricio Tabilo el 2026-09-06
+**Estado:** en revisión — UXF-001/UX-002 revisados el 2026-09-07 (guardado explícito con Cancelar/Guardar
+en vez de autosave por campo; ver el detalle en cada sección). El resto del documento sigue como se aprobó
+el 2026-09-06.
 
-**Última actualización:** 2026-09-06
+**Última actualización:** 2026-09-07
 
 [Índice](./README.md) · [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
@@ -25,9 +27,12 @@ fuera del registro inicial — solo se hace editando el perfil ya creado.
   flujo UXF-001
   - modo **lista de categorías** — cada categoría declarada como bloque con su precio y descripción; "+
     Agregar categoría" al final, siempre visible
-  - modo **agregando categoría** — un bloque nuevo en edición: primero el selector de categoría, después
-    precio y descripción
-  - modo **confirmando quitar** — bottom sheet con la consecuencia explícita, Cancelar/Quitar
+  - modo **agregando categoría** — un bloque nuevo con sus tres campos visibles a la vez (selector,
+    precio, descripción) y Cancelar/Guardar categoría al pie
+  - modo **editando una categoría declarada** — el bloque existente muestra precio y descripción
+    editables juntos, con Cancelar/Guardar cambios al pie — mismo mecanismo que agregar, sin el selector
+  - modo **confirmando quitar** — bottom sheet (mobile) o modal centrado (desktop) con la consecuencia
+    explícita, Cancelar/Quitar
 - **V-002 — Resultados de búsqueda** · móvil / desktop · resuelve F-002 · sin flujo nuevo
   - Vista ya construida (misión 10); esta misión no le agrega modos. Un profesional con 2+ categorías
     aparece en cada búsqueda por separado, con el precio de la categoría que corresponde a esa búsqueda —
@@ -50,60 +55,83 @@ fuera del registro inicial — solo se hace editando el perfil ya creado.
 | Desde                          | Acción                                             | Queda en                       | Qué pasa con el trabajo                                    |
 | ------------------------------- | --------------------------------------------------- | -------------------------------- | -------------------------------------------------------------- |
 | V-001 · lista de categorías      | Toca "+ Agregar categoría"                            | V-001 · agregando categoría       | Los bloques existentes no cambian                              |
-| V-001 · agregando categoría      | Elige categoría, llena precio/descripción (o no) y sale del bloque | V-001 · lista de categorías | Se agrega el bloque nuevo al final de la lista                 |
-| V-001 · agregando categoría      | Toca "Cancelar" antes de elegir categoría             | V-001 · lista de categorías       | No se guarda nada, el bloque en blanco desaparece               |
+| V-001 · agregando categoría      | Elige categoría, llena precio/descripción (o no) y toca "Guardar categoría" | V-001 · lista de categorías | Se agrega el bloque nuevo al final de la lista, con confirmación |
+| V-001 · agregando categoría      | Toca "Cancelar", en cualquier momento                | V-001 · lista de categorías       | No se guarda nada, el bloque en blanco desaparece               |
+| V-001 · lista de categorías      | Toca "Editar" en un bloque declarado                  | V-001 · editando esa categoría    | El resto de los bloques no cambia                               |
+| V-001 · editando una categoría   | Cambia precio/descripción y toca "Guardar cambios"    | V-001 · lista de categorías       | El bloque queda con los valores nuevos, con confirmación        |
+| V-001 · editando una categoría   | Toca "Cancelar"                                       | V-001 · lista de categorías       | El bloque vuelve a sus valores de antes, nada se envía al servidor |
 | V-001 · lista de categorías      | Toca "Quitar" en un bloque (con 2+ categorías)        | V-001 · lista de categorías       | Ese bloque desaparece de inmediato, el resto no cambia          |
 | V-002 · resultados de "Gasfitería en Ñuñoa" | Toca la card de un profesional multi-categoría | V-003 · perfil (contexto: Gasfitería) | El precio, la descripción y el mensaje de WhatsApp usan Gasfitería |
 | V-003 · perfil (cualquier modo)  | Toca "Escribir por WhatsApp" o "Llamar"               | WhatsApp / marcador (fuera de Datealo) | El perfil queda en la misma posición al volver                 |
 
-## UXF-001 — Agregar una categoría al perfil
+## UXF-001 — Agregar o editar una categoría del perfil
 
-**Objetivo:** el profesional agrega una categoría que no tenía, con su propio precio y descripción.
+**Objetivo:** el profesional agrega una categoría que no tenía, o cambia el precio/descripción de una que
+ya declaró, con la certeza de que quedó guardado antes de seguir.
 **Contrato:** [F-001](./producto.md#f-001).
 
 **Punto de entrada:** el profesional está en su perfil (V-001), con al menos una categoría ya declarada
 (todo profesional tiene una desde el registro).
 
-**Criterio de término:** la nueva categoría aparece como un bloque más en la lista, con su precio y
-descripción guardados (o vacíos si no los llenó), y desde ese momento cuenta para las búsquedas de esa
-categoría.
+**Criterio de término:** toca "Guardar categoría" (al agregar) o "Guardar cambios" (al editar) y ve la
+confirmación; el bloque queda con los valores nuevos y, si es una categoría nueva, cuenta desde ese
+momento para las búsquedas de esa categoría.
 
 **Cómo sabe el usuario dónde está:** cada bloque de categoría muestra su nombre como título; el bloque en
-edición se distingue con el mismo borde/fondo resaltado que ya usan hoy los bloques de "Descripción" y
-"Precio" al editarse.
+edición se distingue con el mismo borde/fondo resaltado que ya usan los bloques de "Nombre"/"Comuna" del
+perfil, y siempre trae Cancelar/Guardar visibles al pie mientras dura la edición — nunca solo uno de los
+dos.
 
 ### Salidas
 
 | Salida                | Cómo se ejecuta                                                  | Qué queda del trabajo                                |
 | ---------------------- | ------------------------------------------------------------------ | -------------------------------------------------------- |
-| Termina bien           | Elige categoría y llena precio/descripción (guardado automático al perder el foco de cada campo) | El bloque nuevo queda guardado y visible                 |
-| Cancela                | Toca "Cancelar" antes de elegir categoría                           | Nada se guarda, el bloque en blanco desaparece            |
-| Abandona sin cerrar    | Cierra la app o navega a otra parte a medio llenar                 | Nada se guarda (no hay borrador); al volver ve la lista como estaba antes de tocar "+ Agregar" |
+| Termina bien (agregar) | Elige categoría, llena precio/descripción si quiere, toca "Guardar categoría" | Un solo guardado con los tres datos juntos; el bloque nuevo queda visible con confirmación |
+| Termina bien (editar)  | Cambia precio/descripción, toca "Guardar cambios"                   | Un solo guardado con los dos datos juntos; el bloque queda con los valores nuevos y confirmación |
+| Cancela                | Toca "Cancelar", en cualquier momento mientras el bloque está en edición | Al agregar: nada se guarda, el bloque en blanco desaparece. Al editar: el bloque vuelve a mostrar sus valores de antes, no se envía nada al servidor |
+| Abandona sin cerrar    | Cierra la app o navega a otra parte con el bloque a medio llenar   | Nada se guarda (no hay borrador); al volver ve la lista como estaba antes de entrar en edición |
+| Falla el guardado      | Toca "Guardar categoría"/"Guardar cambios" y el servidor falla      | El bloque conserva todo lo escrito, con un error inline; reintentar no obliga a volver a escribir nada |
 | Quita una categoría    | Toca "Quitar", confirma en el modal ("¿Quitar Gasfitería de tu perfil? Perderás el precio y la descripción que escribiste.") | El bloque desaparece; si cancela el modal, no cambia nada |
 
 ### Secuencia principal
 
+**Agregar:**
+
 | Paso | Acción                                                              | Respuesta del sistema                                                                 | Información visible                                                                 |
 | ---- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------- |
-| 1    | Toca "+ Agregar categoría" al final de la lista                        | Aparece un bloque nuevo en modo edición, con el selector de categoría enfocado              | El selector solo lista las categorías que le faltan (excluye las ya declaradas)            |
-| 2    | Elige una categoría (ej. "Gasfitería")                                  | El bloque muestra el nombre elegido y dos campos: precio y descripción, vacíos              | "Gasfitería" como título del bloque, con el mismo placeholder de ejemplo que ya usa el bloque general de descripción |
-| 3    | Llena precio y/o descripción (ambos opcionales) y sale del campo (blur) | Cada campo se guarda al perder el foco, con el mismo loader que usa hoy "Descripción"/"Precio" | Spinner breve junto al campo que se está guardando                                        |
-| 4    | Termina de editar (toca fuera del bloque, o pasa a otro)                | El bloque pasa a modo lectura: "Gasfitería · Desde $18.000" y la descripción si la ingresó   | El bloque queda tan compacto como los de "Descripción"/"Precio" existentes                 |
+| 1    | Toca "+ Agregar categoría" al final de la lista                        | Aparece un bloque nuevo con sus tres campos visibles a la vez: selector de categoría (enfocado), precio y descripción — ninguno aparece después, todos están ahí desde el primer instante | El selector solo lista las categorías que le faltan (excluye las ya declaradas); "Guardar categoría" empieza deshabilitado |
+| 2    | Elige una categoría y, si quiere, llena precio y/o descripción (ambos opcionales); nada se envía todavía | "Guardar categoría" pasa a habilitado apenas hay una categoría elegida                     | Cancelar y Guardar categoría, siempre visibles al pie del bloque                           |
+| 3    | Toca "Guardar categoría"                                               | Un solo request guarda categoría, precio y descripción juntos; el botón muestra su propio loader mientras espera | El resto del perfil sigue interactivo mientras tanto                                       |
+| 4    | El guardado termina                                                    | El bloque pasa a modo lectura: "Gasfitería · Desde $18.000" y la descripción si la ingresó, más una confirmación visible ("Gasfitería agregada") | El bloque queda tan compacto como los demás de la lista                                    |
+
+**Editar una categoría ya declarada:** mismo mecanismo, sin el paso 1 del selector — tocar "Editar" abre
+directo precio y descripción prellenados con los valores actuales, y el botón dice "Guardar cambios".
 
 ### Variantes y recuperación
 
 | Condición                                              | Qué cambia                                                    | Cómo se entiende                                                        | Cómo se recupera                                             |
 | --------------------------------------------------------- | ------------------------------------------------------------------ | ---------------------------------------------------------------------------- | ------------------------------------------------------------------ |
 | Ya declaró todas las categorías activas                    | El botón "+ Agregar categoría" no aparece                          | Se omite en silencio — es un estado normal, no un error                       | No aplica                                                          |
-| Falla el guardado (categoría, precio o descripción)        | El bloque conserva su valor anterior                                | "No se pudo guardar, toca para reintentar" bajo el campo (patrón ya existente en descripción/precio) | Tocar el mensaje reintenta el guardado                              |
+| Todavía no eligió categoría (agregar)                      | "Guardar categoría" está deshabilitado                             | El botón se ve inactivo — previene el intento en vez de rechazarlo después     | Elegir una categoría lo habilita                                    |
+| Falla el guardado (agregar o editar)                       | El bloque conserva categoría, precio y descripción tal como estaban escritos | "No se pudo guardar. Toca 'Guardar categoría' para reintentar." bajo los botones | Tocar el botón de nuevo reintenta el mismo guardado, sin perder nada |
 | Intenta quitar su única categoría restante                 | El botón "Quitar" de esa categoría no aparece                       | Texto breve junto al bloque: "No puedes quitar tu única categoría. Agrega otra antes de quitar esta." | Agregar otra categoría primero habilita quitar la actual            |
-| Conexión lenta al guardar                                  | El campo muestra el mismo spinner que hoy usan precio/descripción   | Spinner junto al campo, no bloquea el resto del perfil                        | Mismo reintento que ya tienen los demás campos editables            |
+| Conexión lenta al guardar                                  | "Guardar categoría"/"Guardar cambios" muestra su propio loader, deshabilitado mientras dura | Loader en el botón, no bloquea el resto del perfil                            | Espera a que termine; no hay reintento manual necesario             |
 
 ### Decisiones que no deben quedar implícitas
 
-- Elegir una categoría del selector la guarda de inmediato, sin un botón "Confirmar" aparte — mismo patrón
-  de guardado inmediato por campo que ya usa el resto del perfil.
-- Cancelar antes de elegir categoría no deja un bloque vacío a medio crear: el bloque desaparece.
+- El guardado es una acción explícita — "Guardar categoría"/"Guardar cambios" — nunca automática al
+  perder el foco. Con dos o tres campos relacionados a la vez (categoría, precio, descripción), guardar
+  cada uno por separado en silencio no le da al profesional ninguna señal de "ya terminé"; un botón con su
+  propio estado de carga y una confirmación visible sí. Esto es distinto del patrón de "Nombre"/"Contacto"
+  del perfil general (guardado inmediato por campo al perder el foco): ahí cada bloque es un solo dato
+  suelto, acá son dos o tres que se completan juntos antes de comprometerlos.
+- Todos los campos del bloque están visibles desde el primer instante — el selector no revela precio y
+  descripción recién después de elegir categoría. Revelar campos en pasos sorprende con un formulario que
+  cambia de forma a mitad de la tarea, justo cuando el profesional ya empezó a escribir.
+- "Cancelar" está disponible en todo momento mientras el bloque está en edición, tanto al agregar (descarta
+  el bloque entero, nada se guarda) como al editar una categoría ya declarada (revierte los campos a sus
+  valores actuales, sin llamar al servidor). Sin esto, la única forma de salir de la edición es guardar
+  algo, aunque sea un error de tipeo que el profesional quiere descartar.
 - Quitar una categoría pide confirmar, con la consecuencia dicha explícitamente: "¿Quitar Gasfitería de
   tu perfil? Perderás el precio y la descripción que escribiste para esta categoría." con botones
   Cancelar/Quitar. No es el mismo caso que quitar una foto de trabajo (`ProfessionalPhotos.vue`, sin
@@ -115,22 +143,24 @@ edición se distingue con el mismo borde/fondo resaltado que ya usan hoy los blo
   la categoría (ver "Fuera de alcance" en `producto.md`). Salvo que sea la única categoría restante, en
   cuyo caso ni siquiera se ofrece la opción de quitarla. En móvil el modal aparece como bottom sheet (sube
   desde abajo, esquinas superiores redondeadas) — el patrón que Datealo ya tiene decidido para overlays
-  en móvil. Aunque `perfil.vue` mantiene su columna angosta (`max-w-md`) en cualquier ancho de pantalla
-  (ver la vista V-001 más arriba), el modal de confirmación no hereda ese ancho: en desktop se ve
-  centrado en toda la pantalla, con el fondo atenuado cubriendo el viewport completo (no solo la columna),
-  esquinas redondeadas en los cuatro lados y sin el tirador de arrastre — el bottom sheet es un patrón
-  táctil (deslizar para cerrar) que no tiene sentido con mouse, y un sheet de ancho completo en una
-  pantalla de escritorio se vería como una franja larga y vacía. Es el comportamiento por defecto de
-  `UModal` de Nuxt UI entre breakpoints, no algo que haya que construir a mano.
+  en móvil. En desktop se ve centrado en toda la pantalla, con el fondo atenuado cubriendo el viewport
+  completo (no solo la columna angosta de `perfil.vue`), esquinas redondeadas en los cuatro lados y sin el
+  tirador de arrastre — el bottom sheet es un patrón táctil (deslizar para cerrar) que no tiene sentido con
+  mouse, y un sheet de ancho completo en una pantalla de escritorio se vería como una franja larga y vacía.
+  Nuxt UI no cambia esto solo entre tamaños de pantalla (verificado contra el paquete instalado): son dos
+  componentes distintos, uno por ancho de pantalla, elegidos en tiempo de ejecución — no un solo componente
+  con comportamiento responsive nativo.
 - Los botones "Quitar" y "Editar" llevan `aria-label` con el nombre de la categoría ("Quitar Gasfitería",
   "Editar Gasfitería") — el texto visible se queda corto ("Quitar" a secas) cuando hay más de un bloque en
   pantalla y un lector de pantalla los anuncia sin el contexto visual que los separa. Cada uno lleva
   padding suficiente para un área de toque de al menos 24×24px (el texto visible es más chico) y al menos
   8px de separación entre ambos, aunque compartan la misma línea — no solo tamaño de fuente pequeño sin
   margen alrededor.
-- Agregar o quitar un bloque de categoría anuncia el cambio con `aria-live="polite"` sobre la lista de
-  categorías (ej. "Gasfitería agregada" / "Gasfitería quitada") — sin esto, alguien que usa lector de
-  pantalla no se entera de que la lista cambió, porque el bloque aparece o desaparece en silencio.
+- Agregar, editar o quitar una categoría confirma con un toast (`bottom-right`, mismo patrón que ya usa
+  `ProfessionalPublicReviews.vue` para "Reseña publicada") en vez de solo un cambio visual en la lista —
+  "Gasfitería agregada" / "Cambios guardados" / "Gasfitería quitada". Es la única forma de que alguien que
+  usa lector de pantalla se entere de que la lista cambió, y además le da a cualquiera una señal clara de
+  "esto ya terminó" sin tener que interpretar que el bloque volvió a su forma compacta.
 
 ## UXF-002 — Ver y contactar a un profesional con varias categorías
 
@@ -240,9 +270,9 @@ ambigüedad sobre a qué categoría corresponde cada dato aunque no compartan el
 
 <a id="ux-002"></a>
 
-### UX-002 — Agregar una categoría es un bloque más en el mismo perfil, no un modal ni un wizard aparte
+### UX-002 — Agregar o editar una categoría es un bloque más en el mismo perfil, con Guardar/Cancelar explícitos
 
-- **Estado:** aceptada. **Fecha:** 2026-09-06.
+- **Estado:** aceptada. **Fecha:** 2026-09-06, revisada 2026-09-07.
 - **Sustento:** [F-001](./producto.md#f-001).
 - **Alternativas descartadas:** un modal o bottom sheet "Gestionar categorías" separado del scroll
   principal del perfil — descartado porque el perfil ya es una sola pantalla scrolleable y no hay ninguna
@@ -250,10 +280,21 @@ ambigüedad sobre a qué categoría corresponde cada dato aunque no compartan el
   pasos igual al del registro (selector → precio → descripción → confirmar, en pantallas separadas) —
   descartado por sobre-construir un flujo de varios pasos para agregar un solo bloque con dos campos,
   cuando el registro lo justifica ahí por tener 4 datos heterogéneos de una sola vez, no por ser el patrón
-  correcto para "agregar un dato más" sobre un perfil que ya existe.
-- **Decisión y consecuencia:** agregar una categoría reutiliza el mismo patrón de "bloque con borde +
-  edición de campo por campo con guardado automático" que ya usan "Descripción" y "Precio" en V-001. No
-  agrega pantallas nuevas ni navegación fuera del perfil.
+  correcto para "agregar un dato más" sobre un perfil que ya existe. Una primera versión de esta decisión
+  reutilizaba el guardado automático por campo de "Nombre"/"Contacto" (cada campo se guarda solo al perder
+  el foco, sin botón) — descartada tras probarla: con dos o tres campos relacionados a la vez, ese patrón
+  no da ninguna señal de "ya terminé" (el dueño de producto lo describió como quedar "ahí, sin saber si
+  guardé"), y revelar precio/descripción recién después de elegir categoría hacía que el formulario
+  cambiara de forma a mitad de la tarea. Tampoco había forma de cancelar una edición ya empezada — la única
+  salida era guardar algo, aunque fuera un error. Tres problemas del mismo enfoque, no de un detalle suyo.
+- **Decisión y consecuencia:** el bloque de agregar muestra selector, precio y descripción juntos desde el
+  primer instante (nunca revela campos después de elegir categoría), y el bloque de editar muestra precio
+  y descripción juntos con los valores actuales. Ninguno de los dos guarda nada hasta que el profesional
+  toca "Guardar categoría"/"Guardar cambios" — un solo request con todos los campos del bloque, con su
+  propio estado de carga y una confirmación visible al terminar (ver "Decisiones que no deben quedar
+  implícitas" de [UXF-001](#uxf-001)). "Cancelar" siempre está disponible mientras dura la edición. Sigue
+  sin agregar pantallas nuevas ni navegación fuera del perfil — el cambio es el mecanismo de guardado
+  dentro del mismo bloque, no la superficie.
 - **Impacto en producto:** ninguno.
 
 <a id="ux-003"></a>


### PR DESCRIPTION
Closes #231

## Qué hace

Séptimo slice (S-007) del Plan de construcción de la [misión 14](docs/missions/14-multiples-categorias-profesional/ingenieria.md).

- `perfil.vue` reemplaza el formulario de una sola categoría (fila "Categoría" en "Tus datos" + bloques top-level de Descripción y Precio) por un bloque por categoría declarada. El header deja de mostrar una única categoría — queda solo nombre y comuna.
- Cada bloque agrega/edita con **guardado explícito**: los tres campos (selector, precio, descripción) se ven juntos desde el primer instante — nunca se revelan después de elegir categoría — y nada se guarda hasta tocar "Guardar categoría"/"Guardar cambios". "Cancelar" siempre está disponible mientras dura la edición. Confirmación con toast (`useToast()`, mismo patrón que `ProfessionalPublicReviews.vue`).
- `useProfessionalCategorias()`: capa delgada sobre los tres endpoints de `/me/categorias/*`.
- Confirmar quitar usa `UModal` en desktop y `USlideover` (bottom sheet) en mobile, elegido según el ancho de pantalla.
- `CategoriaSelect` gana `exclude` (filtra el catálogo) y expone `focus()`.
- `registro.vue`: línea de ayuda bajo el selector de categoría.

Sustento: UXF-001, UX-002 (`experiencia.md`, revisados el 2026-09-07 — ver el detalle de qué cambió y por qué en el propio documento).

**El diseño cambió dos veces durante la verificación manual**, cada vez por una razón concreta encontrada probando el flujo real, no una preferencia estética:

1. Primera ronda: autosave por campo (guardar al perder el foco), selector primero y precio/descripción revelados después de elegir categoría — igual al patrón de "Descripción"/"Precio" que ya existía en el perfil.
2. Al probarlo, el dueño de producto encontró dos problemas: sin confirmación explícita no había forma de saber "ya terminé" (autosave silencioso), y el formulario cambiaba de forma a mitad de la tarea. Tampoco había forma de cancelar una edición ya empezada.
3. Investigado contra `ui-ux-pro-max` (guía "Submit Feedback": mostrar loading → confirmación de éxito tras un submit, nunca dejar sin respuesta) y el patrón de toast que `experiencia.md` ya tenía decidido — confirma que un guardado explícito con confirmación visible es el enfoque correcto, no solo una preferencia.
4. Rediseño final (este PR): formulario completo desde el inicio, Guardar/Cancelar explícitos, toast de confirmación. `UXF-001`/`UX-002` de `experiencia.md` quedaron revisados con el resultado.

Además, `experiencia.md` asumía que `UModal` de Nuxt UI cambia automáticamente entre bottom sheet (mobile) y modal centrado (desktop) "por defecto". Verificado contra el paquete instalado (Nuxt UI v4): no lo hace — son dos componentes distintos, elegidos en tiempo de ejecución según `matchMedia`. Corregido en el propio documento.

## Test plan

- [x] `npx nuxi typecheck` sin errores
- [x] `npm run build` compila
- [x] Verificación funcional real en mobile (390×844) y desktop (1280×800) con Playwright headless, sesión real vía magic link admin (sin enviar correo), profesionales de prueba descartables:
  - 1 categoría: sin botón "Quitar"; selector + precio + descripción visibles a la vez al agregar; "Guardar categoría" deshabilitado hasta elegir categoría
  - Cancelar durante "agregando" → nada se guarda, la lista queda igual
  - Agregar con categoría + precio + descripción → "Guardar categoría" habilitado, un solo POST con los tres datos, toast "Electricidad agregada", bloque colapsa con los valores correctos
  - Editar una categoría, cambiar el precio y tocar "Cancelar" → **0 requests al servidor**, el valor vuelve al original
  - Editar de nuevo y tocar "Guardar cambios" → **un solo PATCH** con precio y descripción juntos (confirmado inspeccionando el body real de la request)
  - Confirmar quitar en mobile → `USlideover` bottom sheet; en desktop → `UModal` centrado, sin la animación rota de un intento anterior
- [x] Datos y usuarios de prueba eliminados al terminar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UCh4YxpEPvGnpxLJGQeCkw