### PR TITLE
feat(server): /api/search lee la comuna coincidente desde professional_comunas

### DIFF
--- a/server/utils/comunas.ts
+++ b/server/utils/comunas.ts
@@ -1,6 +1,7 @@
 import { and, asc, count, desc, eq } from 'drizzle-orm'
 import { comunaVecinas } from '../db/schema/comuna-vecinas'
 import { comunas } from '../db/schema/comunas'
+import { professionalComunas } from '../db/schema/professional-comunas'
 import { professionals } from '../db/schema/professionals'
 
 export async function findActiveComunas() {
@@ -30,13 +31,16 @@ export async function findVecinasActivas(comunaCodigo: string): Promise<{ codigo
     .orderBy(asc(comunas.nombre))
 }
 
+// Un profesional con varias comunas cuenta una vez por cada una que declaró — no es un double-count
+// indebido, es la misma semántica de "atiende ahí" generalizada de 1 a N comunas por profesional.
 export async function findComunasFrecuentes(limit = 3): Promise<{ codigo: string, nombre: string }[]> {
   return useDb()
     .select({ codigo: comunas.codigo, nombre: comunas.nombre })
     .from(comunas)
+    .innerJoin(professionalComunas, eq(professionalComunas.comunaCodigo, comunas.codigo))
     .innerJoin(
       professionals,
-      and(eq(professionals.comunaCodigo, comunas.codigo), eq(professionals.active, true)),
+      and(eq(professionals.id, professionalComunas.professionalId), eq(professionals.active, true)),
     )
     .where(eq(comunas.activa, true))
     .groupBy(comunas.codigo, comunas.nombre)

--- a/server/utils/search.test.ts
+++ b/server/utils/search.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll, describe, expect, it, vi } from 'vitest'
-import { rankByCompleteness, toSearchResult, type ProfessionalCompletenessInput, type ProfessionalSearchRow } from './search'
+import { pickMatchedComuna, rankByCompleteness, toSearchResult, type ProfessionalCompletenessInput, type ProfessionalSearchRow } from './search'
 
 // buildAvatarUrl/buildPhotoUrls llaman a useRuntimeConfig(), el auto-import de Nitro — no existe fuera de
 // una request real, así que se stubea con la misma forma que el runtime expone en server/utils/professionals.ts.
@@ -52,6 +52,25 @@ describe('rankByCompleteness', () => {
     const a = input({ id: 'a' })
 
     expect(rankByCompleteness([b, a]).map(r => r.id)).toEqual(['a', 'b'])
+  })
+})
+
+describe('pickMatchedComuna', () => {
+  it('con una sola candidata, la devuelve tal cual', () => {
+    const frutillar = { codigo: '10102', nombre: 'Frutillar' }
+    expect(pickMatchedComuna([frutillar])).toEqual(frutillar)
+  })
+
+  it('con varias candidatas, elige la alfabéticamente primera', () => {
+    const puertoVaras = { codigo: '10109', nombre: 'Puerto Varas' }
+    const frutillar = { codigo: '10102', nombre: 'Frutillar' }
+    expect(pickMatchedComuna([puertoVaras, frutillar])).toEqual(frutillar)
+  })
+
+  it('es determinístico: el orden de entrada no cambia el resultado', () => {
+    const puertoVaras = { codigo: '10109', nombre: 'Puerto Varas' }
+    const frutillar = { codigo: '10102', nombre: 'Frutillar' }
+    expect(pickMatchedComuna([frutillar, puertoVaras])).toEqual(pickMatchedComuna([puertoVaras, frutillar]))
   })
 })
 

--- a/server/utils/search.ts
+++ b/server/utils/search.ts
@@ -4,6 +4,7 @@ import { buildAvatarUrl, buildPhotoUrls } from './professionals'
 import { findRatingSummaries, type RatingSummary } from './reviews'
 import { comunas } from '../db/schema/comunas'
 import { professionalCategorias } from '../db/schema/professional-categorias'
+import { professionalComunas } from '../db/schema/professional-comunas'
 import { professionals } from '../db/schema/professionals'
 
 export type SearchMatchType = 'exacta' | 'vecina' | 'ninguna'
@@ -47,6 +48,11 @@ export type ProfessionalSearchRow = {
   description: string | null
 }
 
+// Fila cruda de la query de findActiveProfessionals, antes de agrupar por profesional — un profesional
+// con 2+ comunas puede aparecer más de una vez si matchea por más de una comuna del conjunto buscado a
+// la vez (ver groupByMatchedComuna).
+type ProfessionalSearchQueryRow = ProfessionalSearchRow & { comunaCodigo: string }
+
 function completenessScore(input: ProfessionalCompletenessInput): number {
   return Number(input.hasPhotos) + Number(input.hasDescription) + Number(input.hasPrice)
 }
@@ -87,6 +93,33 @@ export function toSearchResult(row: ProfessionalSearchRow, rating: RatingSummary
   }
 }
 
+// Función pura, sin Drizzle: decide cuál de las comunas coincidentes de un profesional se muestra cuando
+// matchea por más de una a la vez, sin enterrar esa regla de negocio en SQL (mismo criterio que
+// rankByCompleteness). Reusa el orden alfabético que ya fija toda esta misión — determinístico, nunca
+// varía entre requests para el mismo profesional y el mismo conjunto de comunas buscadas.
+export function pickMatchedComuna(
+  candidatas: { codigo: string, nombre: string }[],
+): { codigo: string, nombre: string } {
+  return [...candidatas].sort((a, b) => a.nombre.localeCompare(b.nombre, 'es'))[0]!
+}
+
+// Agrupa las filas crudas por profesional y resuelve, con pickMatchedComuna, cuál de sus comunas
+// coincidentes queda como comunaNombre — el resto de los campos son iguales entre las filas de un mismo
+// profesional (no dependen de la comuna), así que se toman de la primera del grupo.
+function groupByMatchedComuna(rows: ProfessionalSearchQueryRow[]): ProfessionalSearchRow[] {
+  const byId = new Map<string, ProfessionalSearchQueryRow[]>()
+  for (const row of rows) {
+    const group = byId.get(row.id)
+    if (group) group.push(row)
+    else byId.set(row.id, [row])
+  }
+
+  return [...byId.values()].map((group) => {
+    const matched = pickMatchedComuna(group.map(r => ({ codigo: r.comunaCodigo, nombre: r.comunaNombre })))
+    return { ...group[0]!, comunaNombre: matched.nombre }
+  })
+}
+
 async function orderResults(rows: ProfessionalSearchRow[]): Promise<SearchResultProfessional[]> {
   const ranked = rankByCompleteness(rows.map(toCompletenessInput))
   const rowById = new Map(rows.map(row => [row.id, row]))
@@ -98,10 +131,11 @@ async function findActiveProfessionals(
   categoriaSlug: string,
   comunaCodigos: string[],
 ): Promise<ProfessionalSearchRow[]> {
-  return useDb()
+  const rows = await useDb()
     .select({
       id: professionals.id,
       displayName: professionals.displayName,
+      comunaCodigo: professionalComunas.comunaCodigo,
       comunaNombre: comunas.nombre,
       priceFrom: professionalCategorias.priceFrom,
       avatarPath: professionals.avatarPath,
@@ -110,15 +144,18 @@ async function findActiveProfessionals(
       description: professionalCategorias.description,
     })
     .from(professionals)
-    .innerJoin(comunas, eq(professionals.comunaCodigo, comunas.codigo))
+    .innerJoin(professionalComunas, eq(professionalComunas.professionalId, professionals.id))
+    .innerJoin(comunas, eq(professionalComunas.comunaCodigo, comunas.codigo))
     .innerJoin(professionalCategorias, and(
       eq(professionalCategorias.professionalId, professionals.id),
       eq(professionalCategorias.categoriaSlug, categoriaSlug),
     ))
     .where(and(
-      inArray(professionals.comunaCodigo, comunaCodigos),
+      inArray(professionalComunas.comunaCodigo, comunaCodigos),
       eq(professionals.active, true),
     ))
+
+  return groupByMatchedComuna(rows)
 }
 
 // Se une a comunas para excluir zonas que se desactivaron — "existe en otra parte de Chile" solo cuenta
@@ -129,7 +166,8 @@ async function existsActiveProfessionalForCategoria(categoriaSlug: string): Prom
   const [row] = await useDb()
     .select({ id: professionals.id })
     .from(professionals)
-    .innerJoin(comunas, eq(professionals.comunaCodigo, comunas.codigo))
+    .innerJoin(professionalComunas, eq(professionalComunas.professionalId, professionals.id))
+    .innerJoin(comunas, eq(professionalComunas.comunaCodigo, comunas.codigo))
     .innerJoin(professionalCategorias, and(
       eq(professionalCategorias.professionalId, professionals.id),
       eq(professionalCategorias.categoriaSlug, categoriaSlug),


### PR DESCRIPTION
Closes #248

## Qué hace

Quinto slice (S-005) del Plan de construcción de la [misión 15](docs/missions/15-multiples-comunas-profesional/ingenieria.md).

- `findActiveProfessionals` hace join contra `professional_comunas` en vez de `professionals.comunaCodigo`
  — un profesional que matchea por 2+ comunas del conjunto buscado a la vez aparece en varias filas de la
  query.
- `pickMatchedComuna` (función pura nueva, sin Drizzle, T-002): decide alfabéticamente cuál comuna
  coincidente se muestra, sin enterrar esa regla de negocio en SQL — mismo patrón que `rankByCompleteness`.
  `groupByMatchedComuna` agrupa las filas crudas por profesional y aplica esa función antes de pasarle el
  resultado a `orderResults`.
- `existsActiveProfessionalForCategoria` mismo cambio de join, sin cambio de comportamiento.
- `findComunasFrecuentes` (`server/utils/comunas.ts`) cuenta contra `professional_comunas` — un profesional
  con varias comunas cuenta una vez por cada una que declaró (TC-004).
- 3 tests unitarios nuevos para `pickMatchedComuna`.

## Test plan

- [x] `npx nuxi typecheck` sin errores
- [x] `npm run build` compila
- [x] `npx vitest run` — 81/81 (3 nuevos), incluye `pickMatchedComuna`
- [x] `curl` contra `/api/search?categoria=gasfiteria&comuna=10109` con datos reales — dos profesionales de
  Puerto Varas, ambos con `comunaNombre` correcto
- [x] `curl` contra `/api/comunas/frecuentes` — sigue respondiendo correctamente tras el cambio de join
- [ ] No pude verificar en vivo el caso de un profesional con 2+ comunas coincidiendo a la vez (necesitaría
  un profesional de prueba con varias comunas declaradas, que no pude crear por el mismo bloqueo de
  siempre) — cubierto solo por los tests unitarios de `pickMatchedComuna`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EibkC6oT61jTziqZX2dCSH