### PR TITLE
docs(docs): misión 15 pasa a en construcción, issues creados

### DIFF
--- a/docs/missions/15-multiples-comunas-profesional/README.md
+++ b/docs/missions/15-multiples-comunas-profesional/README.md
@@ -4,24 +4,19 @@
 comuna por profesional) y cómo `/api/search` filtra por comuna. **Abierta el** 2026-09-06.
 **Nace de:** ninguna.
 
-**Estado de la misión:** definición
+**Estado de la misión:** en construcción
 
-**En foco:** ninguno — discovery completo, los tres documentos (`producto.md`, `experiencia.md`,
-`ingenieria.md`) están vigentes
+**En foco:** ninguno — discovery cerrado, los tres documentos (`producto.md`, `experiencia.md`,
+`ingenieria.md`) están `vigente`
 
-**Última actualización:** 2026-09-07
+**Última actualización:** 2026-09-09
 
 **Documentos:** [Investigación](./investigacion.md) · [Producto](./producto.md) ·
 [Experiencia](./experiencia.md) · [Ingeniería](./ingenieria.md)
 
-**Próximo hito:** abrir el PR de discovery con los tres documentos vigentes (paso 6 de la secuencia,
-`docs/missions/README.md`) — todavía no abierto. Recién después de mergeado, cerrar el worktree
-(`ExitWorktree action: "remove"`) y, ya en la raíz, cortar el Plan de construcción de `ingenieria.md`
-(S-001 a S-010) en issues. `ingenieria.md` diseña `professional_comunas` (tabla de relación que reemplaza a
-`professionals.comuna_codigo`), 4 contratos (TC-001 a TC-004), su RLS (auditada contra el checklist de
-`seguridad-datos`), y 5 decisiones técnicas (T-001 a T-005) — incluida una ventana de migración entre
-slices y un consumidor de `comunaCodigo` que la auditoría del Carril Full Spec encontró y ya quedó
-corregido en el propio documento.
+**Próximo hito:** issues creados desde el Plan de construcción (#244 a #253, S-001 a S-010). Trabajando
+S-001 (#244) primero — el resto sigue el orden de dependencias del Plan de construcción de
+`ingenieria.md`.
 
 ## Brief
 

--- a/docs/missions/README.md
+++ b/docs/missions/README.md
@@ -23,7 +23,7 @@ abrieron y de dónde salió cada una.
 | 12  | [hero y copy de la landing](./12-hero-y-copy-landing/) | producto | 2026-09-01 | cerrada 2026-09-06 | — | — |
 | 13  | [tamaño de fuente](./13-tamano-de-fuente/) | producto | 2026-09-06 | cerrada 2026-09-06 | — | — |
 | 14  | [múltiples categorías por profesional](./14-multiples-categorias-profesional/) | producto | 2026-09-06 | cerrada 2026-09-09 | — | — |
-| 15  | [múltiples comunas por profesional](./15-multiples-comunas-profesional/) | producto | 2026-09-06 | lista para construir | — | — |
+| 15  | [múltiples comunas por profesional](./15-multiples-comunas-profesional/) | producto | 2026-09-06 | en construcción | — | — |
 
 Misiones 02 a 07 son las seis que llevan al MVP (registrarse, mostrarse, buscar, reseñar), en el orden de
 dependencia definido en la conversación de roadmap del 2026-08-13 — el número no es prioridad, pero acá sí


### PR DESCRIPTION
## Qué hace

El PR de discovery de la misión 15 (#223) ya estaba mergeado desde el 2026-09-07 y su worktree ya no
existe — el README de la misión había quedado desactualizado diciendo "todavía no abierto". Corrige el
estado real y corta los diez slices del Plan de construcción de `ingenieria.md` en issues:

#244 (S-001) · #245 (S-002) · #246 (S-003) · #247 (S-004) · #248 (S-005) · #249 (S-006) · #250 (S-007) ·
#251 (S-008) · #252 (S-009) · #253 (S-010)

Actualiza el estado a `en construcción` en `docs/missions/README.md` y en el README de la propia misión.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EibkC6oT61jTziqZX2dCSH