### PR TITLE
feat(app): [id].vue migra a categorias, categoría de contexto + También hace

### DIFF
--- a/app/components/professional-public/ProfessionalPublicOtherCategorias.vue
+++ b/app/components/professional-public/ProfessionalPublicOtherCategorias.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import type { PublicCategoria } from '~/types/professional'
+
+defineProps<{
+  categorias: PublicCategoria[]
+}>()
+</script>
+
+<template>
+  <div class="border-t border-datealo-surface pt-4">
+    <p class="text-xs font-bold text-datealo-muted">También hace</p>
+    <div class="divide-y divide-datealo-surface">
+      <div
+        v-for="categoria in categorias"
+        :key="categoria.slug"
+        class="flex items-center justify-between gap-3 py-2.5 text-sm text-datealo-text"
+      >
+        <span>{{ categoria.nombre }}</span>
+        <span v-if="categoria.priceFrom" class="font-bold">Desde ${{ formatPriceFrom(categoria.priceFrom) }}</span>
+      </div>
+    </div>
+  </div>
+</template>

--- a/app/components/search/SearchResultCard.test.ts
+++ b/app/components/search/SearchResultCard.test.ts
@@ -26,9 +26,9 @@ function professional(overrides: Partial<SearchResultProfessional> = {}): Search
   }
 }
 
-function mountCard(props: { professional: SearchResultProfessional, vecina?: boolean }) {
+function mountCard(props: { professional: SearchResultProfessional, categoriaSlug?: string, vecina?: boolean }) {
   return mount(SearchResultCard, {
-    props,
+    props: { categoriaSlug: 'gasfiteria', ...props },
     global: { stubs: { NuxtLink: NuxtLinkStub } },
   })
 }
@@ -82,8 +82,8 @@ describe('SearchResultCard', () => {
     expect(wrapper.text()).toContain('Desde $15.000')
   })
 
-  it('es un link al perfil del profesional', () => {
-    const wrapper = mountCard({ professional: professional({ id: 'xyz-789' }) })
-    expect(wrapper.find('a').attributes('href')).toBe('/profesionales/xyz-789')
+  it('es un link al perfil del profesional, con la categoría buscada como contexto', () => {
+    const wrapper = mountCard({ professional: professional({ id: 'xyz-789' }), categoriaSlug: 'electricidad' })
+    expect(wrapper.find('a').attributes('href')).toBe('/profesionales/xyz-789?categoria=electricidad')
   })
 })

--- a/app/components/search/SearchResultCard.vue
+++ b/app/components/search/SearchResultCard.vue
@@ -8,6 +8,7 @@ import { formatMemberSince } from '../../utils/professional-since'
 
 const props = defineProps<{
   professional: SearchResultProfessional
+  categoriaSlug: string
   vecina?: boolean
 }>()
 
@@ -16,7 +17,7 @@ const memberSince = computed(() => formatMemberSince(props.professional.createdA
 
 <template>
   <NuxtLink
-    :to="`/profesionales/${professional.id}`"
+    :to="`/profesionales/${professional.id}?categoria=${categoriaSlug}`"
     class="flex flex-col overflow-hidden rounded-2xl border border-datealo-surface bg-white transition-shadow duration-200 hover:shadow-[0_8px_24px_-12px_rgba(31,41,55,0.25)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
   >
     <img

--- a/app/pages/buscar/index.vue
+++ b/app/pages/buscar/index.vue
@@ -106,10 +106,13 @@ useSeoMeta({
              calcular cuántas columnas entran. Con 23.75rem el cálculo daba justo 2 en el ancho de
              max-w-6xl, sin importar cuánto más ancha fuera la pantalla; 21rem dejan entrar 3 con margen. -->
         <div class="grid gap-4 lg:[grid-template-columns:repeat(auto-fit,minmax(17.5rem,21rem))]">
+          <!-- categoriaSlug! : useSearchResults ya exige categoriaSlug con valor para resolver matchType
+               en 'exacta'/'vecina' (su propio ready), así que acá siempre está seteado. -->
           <SearchResultCard
             v-for="professional in results"
             :key="professional.id"
             :professional="professional"
+            :categoria-slug="categoriaSlug!"
             :vecina="matchType === 'vecina'"
           />
         </div>

--- a/app/pages/profesionales/[id].vue
+++ b/app/pages/profesionales/[id].vue
@@ -11,6 +11,17 @@ const { professional, pending, notFound, slow, refresh, updateProfessional } = u
 
 const memberSince = computed(() => professional.value ? formatMemberSince(professional.value.createdAt) : '')
 
+// La categoría de la búsqueda que trajo al usuario llega por query (?categoria=slug); un link directo la
+// omite, y entonces resolveCategoriaContext cae a la primera categoría declarada.
+const contextSlug = computed(() => {
+  const raw = route.query.categoria
+  return typeof raw === 'string' ? raw : undefined
+})
+
+const categoriaContext = computed(() => professional.value
+  ? resolveCategoriaContext(professional.value.categorias, contextSlug.value)
+  : null)
+
 const contactBarRef = useTemplateRef('contactBar')
 useContactBarHeight(contactBarRef)
 
@@ -21,8 +32,8 @@ function onReviewPublished(review: PublicReview) {
 }
 
 useSeoMeta({
-  title: () => professional.value
-    ? `${professional.value.displayName} · ${professional.value.categoriaNombre} en ${professional.value.comunaNombre}`
+  title: () => professional.value && categoriaContext.value
+    ? `${professional.value.displayName} · ${categoriaContext.value.categoria.nombre} en ${professional.value.comunaNombre}`
     : 'Perfil de profesional',
 })
 </script>
@@ -71,15 +82,23 @@ useSeoMeta({
 
         <div class="px-5 pt-4 lg:px-0">
           <h1 class="text-xl font-extrabold text-datealo-text lg:text-2xl">{{ professional.displayName }}</h1>
-          <p class="mt-0.5 text-sm text-datealo-muted">{{ professional.categoriaNombre }} · {{ professional.comunaNombre }}</p>
+          <p class="mt-0.5 text-sm text-datealo-muted">{{ categoriaContext?.categoria.nombre }} · {{ professional.comunaNombre }}</p>
 
-          <p v-if="professional.priceFrom" class="mt-2 text-base font-bold text-datealo-text lg:text-lg">
-            Desde ${{ formatPriceFrom(professional.priceFrom) }}
+          <p v-if="categoriaContext?.categoria.priceFrom" class="mt-2 text-base font-bold text-datealo-text lg:text-lg">
+            Desde ${{ formatPriceFrom(categoriaContext.categoria.priceFrom) }}
           </p>
 
-          <p v-if="professional.description" class="mt-4 text-base leading-relaxed text-datealo-text">
-            {{ professional.description }}
+          <p v-if="categoriaContext?.categoria.description" class="mt-4 text-base leading-relaxed text-datealo-text">
+            {{ categoriaContext.categoria.description }}
           </p>
+
+          <!-- En mobile va debajo de la descripción, antes de las reseñas; el equivalente de desktop vive
+               en la barra lateral (más abajo), no acá. -->
+          <ProfessionalPublicOtherCategorias
+            v-if="categoriaContext && categoriaContext.secondary.length > 0"
+            :categorias="categoriaContext.secondary"
+            class="mt-5 lg:hidden"
+          />
         </div>
       </div>
 
@@ -121,9 +140,15 @@ useSeoMeta({
             :professional-id="professional.id"
             :contact="professional.contact"
             :display-name="professional.displayName"
-            :categoria-nombre="professional.categoriaNombre"
+            :categoria-nombre="categoriaContext?.categoria.nombre ?? ''"
           />
         </div>
+
+        <ProfessionalPublicOtherCategorias
+          v-if="categoriaContext && categoriaContext.secondary.length > 0"
+          :categorias="categoriaContext.secondary"
+          class="mt-5 hidden lg:block"
+        />
 
         <p class="mt-3.5 hidden text-xs text-datealo-muted lg:block">En Datealo desde {{ memberSince }}</p>
       </div>
@@ -133,7 +158,7 @@ useSeoMeta({
         class="mt-8 px-5 lg:col-span-2 lg:mt-10 lg:px-0"
         :professional-id="professional.id"
         :display-name="professional.displayName"
-        :categoria-nombre="professional.categoriaNombre"
+        :categoria-nombre="categoriaContext?.categoria.nombre ?? ''"
         :reviews="professional.reviews"
         @published="onReviewPublished"
       />

--- a/app/types/professional.ts
+++ b/app/types/professional.ts
@@ -36,6 +36,7 @@ export type PublicProfessionalProfile = {
   contact: string
   description: string | null
   priceFrom: number | null
+  categorias: PublicCategoria[]
   photoUrls: string[]
   avatarUrl: string | null
   createdAt: string

--- a/app/utils/professional-categorias.test.ts
+++ b/app/utils/professional-categorias.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { resolveCategoriaContext } from './professional-categorias'
+import type { PublicCategoria } from '~/types/professional'
+
+function categoria(slug: string, priceFrom: number | null = null): PublicCategoria {
+  return { slug, nombre: slug, priceFrom, description: null }
+}
+
+describe('resolveCategoriaContext', () => {
+  it('usa la categoría del slug de contexto cuando matchea una declarada', () => {
+    const categorias = [categoria('gasfiteria'), categoria('electricidad')]
+    const result = resolveCategoriaContext(categorias, 'electricidad')
+    expect(result.categoria.slug).toBe('electricidad')
+    expect(result.secondary.map(c => c.slug)).toEqual(['gasfiteria'])
+  })
+
+  it('cae a la primera categoría declarada sin slug de contexto', () => {
+    const categorias = [categoria('gasfiteria'), categoria('electricidad')]
+    const result = resolveCategoriaContext(categorias)
+    expect(result.categoria.slug).toBe('gasfiteria')
+    expect(result.secondary.map(c => c.slug)).toEqual(['electricidad'])
+  })
+
+  it('cae a la primera categoría declarada si el slug de contexto no matchea ninguna', () => {
+    const categorias = [categoria('gasfiteria'), categoria('electricidad')]
+    const result = resolveCategoriaContext(categorias, 'pintura')
+    expect(result.categoria.slug).toBe('gasfiteria')
+  })
+
+  it('secondary queda vacío con una sola categoría declarada', () => {
+    const result = resolveCategoriaContext([categoria('gasfiteria')])
+    expect(result.categoria.slug).toBe('gasfiteria')
+    expect(result.secondary).toEqual([])
+  })
+})

--- a/app/utils/professional-categorias.ts
+++ b/app/utils/professional-categorias.ts
@@ -1,0 +1,14 @@
+import type { PublicCategoria } from '~/types/professional'
+
+export type CategoriaContext = {
+  categoria: PublicCategoria
+  secondary: PublicCategoria[]
+}
+
+// El backend garantiza que categorias nunca llega vacío para un profesional activo, así que siempre hay
+// una categoría de contexto: la del slug que llegó por query, o la primera declarada si no matchea ninguna.
+export function resolveCategoriaContext(categorias: PublicCategoria[], contextSlug?: string): CategoriaContext {
+  const categoria = categorias.find(c => c.slug === contextSlug) ?? categorias[0]!
+  const secondary = categorias.filter(c => c.slug !== categoria.slug)
+  return { categoria, secondary }
+}


### PR DESCRIPTION
Closes #232

## Qué hace

Octavo slice (S-008) del Plan de construcción de la [misión 14](docs/missions/14-multiples-categorias-profesional/ingenieria.md).

- `[id].vue` deja de leer los campos legacy (`categoriaNombre`/`priceFrom`/`description` a nivel raíz de `professional`) y resuelve la **categoría de contexto** con `resolveCategoriaContext()`: la del query param (`?categoria=slug`, la que trajo la búsqueda) o la primera categoría declarada si no hay contexto (link directo).
- Esa categoría de contexto alimenta el header, el precio, la descripción, el mensaje de WhatsApp (`ProfessionalPublicContactBar`) y el formulario de reseña (`ProfessionalPublicReviews`) — antes todos leían el campo legado único del profesional.
- Las categorías secundarias se muestran como filas compactas bajo "También hace" (`ProfessionalPublicOtherCategorias.vue`, nuevo componente reutilizado en dos lugares): en mobile, debajo de la descripción, antes de las reseñas; en desktop, en la barra lateral, junto al CTA — nunca en la columna principal. Sin precio si el profesional no lo declaró. Filas no interactivas.
- `PublicProfessionalProfile` (tipo de `app/`) gana `categorias: PublicCategoria[]` — el backend ya la exponía desde S-002, solo faltaba declararla en el tipo del cliente.
- **Fix encontrado al probar el flujo completo**: `SearchResultCard` enlazaba a `/profesionales/[id]` sin ningún query param, así que la categoría de contexto recién agregada nunca recibía el slug de la búsqueda y caía siempre a la primera categoría declarada — reportado como "busqué jardinería y el perfil me mostró electricista". `SearchResultCard` ahora recibe `categoriaSlug` (requerido) y arma el link con `?categoria=<slug>`; `buscar/index.vue` se lo pasa desde el mismo ref que ya usa para buscar.

Sustento: UXF-002, UX-003, UX-004, UX-005 (`docs/missions/14-multiples-categorias-profesional/experiencia.md`).

## Test plan

- [x] `npx nuxi typecheck` sin errores
- [x] `npm run build` compila
- [x] `npx vitest run` — 78/78, incluye 4 tests nuevos para `resolveCategoriaContext` y el test de `SearchResultCard` actualizado para cubrir `?categoria=` en el link
- [x] Verificación visual del caso de una sola categoría (el mayoritario, CL-001) en mobile (390×844) y desktop (1280×800) con Playwright headless, sobre el profesional de prueba existente — sin regresión, se ve igual que antes del cambio
- [x] Confirmado con `curl` sobre `/buscar?categoria=gasfiteria&comuna=...` que la card ahora enlaza con `?categoria=gasfiteria`
- [ ] **No verificado en vivo el modo de varias categorías** ("También hace" con datos reales, ni el resultado de contactar desde una card de una categoría secundaria): generar una sesión de profesional de prueba (magic link admin) e insertar una segunda categoría directo en la base fueron ambas bloqueadas por el clasificador de permisos de esta sesión. La lógica de `resolveCategoriaContext()` está cubierta por tests unitarios y el markup sigue el mockup (`design-mockups/perfil-publico-categorias.html`) al detalle, pero recomiendo una pasada visual manual con un profesional real de 2+ categorías antes o después de mergear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EibkC6oT61jTziqZX2dCSH