### PR TITLE
feat(server): GET /api/professionals/me y /[id] devuelven comunas[]

### DIFF
--- a/app/types/professional.ts
+++ b/app/types/professional.ts
@@ -7,12 +7,18 @@ export type PublicCategoria = {
   description: string | null
 }
 
+export type PublicComuna = {
+  codigo: string
+  nombre: string
+}
+
 export type Professional = {
   id: string
   displayName: string
   comunaCodigo: string
   contact: string
   categorias: PublicCategoria[]
+  comunas: PublicComuna[]
   photoUrls: string[]
   avatarUrl: string | null
   active: boolean
@@ -31,6 +37,7 @@ export type PublicProfessionalProfile = {
   comunaNombre: string
   contact: string
   categorias: PublicCategoria[]
+  comunas: PublicComuna[]
   photoUrls: string[]
   avatarUrl: string | null
   createdAt: string

--- a/server/utils/professionals.ts
+++ b/server/utils/professionals.ts
@@ -63,12 +63,16 @@ export type Professional = {
 
 // Forma que ve un buscador sin sesión (misión 05): categoría/comuna ya resueltas a su nombre (nunca el
 // slug/código, que no significa nada para quien mira el perfil) y createdAt, que Professional no expone.
+//
+// comunaNombre queda calculado desde professionals.comunaCodigo (la primera comuna declarada) mientras
+// conviva con comunas — [id].vue no migra a comunas hasta S-010; ese slice retira comunaNombre.
 export type PublicProfessionalProfile = {
   id: string
   displayName: string
   comunaNombre: string
   contact: string
   categorias: PublicCategoria[]
+  comunas: { codigo: string, nombre: string }[]
   photoUrls: string[]
   avatarUrl: string | null
   createdAt: string
@@ -174,12 +178,18 @@ export async function findPublicProfessionalProfile(id: string): Promise<PublicP
 
   if (!row) return null
 
+  const [categorias, comunasList] = await Promise.all([
+    findProfessionalCategorias(row.id),
+    findProfessionalComunas(row.id),
+  ])
+
   return {
     id: row.id,
     displayName: row.displayName,
     comunaNombre: row.comunaNombre ?? row.comunaCodigo,
     contact: row.contact,
-    categorias: await findProfessionalCategorias(row.id),
+    categorias,
+    comunas: comunasList,
     photoUrls: buildPhotoUrls(row.photoPaths),
     avatarUrl: buildAvatarUrl(row.avatarPath),
     createdAt: row.createdAt.toISOString(),
@@ -211,13 +221,20 @@ export async function findProfessionalComunas(professionalId: string): Promise<{
     .orderBy(asc(comunas.nombre))
 }
 
-export type ProfessionalProfile = Professional & { categorias: PublicCategoria[] }
+export type ProfessionalProfile = Professional & {
+  categorias: PublicCategoria[]
+  comunas: { codigo: string, nombre: string }[]
+}
 
 export async function findProfessionalProfileByUserId(userId: string): Promise<ProfessionalProfile | null> {
   const professional = await findProfessionalByUserId(userId)
   if (!professional) return null
 
-  return { ...professional, categorias: await findProfessionalCategorias(professional.id) }
+  const [categorias, comunas] = await Promise.all([
+    findProfessionalCategorias(professional.id),
+    findProfessionalComunas(professional.id),
+  ])
+  return { ...professional, categorias, comunas }
 }
 
 // Lo único que necesita el correo de aviso de reseña nueva (misión 07) — nunca active, que ya decidió
@@ -275,7 +292,7 @@ export async function createProfessional(
 export async function updateProfessional(
   userId: string,
   patch: ProfessionalPatch,
-): Promise<(ProfessionalProfile & { comunas: { codigo: string, nombre: string }[] }) | null> {
+): Promise<ProfessionalProfile | null> {
   const { comunaCodigos, ...professionalPatch } = patch
 
   const updated = await useDb().transaction(async (tx) => {


### PR DESCRIPTION
Closes #247

## Qué hace

Cuarto slice (S-004) del Plan de construcción de la [misión 15](docs/missions/15-multiples-comunas-profesional/ingenieria.md).

- `ProfessionalProfile` (usado por `GET`/`PATCH /api/professionals/me`) y `PublicProfessionalProfile`
  (`GET /api/professionals/[id]`) ganan `comunas: { codigo, nombre }[]`, siempre en orden alfabético por
  nombre — `findProfessionalComunas`, ya agregado en S-002 (TC-003).
- `comunaNombre` en `PublicProfessionalProfile` sigue vivo, calculado desde `professionals.comunaCodigo`
  igual que hoy — `[id].vue` no migra a `comunas` hasta S-010, que recién ahí retira el campo. Mismo patrón
  de compatibilidad temporal que usó la misión 14 con `categoriaNombre`/`priceFrom`/`description`; sin este
  compat, quitar el campo ahora rompería el `build` completo (no solo un endpoint en runtime), porque
  `[id].vue` todavía lo lee.
- Tipos de `app/` (`Professional`, `PublicProfessionalProfile`) ganan `comunas: PublicComuna[]` en paralelo
  a los del servidor — ningún consumidor los lee todavía, pero el contrato ya está disponible para S-009 y
  S-010.

Simplifiqué de paso las anotaciones de retorno de `createProfessional`/`updateProfessional` (que ya
intersectaban `Professional`/`ProfessionalProfile` con `{ comunas }` ad-hoc desde S-002/S-003): ahora
`ProfessionalProfile` incluye `comunas` directamente en su definición.

## Test plan

- [x] `npx nuxi typecheck` sin errores
- [x] `npm run build` compila
- [x] `npx vitest run` — 78/78, sin cambios necesarios
- [x] `curl` contra `/api/professionals/[id-de-prueba]`: `comunaNombre` y `comunas` conviven y coinciden
  (`comunaNombre: "Puerto Varas"`, `comunas: [{codigo:"10109", nombre:"Puerto Varas"}]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EibkC6oT61jTziqZX2dCSH