### PR TITLE
feat(server): PATCH /api/professionals/me reemplaza el conjunto de comunas

### DIFF
--- a/server/api/professionals/me/index.patch.ts
+++ b/server/api/professionals/me/index.patch.ts
@@ -16,6 +16,20 @@ export default defineEventHandler(async (event) => {
     patch[field] = field === 'contact' ? normalizeContact(value.trim()) : value.trim()
   }
 
+  if ('comunaCodigos' in body) {
+    const value = body.comunaCodigos
+    if (
+      !Array.isArray(value)
+      || value.length === 0
+      || !value.every(codigo => typeof codigo === 'string' && codigo.trim())
+    ) {
+      setResponseStatus(event, 400)
+      return { error: 'missing_field', field: 'comunaCodigos' }
+    }
+    // El servidor deduplica antes de validar e insertar — nunca confía en que el cliente ya lo hizo.
+    patch.comunaCodigos = [...new Set(value.map(codigo => codigo.trim()))]
+  }
+
   const fieldError = await validateProfessionalFields(patch)
   if (fieldError) {
     setResponseStatus(event, 400)

--- a/server/utils/professionals.ts
+++ b/server/utils/professionals.ts
@@ -20,13 +20,18 @@ export type ProfessionalCoreFields = {
   contact: string
 }
 
-// Lo que PATCH /me puede tocar de la fila de professionals — ya sin categoriaSlug/priceFrom/description,
-// que ahora se editan siempre por categoría vía /me/categorias/*.
-export type ProfessionalPatch = Partial<Pick<ProfessionalCoreFields, 'displayName' | 'comunaCodigo' | 'contact'>>
+// Lo que PATCH /me puede tocar — comunaCodigo (columna legacy de professionals) sigue vivo acá porque
+// perfil.vue todavía edita "Comuna" como un campo único; comunaCodigos (conjunto, vía
+// professional_comunas) es el reemplazo real y conviven los dos hasta que perfil.vue migre al selector
+// múltiple. Ya sin categoriaSlug/priceFrom/description, que se editan siempre por categoría vía
+// /me/categorias/*.
+export type ProfessionalPatch = Partial<Pick<ProfessionalCoreFields, 'displayName' | 'comunaCodigo' | 'contact'>> & {
+  comunaCodigos?: string[]
+}
 
 // Campos de creación de POST /api/professionals — comunaCodigos (conjunto) reemplaza a comunaCodigo
-// (ProfessionalCoreFields) en el body de este endpoint; comunaCodigo sigue vivo ahí solo para
-// ProfessionalPatch/PATCH /me, que todavía no migró (S-003).
+// (ProfessionalCoreFields) en el body de este endpoint; comunaCodigo sigue vivo en ProfessionalCoreFields
+// solo para ProfessionalPatch/PATCH /me.
 export type ProfessionalCreateFields = {
   displayName: string
   categoriaSlug: string
@@ -263,21 +268,45 @@ export async function createProfessional(
   return { professional: { ...existing!, comunas: await findProfessionalComunas(existing!.id) }, created: false }
 }
 
-// Devuelve el perfil con categorias (no solo Professional): el cliente guarda esta respuesta como su
-// único estado del perfil propio (useProfessionalProfile), y perfil.vue necesita categorias ahí aunque
-// esta escritura puntual no la haya tocado — perderla haría desaparecer los bloques de categoría hasta
-// el próximo reload.
-export async function updateProfessional(userId: string, patch: ProfessionalPatch): Promise<ProfessionalProfile | null> {
-  const [row] = await useDb()
-    .update(professionals)
-    .set({ ...patch, updatedAt: new Date() })
-    .where(eq(professionals.userId, userId))
-    .returning(publicColumns)
+// Devuelve el perfil con categorias y comunas (no solo Professional): el cliente guarda esta respuesta
+// como su único estado del perfil propio (useProfessionalProfile), y perfil.vue necesita las dos ahí
+// aunque esta escritura puntual no las haya tocado — perderlas haría desaparecer los bloques de categoría
+// o la comuna hasta el próximo reload.
+export async function updateProfessional(
+  userId: string,
+  patch: ProfessionalPatch,
+): Promise<(ProfessionalProfile & { comunas: { codigo: string, nombre: string }[] }) | null> {
+  const { comunaCodigos, ...professionalPatch } = patch
 
-  if (!row) return null
+  const updated = await useDb().transaction(async (tx) => {
+    const [row] = await tx
+      .update(professionals)
+      .set({ ...professionalPatch, updatedAt: new Date() })
+      .where(eq(professionals.userId, userId))
+      .returning(publicColumns)
 
-  const professional = toPublicProfessional(row)
-  return { ...professional, categorias: await findProfessionalCategorias(professional.id) }
+    if (!row) return null
+
+    // delete + insert, nunca un UPDATE en el lugar: reemplaza el conjunto completo dentro de la misma
+    // transacción, así ninguna request concurrente ve el conjunto momentáneamente vacío.
+    if (comunaCodigos !== undefined) {
+      await tx.delete(professionalComunas).where(eq(professionalComunas.professionalId, row.id))
+      await tx.insert(professionalComunas).values(
+        comunaCodigos.map(comunaCodigo => ({ professionalId: row.id, comunaCodigo })),
+      )
+    }
+
+    return row
+  })
+
+  if (!updated) return null
+
+  const professional = toPublicProfessional(updated)
+  const [categorias, comunas] = await Promise.all([
+    findProfessionalCategorias(professional.id),
+    findProfessionalComunas(professional.id),
+  ])
+  return { ...professional, categorias, comunas }
 }
 
 export async function addProfessionalPhoto(userId: string, path: string): Promise<Professional | null> {


### PR DESCRIPTION
Closes #246

## Qué hace

Tercer slice (S-003) del Plan de construcción de la [misión 15](docs/missions/15-multiples-comunas-profesional/ingenieria.md).

- `comunaCodigos?: string[]` se agrega a los campos que `PATCH /api/professionals/me` ya acepta (TC-002) —
  no reemplaza al body existente, se suma. Cuando está presente, reemplaza el conjunto completo dentro de
  una transacción (`delete` + `insert`, nunca un `UPDATE` en el lugar ni un delta) — nunca deja un estado
  intermedio en cero visible a otra request concurrente.
- `comunaCodigos` se deduplica con `Set` antes de insertar (T-003); presente y vacío → 400 `missing_field`,
  la fila existente no se toca (CL-004).
- `comunaCodigo` (columna legacy de `professionals`) sigue vivo sin ningún cambio — `perfil.vue` todavía
  edita "Comuna" como un campo único hasta que S-009 migre esa fila al selector múltiple. TC-002 lo dice
  explícitamente ("se agrega a los campos que ya acepta"), así que los dos caminos conviven sin ventana
  rota, a diferencia de POST (S-002).
- La respuesta ya incluye `comunas` actualizado, junto a `categorias` — mismo motivo por el que ya incluía
  `categorias`: el cliente guarda esta respuesta como su único estado del perfil propio.

## Test plan

- [x] `npx nuxi typecheck` sin errores
- [x] `npm run build` compila
- [x] `npx vitest run` — 78/78, sin cambios necesarios
- [ ] No pude ejercer el endpoint con una sesión real — mismo bloqueo de siempre (generar sesión de prueba
  vía magic link admin). Solo confirmé que sigue respondiendo 401 sin sesión, sin crash por el cambio de
  tipos. Recomiendo una pasada manual con `PATCH` real antes o después de mergear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EibkC6oT61jTziqZX2dCSH