### PR TITLE
feat(db): crear professional_comunas con su RLS y migrar datos existentes

### DIFF
--- a/server/db/migrations/0011_married_wiccan.sql
+++ b/server/db/migrations/0011_married_wiccan.sql
@@ -1,0 +1,16 @@
+CREATE TABLE "professional_comunas" (
+	"professional_id" uuid NOT NULL,
+	"comuna_codigo" text NOT NULL,
+	CONSTRAINT "professional_comunas_professional_id_comuna_codigo_pk" PRIMARY KEY("professional_id","comuna_codigo")
+);
+--> statement-breakpoint
+ALTER TABLE "professional_comunas" ADD CONSTRAINT "professional_comunas_professional_id_professionals_id_fk" FOREIGN KEY ("professional_id") REFERENCES "public"."professionals"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "professional_comunas" ADD CONSTRAINT "professional_comunas_comuna_codigo_comunas_codigo_fk" FOREIGN KEY ("comuna_codigo") REFERENCES "public"."comunas"("codigo") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "professional_comunas_comuna_codigo_idx" ON "professional_comunas" USING btree ("comuna_codigo");--> statement-breakpoint
+-- Backfill idempotente (ON CONFLICT DO NOTHING): cada profesional existente conserva su comuna actual
+-- como su única comuna declarada. Se vuelve a correr, sin cambios, al desplegar S-002 — cierra la
+-- ventana entre que esta migración se aplica y S-002 empieza a escribir en la misma transacción.
+INSERT INTO "professional_comunas" ("professional_id", "comuna_codigo")
+SELECT "id", "comuna_codigo"
+FROM "professionals"
+ON CONFLICT DO NOTHING;

--- a/server/db/migrations/meta/0011_snapshot.json
+++ b/server/db/migrations/meta/0011_snapshot.json
@@ -1,0 +1,664 @@
+{
+  "id": "d0a51342-34ef-4edc-8e8f-419792f222e8",
+  "prevId": "abd88d30-3ac8-4e1f-ab11-ca955b5bdb41",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.categorias": {
+      "name": "categorias",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "nombre": {
+          "name": "nombre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activa": {
+          "name": "activa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comuna_vecinas": {
+      "name": "comuna_vecinas",
+      "schema": "",
+      "columns": {
+        "comuna_codigo": {
+          "name": "comuna_codigo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vecina_codigo": {
+          "name": "vecina_codigo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comuna_vecinas_comuna_codigo_comunas_codigo_fk": {
+          "name": "comuna_vecinas_comuna_codigo_comunas_codigo_fk",
+          "tableFrom": "comuna_vecinas",
+          "tableTo": "comunas",
+          "columnsFrom": [
+            "comuna_codigo"
+          ],
+          "columnsTo": [
+            "codigo"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "comuna_vecinas_vecina_codigo_comunas_codigo_fk": {
+          "name": "comuna_vecinas_vecina_codigo_comunas_codigo_fk",
+          "tableFrom": "comuna_vecinas",
+          "tableTo": "comunas",
+          "columnsFrom": [
+            "vecina_codigo"
+          ],
+          "columnsTo": [
+            "codigo"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "comuna_vecinas_comuna_codigo_vecina_codigo_pk": {
+          "name": "comuna_vecinas_comuna_codigo_vecina_codigo_pk",
+          "columns": [
+            "comuna_codigo",
+            "vecina_codigo"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comunas": {
+      "name": "comunas",
+      "schema": "",
+      "columns": {
+        "codigo": {
+          "name": "codigo",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "nombre": {
+          "name": "nombre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activa": {
+          "name": "activa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.professional_categorias": {
+      "name": "professional_categorias",
+      "schema": "",
+      "columns": {
+        "professional_id": {
+          "name": "professional_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "categoria_slug": {
+          "name": "categoria_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_from": {
+          "name": "price_from",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "professional_categorias_categoria_slug_idx": {
+          "name": "professional_categorias_categoria_slug_idx",
+          "columns": [
+            {
+              "expression": "categoria_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "professional_categorias_professional_id_professionals_id_fk": {
+          "name": "professional_categorias_professional_id_professionals_id_fk",
+          "tableFrom": "professional_categorias",
+          "tableTo": "professionals",
+          "columnsFrom": [
+            "professional_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "professional_categorias_categoria_slug_categorias_slug_fk": {
+          "name": "professional_categorias_categoria_slug_categorias_slug_fk",
+          "tableFrom": "professional_categorias",
+          "tableTo": "categorias",
+          "columnsFrom": [
+            "categoria_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "professional_categorias_professional_id_categoria_slug_pk": {
+          "name": "professional_categorias_professional_id_categoria_slug_pk",
+          "columns": [
+            "professional_id",
+            "categoria_slug"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.professional_contact_events": {
+      "name": "professional_contact_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "professional_id": {
+          "name": "professional_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "professional_contact_events_professional_id_idx": {
+          "name": "professional_contact_events_professional_id_idx",
+          "columns": [
+            {
+              "expression": "professional_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "professional_contact_events_professional_id_professionals_id_fk": {
+          "name": "professional_contact_events_professional_id_professionals_id_fk",
+          "tableFrom": "professional_contact_events",
+          "tableTo": "professionals",
+          "columnsFrom": [
+            "professional_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.professional_contact_tokens": {
+      "name": "professional_contact_tokens",
+      "schema": "",
+      "columns": {
+        "professional_id": {
+          "name": "professional_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "professional_contact_tokens_professional_id_professionals_id_fk": {
+          "name": "professional_contact_tokens_professional_id_professionals_id_fk",
+          "tableFrom": "professional_contact_tokens",
+          "tableTo": "professionals",
+          "columnsFrom": [
+            "professional_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "professional_contact_tokens_professional_id_token_pk": {
+          "name": "professional_contact_tokens_professional_id_token_pk",
+          "columns": [
+            "professional_id",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.professionals": {
+      "name": "professionals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comuna_codigo": {
+          "name": "comuna_codigo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact": {
+          "name": "contact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_paths": {
+          "name": "photo_paths",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "avatar_path": {
+          "name": "avatar_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "professionals_comuna_codigo_idx": {
+          "name": "professionals_comuna_codigo_idx",
+          "columns": [
+            {
+              "expression": "comuna_codigo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "professionals_comuna_codigo_comunas_codigo_fk": {
+          "name": "professionals_comuna_codigo_comunas_codigo_fk",
+          "tableFrom": "professionals",
+          "tableTo": "comunas",
+          "columnsFrom": [
+            "comuna_codigo"
+          ],
+          "columnsTo": [
+            "codigo"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "professionals_user_id_unique": {
+          "name": "professionals_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "professional_id": {
+          "name": "professional_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reviews_professional_id_professionals_id_fk": {
+          "name": "reviews_professional_id_professionals_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "professionals",
+          "columnsFrom": [
+            "professional_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "reviews_professional_id_token_fk": {
+          "name": "reviews_professional_id_token_fk",
+          "tableFrom": "reviews",
+          "tableTo": "professional_contact_tokens",
+          "columnsFrom": [
+            "professional_id",
+            "token"
+          ],
+          "columnsTo": [
+            "professional_id",
+            "token"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reviews_professional_id_token_key": {
+          "name": "reviews_professional_id_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "professional_id",
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "reviews_rating_check": {
+          "name": "reviews_rating_check",
+          "value": "\"reviews\".\"rating\" between 1 and 5"
+        },
+        "reviews_comment_length_check": {
+          "name": "reviews_comment_length_check",
+          "value": "char_length(\"reviews\".\"comment\") <= 500"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.professional_comunas": {
+      "name": "professional_comunas",
+      "schema": "",
+      "columns": {
+        "professional_id": {
+          "name": "professional_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comuna_codigo": {
+          "name": "comuna_codigo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "professional_comunas_comuna_codigo_idx": {
+          "name": "professional_comunas_comuna_codigo_idx",
+          "columns": [
+            {
+              "expression": "comuna_codigo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "professional_comunas_professional_id_professionals_id_fk": {
+          "name": "professional_comunas_professional_id_professionals_id_fk",
+          "tableFrom": "professional_comunas",
+          "tableTo": "professionals",
+          "columnsFrom": [
+            "professional_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "professional_comunas_comuna_codigo_comunas_codigo_fk": {
+          "name": "professional_comunas_comuna_codigo_comunas_codigo_fk",
+          "tableFrom": "professional_comunas",
+          "tableTo": "comunas",
+          "columnsFrom": [
+            "comuna_codigo"
+          ],
+          "columnsTo": [
+            "codigo"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "professional_comunas_professional_id_comuna_codigo_pk": {
+          "name": "professional_comunas_professional_id_comuna_codigo_pk",
+          "columns": [
+            "professional_id",
+            "comuna_codigo"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/db/migrations/meta/_journal.json
+++ b/server/db/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1788963933629,
       "tag": "0010_rapid_nuke",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1788966110025,
+      "tag": "0011_married_wiccan",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/schema/professional-comunas.ts
+++ b/server/db/schema/professional-comunas.ts
@@ -1,0 +1,22 @@
+import { index, pgTable, primaryKey, text, uuid } from 'drizzle-orm/pg-core'
+import { comunas } from './comunas'
+import { professionals } from './professionals'
+
+export const professionalComunas = pgTable(
+  'professional_comunas',
+  {
+    professionalId: uuid('professional_id')
+      .notNull()
+      .references(() => professionals.id, { onDelete: 'cascade' }),
+    comunaCodigo: text('comuna_codigo')
+      .notNull()
+      .references(() => comunas.codigo),
+  },
+  table => [
+    primaryKey({ columns: [table.professionalId, table.comunaCodigo] }),
+    // La PK ya cubre "todas las comunas de un profesional" (professionalId es su columna líder). La
+    // búsqueda necesita el sentido contrario: "qué profesionales declararon esta comuna" — sin este
+    // índice, /api/search hace seq scan de toda la tabla en cada request.
+    index('professional_comunas_comuna_codigo_idx').on(table.comunaCodigo),
+  ],
+)

--- a/server/db/sql/rls.sql
+++ b/server/db/sql/rls.sql
@@ -120,6 +120,37 @@ create policy professional_categorias_delete_own on professional_categorias
 -- Igual que professionals: cierra PostgREST por completo. Drizzle usa el rol dueño y no le afecta.
 revoke all on public.professional_categorias from anon, authenticated;
 
+-- professional_comunas (misión 15): mismo patrón asimétrico y misma pertenencia por exists que
+-- professional_categorias. Sin policy de update: el reemplazo del conjunto siempre es delete + insert
+-- (nunca un UPDATE en el lugar), así que una policy de update quedaría sin ningún caller real.
+
+alter table professional_comunas enable row level security;
+
+drop policy if exists professional_comunas_select_public on professional_comunas;
+create policy professional_comunas_select_public on professional_comunas
+  for select to authenticated, anon using (true);
+
+drop policy if exists professional_comunas_insert_own on professional_comunas;
+create policy professional_comunas_insert_own on professional_comunas
+  for insert to authenticated with check (
+    exists (
+      select 1 from professionals p
+      where p.id = professional_comunas.professional_id and p.user_id = (select auth.uid())
+    )
+  );
+
+drop policy if exists professional_comunas_delete_own on professional_comunas;
+create policy professional_comunas_delete_own on professional_comunas
+  for delete to authenticated using (
+    exists (
+      select 1 from professionals p
+      where p.id = professional_comunas.professional_id and p.user_id = (select auth.uid())
+    )
+  );
+
+-- Igual que professionals: cierra PostgREST por completo. Drizzle usa el rol dueño y no le afecta.
+revoke all on public.professional_comunas from anon, authenticated;
+
 -- professional-photos: acá la policy es la barrera real, no un respaldo — las fotos se suben con el
 -- cliente de sesión del propio usuario (mismo publishable key + JWT que arma requireUser()), que sí
 -- evalúa storage.objects. file_size_limit y allowed_mime_types quedan fijados en el propio bucket:


### PR DESCRIPTION
Closes #244

## Qué hace

Primer slice (S-001) del Plan de construcción de la [misión 15](docs/missions/15-multiples-comunas-profesional/ingenieria.md).

- Tabla nueva `professional_comunas` (`professional_id`, `comuna_codigo`), PK compuesta, FK
  `professional_id` → `professionals.id` (`on delete cascade`) y `comuna_codigo` → `comunas.codigo`, con
  índice sobre `comuna_codigo` para el join de `/api/search` (S-005).
- RLS habilitada con 3 policies (`select_public`, `insert_own`, `delete_own` — sin `update`: el reemplazo
  del conjunto siempre es delete+insert, TC-002) más el `revoke` que cierra PostgREST — mismo patrón
  asimétrico que `professional_categorias`.
- Backfill idempotente (`ON CONFLICT DO NOTHING`): cada profesional existente conserva su `comuna_codigo`
  actual como su única comuna declarada. Se vuelve a correr al desplegar S-002 (T-005), para cerrar la
  ventana entre ambos despliegues.
- Expand puro (T-004): `professionals.comuna_codigo` sigue existiendo, ningún endpoint cambia de
  comportamiento todavía.

Sustento: D-003, "Modelo de datos", "Impacto en RLS" (`docs/missions/15-multiples-comunas-profesional/ingenieria.md`) — el checklist de `seguridad-datos` ya está corrido contra este diseño en el propio documento.

## Test plan

- [x] `npx nuxi typecheck` sin errores
- [x] `npm run build` compila
- [x] `npx vitest run` — 78/78, sin cambios necesarios (este slice no toca código de app/server, solo schema+RLS)
- [x] Migración (`npm run db:migrate`) y RLS (`npm run db:rls`) ya aplicadas contra la base real de Supabase
- [x] Backfill verificado: la app sigue respondiendo igual (no lee `professional_comunas` todavía)
- [x] `professional_comunas` cerrada a `anon`/`authenticated`, verificado con `curl` directo a PostgREST — `42501 permission denied for table professional_comunas`, mismo comportamiento que `professional_categorias`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EibkC6oT61jTziqZX2dCSH