### PR TITLE
docs(docs): cerrar la misión 14 (múltiples categorías por profesional)

### DIFF
--- a/docs/missions/14-multiples-categorias-profesional/README.md
+++ b/docs/missions/14-multiples-categorias-profesional/README.md
@@ -4,19 +4,20 @@
 categoría por profesional) y cómo `/api/search` filtra por categoría. **Abierta el** 2026-09-06.
 **Nace de:** ninguna.
 
-**Estado de la misión:** en construcción
+**Estado de la misión:** cerrada 2026-09-09
 
 **En foco:** ninguno — discovery cerrado, los tres documentos (`producto.md`, `experiencia.md`,
 `ingenieria.md`) están `vigente`
 
-**Última actualización:** 2026-09-07
+**Última actualización:** 2026-09-09
 
 **Documentos:** [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-**Próximo hito:** issues creados desde el Plan de construcción (#225 a #233, S-001 a S-009). Trabajando
-S-001 (#225) primero — el resto sigue el orden de dependencias del Plan de construcción de
-`ingenieria.md`.
+**Plan de construcción:** los nueve slices (S-001 a S-009, #225 a #233) están mergeados — la migración
+expand/contract completa, de una sola categoría por profesional a `professional_categorias`, con
+`perfil.vue` y `[id].vue` ya leyendo y escribiendo la forma nueva y las columnas legacy retiradas de
+`professionals`.
 
 ## Brief
 

--- a/docs/missions/README.md
+++ b/docs/missions/README.md
@@ -22,7 +22,7 @@ abrieron y de dónde salió cada una.
 | 11  | [vista de detalle de perfil](./11-perfil-profesional/) | producto | 2026-09-01 | cerrada 2026-09-04 | — | — |
 | 12  | [hero y copy de la landing](./12-hero-y-copy-landing/) | producto | 2026-09-01 | cerrada 2026-09-06 | — | — |
 | 13  | [tamaño de fuente](./13-tamano-de-fuente/) | producto | 2026-09-06 | cerrada 2026-09-06 | — | — |
-| 14  | [múltiples categorías por profesional](./14-multiples-categorias-profesional/) | producto | 2026-09-06 | en construcción | — | — |
+| 14  | [múltiples categorías por profesional](./14-multiples-categorias-profesional/) | producto | 2026-09-06 | cerrada 2026-09-09 | — | — |
 | 15  | [múltiples comunas por profesional](./15-multiples-comunas-profesional/) | producto | 2026-09-06 | lista para construir | — | — |
 
 Misiones 02 a 07 son las seis que llevan al MVP (registrarse, mostrarse, buscar, reseñar), en el orden de


### PR DESCRIPTION
## Qué hace

Cierra la misión 14 — los nueve slices de su Plan de construcción (S-001 a S-009, issues #225 a #233) ya
están todos mergeados en `main`:

- `professional_categorias` creada con RLS, datos migrados (S-001).
- `GET`/`POST`/`PATCH`/`DELETE` de categorías, `/api/search` leyendo por categoría (S-002 a S-006).
- `perfil.vue` y `[id].vue` migrados a `categorias[]` (S-007, S-008).
- Columnas legacy (`categoria_slug`, `price_from`, `description`) retiradas de `professionals` (S-009).

Actualiza el estado a `cerrada 2026-09-09` en `docs/missions/README.md` y en el README de la propia
misión.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EibkC6oT61jTziqZX2dCSH