### PR TITLE
refactor(db): retirar categoria_slug/price_from/description legacy de professionals

### DIFF
--- a/app/types/professional.ts
+++ b/app/types/professional.ts
@@ -10,11 +10,8 @@ export type PublicCategoria = {
 export type Professional = {
   id: string
   displayName: string
-  categoriaSlug: string
   comunaCodigo: string
   contact: string
-  description: string | null
-  priceFrom: number | null
   categorias: PublicCategoria[]
   photoUrls: string[]
   avatarUrl: string | null
@@ -31,11 +28,8 @@ export type ProfessionalField =
 export type PublicProfessionalProfile = {
   id: string
   displayName: string
-  categoriaNombre: string
   comunaNombre: string
   contact: string
-  description: string | null
-  priceFrom: number | null
   categorias: PublicCategoria[]
   photoUrls: string[]
   avatarUrl: string | null

--- a/server/api/professionals/me/index.patch.ts
+++ b/server/api/professionals/me/index.patch.ts
@@ -1,10 +1,10 @@
-const TEXT_FIELDS = ['displayName', 'categoriaSlug', 'comunaCodigo', 'contact'] as const
+const TEXT_FIELDS = ['displayName', 'comunaCodigo', 'contact'] as const
 
 export default defineEventHandler(async (event) => {
   const user = await requireUser(event)
   const body = await readBody<Record<string, unknown>>(event)
 
-  const patch: ProfessionalFieldsInput = {}
+  const patch: ProfessionalPatch = {}
 
   for (const field of TEXT_FIELDS) {
     if (!(field in body)) continue
@@ -14,24 +14,6 @@ export default defineEventHandler(async (event) => {
       return { error: 'missing_field', field }
     }
     patch[field] = field === 'contact' ? normalizeContact(value.trim()) : value.trim()
-  }
-
-  if ('description' in body) {
-    const value = body.description
-    if (value !== null && typeof value !== 'string') {
-      setResponseStatus(event, 400)
-      return { error: 'invalid_description' }
-    }
-    patch.description = typeof value === 'string' ? value.trim() || null : null
-  }
-
-  if ('priceFrom' in body) {
-    const value = body.priceFrom
-    if (value !== null && typeof value !== 'number') {
-      setResponseStatus(event, 400)
-      return { error: 'invalid_price' }
-    }
-    patch.priceFrom = value
   }
 
   const fieldError = await validateProfessionalFields(patch)

--- a/server/db/migrations/0010_rapid_nuke.sql
+++ b/server/db/migrations/0010_rapid_nuke.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "professionals" DROP CONSTRAINT "professionals_categoria_slug_categorias_slug_fk";
+--> statement-breakpoint
+DROP INDEX "professionals_categoria_slug_idx";--> statement-breakpoint
+ALTER TABLE "professionals" DROP COLUMN "categoria_slug";--> statement-breakpoint
+ALTER TABLE "professionals" DROP COLUMN "description";--> statement-breakpoint
+ALTER TABLE "professionals" DROP COLUMN "price_from";

--- a/server/db/migrations/meta/0010_snapshot.json
+++ b/server/db/migrations/meta/0010_snapshot.json
@@ -1,0 +1,588 @@
+{
+  "id": "abd88d30-3ac8-4e1f-ab11-ca955b5bdb41",
+  "prevId": "ae6f0cdd-2b9e-4f63-95e4-d6c06a0a9129",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.categorias": {
+      "name": "categorias",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "nombre": {
+          "name": "nombre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activa": {
+          "name": "activa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comuna_vecinas": {
+      "name": "comuna_vecinas",
+      "schema": "",
+      "columns": {
+        "comuna_codigo": {
+          "name": "comuna_codigo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vecina_codigo": {
+          "name": "vecina_codigo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comuna_vecinas_comuna_codigo_comunas_codigo_fk": {
+          "name": "comuna_vecinas_comuna_codigo_comunas_codigo_fk",
+          "tableFrom": "comuna_vecinas",
+          "tableTo": "comunas",
+          "columnsFrom": [
+            "comuna_codigo"
+          ],
+          "columnsTo": [
+            "codigo"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "comuna_vecinas_vecina_codigo_comunas_codigo_fk": {
+          "name": "comuna_vecinas_vecina_codigo_comunas_codigo_fk",
+          "tableFrom": "comuna_vecinas",
+          "tableTo": "comunas",
+          "columnsFrom": [
+            "vecina_codigo"
+          ],
+          "columnsTo": [
+            "codigo"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "comuna_vecinas_comuna_codigo_vecina_codigo_pk": {
+          "name": "comuna_vecinas_comuna_codigo_vecina_codigo_pk",
+          "columns": [
+            "comuna_codigo",
+            "vecina_codigo"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comunas": {
+      "name": "comunas",
+      "schema": "",
+      "columns": {
+        "codigo": {
+          "name": "codigo",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "nombre": {
+          "name": "nombre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activa": {
+          "name": "activa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.professional_categorias": {
+      "name": "professional_categorias",
+      "schema": "",
+      "columns": {
+        "professional_id": {
+          "name": "professional_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "categoria_slug": {
+          "name": "categoria_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_from": {
+          "name": "price_from",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "professional_categorias_categoria_slug_idx": {
+          "name": "professional_categorias_categoria_slug_idx",
+          "columns": [
+            {
+              "expression": "categoria_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "professional_categorias_professional_id_professionals_id_fk": {
+          "name": "professional_categorias_professional_id_professionals_id_fk",
+          "tableFrom": "professional_categorias",
+          "tableTo": "professionals",
+          "columnsFrom": [
+            "professional_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "professional_categorias_categoria_slug_categorias_slug_fk": {
+          "name": "professional_categorias_categoria_slug_categorias_slug_fk",
+          "tableFrom": "professional_categorias",
+          "tableTo": "categorias",
+          "columnsFrom": [
+            "categoria_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "professional_categorias_professional_id_categoria_slug_pk": {
+          "name": "professional_categorias_professional_id_categoria_slug_pk",
+          "columns": [
+            "professional_id",
+            "categoria_slug"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.professional_contact_events": {
+      "name": "professional_contact_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "professional_id": {
+          "name": "professional_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "professional_contact_events_professional_id_idx": {
+          "name": "professional_contact_events_professional_id_idx",
+          "columns": [
+            {
+              "expression": "professional_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "professional_contact_events_professional_id_professionals_id_fk": {
+          "name": "professional_contact_events_professional_id_professionals_id_fk",
+          "tableFrom": "professional_contact_events",
+          "tableTo": "professionals",
+          "columnsFrom": [
+            "professional_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.professional_contact_tokens": {
+      "name": "professional_contact_tokens",
+      "schema": "",
+      "columns": {
+        "professional_id": {
+          "name": "professional_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "professional_contact_tokens_professional_id_professionals_id_fk": {
+          "name": "professional_contact_tokens_professional_id_professionals_id_fk",
+          "tableFrom": "professional_contact_tokens",
+          "tableTo": "professionals",
+          "columnsFrom": [
+            "professional_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "professional_contact_tokens_professional_id_token_pk": {
+          "name": "professional_contact_tokens_professional_id_token_pk",
+          "columns": [
+            "professional_id",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.professionals": {
+      "name": "professionals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comuna_codigo": {
+          "name": "comuna_codigo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact": {
+          "name": "contact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_paths": {
+          "name": "photo_paths",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "avatar_path": {
+          "name": "avatar_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "professionals_comuna_codigo_idx": {
+          "name": "professionals_comuna_codigo_idx",
+          "columns": [
+            {
+              "expression": "comuna_codigo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "professionals_comuna_codigo_comunas_codigo_fk": {
+          "name": "professionals_comuna_codigo_comunas_codigo_fk",
+          "tableFrom": "professionals",
+          "tableTo": "comunas",
+          "columnsFrom": [
+            "comuna_codigo"
+          ],
+          "columnsTo": [
+            "codigo"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "professionals_user_id_unique": {
+          "name": "professionals_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "professional_id": {
+          "name": "professional_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reviews_professional_id_professionals_id_fk": {
+          "name": "reviews_professional_id_professionals_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "professionals",
+          "columnsFrom": [
+            "professional_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "reviews_professional_id_token_fk": {
+          "name": "reviews_professional_id_token_fk",
+          "tableFrom": "reviews",
+          "tableTo": "professional_contact_tokens",
+          "columnsFrom": [
+            "professional_id",
+            "token"
+          ],
+          "columnsTo": [
+            "professional_id",
+            "token"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reviews_professional_id_token_key": {
+          "name": "reviews_professional_id_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "professional_id",
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "reviews_rating_check": {
+          "name": "reviews_rating_check",
+          "value": "\"reviews\".\"rating\" between 1 and 5"
+        },
+        "reviews_comment_length_check": {
+          "name": "reviews_comment_length_check",
+          "value": "char_length(\"reviews\".\"comment\") <= 500"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/db/migrations/meta/_journal.json
+++ b/server/db/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1788812415080,
       "tag": "0009_sturdy_puma",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1788963933629,
+      "tag": "0010_rapid_nuke",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/schema/professionals.ts
+++ b/server/db/schema/professionals.ts
@@ -1,5 +1,4 @@
-import { boolean, index, integer, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core'
-import { categorias } from './categorias'
+import { boolean, index, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core'
 import { comunas } from './comunas'
 
 export const professionals = pgTable(
@@ -11,9 +10,6 @@ export const professionals = pgTable(
     // Sin foreign key formal a auth.users: esa tabla la gestiona Supabase, no Drizzle.
     userId: uuid('user_id').notNull().unique(),
     displayName: text('display_name').notNull(),
-    categoriaSlug: text('categoria_slug')
-      .notNull()
-      .references(() => categorias.slug, { onUpdate: 'cascade' }),
     comunaCodigo: text('comuna_codigo')
       .notNull()
       .references(() => comunas.codigo),
@@ -21,8 +17,6 @@ export const professionals = pgTable(
     // Copia de auth.users.email al momento del registro, nunca leída en vivo desde ahí — dato interno
     // para el correo de aviso de reseña nueva, jamás parte de la forma pública del profesional.
     email: text('email'),
-    description: text('description'),
-    priceFrom: integer('price_from'),
     // Paths dentro del bucket professional-photos, nunca URLs completas — la URL pública se
     // calcula al responder, no se guarda.
     photoPaths: text('photo_paths').array().notNull().default([]),
@@ -34,9 +28,7 @@ export const professionals = pgTable(
     updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
   },
   (table) => [
-    // Postgres no indexa una FK automáticamente — son las dos columnas por las que la búsqueda
-    // va a filtrar y hacer join.
-    index('professionals_categoria_slug_idx').on(table.categoriaSlug),
+    // Postgres no indexa una FK automáticamente — es la columna por la que la búsqueda hace join.
     index('professionals_comuna_codigo_idx').on(table.comunaCodigo),
   ],
 )

--- a/server/utils/professional-categorias.ts
+++ b/server/utils/professional-categorias.ts
@@ -24,16 +24,6 @@ export async function createProfessionalCategoria(
   await tx.insert(professionalCategorias).values({ professionalId, categoriaSlug })
 }
 
-// Hasta que exista más de una categoría por profesional, esta es siempre la única fila — no hace
-// falta el slug en la firma para saber cuál actualizar.
-export async function updateSoleProfessionalCategoria(
-  tx: DbOrTx,
-  professionalId: string,
-  patch: { categoriaSlug?: string, priceFrom?: number | null, description?: string | null },
-): Promise<void> {
-  await tx.update(professionalCategorias).set(patch).where(eq(professionalCategorias.professionalId, professionalId))
-}
-
 // Orden por createdAt ascendente: la primera categoría declarada queda primera, que es lo que usa el
 // resto del sistema como categoría de contexto por default sin un query param de búsqueda. Acepta un
 // tx opcional para poder leer el estado ya actualizado desde dentro de la misma transacción

--- a/server/utils/professionals.ts
+++ b/server/utils/professionals.ts
@@ -4,7 +4,6 @@ import { existsActiveComuna } from './comunas'
 import {
   createProfessionalCategoria,
   findProfessionalCategorias,
-  updateSoleProfessionalCategoria,
   type PublicCategoria,
 } from './professional-categorias'
 import { isUuid } from './validation'
@@ -20,6 +19,13 @@ export type ProfessionalCoreFields = {
   contact: string
 }
 
+// Lo que PATCH /me puede tocar de la fila de professionals — ya sin categoriaSlug/priceFrom/description,
+// que ahora se editan siempre por categoría vía /me/categorias/*.
+export type ProfessionalPatch = Partial<Pick<ProfessionalCoreFields, 'displayName' | 'comunaCodigo' | 'contact'>>
+
+// Usado tanto para el patch de professionals (displayName/comunaCodigo/contact) como para el de una
+// categoría puntual (categoriaSlug/priceFrom/description vía /me/categorias/*) — validateProfessionalFields
+// es genérica sobre las dos, cada endpoint le pasa solo los campos que le tocan.
 export type ProfessionalFieldsInput = Partial<ProfessionalCoreFields> & {
   description?: string | null
   priceFrom?: number | null
@@ -30,11 +36,8 @@ export type ProfessionalFieldError = { error: string }
 export type Professional = {
   id: string
   displayName: string
-  categoriaSlug: string
   comunaCodigo: string
   contact: string
-  description: string | null
-  priceFrom: number | null
   photoUrls: string[]
   avatarUrl: string | null
   active: boolean
@@ -42,18 +45,11 @@ export type Professional = {
 
 // Forma que ve un buscador sin sesión (misión 05): categoría/comuna ya resueltas a su nombre (nunca el
 // slug/código, que no significa nada para quien mira el perfil) y createdAt, que Professional no expone.
-//
-// categoriaNombre/priceFrom/description quedan calculados desde categorias[0] mientras conviva con el
-// array nuevo — categorias es la forma real; esos tres campos se retiran una vez que perfil.vue y
-// [id].vue dejen de leerlos directamente.
 export type PublicProfessionalProfile = {
   id: string
   displayName: string
-  categoriaNombre: string
   comunaNombre: string
   contact: string
-  description: string | null
-  priceFrom: number | null
   categorias: PublicCategoria[]
   photoUrls: string[]
   avatarUrl: string | null
@@ -63,11 +59,8 @@ export type PublicProfessionalProfile = {
 type ProfessionalRow = {
   id: string
   displayName: string
-  categoriaSlug: string
   comunaCodigo: string
   contact: string
-  description: string | null
-  priceFrom: number | null
   photoPaths: string[]
   avatarPath: string | null
   active: boolean
@@ -78,11 +71,8 @@ type ProfessionalRow = {
 const publicColumns = {
   id: professionals.id,
   displayName: professionals.displayName,
-  categoriaSlug: professionals.categoriaSlug,
   comunaCodigo: professionals.comunaCodigo,
   contact: professionals.contact,
-  description: professionals.description,
-  priceFrom: professionals.priceFrom,
   photoPaths: professionals.photoPaths,
   avatarPath: professionals.avatarPath,
   active: professionals.active,
@@ -128,11 +118,8 @@ function toPublicProfessional(row: ProfessionalRow): Professional {
   return {
     id: row.id,
     displayName: row.displayName,
-    categoriaSlug: row.categoriaSlug,
     comunaCodigo: row.comunaCodigo,
     contact: row.contact,
-    description: row.description,
-    priceFrom: row.priceFrom,
     photoUrls: buildPhotoUrls(row.photoPaths),
     avatarUrl: buildAvatarUrl(row.avatarPath),
     active: row.active,
@@ -164,21 +151,12 @@ export async function findPublicProfessionalProfile(id: string): Promise<PublicP
 
   if (!row) return null
 
-  const categoriasList = await findProfessionalCategorias(row.id)
-  // Un profesional activo nunca tiene 0 filas en professional_categorias — la única forma de llegar
-  // a cero se bloquea al quitar la última categoría, no acá, así que esta lectura confía en que
-  // categoriasList siempre trae al menos una fila.
-  const [primaryCategoria] = categoriasList
-
   return {
     id: row.id,
     displayName: row.displayName,
-    categoriaNombre: primaryCategoria!.nombre,
     comunaNombre: row.comunaNombre ?? row.comunaCodigo,
     contact: row.contact,
-    description: primaryCategoria!.description,
-    priceFrom: primaryCategoria!.priceFrom,
-    categorias: categoriasList,
+    categorias: await findProfessionalCategorias(row.id),
     photoUrls: buildPhotoUrls(row.photoPaths),
     avatarUrl: buildAvatarUrl(row.avatarPath),
     createdAt: row.createdAt.toISOString(),
@@ -199,28 +177,13 @@ export async function findProfessionalByUserId(userId: string): Promise<Professi
   return row ? toPublicProfessional(row) : null
 }
 
-// categoriaSlug/priceFrom/description quedan calculados desde categorias[0], igual que
-// findPublicProfessionalProfile — esto es solo para GET /me. Los endpoints de escritura (POST /me,
-// PATCH /me) todavía leen y escriben la fila de professionals tal cual, sin pasar por acá.
 export type ProfessionalProfile = Professional & { categorias: PublicCategoria[] }
 
 export async function findProfessionalProfileByUserId(userId: string): Promise<ProfessionalProfile | null> {
   const professional = await findProfessionalByUserId(userId)
   if (!professional) return null
 
-  const categoriasList = await findProfessionalCategorias(professional.id)
-  // Un profesional activo nunca tiene 0 filas en professional_categorias — la única forma de llegar
-  // a cero se bloquea al quitar la última categoría, no acá, así que esta lectura confía en que
-  // categoriasList siempre trae al menos una fila.
-  const [primaryCategoria] = categoriasList
-
-  return {
-    ...professional,
-    categoriaSlug: primaryCategoria!.slug,
-    priceFrom: primaryCategoria!.priceFrom,
-    description: primaryCategoria!.description,
-    categorias: categoriasList,
-  }
+  return { ...professional, categorias: await findProfessionalCategorias(professional.id) }
 }
 
 // Lo único que necesita el correo de aviso de reseña nueva (misión 07) — nunca active, que ya decidió
@@ -240,16 +203,18 @@ export async function createProfessional(
   fields: ProfessionalCoreFields,
   email: string | null,
 ): Promise<{ professional: Professional, created: boolean }> {
+  const { categoriaSlug, ...professionalFields } = fields
+
   const inserted = await useDb().transaction(async (tx) => {
     const [professional] = await tx
       .insert(professionals)
-      .values({ userId, ...fields, email })
+      .values({ userId, ...professionalFields, email })
       .onConflictDoNothing({ target: professionals.userId })
       .returning(publicColumns)
 
     if (!professional) return null
 
-    await createProfessionalCategoria(tx, professional.id, fields.categoriaSlug)
+    await createProfessionalCategoria(tx, professional.id, categoriaSlug)
     return professional
   })
 
@@ -263,32 +228,21 @@ export async function createProfessional(
   return { professional: existing!, created: false }
 }
 
-export async function updateProfessional(
-  userId: string,
-  patch: ProfessionalFieldsInput,
-): Promise<ProfessionalProfile | null> {
-  const { categoriaSlug, priceFrom, description, ...professionalPatch } = patch
+// Devuelve el perfil con categorias (no solo Professional): el cliente guarda esta respuesta como su
+// único estado del perfil propio (useProfessionalProfile), y perfil.vue necesita categorias ahí aunque
+// esta escritura puntual no la haya tocado — perderla haría desaparecer los bloques de categoría hasta
+// el próximo reload.
+export async function updateProfessional(userId: string, patch: ProfessionalPatch): Promise<ProfessionalProfile | null> {
+  const [row] = await useDb()
+    .update(professionals)
+    .set({ ...patch, updatedAt: new Date() })
+    .where(eq(professionals.userId, userId))
+    .returning(publicColumns)
 
-  const updated = await useDb().transaction(async (tx) => {
-    const [row] = await tx
-      .update(professionals)
-      .set({ ...professionalPatch, updatedAt: new Date() })
-      .where(eq(professionals.userId, userId))
-      .returning({ id: professionals.id })
+  if (!row) return null
 
-    if (!row) return null
-
-    if (categoriaSlug !== undefined || priceFrom !== undefined || description !== undefined) {
-      await updateSoleProfessionalCategoria(tx, row.id, { categoriaSlug, priceFrom, description })
-    }
-
-    return row
-  })
-
-  // Releer en vez de armar la respuesta a mano con lo que se acaba de escribir: priceFrom/description
-  // ahora viven en professional_categorias, no en la fila de professionals que devolvería el update de
-  // arriba, así que reconstruirla acá evitaría duplicar exactamente el cálculo que ya hace GET /me.
-  return updated ? findProfessionalProfileByUserId(userId) : null
+  const professional = toPublicProfessional(row)
+  return { ...professional, categorias: await findProfessionalCategorias(professional.id) }
 }
 
 export async function addProfessionalPhoto(userId: string, path: string): Promise<Professional | null> {


### PR DESCRIPTION
Closes #233

## Qué hace

Noveno y último slice (S-009, fase *contract*) del Plan de construcción de la [misión 14](docs/missions/14-multiples-categorias-profesional/ingenieria.md) — cierra la ventana de transición expand/contract que abrió S-001/T-004, ya sin consumidores de los campos legacy (`perfil.vue` y `[id].vue` migraron a `categorias[]` en S-007/S-008).

- **Migración de Drizzle** (`0010_rapid_nuke.sql`): `DROP COLUMN` de `categoria_slug`, `price_from`, `description` y su índice en `professionals`. Los datos ya viven en `professional_categorias` desde S-001, no se pierden. **Ya aplicada contra la base de Supabase** (`npm run db:migrate`), confirmado con `curl` sobre `/api/professionals/[id]` que la respuesta ya no trae los campos legacy y `categorias` sigue funcionando igual.
- `GET /api/professionals/[id]` y `GET /api/professionals/me` dejan de exponer `categoriaNombre`/`priceFrom`/`description` a nivel raíz de `professional` — `categorias` pasa a ser la única forma.
- `PATCH /api/professionals/me` deja de aceptar `categoriaSlug`/`priceFrom`/`description` sueltos — esos tres campos ya se editan siempre por categoría vía `/me/categorias/*` desde S-005/S-006. `updateSoleProfessionalCategoria` queda sin ningún caller, se borra.
- `Professional` (tipo de `app/` y de `server/`) pierde los mismos tres campos legacy.

Sustento: T-001 (fase contract), T-004 (`docs/missions/14-multiples-categorias-profesional/ingenieria.md`).

## Test plan

- [x] `npx nuxi typecheck` sin errores
- [x] `npm run build` compila
- [x] `npx vitest run` — 78/78, sin cambios necesarios en los tests existentes
- [x] Migración aplicada contra la base real; confirmado con `curl "/api/professionals/[id-de-prueba]"` que la respuesta ya no trae `categoriaNombre`/`priceFrom`/`description` sueltos y `categorias` sigue devolviendo la data correcta
- [x] `curl -X PATCH /api/professionals/me` sin sesión sigue devolviendo 401 (endpoint sigue vivo, sin crash por el cambio de tipos)
- [ ] No hice una edición autenticada real de nombre/comuna/contacto desde `perfil.vue` para confirmar visualmente que `PATCH /me` sigue devolviendo `categorias` en la respuesta (necesario para que los bloques de categoría no desaparezcan del estado del cliente tras editar otro campo) — recomiendo esa pasada manual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EibkC6oT61jTziqZX2dCSH