### PR TITLE
feat(server): POST /api/professionals crea el profesional con varias comunas

### DIFF
--- a/server/api/professionals/index.post.ts
+++ b/server/api/professionals/index.post.ts
@@ -1,11 +1,11 @@
-const REQUIRED_FIELDS = ['displayName', 'categoriaSlug', 'comunaCodigo', 'contact'] as const
+const TEXT_FIELDS = ['displayName', 'categoriaSlug', 'contact'] as const
 
 export default defineEventHandler(async (event) => {
   const user = await requireUser(event)
   const body = await readBody<Record<string, unknown>>(event)
 
-  const fields = { displayName: '', categoriaSlug: '', comunaCodigo: '', contact: '' }
-  for (const field of REQUIRED_FIELDS) {
+  const fields = { displayName: '', categoriaSlug: '', contact: '' }
+  for (const field of TEXT_FIELDS) {
     const value = body[field]
     if (typeof value !== 'string' || !value.trim()) {
       setResponseStatus(event, 400)
@@ -15,24 +15,34 @@ export default defineEventHandler(async (event) => {
   }
   fields.contact = normalizeContact(fields.contact)
 
-  const fieldError = await validateProfessionalFields(fields)
+  const comunaCodigosRaw = body.comunaCodigos
+  if (
+    !Array.isArray(comunaCodigosRaw)
+    || comunaCodigosRaw.length === 0
+    || !comunaCodigosRaw.every(codigo => typeof codigo === 'string' && codigo.trim())
+  ) {
+    setResponseStatus(event, 400)
+    return { error: 'missing_field', field: 'comunaCodigos' }
+  }
+  // El servidor deduplica antes de validar e insertar — nunca confía en que el cliente ya lo hizo.
+  const comunaCodigos = [...new Set(comunaCodigosRaw.map(codigo => codigo.trim()))]
+
+  const fieldError = await validateProfessionalFields({ ...fields, comunaCodigos })
   if (fieldError) {
     setResponseStatus(event, 400)
     return fieldError
   }
 
-  const { professional, created } = await createProfessional(user.id, fields, user.email ?? null)
+  const { professional, created } = await createProfessional(user.id, { ...fields, comunaCodigos }, user.email ?? null)
 
   // El correo solo se dispara al crear de verdad — si el usuario ya tenía perfil, no se reenvía.
   if (created && user.email) {
-    const [categoriaNombre, comunaNombre] = await Promise.all([
-      findCategoriaNombre(fields.categoriaSlug),
-      findComunaNombre(fields.comunaCodigo),
-    ])
+    const categoriaNombre = await findCategoriaNombre(fields.categoriaSlug)
+    const comunaNombre = new Intl.ListFormat('es-CL', { type: 'conjunction' }).format(professional.comunas.map(c => c.nombre))
     const { subject, html } = buildProfessionalWelcomeEmail({
       displayName: fields.displayName,
       categoriaNombre: categoriaNombre ?? fields.categoriaSlug,
-      comunaNombre: comunaNombre ?? fields.comunaCodigo,
+      comunaNombre,
       profileUrl: `${getRequestURL(event).origin}/profesional/perfil`,
     })
     // waitUntil mantiene la función viva para el correo sin bloquear la respuesta al cliente; el

--- a/server/utils/comunas.ts
+++ b/server/utils/comunas.ts
@@ -19,11 +19,6 @@ export async function existsActiveComuna(codigo: string): Promise<boolean> {
   return Boolean(row)
 }
 
-export async function findComunaNombre(codigo: string): Promise<string | null> {
-  const [row] = await useDb().select({ nombre: comunas.nombre }).from(comunas).where(eq(comunas.codigo, codigo))
-  return row?.nombre ?? null
-}
-
 // Nunca devuelve una comuna inactiva, aunque comparta límite real — activar una comuna nueva no exige
 // tocar esta query, el filtro ya vive acá.
 export async function findVecinasActivas(comunaCodigo: string): Promise<{ codigo: string, nombre: string }[]> {

--- a/server/utils/professionals.ts
+++ b/server/utils/professionals.ts
@@ -1,4 +1,4 @@
-import { and, eq, sql } from 'drizzle-orm'
+import { and, asc, eq, sql } from 'drizzle-orm'
 import { existsActiveCategoria } from './categorias'
 import { existsActiveComuna } from './comunas'
 import {
@@ -8,6 +8,7 @@ import {
 } from './professional-categorias'
 import { isUuid } from './validation'
 import { comunas } from '../db/schema/comunas'
+import { professionalComunas } from '../db/schema/professional-comunas'
 import { professionals } from '../db/schema/professionals'
 
 const CONTACT_REGEX = /^\+56\d{9}$/
@@ -23,10 +24,22 @@ export type ProfessionalCoreFields = {
 // que ahora se editan siempre por categoría vía /me/categorias/*.
 export type ProfessionalPatch = Partial<Pick<ProfessionalCoreFields, 'displayName' | 'comunaCodigo' | 'contact'>>
 
-// Usado tanto para el patch de professionals (displayName/comunaCodigo/contact) como para el de una
-// categoría puntual (categoriaSlug/priceFrom/description vía /me/categorias/*) — validateProfessionalFields
-// es genérica sobre las dos, cada endpoint le pasa solo los campos que le tocan.
+// Campos de creación de POST /api/professionals — comunaCodigos (conjunto) reemplaza a comunaCodigo
+// (ProfessionalCoreFields) en el body de este endpoint; comunaCodigo sigue vivo ahí solo para
+// ProfessionalPatch/PATCH /me, que todavía no migró (S-003).
+export type ProfessionalCreateFields = {
+  displayName: string
+  categoriaSlug: string
+  comunaCodigos: string[]
+  contact: string
+}
+
+// Usado para el patch de professionals (displayName/comunaCodigo/contact), la creación
+// (displayName/categoriaSlug/comunaCodigos/contact) y el patch de una categoría puntual
+// (categoriaSlug/priceFrom/description vía /me/categorias/*) — validateProfessionalFields es genérica
+// sobre las tres, cada endpoint le pasa solo los campos que le tocan.
 export type ProfessionalFieldsInput = Partial<ProfessionalCoreFields> & {
+  comunaCodigos?: string[]
   description?: string | null
   priceFrom?: number | null
 }
@@ -90,6 +103,11 @@ export async function validateProfessionalFields(
   }
   if (fields.comunaCodigo !== undefined && !(await existsActiveComuna(fields.comunaCodigo))) {
     return { error: 'invalid_comuna' }
+  }
+  if (fields.comunaCodigos !== undefined) {
+    for (const codigo of fields.comunaCodigos) {
+      if (!(await existsActiveComuna(codigo))) return { error: 'invalid_comuna' }
+    }
   }
   if (fields.contact !== undefined && !CONTACT_REGEX.test(fields.contact)) {
     return { error: 'invalid_contact' }
@@ -177,6 +195,17 @@ export async function findProfessionalByUserId(userId: string): Promise<Professi
   return row ? toPublicProfessional(row) : null
 }
 
+// Alfabético por nombre — mismo orden que ya usa findActiveComunas, y el que toda esta misión asume
+// para no tener que reordenar en ningún consumidor.
+export async function findProfessionalComunas(professionalId: string): Promise<{ codigo: string, nombre: string }[]> {
+  return useDb()
+    .select({ codigo: professionalComunas.comunaCodigo, nombre: comunas.nombre })
+    .from(professionalComunas)
+    .innerJoin(comunas, eq(professionalComunas.comunaCodigo, comunas.codigo))
+    .where(eq(professionalComunas.professionalId, professionalId))
+    .orderBy(asc(comunas.nombre))
+}
+
 export type ProfessionalProfile = Professional & { categorias: PublicCategoria[] }
 
 export async function findProfessionalProfileByUserId(userId: string): Promise<ProfessionalProfile | null> {
@@ -200,32 +229,38 @@ export async function findProfessionalNotificationInfo(
 
 export async function createProfessional(
   userId: string,
-  fields: ProfessionalCoreFields,
+  fields: ProfessionalCreateFields,
   email: string | null,
-): Promise<{ professional: Professional, created: boolean }> {
-  const { categoriaSlug, ...professionalFields } = fields
+): Promise<{ professional: Professional & { comunas: { codigo: string, nombre: string }[] }, created: boolean }> {
+  const { categoriaSlug, comunaCodigos, displayName, contact } = fields
 
   const inserted = await useDb().transaction(async (tx) => {
     const [professional] = await tx
       .insert(professionals)
-      .values({ userId, ...professionalFields, email })
+      // comunaCodigo sigue siendo NOT NULL en professionals hasta S-006 — se le escribe la primera
+      // comuna del conjunto (comunaCodigos siempre trae al menos un elemento, ya validado antes de
+      // llegar acá) mientras conviven las dos fuentes de verdad.
+      .values({ userId, displayName, contact, comunaCodigo: comunaCodigos[0]!, email })
       .onConflictDoNothing({ target: professionals.userId })
       .returning(publicColumns)
 
     if (!professional) return null
 
     await createProfessionalCategoria(tx, professional.id, categoriaSlug)
+    await tx.insert(professionalComunas).values(
+      comunaCodigos.map(comunaCodigo => ({ professionalId: professional.id, comunaCodigo })),
+    )
     return professional
   })
 
   if (inserted) {
-    return { professional: toPublicProfessional(inserted), created: true }
+    return { professional: { ...toPublicProfessional(inserted), comunas: await findProfessionalComunas(inserted.id) }, created: true }
   }
 
   // userId es unique — si el insert no devolvió fila es porque ya existía una, nunca porque el insert
   // falló en silencio.
   const existing = await findProfessionalByUserId(userId)
-  return { professional: existing!, created: false }
+  return { professional: { ...existing!, comunas: await findProfessionalComunas(existing!.id) }, created: false }
 }
 
 // Devuelve el perfil con categorias (no solo Professional): el cliente guarda esta respuesta como su


### PR DESCRIPTION
Closes #245

## Qué hace

Segundo slice (S-002) del Plan de construcción de la [misión 15](docs/missions/15-multiples-comunas-profesional/ingenieria.md).

- El body de `POST /api/professionals` pasa de `comunaCodigo` a `comunaCodigos: string[]` (TC-001) — al
  menos un elemento, el servidor deduplica con `Set` antes de validar e insertar (T-003), cada código debe
  existir y estar activo.
- La fila de `professionals` y las N filas de `professional_comunas` se crean en una sola transacción.
  `professionals.comunaCodigo` (columna legacy, sigue `NOT NULL` hasta S-006) se escribe con la primera
  comuna del conjunto mientras conviven las dos fuentes de verdad — mismo patrón que usó la misión 14 con
  `categoriaSlug` hasta su propio slice de contract.
- `findProfessionalComunas()` nuevo en `professionals.ts` (no en su propio archivo de utils, a diferencia
  de categorías — la Arquitectura de esta misión deja el conjunto de comunas como responsabilidad directa
  del dominio "profesional"), alfabético por nombre.
- El correo de bienvenida ya arma la lista de comunas con `Intl.ListFormat` en vez de una sola — adelanta
  ese detalle de TC-003/S-004 porque el dato ya está disponible acá, sin costo extra.
- `findComunaNombre()` en `comunas.ts` quedó sin ningún caller, se borra.

## Ventana conocida y aceptada

`registro.vue` sigue mandando `comunaCodigo` singular hasta que S-008 lo migre al selector múltiple — el
registro real queda roto (400 `missing_field`) entre que este PR se mergea y S-008 se mergea.
`ingenieria.md` no tiene un T-004-estilo de compatibilidad de *body* para este endpoint (T-005 solo cubre
la ventana del *backfill* de datos, no la forma del request). Conversado explícitamente antes de
implementar: se decide no agregar un fallback no documentado y asumir la ventana rota hasta terminar el
resto de los slices — dado que es pre-lanzamiento sin usuarios reales.

## Test plan

- [x] `npx nuxi typecheck` sin errores
- [x] `npm run build` compila
- [x] `npx vitest run` — 78/78, sin cambios necesarios
- [ ] No pude ejercer el endpoint con una sesión real (bloqueado el mismo camino de siempre — generar una
  sesión de prueba vía magic link admin) — solo confirmé que sigue respondiendo 401 sin sesión, sin crash
  por el cambio de tipos. La lógica de validación/creación no quedó probada en vivo con un `POST` real;
  recomiendo esa pasada manual antes o después de mergear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EibkC6oT61jTziqZX2dCSH